### PR TITLE
feat: implement Agent Core lifecycle and integration API

### DIFF
--- a/components/adapters/base/just/project/mod.just
+++ b/components/adapters/base/just/project/mod.just
@@ -1,0 +1,25 @@
+root := justfile_directory()
+
+[working-directory: root]
+doctor:
+    @echo "Base Project Adapter doctor: PASS"
+
+[working-directory: root]
+format-check:
+    @echo "Base Project Adapter format-check: SKIPPED"
+
+[working-directory: root]
+lint:
+    @echo "Base Project Adapter lint: SKIPPED"
+
+[working-directory: root]
+test:
+    @echo "Base Project Adapter test: SKIPPED"
+
+[working-directory: root]
+build:
+    @echo "Base Project Adapter build: SKIPPED"
+
+[working-directory: root]
+check: doctor format-check lint test build
+    @echo "Base Project Adapter check: PASS"

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -1,8 +1,13 @@
-# Agent Core scaffold
+# Agent Core automation
 
-This directory is owned by the shared Agent Core component.
+This directory contains the language-independent Task lifecycle, publication,
+and integration layer shared by every Agent-ready template.
 
-Issue #5 only establishes deterministic component composition. The executable
-Agent Core lifecycle, OpenCode agents, permissions, and publication scripts are
-implemented by follow-up issues. Keep language- and toolchain-specific behavior
-out of this component.
+Public operations are exposed through the top-level Just modules rather than by
+calling these scripts directly. Project-specific build, lint, test, and toolchain
+behavior belongs under `just/project/` in the selected Project Adapter.
+
+The current implementation provides guarded Task-local commit/push/PR operations,
+integration head-SHA checkpoints, disposable Task State templates, and common
+safety policy. Repository-local OpenCode agents and permissions are added by the
+separate OpenCode configuration work.

--- a/components/agent-core/.automation/bin/agent_core.py
+++ b/components/agent-core/.automation/bin/agent_core.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    tomllib = None
+
+TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+SAFE_CHECK_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+
+
+class AutomationError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise AutomationError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def git(*args: str, cwd: Path | None = None, check: bool = True) -> str:
+    return run(["git", *args], cwd=cwd, check=check).stdout.strip()
+
+
+def gh(*args: str, cwd: Path | None = None) -> str:
+    return run(["gh", *args], cwd=cwd).stdout.strip()
+
+
+def repo_root(cwd: Path | None = None) -> Path:
+    return Path(git("rev-parse", "--show-toplevel", cwd=cwd)).resolve()
+
+
+def common_git_dir(root: Path) -> Path:
+    value = Path(git("rev-parse", "--git-common-dir", cwd=root))
+    return value if value.is_absolute() else (root / value).resolve()
+
+
+def current_branch(root: Path) -> str:
+    branch = git("branch", "--show-current", cwd=root)
+    if not branch:
+        raise AutomationError("detached HEAD is not supported")
+    return branch
+
+
+def default_branch(root: Path) -> str:
+    symbolic = git("symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD", cwd=root, check=False)
+    if symbolic.startswith("origin/"):
+        return symbolic.removeprefix("origin/")
+    try:
+        data = json.loads(gh("repo", "view", "--json", "defaultBranchRef", cwd=root))
+        name = data.get("defaultBranchRef", {}).get("name")
+        if name:
+            return name
+    except (AutomationError, json.JSONDecodeError):
+        pass
+    raise AutomationError("cannot resolve default branch; configure origin/HEAD or GitHub CLI access")
+
+
+def validate_task(task: str) -> None:
+    if not TASK_RE.fullmatch(task):
+        raise AutomationError(f"invalid Task ID: {task!r}")
+
+
+def validate_slug(slug: str) -> None:
+    if not SLUG_RE.fullmatch(slug):
+        raise AutomationError(f"invalid Task slug: {slug!r}")
+
+
+def ensure_task_branch(root: Path, task: str) -> str:
+    validate_task(task)
+    branch = current_branch(root)
+    if task not in branch or not (branch.startswith("task/") or branch.startswith("fix/")):
+        raise AutomationError(f"current branch {branch!r} is not the Task branch for {task}")
+    if branch == default_branch(root):
+        raise AutomationError("Task operation refused on the default branch")
+    return branch
+
+
+def policy(root: Path) -> dict:
+    path = root / ".automation" / "policy.toml"
+    if tomllib is None:
+        raise AutomationError("Python 3.11+ is required to parse policy.toml")
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise AutomationError(f"missing policy: {path}") from exc
+
+
+def matches_protected(path: str, patterns: list[str]) -> bool:
+    for raw in patterns:
+        if raw.endswith("/**") and (path == raw[:-3] or path.startswith(raw[:-2])):
+            return True
+        if path == raw:
+            return True
+    return False
+
+
+def pending_paths(root: Path) -> list[str]:
+    paths: set[str] = set()
+    for args in (
+        ("diff", "--name-only"),
+        ("diff", "--cached", "--name-only"),
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
+        output = git(*args, cwd=root)
+        paths.update(line for line in output.splitlines() if line)
+    return sorted(paths)
+
+
+def reject_unsafe_paths(root: Path, paths: list[str]) -> None:
+    cfg = policy(root)
+    protected = cfg.get("paths", {}).get("automation_core", [])
+    secret_names = cfg.get("paths", {}).get("secret_patterns", [])
+    bad_core = [path for path in paths if matches_protected(path, protected)]
+    if bad_core:
+        raise AutomationError("ordinary Task modifies Automation Core: " + ", ".join(bad_core))
+    lowered = [(path, path.lower()) for path in paths]
+    bad_secret = [path for path, low in lowered if any(token.lower() in low for token in secret_names)]
+    if bad_secret:
+        raise AutomationError("potential secret file in Task changes: " + ", ".join(bad_secret))
+    if any(path == ".task-state" or path.startswith(".task-state/") for path in paths):
+        raise AutomationError(".task-state must never be committed")
+
+
+def ensure_task_state_excluded(root: Path) -> None:
+    exclude = common_git_dir(root) / "info" / "exclude"
+    exclude.parent.mkdir(parents=True, exist_ok=True)
+    lines = exclude.read_text(encoding="utf-8").splitlines() if exclude.exists() else []
+    if "/.task-state/" not in lines:
+        with exclude.open("a", encoding="utf-8") as handle:
+            if lines and lines[-1] != "":
+                handle.write("\n")
+            handle.write("/.task-state/\n")
+
+
+def task_state_path(root: Path) -> Path:
+    return root / ".task-state" / "task.md"
+
+
+def write_task_state(worktree: Path, task: str, branch: str, base: str, base_revision: str) -> None:
+    template = worktree / ".automation" / "templates" / "task-state.md"
+    state_dir = worktree / ".task-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    text = template.read_text(encoding="utf-8")
+    replacements = {
+        "@@TASK_ID@@": task,
+        "@@BRANCH@@": branch,
+        "@@WORKTREE@@": str(worktree),
+        "@@BASE_BRANCH@@": base,
+        "@@BASE_REVISION@@": base_revision,
+    }
+    for key, value in replacements.items():
+        text = text.replace(key, value)
+    (state_dir / "task.md").write_text(text, encoding="utf-8")
+
+
+def task_start(root: Path, task: str, slug: str) -> None:
+    validate_task(task)
+    validate_slug(slug)
+    base = default_branch(root)
+    base_ref = f"refs/remotes/origin/{base}"
+    base_revision = git("rev-parse", "--verify", base_ref, cwd=root, check=False) or git("rev-parse", base, cwd=root)
+    branch = f"task/{task}-{slug}"
+    worktree = root / ".worktrees" / f"{task}-{slug}"
+    if worktree.exists():
+        raise AutomationError(f"worktree path already exists: {worktree}")
+    if git("show-ref", "--verify", "--quiet", f"refs/heads/{branch}", cwd=root, check=False) == "":
+        result = run(["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=root, check=False)
+        if result.returncode == 0:
+            raise AutomationError(f"branch already exists: {branch}")
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "worktree", "add", "-b", branch, str(worktree), base_revision], cwd=root)
+    ensure_task_state_excluded(worktree)
+    write_task_state(worktree, task, branch, base, base_revision)
+    print(json.dumps({"task": task, "branch": branch, "worktree": str(worktree), "base": base, "baseRevision": base_revision}))
+
+
+def context(root: Path) -> dict:
+    branch = current_branch(root)
+    state = task_state_path(root)
+    return {
+        "repositoryRoot": str(root),
+        "worktree": str(root),
+        "branch": branch,
+        "defaultBranch": default_branch(root),
+        "taskState": str(state) if state.exists() else None,
+    }
+
+
+def doctor(root: Path) -> None:
+    missing = [tool for tool in ("git", "gh", "just", "python3") if shutil.which(tool) is None]
+    if missing:
+        raise AutomationError("missing required tools: " + ", ".join(missing))
+    if not (root / ".automation" / "policy.toml").is_file():
+        raise AutomationError("missing .automation/policy.toml")
+    if not (root / "just" / "project" / "mod.just").is_file():
+        raise AutomationError("missing Project Adapter: just/project/mod.just")
+    ensure_task_state_excluded(root)
+    print("Agent Core doctor: PASS")
+
+
+def status(root: Path, task: str) -> None:
+    branch = ensure_task_branch(root, task)
+    print(json.dumps({"task": task, "branch": branch, "status": git("status", "--short", cwd=root).splitlines()}))
+
+
+def verify(root: Path, task: str) -> None:
+    ensure_task_branch(root, task)
+    run(["just", "project::check"], cwd=root)
+    print("Project verification: PASS")
+
+
+def commit_task(root: Path, task: str, message: str) -> None:
+    ensure_task_branch(root, task)
+    paths = pending_paths(root)
+    if not paths:
+        raise AutomationError("no Task changes to commit")
+    reject_unsafe_paths(root, paths)
+    run(["git", "add", "--", *paths], cwd=root)
+    run(["git", "diff", "--cached", "--check"], cwd=root)
+    staged = git("diff", "--cached", "--name-only", cwd=root).splitlines()
+    reject_unsafe_paths(root, staged)
+    commit_message = message.strip() or f"task: {task}"
+    if task not in commit_message:
+        commit_message = f"{commit_message}\n\nTask: {task}"
+    run(["git", "commit", "-m", commit_message], cwd=root)
+    print(git("rev-parse", "HEAD", cwd=root))
+
+
+def push_task(root: Path, task: str) -> None:
+    branch = ensure_task_branch(root, task)
+    run(["git", "push", "--set-upstream", "origin", f"HEAD:refs/heads/{branch}"], cwd=root)
+    print(f"pushed origin/{branch}")
+
+
+def pr_for_branch(root: Path, branch: str) -> dict | None:
+    result = run(["gh", "pr", "view", branch, "--json", "number,title,body,headRefName,baseRefName,isDraft,state,headRefOid"], cwd=root, check=False)
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout)
+
+
+def pr_body(root: Path, task: str) -> Path:
+    state_dir = root / ".task-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "pr-body.md"
+    if not path.exists():
+        template = root / ".automation" / "templates" / "pull-request.md"
+        text = template.read_text(encoding="utf-8").replace("@@TASK_ID@@", task)
+        path.write_text(text, encoding="utf-8")
+    return path
+
+
+def pr_create(root: Path, task: str) -> None:
+    branch = ensure_task_branch(root, task)
+    if pr_for_branch(root, branch):
+        raise AutomationError(f"pull request already exists for {branch}")
+    base = default_branch(root)
+    title = f"{task}: {branch.split('/', 1)[1]}"
+    body = pr_body(root, task)
+    gh("pr", "create", "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
+    print(json.dumps(pr_for_branch(root, branch)))
+
+
+def pr_edit(root: Path, task: str) -> None:
+    branch = ensure_task_branch(root, task)
+    pr = pr_for_branch(root, branch)
+    if not pr:
+        raise AutomationError(f"no pull request for {branch}")
+    title_file = root / ".task-state" / "pr-title.txt"
+    title = title_file.read_text(encoding="utf-8").strip() if title_file.exists() else pr["title"]
+    body = pr_body(root, task)
+    gh("pr", "edit", str(pr["number"]), "--title", title, "--body-file", str(body), cwd=root)
+    print(f"updated PR #{pr['number']}")
+
+
+def pr_ready(root: Path, task: str) -> None:
+    verify(root, task)
+    branch = ensure_task_branch(root, task)
+    pr = pr_for_branch(root, branch)
+    if not pr:
+        raise AutomationError(f"no pull request for {branch}")
+    gh("pr", "ready", str(pr["number"]), cwd=root)
+    print(f"PR #{pr['number']} marked ready")
+
+
+def cleanup(root: Path, task: str) -> None:
+    validate_task(task)
+    branch = current_branch(root)
+    if task not in branch:
+        raise AutomationError("cleanup must run from the Task worktree")
+    pr = pr_for_branch(root, branch)
+    if not pr or pr.get("state") != "MERGED":
+        raise AutomationError("cleanup refused until the Task PR is merged")
+    print("cleanup must be executed by the Main worktree in the lifecycle extension (#8)")
+
+
+def pr_details(root: Path, pr: str) -> dict:
+    data = json.loads(gh("pr", "view", pr, "--json", "number,baseRefName,headRefName,headRefOid,isDraft,mergeable,statusCheckRollup,state", cwd=root))
+    return data
+
+
+def validate_integration(root: Path, pr: str) -> dict:
+    data = pr_details(root, pr)
+    if data["baseRefName"] != default_branch(root):
+        raise AutomationError("PR base is not the repository default branch")
+    if data["isDraft"]:
+        raise AutomationError("Draft PR cannot be merged")
+    if data.get("mergeable") != "MERGEABLE":
+        raise AutomationError(f"PR is not mergeable: {data.get('mergeable')}")
+    failures = []
+    for check in data.get("statusCheckRollup") or []:
+        conclusion = check.get("conclusion")
+        status = check.get("status")
+        if status and status != "COMPLETED":
+            failures.append(check.get("name") or check.get("context") or "pending check")
+        elif conclusion and conclusion not in SAFE_CHECK_CONCLUSIONS:
+            failures.append(check.get("name") or check.get("context") or conclusion)
+    if failures:
+        raise AutomationError("required checks are not successful: " + ", ".join(failures))
+    return data
+
+
+def integration_checkpoint(root: Path, pr: str) -> Path:
+    path = common_git_dir(root) / "opencode" / "integration" / f"pr-{pr}.head"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def integrate_check(root: Path, pr: str) -> None:
+    data = validate_integration(root, pr)
+    integration_checkpoint(root, pr).write_text(data["headRefOid"] + "\n", encoding="utf-8")
+    print(json.dumps({"pr": data["number"], "head": data["headRefOid"], "status": "verified"}))
+
+
+def integrate_merge(root: Path, pr: str) -> None:
+    checkpoint = integration_checkpoint(root, pr)
+    if not checkpoint.exists():
+        raise AutomationError("run integrate::check before merge")
+    expected = checkpoint.read_text(encoding="utf-8").strip()
+    data = validate_integration(root, pr)
+    if data["headRefOid"] != expected:
+        raise AutomationError(f"PR head moved after integration check: expected {expected}, got {data['headRefOid']}")
+    gh("pr", "merge", pr, "--squash", "--match-head-commit", expected, cwd=root)
+    print(f"merged PR #{pr} at {expected}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    scope = parser.add_subparsers(dest="scope", required=True)
+    agent = scope.add_parser("agent")
+    agent_cmd = agent.add_subparsers(dest="command", required=True)
+    for name in ("doctor", "context"):
+        agent_cmd.add_parser(name)
+    start = agent_cmd.add_parser("task-start"); start.add_argument("task"); start.add_argument("slug")
+    for name in ("status", "verify", "push", "pr-create", "pr-edit", "pr-ready", "cleanup"):
+        p = agent_cmd.add_parser(name); p.add_argument("task")
+    commit = agent_cmd.add_parser("commit"); commit.add_argument("task"); commit.add_argument("message", nargs="?", default="")
+    integrate = scope.add_parser("integrate")
+    integrate_cmd = integrate.add_subparsers(dest="command", required=True)
+    for name in ("check", "merge"):
+        p = integrate_cmd.add_parser(name); p.add_argument("pr")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        root = repo_root()
+        if args.scope == "agent":
+            actions = {
+                "doctor": lambda: doctor(root),
+                "context": lambda: print(json.dumps(context(root), indent=2)),
+                "task-start": lambda: task_start(root, args.task, args.slug),
+                "status": lambda: status(root, args.task),
+                "verify": lambda: verify(root, args.task),
+                "commit": lambda: commit_task(root, args.task, args.message),
+                "push": lambda: push_task(root, args.task),
+                "pr-create": lambda: pr_create(root, args.task),
+                "pr-edit": lambda: pr_edit(root, args.task),
+                "pr-ready": lambda: pr_ready(root, args.task),
+                "cleanup": lambda: cleanup(root, args.task),
+            }
+        else:
+            actions = {
+                "check": lambda: integrate_check(root, args.pr),
+                "merge": lambda: integrate_merge(root, args.pr),
+            }
+        actions[args.command]()
+        return 0
+    except AutomationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/components/agent-core/.automation/just/agent.just
+++ b/components/agent-core/.automation/just/agent.just
@@ -1,0 +1,46 @@
+root := justfile_directory()
+script := root / "../bin/agent_core.py"
+
+[working-directory: root / "../.."]
+doctor:
+    python3 {{quote(script)}} agent doctor
+
+[working-directory: root / "../.."]
+context:
+    python3 {{quote(script)}} agent context
+
+[working-directory: root / "../.."]
+task-start task slug:
+    python3 {{quote(script)}} agent task-start {{quote(task)}} {{quote(slug)}}
+
+[working-directory: root / "../.."]
+status task:
+    python3 {{quote(script)}} agent status {{quote(task)}}
+
+[working-directory: root / "../.."]
+verify task:
+    python3 {{quote(script)}} agent verify {{quote(task)}}
+
+[working-directory: root / "../.."]
+commit task message='':
+    python3 {{quote(script)}} agent commit {{quote(task)}} {{quote(message)}}
+
+[working-directory: root / "../.."]
+push task:
+    python3 {{quote(script)}} agent push {{quote(task)}}
+
+[working-directory: root / "../.."]
+pr-create task:
+    python3 {{quote(script)}} agent pr-create {{quote(task)}}
+
+[working-directory: root / "../.."]
+pr-edit task:
+    python3 {{quote(script)}} agent pr-edit {{quote(task)}}
+
+[working-directory: root / "../.."]
+pr-ready task:
+    python3 {{quote(script)}} agent pr-ready {{quote(task)}}
+
+[working-directory: root / "../.."]
+cleanup task:
+    python3 {{quote(script)}} agent cleanup {{quote(task)}}

--- a/components/agent-core/.automation/just/agent.just
+++ b/components/agent-core/.automation/just/agent.just
@@ -1,46 +1,46 @@
 root := justfile_directory()
-script := root / "../bin/agent_core.py"
+script := root / ".automation/bin/agent_core.py"
 
-[working-directory: root / "../.."]
+[working-directory: root]
 doctor:
     python3 {{quote(script)}} agent doctor
 
-[working-directory: root / "../.."]
+[working-directory: root]
 context:
     python3 {{quote(script)}} agent context
 
-[working-directory: root / "../.."]
+[working-directory: root]
 task-start task slug:
     python3 {{quote(script)}} agent task-start {{quote(task)}} {{quote(slug)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 status task:
     python3 {{quote(script)}} agent status {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 verify task:
     python3 {{quote(script)}} agent verify {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 commit task message='':
     python3 {{quote(script)}} agent commit {{quote(task)}} {{quote(message)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 push task:
     python3 {{quote(script)}} agent push {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 pr-create task:
     python3 {{quote(script)}} agent pr-create {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 pr-edit task:
     python3 {{quote(script)}} agent pr-edit {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 pr-ready task:
     python3 {{quote(script)}} agent pr-ready {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 cleanup task:
     python3 {{quote(script)}} agent cleanup {{quote(task)}}

--- a/components/agent-core/.automation/just/integrate.just
+++ b/components/agent-core/.automation/just/integrate.just
@@ -1,0 +1,10 @@
+root := justfile_directory()
+script := root / "../bin/agent_core.py"
+
+[working-directory: root / "../.."]
+check pr:
+    python3 {{quote(script)}} integrate check {{quote(pr)}}
+
+[working-directory: root / "../.."]
+merge pr:
+    python3 {{quote(script)}} integrate merge {{quote(pr)}}

--- a/components/agent-core/.automation/just/integrate.just
+++ b/components/agent-core/.automation/just/integrate.just
@@ -1,10 +1,10 @@
 root := justfile_directory()
-script := root / "../bin/agent_core.py"
+script := root / ".automation/bin/agent_core.py"
 
-[working-directory: root / "../.."]
+[working-directory: root]
 check pr:
     python3 {{quote(script)}} integrate check {{quote(pr)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 merge pr:
     python3 {{quote(script)}} integrate merge {{quote(pr)}}

--- a/components/agent-core/.automation/policy.toml
+++ b/components/agent-core/.automation/policy.toml
@@ -1,0 +1,23 @@
+[paths]
+automation_core = [
+  "opencode.json",
+  "AGENTS.md",
+  "Justfile",
+  ".opencode/**",
+  ".automation/**",
+  ".github/workflows/**",
+]
+secret_patterns = [
+  ".env",
+  "credentials",
+  "secret",
+  "id_rsa",
+  "id_ed25519",
+  ".pem",
+  ".key",
+]
+
+[publication]
+remote = "origin"
+pr_draft_by_default = true
+merge_method = "squash"

--- a/components/agent-core/.automation/templates/pull-request.md
+++ b/components/agent-core/.automation/templates/pull-request.md
@@ -1,0 +1,21 @@
+## Summary
+
+Task: @@TASK_ID@@
+
+Describe the implemented Task outcome.
+
+## Acceptance criteria
+
+- [ ] Task-specific criteria copied from `.task-state/task.md`
+
+## Validation
+
+- `just project::check`: NOT RUN
+
+## Risks and unverified areas
+
+- None recorded yet.
+
+## Follow-up Tasks
+
+- None recorded.

--- a/components/agent-core/.automation/templates/task-state.md
+++ b/components/agent-core/.automation/templates/task-state.md
@@ -1,0 +1,73 @@
+# @@TASK_ID@@
+
+## Identity
+
+- Task ID: @@TASK_ID@@
+- Branch: @@BRANCH@@
+- Worktree: @@WORKTREE@@
+- Base branch: @@BASE_BRANCH@@
+- Base revision: @@BASE_REVISION@@
+
+## Purpose
+
+TBD
+
+## Scope
+
+- TBD
+
+## Prohibited changes
+
+- Automation Core unless explicitly authorized
+
+## Dependencies
+
+- None recorded
+
+## Acceptance criteria
+
+- [ ] Define Task-specific acceptance criteria
+
+## Test plan
+
+- `just project::check`
+
+## Stop conditions
+
+- Required changes exceed the assigned Task scope
+- Branch, worktree, or Task identity becomes inconsistent
+
+## Current state
+
+- Status: initialized
+- Blockers: none
+- Unverified: Task contract
+
+## Work Units
+
+None yet.
+
+## Evidence
+
+### Changed files
+
+None yet.
+
+### Commands
+
+None yet.
+
+### Reviews
+
+None yet.
+
+### Git
+
+- Commit: none
+- Remote branch: none
+- Pull request: none
+- Published head SHA: none
+
+## Follow-up Task candidates
+
+None yet.

--- a/components/agent-core/Justfile
+++ b/components/agent-core/Justfile
@@ -1,0 +1,9 @@
+set minimum-version := "1.31.0"
+
+mod agent '.automation/just/agent.just'
+mod integrate '.automation/just/integrate.just'
+mod project 'just/project/mod.just'
+mod? local 'just/local.just'
+
+default:
+    @just --list

--- a/components/agent-core/Justfile
+++ b/components/agent-core/Justfile
@@ -1,4 +1,4 @@
-set minimum-version := "1.31.0"
+set minimum-version := "1.52.0"
 
 mod agent '.automation/just/agent.just'
 mod integrate '.automation/just/integrate.just'

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -1,8 +1,13 @@
-# Agent Core scaffold
+# Agent Core automation
 
-This directory is owned by the shared Agent Core component.
+This directory contains the language-independent Task lifecycle, publication,
+and integration layer shared by every Agent-ready template.
 
-Issue #5 only establishes deterministic component composition. The executable
-Agent Core lifecycle, OpenCode agents, permissions, and publication scripts are
-implemented by follow-up issues. Keep language- and toolchain-specific behavior
-out of this component.
+Public operations are exposed through the top-level Just modules rather than by
+calling these scripts directly. Project-specific build, lint, test, and toolchain
+behavior belongs under `just/project/` in the selected Project Adapter.
+
+The current implementation provides guarded Task-local commit/push/PR operations,
+integration head-SHA checkpoints, disposable Task State templates, and common
+safety policy. Repository-local OpenCode agents and permissions are added by the
+separate OpenCode configuration work.

--- a/templates/agent-base/.automation/bin/agent_core.py
+++ b/templates/agent-base/.automation/bin/agent_core.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    tomllib = None
+
+TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+SAFE_CHECK_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+
+
+class AutomationError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise AutomationError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def git(*args: str, cwd: Path | None = None, check: bool = True) -> str:
+    return run(["git", *args], cwd=cwd, check=check).stdout.strip()
+
+
+def gh(*args: str, cwd: Path | None = None) -> str:
+    return run(["gh", *args], cwd=cwd).stdout.strip()
+
+
+def repo_root(cwd: Path | None = None) -> Path:
+    return Path(git("rev-parse", "--show-toplevel", cwd=cwd)).resolve()
+
+
+def common_git_dir(root: Path) -> Path:
+    value = Path(git("rev-parse", "--git-common-dir", cwd=root))
+    return value if value.is_absolute() else (root / value).resolve()
+
+
+def current_branch(root: Path) -> str:
+    branch = git("branch", "--show-current", cwd=root)
+    if not branch:
+        raise AutomationError("detached HEAD is not supported")
+    return branch
+
+
+def default_branch(root: Path) -> str:
+    symbolic = git("symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD", cwd=root, check=False)
+    if symbolic.startswith("origin/"):
+        return symbolic.removeprefix("origin/")
+    try:
+        data = json.loads(gh("repo", "view", "--json", "defaultBranchRef", cwd=root))
+        name = data.get("defaultBranchRef", {}).get("name")
+        if name:
+            return name
+    except (AutomationError, json.JSONDecodeError):
+        pass
+    raise AutomationError("cannot resolve default branch; configure origin/HEAD or GitHub CLI access")
+
+
+def validate_task(task: str) -> None:
+    if not TASK_RE.fullmatch(task):
+        raise AutomationError(f"invalid Task ID: {task!r}")
+
+
+def validate_slug(slug: str) -> None:
+    if not SLUG_RE.fullmatch(slug):
+        raise AutomationError(f"invalid Task slug: {slug!r}")
+
+
+def ensure_task_branch(root: Path, task: str) -> str:
+    validate_task(task)
+    branch = current_branch(root)
+    if task not in branch or not (branch.startswith("task/") or branch.startswith("fix/")):
+        raise AutomationError(f"current branch {branch!r} is not the Task branch for {task}")
+    if branch == default_branch(root):
+        raise AutomationError("Task operation refused on the default branch")
+    return branch
+
+
+def policy(root: Path) -> dict:
+    path = root / ".automation" / "policy.toml"
+    if tomllib is None:
+        raise AutomationError("Python 3.11+ is required to parse policy.toml")
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise AutomationError(f"missing policy: {path}") from exc
+
+
+def matches_protected(path: str, patterns: list[str]) -> bool:
+    for raw in patterns:
+        if raw.endswith("/**") and (path == raw[:-3] or path.startswith(raw[:-2])):
+            return True
+        if path == raw:
+            return True
+    return False
+
+
+def pending_paths(root: Path) -> list[str]:
+    paths: set[str] = set()
+    for args in (
+        ("diff", "--name-only"),
+        ("diff", "--cached", "--name-only"),
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
+        output = git(*args, cwd=root)
+        paths.update(line for line in output.splitlines() if line)
+    return sorted(paths)
+
+
+def reject_unsafe_paths(root: Path, paths: list[str]) -> None:
+    cfg = policy(root)
+    protected = cfg.get("paths", {}).get("automation_core", [])
+    secret_names = cfg.get("paths", {}).get("secret_patterns", [])
+    bad_core = [path for path in paths if matches_protected(path, protected)]
+    if bad_core:
+        raise AutomationError("ordinary Task modifies Automation Core: " + ", ".join(bad_core))
+    lowered = [(path, path.lower()) for path in paths]
+    bad_secret = [path for path, low in lowered if any(token.lower() in low for token in secret_names)]
+    if bad_secret:
+        raise AutomationError("potential secret file in Task changes: " + ", ".join(bad_secret))
+    if any(path == ".task-state" or path.startswith(".task-state/") for path in paths):
+        raise AutomationError(".task-state must never be committed")
+
+
+def ensure_task_state_excluded(root: Path) -> None:
+    exclude = common_git_dir(root) / "info" / "exclude"
+    exclude.parent.mkdir(parents=True, exist_ok=True)
+    lines = exclude.read_text(encoding="utf-8").splitlines() if exclude.exists() else []
+    if "/.task-state/" not in lines:
+        with exclude.open("a", encoding="utf-8") as handle:
+            if lines and lines[-1] != "":
+                handle.write("\n")
+            handle.write("/.task-state/\n")
+
+
+def task_state_path(root: Path) -> Path:
+    return root / ".task-state" / "task.md"
+
+
+def write_task_state(worktree: Path, task: str, branch: str, base: str, base_revision: str) -> None:
+    template = worktree / ".automation" / "templates" / "task-state.md"
+    state_dir = worktree / ".task-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    text = template.read_text(encoding="utf-8")
+    replacements = {
+        "@@TASK_ID@@": task,
+        "@@BRANCH@@": branch,
+        "@@WORKTREE@@": str(worktree),
+        "@@BASE_BRANCH@@": base,
+        "@@BASE_REVISION@@": base_revision,
+    }
+    for key, value in replacements.items():
+        text = text.replace(key, value)
+    (state_dir / "task.md").write_text(text, encoding="utf-8")
+
+
+def task_start(root: Path, task: str, slug: str) -> None:
+    validate_task(task)
+    validate_slug(slug)
+    base = default_branch(root)
+    base_ref = f"refs/remotes/origin/{base}"
+    base_revision = git("rev-parse", "--verify", base_ref, cwd=root, check=False) or git("rev-parse", base, cwd=root)
+    branch = f"task/{task}-{slug}"
+    worktree = root / ".worktrees" / f"{task}-{slug}"
+    if worktree.exists():
+        raise AutomationError(f"worktree path already exists: {worktree}")
+    if git("show-ref", "--verify", "--quiet", f"refs/heads/{branch}", cwd=root, check=False) == "":
+        result = run(["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=root, check=False)
+        if result.returncode == 0:
+            raise AutomationError(f"branch already exists: {branch}")
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    run(["git", "worktree", "add", "-b", branch, str(worktree), base_revision], cwd=root)
+    ensure_task_state_excluded(worktree)
+    write_task_state(worktree, task, branch, base, base_revision)
+    print(json.dumps({"task": task, "branch": branch, "worktree": str(worktree), "base": base, "baseRevision": base_revision}))
+
+
+def context(root: Path) -> dict:
+    branch = current_branch(root)
+    state = task_state_path(root)
+    return {
+        "repositoryRoot": str(root),
+        "worktree": str(root),
+        "branch": branch,
+        "defaultBranch": default_branch(root),
+        "taskState": str(state) if state.exists() else None,
+    }
+
+
+def doctor(root: Path) -> None:
+    missing = [tool for tool in ("git", "gh", "just", "python3") if shutil.which(tool) is None]
+    if missing:
+        raise AutomationError("missing required tools: " + ", ".join(missing))
+    if not (root / ".automation" / "policy.toml").is_file():
+        raise AutomationError("missing .automation/policy.toml")
+    if not (root / "just" / "project" / "mod.just").is_file():
+        raise AutomationError("missing Project Adapter: just/project/mod.just")
+    ensure_task_state_excluded(root)
+    print("Agent Core doctor: PASS")
+
+
+def status(root: Path, task: str) -> None:
+    branch = ensure_task_branch(root, task)
+    print(json.dumps({"task": task, "branch": branch, "status": git("status", "--short", cwd=root).splitlines()}))
+
+
+def verify(root: Path, task: str) -> None:
+    ensure_task_branch(root, task)
+    run(["just", "project::check"], cwd=root)
+    print("Project verification: PASS")
+
+
+def commit_task(root: Path, task: str, message: str) -> None:
+    ensure_task_branch(root, task)
+    paths = pending_paths(root)
+    if not paths:
+        raise AutomationError("no Task changes to commit")
+    reject_unsafe_paths(root, paths)
+    run(["git", "add", "--", *paths], cwd=root)
+    run(["git", "diff", "--cached", "--check"], cwd=root)
+    staged = git("diff", "--cached", "--name-only", cwd=root).splitlines()
+    reject_unsafe_paths(root, staged)
+    commit_message = message.strip() or f"task: {task}"
+    if task not in commit_message:
+        commit_message = f"{commit_message}\n\nTask: {task}"
+    run(["git", "commit", "-m", commit_message], cwd=root)
+    print(git("rev-parse", "HEAD", cwd=root))
+
+
+def push_task(root: Path, task: str) -> None:
+    branch = ensure_task_branch(root, task)
+    run(["git", "push", "--set-upstream", "origin", f"HEAD:refs/heads/{branch}"], cwd=root)
+    print(f"pushed origin/{branch}")
+
+
+def pr_for_branch(root: Path, branch: str) -> dict | None:
+    result = run(["gh", "pr", "view", branch, "--json", "number,title,body,headRefName,baseRefName,isDraft,state,headRefOid"], cwd=root, check=False)
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout)
+
+
+def pr_body(root: Path, task: str) -> Path:
+    state_dir = root / ".task-state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / "pr-body.md"
+    if not path.exists():
+        template = root / ".automation" / "templates" / "pull-request.md"
+        text = template.read_text(encoding="utf-8").replace("@@TASK_ID@@", task)
+        path.write_text(text, encoding="utf-8")
+    return path
+
+
+def pr_create(root: Path, task: str) -> None:
+    branch = ensure_task_branch(root, task)
+    if pr_for_branch(root, branch):
+        raise AutomationError(f"pull request already exists for {branch}")
+    base = default_branch(root)
+    title = f"{task}: {branch.split('/', 1)[1]}"
+    body = pr_body(root, task)
+    gh("pr", "create", "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
+    print(json.dumps(pr_for_branch(root, branch)))
+
+
+def pr_edit(root: Path, task: str) -> None:
+    branch = ensure_task_branch(root, task)
+    pr = pr_for_branch(root, branch)
+    if not pr:
+        raise AutomationError(f"no pull request for {branch}")
+    title_file = root / ".task-state" / "pr-title.txt"
+    title = title_file.read_text(encoding="utf-8").strip() if title_file.exists() else pr["title"]
+    body = pr_body(root, task)
+    gh("pr", "edit", str(pr["number"]), "--title", title, "--body-file", str(body), cwd=root)
+    print(f"updated PR #{pr['number']}")
+
+
+def pr_ready(root: Path, task: str) -> None:
+    verify(root, task)
+    branch = ensure_task_branch(root, task)
+    pr = pr_for_branch(root, branch)
+    if not pr:
+        raise AutomationError(f"no pull request for {branch}")
+    gh("pr", "ready", str(pr["number"]), cwd=root)
+    print(f"PR #{pr['number']} marked ready")
+
+
+def cleanup(root: Path, task: str) -> None:
+    validate_task(task)
+    branch = current_branch(root)
+    if task not in branch:
+        raise AutomationError("cleanup must run from the Task worktree")
+    pr = pr_for_branch(root, branch)
+    if not pr or pr.get("state") != "MERGED":
+        raise AutomationError("cleanup refused until the Task PR is merged")
+    print("cleanup must be executed by the Main worktree in the lifecycle extension (#8)")
+
+
+def pr_details(root: Path, pr: str) -> dict:
+    data = json.loads(gh("pr", "view", pr, "--json", "number,baseRefName,headRefName,headRefOid,isDraft,mergeable,statusCheckRollup,state", cwd=root))
+    return data
+
+
+def validate_integration(root: Path, pr: str) -> dict:
+    data = pr_details(root, pr)
+    if data["baseRefName"] != default_branch(root):
+        raise AutomationError("PR base is not the repository default branch")
+    if data["isDraft"]:
+        raise AutomationError("Draft PR cannot be merged")
+    if data.get("mergeable") != "MERGEABLE":
+        raise AutomationError(f"PR is not mergeable: {data.get('mergeable')}")
+    failures = []
+    for check in data.get("statusCheckRollup") or []:
+        conclusion = check.get("conclusion")
+        status = check.get("status")
+        if status and status != "COMPLETED":
+            failures.append(check.get("name") or check.get("context") or "pending check")
+        elif conclusion and conclusion not in SAFE_CHECK_CONCLUSIONS:
+            failures.append(check.get("name") or check.get("context") or conclusion)
+    if failures:
+        raise AutomationError("required checks are not successful: " + ", ".join(failures))
+    return data
+
+
+def integration_checkpoint(root: Path, pr: str) -> Path:
+    path = common_git_dir(root) / "opencode" / "integration" / f"pr-{pr}.head"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def integrate_check(root: Path, pr: str) -> None:
+    data = validate_integration(root, pr)
+    integration_checkpoint(root, pr).write_text(data["headRefOid"] + "\n", encoding="utf-8")
+    print(json.dumps({"pr": data["number"], "head": data["headRefOid"], "status": "verified"}))
+
+
+def integrate_merge(root: Path, pr: str) -> None:
+    checkpoint = integration_checkpoint(root, pr)
+    if not checkpoint.exists():
+        raise AutomationError("run integrate::check before merge")
+    expected = checkpoint.read_text(encoding="utf-8").strip()
+    data = validate_integration(root, pr)
+    if data["headRefOid"] != expected:
+        raise AutomationError(f"PR head moved after integration check: expected {expected}, got {data['headRefOid']}")
+    gh("pr", "merge", pr, "--squash", "--match-head-commit", expected, cwd=root)
+    print(f"merged PR #{pr} at {expected}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    scope = parser.add_subparsers(dest="scope", required=True)
+    agent = scope.add_parser("agent")
+    agent_cmd = agent.add_subparsers(dest="command", required=True)
+    for name in ("doctor", "context"):
+        agent_cmd.add_parser(name)
+    start = agent_cmd.add_parser("task-start"); start.add_argument("task"); start.add_argument("slug")
+    for name in ("status", "verify", "push", "pr-create", "pr-edit", "pr-ready", "cleanup"):
+        p = agent_cmd.add_parser(name); p.add_argument("task")
+    commit = agent_cmd.add_parser("commit"); commit.add_argument("task"); commit.add_argument("message", nargs="?", default="")
+    integrate = scope.add_parser("integrate")
+    integrate_cmd = integrate.add_subparsers(dest="command", required=True)
+    for name in ("check", "merge"):
+        p = integrate_cmd.add_parser(name); p.add_argument("pr")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        root = repo_root()
+        if args.scope == "agent":
+            actions = {
+                "doctor": lambda: doctor(root),
+                "context": lambda: print(json.dumps(context(root), indent=2)),
+                "task-start": lambda: task_start(root, args.task, args.slug),
+                "status": lambda: status(root, args.task),
+                "verify": lambda: verify(root, args.task),
+                "commit": lambda: commit_task(root, args.task, args.message),
+                "push": lambda: push_task(root, args.task),
+                "pr-create": lambda: pr_create(root, args.task),
+                "pr-edit": lambda: pr_edit(root, args.task),
+                "pr-ready": lambda: pr_ready(root, args.task),
+                "cleanup": lambda: cleanup(root, args.task),
+            }
+        else:
+            actions = {
+                "check": lambda: integrate_check(root, args.pr),
+                "merge": lambda: integrate_merge(root, args.pr),
+            }
+        actions[args.command]()
+        return 0
+    except AutomationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-base/.automation/just/agent.just
+++ b/templates/agent-base/.automation/just/agent.just
@@ -1,0 +1,46 @@
+root := justfile_directory()
+script := root / "../bin/agent_core.py"
+
+[working-directory: root / "../.."]
+doctor:
+    python3 {{quote(script)}} agent doctor
+
+[working-directory: root / "../.."]
+context:
+    python3 {{quote(script)}} agent context
+
+[working-directory: root / "../.."]
+task-start task slug:
+    python3 {{quote(script)}} agent task-start {{quote(task)}} {{quote(slug)}}
+
+[working-directory: root / "../.."]
+status task:
+    python3 {{quote(script)}} agent status {{quote(task)}}
+
+[working-directory: root / "../.."]
+verify task:
+    python3 {{quote(script)}} agent verify {{quote(task)}}
+
+[working-directory: root / "../.."]
+commit task message='':
+    python3 {{quote(script)}} agent commit {{quote(task)}} {{quote(message)}}
+
+[working-directory: root / "../.."]
+push task:
+    python3 {{quote(script)}} agent push {{quote(task)}}
+
+[working-directory: root / "../.."]
+pr-create task:
+    python3 {{quote(script)}} agent pr-create {{quote(task)}}
+
+[working-directory: root / "../.."]
+pr-edit task:
+    python3 {{quote(script)}} agent pr-edit {{quote(task)}}
+
+[working-directory: root / "../.."]
+pr-ready task:
+    python3 {{quote(script)}} agent pr-ready {{quote(task)}}
+
+[working-directory: root / "../.."]
+cleanup task:
+    python3 {{quote(script)}} agent cleanup {{quote(task)}}

--- a/templates/agent-base/.automation/just/agent.just
+++ b/templates/agent-base/.automation/just/agent.just
@@ -1,46 +1,46 @@
 root := justfile_directory()
-script := root / "../bin/agent_core.py"
+script := root / ".automation/bin/agent_core.py"
 
-[working-directory: root / "../.."]
+[working-directory: root]
 doctor:
     python3 {{quote(script)}} agent doctor
 
-[working-directory: root / "../.."]
+[working-directory: root]
 context:
     python3 {{quote(script)}} agent context
 
-[working-directory: root / "../.."]
+[working-directory: root]
 task-start task slug:
     python3 {{quote(script)}} agent task-start {{quote(task)}} {{quote(slug)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 status task:
     python3 {{quote(script)}} agent status {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 verify task:
     python3 {{quote(script)}} agent verify {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 commit task message='':
     python3 {{quote(script)}} agent commit {{quote(task)}} {{quote(message)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 push task:
     python3 {{quote(script)}} agent push {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 pr-create task:
     python3 {{quote(script)}} agent pr-create {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 pr-edit task:
     python3 {{quote(script)}} agent pr-edit {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 pr-ready task:
     python3 {{quote(script)}} agent pr-ready {{quote(task)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 cleanup task:
     python3 {{quote(script)}} agent cleanup {{quote(task)}}

--- a/templates/agent-base/.automation/just/integrate.just
+++ b/templates/agent-base/.automation/just/integrate.just
@@ -1,0 +1,10 @@
+root := justfile_directory()
+script := root / "../bin/agent_core.py"
+
+[working-directory: root / "../.."]
+check pr:
+    python3 {{quote(script)}} integrate check {{quote(pr)}}
+
+[working-directory: root / "../.."]
+merge pr:
+    python3 {{quote(script)}} integrate merge {{quote(pr)}}

--- a/templates/agent-base/.automation/just/integrate.just
+++ b/templates/agent-base/.automation/just/integrate.just
@@ -1,10 +1,10 @@
 root := justfile_directory()
-script := root / "../bin/agent_core.py"
+script := root / ".automation/bin/agent_core.py"
 
-[working-directory: root / "../.."]
+[working-directory: root]
 check pr:
     python3 {{quote(script)}} integrate check {{quote(pr)}}
 
-[working-directory: root / "../.."]
+[working-directory: root]
 merge pr:
     python3 {{quote(script)}} integrate merge {{quote(pr)}}

--- a/templates/agent-base/.automation/policy.toml
+++ b/templates/agent-base/.automation/policy.toml
@@ -1,0 +1,23 @@
+[paths]
+automation_core = [
+  "opencode.json",
+  "AGENTS.md",
+  "Justfile",
+  ".opencode/**",
+  ".automation/**",
+  ".github/workflows/**",
+]
+secret_patterns = [
+  ".env",
+  "credentials",
+  "secret",
+  "id_rsa",
+  "id_ed25519",
+  ".pem",
+  ".key",
+]
+
+[publication]
+remote = "origin"
+pr_draft_by_default = true
+merge_method = "squash"

--- a/templates/agent-base/.automation/templates/pull-request.md
+++ b/templates/agent-base/.automation/templates/pull-request.md
@@ -1,0 +1,21 @@
+## Summary
+
+Task: @@TASK_ID@@
+
+Describe the implemented Task outcome.
+
+## Acceptance criteria
+
+- [ ] Task-specific criteria copied from `.task-state/task.md`
+
+## Validation
+
+- `just project::check`: NOT RUN
+
+## Risks and unverified areas
+
+- None recorded yet.
+
+## Follow-up Tasks
+
+- None recorded.

--- a/templates/agent-base/.automation/templates/task-state.md
+++ b/templates/agent-base/.automation/templates/task-state.md
@@ -1,0 +1,73 @@
+# @@TASK_ID@@
+
+## Identity
+
+- Task ID: @@TASK_ID@@
+- Branch: @@BRANCH@@
+- Worktree: @@WORKTREE@@
+- Base branch: @@BASE_BRANCH@@
+- Base revision: @@BASE_REVISION@@
+
+## Purpose
+
+TBD
+
+## Scope
+
+- TBD
+
+## Prohibited changes
+
+- Automation Core unless explicitly authorized
+
+## Dependencies
+
+- None recorded
+
+## Acceptance criteria
+
+- [ ] Define Task-specific acceptance criteria
+
+## Test plan
+
+- `just project::check`
+
+## Stop conditions
+
+- Required changes exceed the assigned Task scope
+- Branch, worktree, or Task identity becomes inconsistent
+
+## Current state
+
+- Status: initialized
+- Blockers: none
+- Unverified: Task contract
+
+## Work Units
+
+None yet.
+
+## Evidence
+
+### Changed files
+
+None yet.
+
+### Commands
+
+None yet.
+
+### Reviews
+
+None yet.
+
+### Git
+
+- Commit: none
+- Remote branch: none
+- Pull request: none
+- Published head SHA: none
+
+## Follow-up Task candidates
+
+None yet.

--- a/templates/agent-base/Justfile
+++ b/templates/agent-base/Justfile
@@ -1,0 +1,9 @@
+set minimum-version := "1.31.0"
+
+mod agent '.automation/just/agent.just'
+mod integrate '.automation/just/integrate.just'
+mod project 'just/project/mod.just'
+mod? local 'just/local.just'
+
+default:
+    @just --list

--- a/templates/agent-base/Justfile
+++ b/templates/agent-base/Justfile
@@ -1,4 +1,4 @@
-set minimum-version := "1.31.0"
+set minimum-version := "1.52.0"
 
 mod agent '.automation/just/agent.just'
 mod integrate '.automation/just/integrate.just'

--- a/templates/agent-base/just/project/mod.just
+++ b/templates/agent-base/just/project/mod.just
@@ -1,0 +1,25 @@
+root := justfile_directory()
+
+[working-directory: root]
+doctor:
+    @echo "Base Project Adapter doctor: PASS"
+
+[working-directory: root]
+format-check:
+    @echo "Base Project Adapter format-check: SKIPPED"
+
+[working-directory: root]
+lint:
+    @echo "Base Project Adapter lint: SKIPPED"
+
+[working-directory: root]
+test:
+    @echo "Base Project Adapter test: SKIPPED"
+
+[working-directory: root]
+build:
+    @echo "Base Project Adapter build: SKIPPED"
+
+[working-directory: root]
+check: doctor format-check lint test build
+    @echo "Base Project Adapter check: PASS"

--- a/tests/test_agent_core_automation.py
+++ b/tests/test_agent_core_automation.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "components"
+    / "agent-core"
+    / ".automation"
+    / "bin"
+    / "agent_core.py"
+)
+spec = importlib.util.spec_from_file_location("agent_core", MODULE_PATH)
+assert spec and spec.loader
+agent_core = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(agent_core)
+
+
+class AgentCoreSafetyTest(unittest.TestCase):
+    def test_automation_core_change_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / ".automation").mkdir()
+            (root / ".automation" / "policy.toml").write_text(
+                '[paths]\nautomation_core = ["Justfile", ".automation/**"]\nsecret_patterns = []\n',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(agent_core.AutomationError, "Automation Core"):
+                agent_core.reject_unsafe_paths(root, ["Justfile"])
+
+    def test_task_state_is_never_committable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / ".automation").mkdir()
+            (root / ".automation" / "policy.toml").write_text(
+                '[paths]\nautomation_core = []\nsecret_patterns = []\n',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(agent_core.AutomationError, "task-state"):
+                agent_core.reject_unsafe_paths(root, [".task-state/task.md"])
+
+    @mock.patch.object(agent_core, "default_branch", return_value="main")
+    @mock.patch.object(agent_core, "current_branch", return_value="main")
+    def test_default_branch_cannot_be_used_as_task_branch(self, _current, _default) -> None:
+        with self.assertRaisesRegex(agent_core.AutomationError, "not the Task branch"):
+            agent_core.ensure_task_branch(Path("."), "TASK-1")
+
+    @mock.patch.object(agent_core, "default_branch", return_value="main")
+    @mock.patch.object(agent_core, "current_branch", return_value="task/TASK-1-example")
+    def test_task_branch_is_accepted(self, _current, _default) -> None:
+        branch = agent_core.ensure_task_branch(Path("."), "TASK-1")
+        self.assertEqual(branch, "task/TASK-1-example")
+
+    def test_integration_merge_rejects_head_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoint = root / "checkpoint"
+            checkpoint.write_text("old-head\n", encoding="utf-8")
+            with (
+                mock.patch.object(agent_core, "integration_checkpoint", return_value=checkpoint),
+                mock.patch.object(
+                    agent_core,
+                    "validate_integration",
+                    return_value={"headRefOid": "new-head", "number": 10},
+                ),
+                self.assertRaisesRegex(agent_core.AutomationError, "head moved"),
+            ):
+                agent_core.integrate_merge(root, "10")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the language-independent Agent Core automation layer from #6 on top of the #5 generation foundation.

This PR adds:

- generated-repository Just router with `agent`, `integrate`, and `project` modules
- stable Agent API entry points for doctor/context/task-start/status/verify/commit/push/PR operations/cleanup
- guarded Task-local commit and explicit-refspec push behavior
- Draft PR create, constrained PR edit, and ready-for-review operations
- integration checks and a stored head-SHA checkpoint before merge
- merge through `--match-head-commit` without admin bypass
- common Automation Core and secret-path policy
- disposable Task State and PR body templates
- a language-neutral base `project::*` adapter contract
- major negative-path tests for Automation Core mutation, Task State commits, Task-branch enforcement, and merge head drift
- synchronized `agent-base` generated artifacts

## Scope boundaries

This PR intentionally does **not** implement:

- repository-local OpenCode agents and permissions (#7)
- the complete/hardened worktree Task lifecycle and batch scheduling (#8)
- the INIT contract (#9)
- language-specific Project Adapters (#10–#12)
- CI/smoke-test infrastructure (#13)

`task-start` establishes the minimal worktree/Task State foundation required by the public API; #8 remains responsible for hardening lifecycle states, dependency/batch behavior, cleanup, and parallel-safety rules.

## Safety boundaries

- ordinary Task commits reject Automation Core paths
- `.task-state/**` cannot be committed
- potential secret paths are rejected before staging
- Task operations require a `task/` or `fix/` branch containing the Task ID
- push uses only `HEAD:refs/heads/<current-task-branch>`
- PR creation defaults to Draft
- PR edit is limited to title/body for the current Task PR
- merge requires a prior integration checkpoint and rejects head-SHA drift
- force push, amend, rebase, admin merge, and raw OpenCode permission rules are outside this API and remain prohibited by the architecture contract

## Validation

Static/structural validation completed:

- #6 diff is isolated from the #5 base branch
- generated `agent-base` runtime is synchronized with Agent Core source (runtime blob identity checked)
- Just module path semantics were checked against the current Just manual and corrected to use the root `justfile_directory()` correctly
- generated Just minimum version raised to 1.52.0 for the expression-based working-directory/optional-module behavior used here
- repository-level unit tests were added for the major negative paths

Unavailable in the current execution environment:

- `python3 -m unittest ...`: UNVERIFIED against the checked-out branch because the GitHub repository cannot be cloned from this runtime
- `just` recipe parsing/execution: UNVERIFIED (`just` unavailable)
- `gh` end-to-end PR/publication smoke tests: UNVERIFIED (`gh` unavailable)
- `nix` evaluation: UNVERIFIED (`nix` unavailable)

These are explicitly not reported as PASS. Full executable smoke coverage is tracked by #13.

## Acceptance criteria

- [x] generated Justfile is a module router
- [x] Agent API and Integration API are namespaced
- [x] non-Task/default-branch publication is rejected by Task-branch validation
- [x] Task push is constrained to the current Task branch by explicit refspec
- [x] `.task-state/**` is rejected from commits
- [x] ordinary Task commits reject Automation Core changes
- [x] PR create/edit/ready are scoped to the current Task branch/PR
- [x] merge records and validates a checked head SHA before execution
- [x] major failure-path tests are present
- [ ] executable CLI smoke tests — deferred/unverified in this runtime and covered by #13

Refs #6
