### PR TITLE
feat: add role-scoped model fallback

### DIFF
--- a/components/agent-core/.automation/bin/model_fallback.py
+++ b/components/agent-core/.automation/bin/model_fallback.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+class FallbackError(RuntimeError):
+    pass
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def policy(root: Path) -> dict:
+    path = root / ".automation" / "model-fallback.toml"
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise FallbackError(f"missing fallback policy: {path}") from exc
+
+
+def classify(text: str, status: int | None, cfg: dict) -> dict:
+    lower = text.lower()
+    non_fallback = cfg["classification"].get("non_fallback_markers", [])
+    for marker in non_fallback:
+        if marker.lower() in lower:
+            return {"fallback": False, "reason": f"non-fallback marker: {marker}"}
+
+    if status in cfg["classification"].get("retryable_http_status", []):
+        return {"fallback": True, "reason": f"HTTP {status}"}
+
+    for marker in cfg["classification"].get("usage_markers", []):
+        if marker.lower() in lower:
+            return {"fallback": True, "reason": marker}
+
+    return {"fallback": False, "reason": "unclassified error"}
+
+
+def role_chain(role: str, cfg: dict) -> dict:
+    roles = cfg.get("roles", {})
+    if role not in roles:
+        raise FallbackError(f"unknown fallback role: {role}")
+    entry = roles[role]
+    agents = [entry["primary_agent"], *entry.get("fallback_agents", [])]
+    models = [entry["primary_model"], *entry.get("fallback_models", [])]
+    if len(agents) != len(models):
+        raise FallbackError(f"invalid fallback chain for {role}: agent/model length mismatch")
+    if len(set(models)) != len(models):
+        raise FallbackError(f"invalid fallback chain for {role}: duplicate model")
+    return {
+        "role": role,
+        "automatic": bool(entry.get("automatic", False)),
+        "agents": agents,
+        "models": models,
+    }
+
+
+def next_fallback(role: str, failed_agent: str, cfg: dict) -> dict:
+    chain = role_chain(role, cfg)
+    if not chain["automatic"]:
+        return {"available": False, "reason": "automatic fallback disabled", **chain}
+    try:
+        index = chain["agents"].index(failed_agent)
+    except ValueError as exc:
+        raise FallbackError(f"agent {failed_agent!r} is not in fallback chain for {role}") from exc
+    next_index = index + 1
+    if next_index >= len(chain["agents"]):
+        return {"available": False, "reason": "fallback chain exhausted", **chain}
+    return {
+        "available": True,
+        "agent": chain["agents"][next_index],
+        "model": chain["models"][next_index],
+        **chain,
+    }
+
+
+def append_evidence(root: Path, role: str, failed_model: str, fallback_model: str, reason: str, outcome: str) -> None:
+    state = root / ".task-state" / "task.md"
+    if not state.is_file():
+        raise FallbackError("Task State is required to record automatic fallback evidence")
+    text = state.read_text(encoding="utf-8")
+    heading = "### Model fallback"
+    entry = (
+        f"\n- Role: {role}; failed model: {failed_model}; fallback model: {fallback_model}; "
+        f"reason: {reason}; outcome: {outcome}\n"
+    )
+    if heading in text:
+        text = text.replace(heading, heading + entry, 1)
+    elif "## Evidence" in text:
+        text = text.replace("## Evidence", "## Evidence\n\n" + heading + entry, 1)
+    else:
+        text += "\n## Evidence\n\n" + heading + entry
+    state.write_text(text, encoding="utf-8")
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Role-scoped model fallback policy helper")
+    sub = p.add_subparsers(dest="command", required=True)
+    c = sub.add_parser("classify")
+    c.add_argument("text")
+    c.add_argument("--status", type=int)
+    n = sub.add_parser("next")
+    n.add_argument("role")
+    n.add_argument("failed_agent")
+    r = sub.add_parser("record")
+    r.add_argument("role")
+    r.add_argument("failed_model")
+    r.add_argument("fallback_model")
+    r.add_argument("reason")
+    r.add_argument("outcome", choices=["retrying", "succeeded", "failed", "blocked"])
+    return p
+
+
+def main() -> int:
+    args = parser().parse_args()
+    root = repository_root()
+    cfg = policy(root)
+    try:
+        if args.command == "classify":
+            print(json.dumps(classify(args.text, args.status, cfg)))
+        elif args.command == "next":
+            print(json.dumps(next_fallback(args.role, args.failed_agent, cfg)))
+        elif args.command == "record":
+            append_evidence(root, args.role, args.failed_model, args.fallback_model, args.reason, args.outcome)
+            print(json.dumps({"recorded": True}))
+    except FallbackError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/components/agent-core/.automation/just/agent.just
+++ b/components/agent-core/.automation/just/agent.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 script := root / ".automation/bin/agent_core.py"
 lifecycle := root / ".automation/bin/task_lifecycle.py"
+fallback := root / ".automation/bin/model_fallback.py"
 
 [working-directory: root]
 doctor:
@@ -25,6 +26,10 @@ state-set task status:
 [working-directory: root]
 batch-plan +tasks:
     python3 {{quote(lifecycle)}} batch-plan {{tasks}}
+
+[working-directory: root]
+fallback-record role failed_model fallback_model reason outcome:
+    python3 {{quote(fallback)}} record {{quote(role)}} {{quote(failed_model)}} {{quote(fallback_model)}} {{quote(reason)}} {{quote(outcome)}}
 
 [working-directory: root]
 verify task:

--- a/components/agent-core/.automation/model-fallback.toml
+++ b/components/agent-core/.automation/model-fallback.toml
@@ -1,0 +1,96 @@
+version = 1
+
+[classification]
+retryable_http_status = [429]
+usage_markers = [
+  "rate limit",
+  "rate_limit_exceeded",
+  "usage limit",
+  "usage_limit",
+  "quota exceeded",
+  "quota_exceeded",
+  "freeusagelimiterror",
+  "too many requests",
+]
+non_fallback_markers = [
+  "authentication",
+  "unauthorized",
+  "forbidden",
+  "permission denied",
+  "context length",
+  "context window",
+  "validation error",
+  "invalid request",
+  "tool error",
+  "safety",
+]
+
+[roles.build]
+primary_agent = "build"
+primary_model = "openai/gpt-5.6-sol"
+fallback_agents = ["build-fallback"]
+fallback_models = ["openai/gpt-5.6-terra"]
+automatic = false
+
+[roles.architect]
+primary_agent = "architect"
+primary_model = "openai/gpt-5.6-sol"
+fallback_agents = ["architect-fallback"]
+fallback_models = ["openai/gpt-5.6-terra"]
+automatic = true
+
+[roles.task-orchestrator]
+primary_agent = "task-orchestrator"
+primary_model = "openai/gpt-5.3-codex-spark"
+fallback_agents = ["task-orchestrator-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.general]
+primary_agent = "general"
+primary_model = "openai/gpt-5.3-codex-spark"
+fallback_agents = ["general-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.explore]
+primary_agent = "explore"
+primary_model = "openai/gpt-5.3-codex-spark"
+fallback_agents = ["explore-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.verifier]
+primary_agent = "verifier"
+primary_model = "openai/gpt-5.3-codex-spark"
+fallback_agents = ["verifier-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.reviewer]
+primary_agent = "reviewer"
+primary_model = "openai/gpt-5.6-terra"
+fallback_agents = ["reviewer-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.investigator]
+primary_agent = "investigator"
+primary_model = "openai/gpt-5.6-terra"
+fallback_agents = ["investigator-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.security-reviewer]
+primary_agent = "security-reviewer"
+primary_model = "openai/gpt-5.6-terra"
+fallback_agents = ["security-reviewer-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.scout]
+primary_agent = "scout"
+primary_model = "openai/gpt-5.6-luna"
+fallback_agents = ["scout-fallback"]
+fallback_models = ["openai/gpt-5.6-terra"]
+automatic = true

--- a/components/agent-core/.opencode/agents/architect-fallback.md
+++ b/components/agent-core/.opencode/agents/architect-fallback.md
@@ -1,0 +1,11 @@
+---
+description: Usage-limit fallback for architecture analysis
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-terra
+permission:
+  edit: deny
+  task: deny
+---
+
+Analyze architecture with the same read-only authority as `architect`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/components/agent-core/.opencode/agents/build-fallback.md
+++ b/components/agent-core/.opencode/agents/build-fallback.md
@@ -1,0 +1,29 @@
+---
+description: Manual usage-limit fallback for Main Orchestrator with identical authority
+mode: primary
+hidden: true
+model: openai/gpt-5.6-terra
+permission:
+  edit: deny
+  task:
+    "*": deny
+    task-orchestrator: allow
+    task-orchestrator-fallback: allow
+    architect: allow
+    architect-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    investigator: allow
+    investigator-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    scout: allow
+    scout-fallback: allow
+  bash:
+    "just agent::commit *": deny
+    "just agent::pr-create *": deny
+    "just agent::pr-edit *": deny
+    "just agent::pr-ready *": deny
+---
+
+Perform the same Main Orchestrator role as `build`. This is a manual fallback only; OpenCode does not currently provide safe native transparent cross-model fallback for the active primary session. Do not implement Task code directly.

--- a/components/agent-core/.opencode/agents/build.md
+++ b/components/agent-core/.opencode/agents/build.md
@@ -7,11 +7,17 @@ permission:
   task:
     "*": deny
     task-orchestrator: allow
+    task-orchestrator-fallback: allow
     architect: allow
+    architect-fallback: allow
     reviewer: allow
+    reviewer-fallback: allow
     investigator: allow
+    investigator-fallback: allow
     security-reviewer: allow
+    security-reviewer-fallback: allow
     scout: allow
+    scout-fallback: allow
   bash:
     "just agent::task-start *": allow
     "just agent::batch-plan *": allow
@@ -24,5 +30,7 @@ permission:
 You are the Main Orchestrator. Own repository-wide Task selection, dependency analysis, Task worktree creation, Task Orchestrator launch, integration ordering, and guarded merge decisions.
 
 Create Task worktrees only through the guarded lifecycle API. Before running multiple Tasks concurrently, evaluate the explicit Task set with `just agent::batch-plan ...`; serialize any pair with declared dependency, overlapping scope, coordination surfaces, or external resources.
+
+When a delegated agent invocation fails specifically because of a classified usage/quota/rate-limit condition, follow `.automation/model-fallback.toml` and retry the same objective once with the named fallback agent variant. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Main-session fallback is manual through `build-fallback` because native transparent cross-model fallback is not available.
 
 Do not implement Task code directly. Delegate implementation to exactly one Task Orchestrator per Task. Inspect returned evidence before integration. Never treat an unverified command as successful.

--- a/components/agent-core/.opencode/agents/explore-fallback.md
+++ b/components/agent-core/.opencode/agents/explore-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for repository exploration
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Explore with the same read-only authority as `explore`. This variant is only for classified usage-limit fallback. Do not edit, delegate, publish, or mutate repository state.

--- a/components/agent-core/.opencode/agents/general-fallback.md
+++ b/components/agent-core/.opencode/agents/general-fallback.md
@@ -1,0 +1,21 @@
+---
+description: Usage-limit fallback for bounded implementation work
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  task: deny
+  bash:
+    "just agent::task-start *": deny
+    "just agent::commit *": deny
+    "just agent::push *": deny
+    "just agent::pr-create *": deny
+    "just agent::pr-edit *": deny
+    "just agent::pr-ready *": deny
+    "just agent::cleanup *": deny
+    "just agent::fallback-record *": deny
+    "just integrate::check *": deny
+    "just integrate::merge *": deny
+---
+
+Implement only the assigned Work Unit with the same scope and authority as `general`. This variant is only for classified usage-limit fallback. Do not update Task State, publish, integrate, clean up, or delegate.

--- a/components/agent-core/.opencode/agents/investigator-fallback.md
+++ b/components/agent-core/.opencode/agents/investigator-fallback.md
@@ -1,0 +1,11 @@
+---
+description: Usage-limit fallback for root-cause investigation
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+---
+
+Investigate with the same read-only authority and evidence contract as `investigator`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/components/agent-core/.opencode/agents/reviewer-fallback.md
+++ b/components/agent-core/.opencode/agents/reviewer-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for correctness review
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Review with the same read-only authority and evidence contract as `reviewer`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/components/agent-core/.opencode/agents/scout-fallback.md
+++ b/components/agent-core/.opencode/agents/scout-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for external primary-source research
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-terra
+permission:
+  edit: deny
+  task: deny
+  webfetch: allow
+  websearch: allow
+---
+
+Research with the same external-source authority and evidence contract as `scout`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/components/agent-core/.opencode/agents/security-reviewer-fallback.md
+++ b/components/agent-core/.opencode/agents/security-reviewer-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for security-boundary review
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+  webfetch: ask
+  websearch: ask
+---
+
+Review security with the same authority and evidence contract as `security-reviewer`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/components/agent-core/.opencode/agents/task-orchestrator-fallback.md
+++ b/components/agent-core/.opencode/agents/task-orchestrator-fallback.md
@@ -1,0 +1,32 @@
+---
+description: Usage-limit fallback for the Task Orchestrator with identical authority
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  task:
+    "*": deny
+    general: allow
+    general-fallback: allow
+    explore: allow
+    explore-fallback: allow
+    verifier: allow
+    verifier-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    investigator: allow
+    investigator-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    scout: allow
+    scout-fallback: allow
+  bash:
+    "just agent::task-start *": deny
+    "just agent::batch-plan *": deny
+    "just agent::state-set *": allow
+    "just agent::fallback-record *": allow
+    "just integrate::check *": deny
+    "just integrate::merge *": deny
+---
+
+Own exactly one Task with the same authority and constraints as `task-orchestrator`. This agent may be selected only by the explicit model fallback policy after a classified usage/quota/rate-limit failure. Never invoke another Task Orchestrator, merge, or operate on sibling worktrees.

--- a/components/agent-core/.opencode/agents/task-orchestrator.md
+++ b/components/agent-core/.opencode/agents/task-orchestrator.md
@@ -7,20 +7,30 @@ permission:
   task:
     "*": deny
     general: allow
+    general-fallback: allow
     explore: allow
+    explore-fallback: allow
     verifier: allow
+    verifier-fallback: allow
     reviewer: allow
+    reviewer-fallback: allow
     investigator: allow
+    investigator-fallback: allow
     security-reviewer: allow
+    security-reviewer-fallback: allow
     scout: allow
+    scout-fallback: allow
   bash:
     "just agent::task-start *": deny
     "just agent::batch-plan *": deny
     "just agent::state-set *": allow
+    "just agent::fallback-record *": allow
     "just integrate::check *": deny
     "just integrate::merge *": deny
 ---
 
-Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through `just agent::state-set`, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+
+When a leaf invocation fails because of a usage/quota/rate-limit condition listed in `.automation/model-fallback.toml`, retry the identical Work Unit once with the configured fallback agent variant. Record the failed model, classified reason, selected fallback model, and result in Task State. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Do not invent a fallback not listed in policy; when the chain is exhausted, set the Task BLOCKED.
 
 Never invoke another Task Orchestrator. Never merge. Never operate on sibling Task worktrees. Stop and report BLOCKED when Task/worktree identity or consequential requirements are inconsistent.

--- a/components/agent-core/.opencode/agents/verifier-fallback.md
+++ b/components/agent-core/.opencode/agents/verifier-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for project verification
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Run the same verification entry points and reporting contract as `verifier`. This variant is only for classified usage-limit fallback. Do not edit source, delegate, publish, or repair failures.

--- a/components/agent-core/.opencode/skills/task-orchestration/SKILL.md
+++ b/components/agent-core/.opencode/skills/task-orchestration/SKILL.md
@@ -11,7 +11,12 @@ Use this skill when the Main Orchestrator is asked to run a specific Task that a
 2. Confirm the Task is not already owned by another active Task Orchestrator.
 3. Launch exactly one `task-orchestrator` for that Task.
 4. Require the Task Orchestrator to operate only in the assigned worktree and to use bounded Work Units.
-5. Accept only evidence-backed completion: changed files, verification results, review results, commit/PR state, blockers, and unverified checks.
-6. Stop at integration-pending. Do not merge from this skill.
+5. If the Task Orchestrator invocation fails with a usage/quota/rate-limit condition explicitly listed in `.automation/model-fallback.toml`, retry the identical Task once with the configured `task-orchestrator-fallback` variant.
+6. Inside the Task, leaf Work Units may use the same controlled retry rule for their role-specific fallback variants. Do not fallback for authentication, permission, validation, context-window, tool, or safety errors.
+7. Record every attempted fallback in Task State evidence. When a configured chain is exhausted, mark the Task BLOCKED instead of inventing another model.
+8. Accept only evidence-backed completion: changed files, verification results, review results, commit/PR state, blockers, and unverified checks.
+9. Stop at integration-pending. Do not merge from this skill.
+
+Main Orchestrator fallback is not transparent: if the active `build` model hits a usage limit, switch manually to the explicitly configured `build-fallback` agent. OpenCode currently has no safe native cross-model failover for the already-active primary session.
 
 Do not silently select another Issue or Task. Do not weaken permissions to work around a blocked approval or missing tool/model.

--- a/docs/model-fallback.md
+++ b/docs/model-fallback.md
@@ -1,0 +1,50 @@
+# Model fallback
+
+Agent-ready repositories use an explicit role-scoped model fallback policy at `.automation/model-fallback.toml`.
+
+## Why this is controlled rather than transparent
+
+OpenCode does not currently expose first-class cross-model failover for an active agent session. The upstream request for native model fallback is still open. OpenCode also treats some retryable provider errors as retry states, so an unbounded automatic retry loop would be unsafe.
+
+For that reason, this repository implements fallback as explicit alternate agent definitions. Each fallback agent keeps the same role and permission boundary while changing only the configured model.
+
+## Automatic subagent fallback
+
+Automatic fallback is allowed only when the failed invocation is classified as a usage/quota/rate-limit failure, such as HTTP 429, `rate_limit_exceeded`, quota exhaustion, or usage-limit exhaustion.
+
+The parent agent retries the identical Task or Work Unit with the next named fallback agent in policy. Each configured model is attempted at most once. When the chain is exhausted, the Task becomes BLOCKED.
+
+The following failures do not trigger automatic fallback:
+
+- authentication or authorization failure
+- permission denial
+- invalid request or validation failure
+- context-window exhaustion
+- tool execution failure
+- safety refusal
+- unclassified failures
+
+## Main Orchestrator
+
+The active Main Orchestrator cannot be transparently replaced safely with the current OpenCode API. The policy therefore sets `roles.build.automatic = false` and provides `build-fallback` as a manual primary-agent fallback with the same authority.
+
+This boundary should be revisited when OpenCode adds native cross-model fallback or provides a stable plugin API that can replace the active primary model without replaying prompts, duplicating tool calls, or corrupting session state.
+
+## Evidence
+
+Task-level fallback records are appended under `### Model fallback` in `.task-state/task.md`. Evidence includes role, failed model, fallback model, classified reason, and outcome. Provider credentials and secret values must never be recorded.
+
+## Upstream migration
+
+When OpenCode adds native ordered model fallback:
+
+1. confirm it preserves agent permissions and current worktree/session identity;
+2. map `.automation/model-fallback.toml` chains to the native configuration;
+3. retain error classification and Task State evidence requirements;
+4. remove fallback agent variants only after equivalent smoke tests pass;
+5. keep manual fallback as a compatibility path until generated repositories are upgraded.
+
+Upstream references:
+
+- https://github.com/anomalyco/opencode/issues/7602
+- https://github.com/anomalyco/opencode/issues/21960

--- a/templates/agent-base/.automation/bin/model_fallback.py
+++ b/templates/agent-base/.automation/bin/model_fallback.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+class FallbackError(RuntimeError):
+    pass
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def policy(root: Path) -> dict:
+    path = root / ".automation" / "model-fallback.toml"
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise FallbackError(f"missing fallback policy: {path}") from exc
+
+
+def classify(text: str, status: int | None, cfg: dict) -> dict:
+    lower = text.lower()
+    non_fallback = cfg["classification"].get("non_fallback_markers", [])
+    for marker in non_fallback:
+        if marker.lower() in lower:
+            return {"fallback": False, "reason": f"non-fallback marker: {marker}"}
+
+    if status in cfg["classification"].get("retryable_http_status", []):
+        return {"fallback": True, "reason": f"HTTP {status}"}
+
+    for marker in cfg["classification"].get("usage_markers", []):
+        if marker.lower() in lower:
+            return {"fallback": True, "reason": marker}
+
+    return {"fallback": False, "reason": "unclassified error"}
+
+
+def role_chain(role: str, cfg: dict) -> dict:
+    roles = cfg.get("roles", {})
+    if role not in roles:
+        raise FallbackError(f"unknown fallback role: {role}")
+    entry = roles[role]
+    agents = [entry["primary_agent"], *entry.get("fallback_agents", [])]
+    models = [entry["primary_model"], *entry.get("fallback_models", [])]
+    if len(agents) != len(models):
+        raise FallbackError(f"invalid fallback chain for {role}: agent/model length mismatch")
+    if len(set(models)) != len(models):
+        raise FallbackError(f"invalid fallback chain for {role}: duplicate model")
+    return {
+        "role": role,
+        "automatic": bool(entry.get("automatic", False)),
+        "agents": agents,
+        "models": models,
+    }
+
+
+def next_fallback(role: str, failed_agent: str, cfg: dict) -> dict:
+    chain = role_chain(role, cfg)
+    if not chain["automatic"]:
+        return {"available": False, "reason": "automatic fallback disabled", **chain}
+    try:
+        index = chain["agents"].index(failed_agent)
+    except ValueError as exc:
+        raise FallbackError(f"agent {failed_agent!r} is not in fallback chain for {role}") from exc
+    next_index = index + 1
+    if next_index >= len(chain["agents"]):
+        return {"available": False, "reason": "fallback chain exhausted", **chain}
+    return {
+        "available": True,
+        "agent": chain["agents"][next_index],
+        "model": chain["models"][next_index],
+        **chain,
+    }
+
+
+def append_evidence(root: Path, role: str, failed_model: str, fallback_model: str, reason: str, outcome: str) -> None:
+    state = root / ".task-state" / "task.md"
+    if not state.is_file():
+        raise FallbackError("Task State is required to record automatic fallback evidence")
+    text = state.read_text(encoding="utf-8")
+    heading = "### Model fallback"
+    entry = (
+        f"\n- Role: {role}; failed model: {failed_model}; fallback model: {fallback_model}; "
+        f"reason: {reason}; outcome: {outcome}\n"
+    )
+    if heading in text:
+        text = text.replace(heading, heading + entry, 1)
+    elif "## Evidence" in text:
+        text = text.replace("## Evidence", "## Evidence\n\n" + heading + entry, 1)
+    else:
+        text += "\n## Evidence\n\n" + heading + entry
+    state.write_text(text, encoding="utf-8")
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Role-scoped model fallback policy helper")
+    sub = p.add_subparsers(dest="command", required=True)
+    c = sub.add_parser("classify")
+    c.add_argument("text")
+    c.add_argument("--status", type=int)
+    n = sub.add_parser("next")
+    n.add_argument("role")
+    n.add_argument("failed_agent")
+    r = sub.add_parser("record")
+    r.add_argument("role")
+    r.add_argument("failed_model")
+    r.add_argument("fallback_model")
+    r.add_argument("reason")
+    r.add_argument("outcome", choices=["retrying", "succeeded", "failed", "blocked"])
+    return p
+
+
+def main() -> int:
+    args = parser().parse_args()
+    root = repository_root()
+    cfg = policy(root)
+    try:
+        if args.command == "classify":
+            print(json.dumps(classify(args.text, args.status, cfg)))
+        elif args.command == "next":
+            print(json.dumps(next_fallback(args.role, args.failed_agent, cfg)))
+        elif args.command == "record":
+            append_evidence(root, args.role, args.failed_model, args.fallback_model, args.reason, args.outcome)
+            print(json.dumps({"recorded": True}))
+    except FallbackError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-base/.automation/just/agent.just
+++ b/templates/agent-base/.automation/just/agent.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 script := root / ".automation/bin/agent_core.py"
 lifecycle := root / ".automation/bin/task_lifecycle.py"
+fallback := root / ".automation/bin/model_fallback.py"
 
 [working-directory: root]
 doctor:
@@ -25,6 +26,10 @@ state-set task status:
 [working-directory: root]
 batch-plan +tasks:
     python3 {{quote(lifecycle)}} batch-plan {{tasks}}
+
+[working-directory: root]
+fallback-record role failed_model fallback_model reason outcome:
+    python3 {{quote(fallback)}} record {{quote(role)}} {{quote(failed_model)}} {{quote(fallback_model)}} {{quote(reason)}} {{quote(outcome)}}
 
 [working-directory: root]
 verify task:

--- a/templates/agent-base/.automation/model-fallback.toml
+++ b/templates/agent-base/.automation/model-fallback.toml
@@ -1,0 +1,96 @@
+version = 1
+
+[classification]
+retryable_http_status = [429]
+usage_markers = [
+  "rate limit",
+  "rate_limit_exceeded",
+  "usage limit",
+  "usage_limit",
+  "quota exceeded",
+  "quota_exceeded",
+  "freeusagelimiterror",
+  "too many requests",
+]
+non_fallback_markers = [
+  "authentication",
+  "unauthorized",
+  "forbidden",
+  "permission denied",
+  "context length",
+  "context window",
+  "validation error",
+  "invalid request",
+  "tool error",
+  "safety",
+]
+
+[roles.build]
+primary_agent = "build"
+primary_model = "openai/gpt-5.6-sol"
+fallback_agents = ["build-fallback"]
+fallback_models = ["openai/gpt-5.6-terra"]
+automatic = false
+
+[roles.architect]
+primary_agent = "architect"
+primary_model = "openai/gpt-5.6-sol"
+fallback_agents = ["architect-fallback"]
+fallback_models = ["openai/gpt-5.6-terra"]
+automatic = true
+
+[roles.task-orchestrator]
+primary_agent = "task-orchestrator"
+primary_model = "openai/gpt-5.3-codex-spark"
+fallback_agents = ["task-orchestrator-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.general]
+primary_agent = "general"
+primary_model = "openai/gpt-5.3-codex-spark"
+fallback_agents = ["general-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.explore]
+primary_agent = "explore"
+primary_model = "openai/gpt-5.3-codex-spark"
+fallback_agents = ["explore-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.verifier]
+primary_agent = "verifier"
+primary_model = "openai/gpt-5.3-codex-spark"
+fallback_agents = ["verifier-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.reviewer]
+primary_agent = "reviewer"
+primary_model = "openai/gpt-5.6-terra"
+fallback_agents = ["reviewer-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.investigator]
+primary_agent = "investigator"
+primary_model = "openai/gpt-5.6-terra"
+fallback_agents = ["investigator-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.security-reviewer]
+primary_agent = "security-reviewer"
+primary_model = "openai/gpt-5.6-terra"
+fallback_agents = ["security-reviewer-fallback"]
+fallback_models = ["openai/gpt-5.6-sol"]
+automatic = true
+
+[roles.scout]
+primary_agent = "scout"
+primary_model = "openai/gpt-5.6-luna"
+fallback_agents = ["scout-fallback"]
+fallback_models = ["openai/gpt-5.6-terra"]
+automatic = true

--- a/templates/agent-base/.opencode/agents/architect-fallback.md
+++ b/templates/agent-base/.opencode/agents/architect-fallback.md
@@ -1,0 +1,11 @@
+---
+description: Usage-limit fallback for architecture analysis
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-terra
+permission:
+  edit: deny
+  task: deny
+---
+
+Analyze architecture with the same read-only authority as `architect`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/templates/agent-base/.opencode/agents/build-fallback.md
+++ b/templates/agent-base/.opencode/agents/build-fallback.md
@@ -1,0 +1,29 @@
+---
+description: Manual usage-limit fallback for Main Orchestrator with identical authority
+mode: primary
+hidden: true
+model: openai/gpt-5.6-terra
+permission:
+  edit: deny
+  task:
+    "*": deny
+    task-orchestrator: allow
+    task-orchestrator-fallback: allow
+    architect: allow
+    architect-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    investigator: allow
+    investigator-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    scout: allow
+    scout-fallback: allow
+  bash:
+    "just agent::commit *": deny
+    "just agent::pr-create *": deny
+    "just agent::pr-edit *": deny
+    "just agent::pr-ready *": deny
+---
+
+Perform the same Main Orchestrator role as `build`. This is a manual fallback only; OpenCode does not currently provide safe native transparent cross-model fallback for the active primary session. Do not implement Task code directly.

--- a/templates/agent-base/.opencode/agents/build.md
+++ b/templates/agent-base/.opencode/agents/build.md
@@ -7,11 +7,17 @@ permission:
   task:
     "*": deny
     task-orchestrator: allow
+    task-orchestrator-fallback: allow
     architect: allow
+    architect-fallback: allow
     reviewer: allow
+    reviewer-fallback: allow
     investigator: allow
+    investigator-fallback: allow
     security-reviewer: allow
+    security-reviewer-fallback: allow
     scout: allow
+    scout-fallback: allow
   bash:
     "just agent::task-start *": allow
     "just agent::batch-plan *": allow
@@ -24,5 +30,7 @@ permission:
 You are the Main Orchestrator. Own repository-wide Task selection, dependency analysis, Task worktree creation, Task Orchestrator launch, integration ordering, and guarded merge decisions.
 
 Create Task worktrees only through the guarded lifecycle API. Before running multiple Tasks concurrently, evaluate the explicit Task set with `just agent::batch-plan ...`; serialize any pair with declared dependency, overlapping scope, coordination surfaces, or external resources.
+
+When a delegated agent invocation fails specifically because of a classified usage/quota/rate-limit condition, follow `.automation/model-fallback.toml` and retry the same objective once with the named fallback agent variant. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Main-session fallback is manual through `build-fallback` because native transparent cross-model fallback is not available.
 
 Do not implement Task code directly. Delegate implementation to exactly one Task Orchestrator per Task. Inspect returned evidence before integration. Never treat an unverified command as successful.

--- a/templates/agent-base/.opencode/agents/explore-fallback.md
+++ b/templates/agent-base/.opencode/agents/explore-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for repository exploration
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Explore with the same read-only authority as `explore`. This variant is only for classified usage-limit fallback. Do not edit, delegate, publish, or mutate repository state.

--- a/templates/agent-base/.opencode/agents/general-fallback.md
+++ b/templates/agent-base/.opencode/agents/general-fallback.md
@@ -1,0 +1,21 @@
+---
+description: Usage-limit fallback for bounded implementation work
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  task: deny
+  bash:
+    "just agent::task-start *": deny
+    "just agent::commit *": deny
+    "just agent::push *": deny
+    "just agent::pr-create *": deny
+    "just agent::pr-edit *": deny
+    "just agent::pr-ready *": deny
+    "just agent::cleanup *": deny
+    "just agent::fallback-record *": deny
+    "just integrate::check *": deny
+    "just integrate::merge *": deny
+---
+
+Implement only the assigned Work Unit with the same scope and authority as `general`. This variant is only for classified usage-limit fallback. Do not update Task State, publish, integrate, clean up, or delegate.

--- a/templates/agent-base/.opencode/agents/investigator-fallback.md
+++ b/templates/agent-base/.opencode/agents/investigator-fallback.md
@@ -1,0 +1,11 @@
+---
+description: Usage-limit fallback for root-cause investigation
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+---
+
+Investigate with the same read-only authority and evidence contract as `investigator`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/templates/agent-base/.opencode/agents/reviewer-fallback.md
+++ b/templates/agent-base/.opencode/agents/reviewer-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for correctness review
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Review with the same read-only authority and evidence contract as `reviewer`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/templates/agent-base/.opencode/agents/scout-fallback.md
+++ b/templates/agent-base/.opencode/agents/scout-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for external primary-source research
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-terra
+permission:
+  edit: deny
+  task: deny
+  webfetch: allow
+  websearch: allow
+---
+
+Research with the same external-source authority and evidence contract as `scout`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/templates/agent-base/.opencode/agents/security-reviewer-fallback.md
+++ b/templates/agent-base/.opencode/agents/security-reviewer-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for security-boundary review
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+  webfetch: ask
+  websearch: ask
+---
+
+Review security with the same authority and evidence contract as `security-reviewer`. This variant is only for classified usage-limit fallback. Do not edit or delegate.

--- a/templates/agent-base/.opencode/agents/task-orchestrator-fallback.md
+++ b/templates/agent-base/.opencode/agents/task-orchestrator-fallback.md
@@ -1,0 +1,32 @@
+---
+description: Usage-limit fallback for the Task Orchestrator with identical authority
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  task:
+    "*": deny
+    general: allow
+    general-fallback: allow
+    explore: allow
+    explore-fallback: allow
+    verifier: allow
+    verifier-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    investigator: allow
+    investigator-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    scout: allow
+    scout-fallback: allow
+  bash:
+    "just agent::task-start *": deny
+    "just agent::batch-plan *": deny
+    "just agent::state-set *": allow
+    "just agent::fallback-record *": allow
+    "just integrate::check *": deny
+    "just integrate::merge *": deny
+---
+
+Own exactly one Task with the same authority and constraints as `task-orchestrator`. This agent may be selected only by the explicit model fallback policy after a classified usage/quota/rate-limit failure. Never invoke another Task Orchestrator, merge, or operate on sibling worktrees.

--- a/templates/agent-base/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-base/.opencode/agents/task-orchestrator.md
@@ -7,20 +7,30 @@ permission:
   task:
     "*": deny
     general: allow
+    general-fallback: allow
     explore: allow
+    explore-fallback: allow
     verifier: allow
+    verifier-fallback: allow
     reviewer: allow
+    reviewer-fallback: allow
     investigator: allow
+    investigator-fallback: allow
     security-reviewer: allow
+    security-reviewer-fallback: allow
     scout: allow
+    scout-fallback: allow
   bash:
     "just agent::task-start *": deny
     "just agent::batch-plan *": deny
     "just agent::state-set *": allow
+    "just agent::fallback-record *": allow
     "just integrate::check *": deny
     "just integrate::merge *": deny
 ---
 
-Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through `just agent::state-set`, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+
+When a leaf invocation fails because of a usage/quota/rate-limit condition listed in `.automation/model-fallback.toml`, retry the identical Work Unit once with the configured fallback agent variant. Record the failed model, classified reason, selected fallback model, and result in Task State. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Do not invent a fallback not listed in policy; when the chain is exhausted, set the Task BLOCKED.
 
 Never invoke another Task Orchestrator. Never merge. Never operate on sibling Task worktrees. Stop and report BLOCKED when Task/worktree identity or consequential requirements are inconsistent.

--- a/templates/agent-base/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-base/.opencode/agents/verifier-fallback.md
@@ -1,0 +1,13 @@
+---
+description: Usage-limit fallback for project verification
+mode: subagent
+hidden: true
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  task: deny
+  webfetch: deny
+  websearch: deny
+---
+
+Run the same verification entry points and reporting contract as `verifier`. This variant is only for classified usage-limit fallback. Do not edit source, delegate, publish, or repair failures.

--- a/templates/agent-base/.opencode/skills/task-orchestration/SKILL.md
+++ b/templates/agent-base/.opencode/skills/task-orchestration/SKILL.md
@@ -11,7 +11,12 @@ Use this skill when the Main Orchestrator is asked to run a specific Task that a
 2. Confirm the Task is not already owned by another active Task Orchestrator.
 3. Launch exactly one `task-orchestrator` for that Task.
 4. Require the Task Orchestrator to operate only in the assigned worktree and to use bounded Work Units.
-5. Accept only evidence-backed completion: changed files, verification results, review results, commit/PR state, blockers, and unverified checks.
-6. Stop at integration-pending. Do not merge from this skill.
+5. If the Task Orchestrator invocation fails with a usage/quota/rate-limit condition explicitly listed in `.automation/model-fallback.toml`, retry the identical Task once with the configured `task-orchestrator-fallback` variant.
+6. Inside the Task, leaf Work Units may use the same controlled retry rule for their role-specific fallback variants. Do not fallback for authentication, permission, validation, context-window, tool, or safety errors.
+7. Record every attempted fallback in Task State evidence. When a configured chain is exhausted, mark the Task BLOCKED instead of inventing another model.
+8. Accept only evidence-backed completion: changed files, verification results, review results, commit/PR state, blockers, and unverified checks.
+9. Stop at integration-pending. Do not merge from this skill.
+
+Main Orchestrator fallback is not transparent: if the active `build` model hits a usage limit, switch manually to the explicitly configured `build-fallback` agent. OpenCode currently has no safe native cross-model failover for the already-active primary session.
 
 Do not silently select another Issue or Task. Do not weaken permissions to work around a blocked approval or missing tool/model.

--- a/tests/test_model_fallback.py
+++ b/tests/test_model_fallback.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "components" / "agent-core" / ".automation" / "bin" / "model_fallback.py"
+spec = importlib.util.spec_from_file_location("model_fallback", MODULE_PATH)
+assert spec and spec.loader
+fallback = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = fallback
+spec.loader.exec_module(fallback)
+
+
+class ModelFallbackTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.policy_path = ROOT / "components" / "agent-core" / ".automation" / "model-fallback.toml"
+        cls.cfg = tomllib.loads(cls.policy_path.read_text(encoding="utf-8"))
+
+    def test_usage_limit_error_is_fallback_eligible(self) -> None:
+        result = fallback.classify("rate_limit_exceeded: usage limit reached", 429, self.cfg)
+        self.assertTrue(result["fallback"])
+
+    def test_auth_and_permission_errors_do_not_fallback(self) -> None:
+        for text in ("authentication failed", "permission denied", "context window exceeded", "tool error"):
+            result = fallback.classify(text, None, self.cfg)
+            self.assertFalse(result["fallback"], text)
+
+    def test_task_orchestrator_has_explicit_next_agent(self) -> None:
+        result = fallback.next_fallback("task-orchestrator", "task-orchestrator", self.cfg)
+        self.assertTrue(result["available"])
+        self.assertEqual(result["agent"], "task-orchestrator-fallback")
+        self.assertEqual(result["model"], "openai/gpt-5.6-sol")
+
+    def test_chain_exhaustion_stops(self) -> None:
+        result = fallback.next_fallback("general", "general-fallback", self.cfg)
+        self.assertFalse(result["available"])
+        self.assertEqual(result["reason"], "fallback chain exhausted")
+
+    def test_main_fallback_is_not_automatic(self) -> None:
+        result = fallback.next_fallback("build", "build", self.cfg)
+        self.assertFalse(result["available"])
+        self.assertEqual(result["reason"], "automatic fallback disabled")
+
+    def test_fallback_evidence_is_recorded_without_credentials(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state_dir = root / ".task-state"
+            state_dir.mkdir()
+            state = state_dir / "task.md"
+            state.write_text("# TASK\n\n## Evidence\n", encoding="utf-8")
+            fallback.append_evidence(
+                root,
+                "general",
+                "openai/gpt-5.3-codex-spark",
+                "openai/gpt-5.6-sol",
+                "usage limit",
+                "succeeded",
+            )
+            text = state.read_text(encoding="utf-8")
+            self.assertIn("### Model fallback", text)
+            self.assertIn("usage limit", text)
+            self.assertNotIn("api_key", text.lower())
+
+    def test_generated_files_match_sources(self) -> None:
+        pairs = [
+            (
+                ROOT / "components" / "agent-core" / ".automation" / "model-fallback.toml",
+                ROOT / "templates" / "agent-base" / ".automation" / "model-fallback.toml",
+            ),
+            (
+                ROOT / "components" / "agent-core" / ".automation" / "bin" / "model_fallback.py",
+                ROOT / "templates" / "agent-base" / ".automation" / "bin" / "model_fallback.py",
+            ),
+            (
+                ROOT / "components" / "agent-core" / ".automation" / "just" / "agent.just",
+                ROOT / "templates" / "agent-base" / ".automation" / "just" / "agent.just",
+            ),
+            (
+                ROOT / "components" / "agent-core" / ".opencode" / "agents" / "task-orchestrator.md",
+                ROOT / "templates" / "agent-base" / ".opencode" / "agents" / "task-orchestrator.md",
+            ),
+        ]
+        for source, generated in pairs:
+            self.assertEqual(source.read_bytes(), generated.read_bytes(), source.as_posix())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_model_fallback.py
+++ b/tests/test_model_fallback.py
@@ -85,8 +85,21 @@ class ModelFallbackTest(unittest.TestCase):
                 ROOT / "components" / "agent-core" / ".opencode" / "agents" / "task-orchestrator.md",
                 ROOT / "templates" / "agent-base" / ".opencode" / "agents" / "task-orchestrator.md",
             ),
+            (
+                ROOT / "components" / "agent-core" / ".opencode" / "skills" / "task-orchestration" / "SKILL.md",
+                ROOT / "templates" / "agent-base" / ".opencode" / "skills" / "task-orchestration" / "SKILL.md",
+            ),
         ]
         for source, generated in pairs:
+            self.assertEqual(source.read_bytes(), generated.read_bytes(), source.as_posix())
+
+        source_agents = ROOT / "components" / "agent-core" / ".opencode" / "agents"
+        generated_agents = ROOT / "templates" / "agent-base" / ".opencode" / "agents"
+        fallback_agents = sorted(source_agents.glob("*-fallback.md"))
+        self.assertGreaterEqual(len(fallback_agents), 10)
+        for source in fallback_agents:
+            generated = generated_agents / source.name
+            self.assertTrue(generated.is_file(), generated.as_posix())
             self.assertEqual(source.read_bytes(), generated.read_bytes(), source.as_posix())
 
 


### PR DESCRIPTION
## Summary

Implements #23: controlled model fallback for usage/quota/rate-limit exhaustion without changing agent roles, permissions, or worktree ownership.

This PR adds:

- `.automation/model-fallback.toml` with explicit ordered fallback chains per role
- a fallback classifier for HTTP 429 / rate-limit / quota / usage-limit conditions
- explicit non-fallback classification for auth, permission, validation, context-window, tool, safety, and unclassified failures
- hidden fallback agent variants whose role/authority remains equivalent while only the model changes
- parent-Orchestrator routing to fallback variants for failed delegated invocations
- bounded single-step fallback chains with exhaustion reporting instead of infinite retries
- Task State evidence recording through `just agent::fallback-record`
- manual `build-fallback` primary agent for Main-session usage-limit recovery
- generated `agent-base` synchronization
- unit tests covering classification, chain exhaustion, Main automatic-fallback prohibition, evidence recording, and generated parity
- documentation of current OpenCode limitations and native-fallback migration strategy

## Default fallback policy

```text
build                 Sol   -> Terra   (manual only)
architect             Sol   -> Terra
task-orchestrator     Spark -> Sol
general               Spark -> Sol
explore               Spark -> Sol
verifier              Spark -> Sol
reviewer               Terra -> Sol
investigator           Terra -> Sol
security-reviewer      Terra -> Sol
scout                  Luna  -> Terra
```

No model is inferred by similarity. Only variants named in policy may be used.

## Trigger boundary

Automatic fallback applies only to classified usage/quota/rate-limit failures, including HTTP 429, `rate_limit_exceeded`, usage-limit exhaustion, quota exhaustion, and equivalent known markers.

It does **not** apply to:

- authentication / authorization failures
- permission denial
- invalid request / validation failure
- context-window exhaustion
- tool execution failure
- safety refusal
- unclassified failures

## Main Orchestrator limitation

OpenCode does not currently provide first-class cross-model failover for an already-active primary session. Therefore `roles.build.automatic = false`; `build-fallback` is an explicit manual primary-agent fallback with the same authority. The upstream native fallback request remains open.

## Evidence and exhaustion

Fallback attempts are recorded under `### Model fallback` in `.task-state/task.md`, including role, failed model, selected fallback model, classified reason, and outcome. Credentials are never recorded.

Each configured model is attempted at most once. When the chain is exhausted, the Task must be marked BLOCKED rather than retrying indefinitely or selecting an unlisted model.

## Validation

Static validation completed:

- source/generated fallback policy and classifier are synchronized
- source/generated Task Orchestrator, Just Agent API, and task-orchestration skill are synchronized
- all `*-fallback.md` source agents have generated counterparts
- parent agent call graphs explicitly permit only named fallback variants
- Main fallback remains explicitly non-automatic

Repository tests added but not executable in the connector-only runtime:

- `tests/test_model_fallback.py`: UNVERIFIED
- full `python3 -m unittest discover -s tests -v`: UNVERIFIED
- `just template::check`: UNVERIFIED
- real OpenCode usage-limit subagent smoke test: UNVERIFIED
- real Main-session manual fallback smoke test: UNVERIFIED

Unexecuted checks are not reported as PASS.

## Acceptance criteria

- [x] role-specific ordered fallback chains are explicit
- [x] no fallback configuration preserves explicit failure behavior
- [x] only usage/quota/rate-limit failures are eligible
- [x] auth/permission/validation/context/tool/safety failures are excluded
- [x] fallback variants preserve role/worktree boundaries and do not gain broader authority
- [x] fallback chains are bounded and do not retry the same model indefinitely
- [x] exhausted chains terminate as BLOCKED by orchestration contract
- [x] Task State fallback evidence recording is implemented
- [x] subagent fallback variants and routing are implemented
- [x] Main fallback is explicitly manual with documented API limitation
- [x] migration path to future OpenCode native fallback is documented
- [ ] real OpenCode usage-limit smoke tests — UNVERIFIED in this runtime

Refs #23

Upstream:
- anomalyco/opencode#7602
- anomalyco/opencode#21960