### PR TITLE
feat: add existing repository adoption workflow

### DIFF
--- a/components/adapters/base/.automation/adoption.toml
+++ b/components/adapters/base/.automation/adoption.toml
@@ -1,0 +1,16 @@
+version = 1
+
+# Existing repository-owned environment files are preserved when adopting the
+# language-neutral base adapter. Agent Core remains responsible for its own
+# automation files and public Just modules.
+preserve_existing = [
+  "flake.nix",
+  "flake.lock",
+]
+
+[line_merge]
+".gitignore" = ["/.worktrees/"]
+
+[structured_merge]
+Justfile = "agent-module-router"
+AGENTS.md = "agent-rules-block"

--- a/docs/existing-repository-adoption.md
+++ b/docs/existing-repository-adoption.md
@@ -1,0 +1,69 @@
+# Existing repository adoption
+
+Agent-ready repositories always have a Project Adapter. A repository without a dedicated adapter uses the `base` Adapter rather than entering an adapter-less state.
+
+## Commands
+
+From the Templates repository:
+
+```sh
+just template::adopt-plan /path/to/repository
+just template::adopt-plan /path/to/repository base
+just template::adopt-apply /path/to/repository base
+just template::adapter-migrate-plan /path/to/repository cpp-cmake
+```
+
+`adopt-plan` is read-only. It reports the selected Adapter, selection reason, Agent Core version, dirty-state status, planned file actions, and blockers.
+
+`adopt-apply` performs no commit, push, or merge. It refuses to run when the target working tree is dirty or when the plan contains unresolved collisions.
+
+## Adapter selection
+
+Explicit `--adapter <id>` always wins when the Adapter exists.
+
+Auto selection uses only dedicated Adapters that are actually present in the current Templates source. Known marker examples are `CMakeLists.txt`, `pyproject.toml`, `Cargo.toml`, and `flake.nix`.
+
+When no dedicated Adapter matches, or more than one dedicated Adapter matches, selection falls back to `base`. It does not guess which dedicated Adapter the repository intended to use.
+
+## Ownership and collisions
+
+Adoption classifies each generated path before changing the repository.
+
+- `create`: path is absent and may be materialized.
+- `noop`: existing content already matches.
+- `preserve`: the Adapter adoption policy leaves the repository-owned file unchanged.
+- `merge`: a specifically defined safe merge strategy exists.
+- `blocked`: non-identical content has no safe merge strategy.
+
+The base Adapter preserves existing `flake.nix` and `flake.lock` files. It line-merges `/.worktrees/` into `.gitignore`.
+
+Existing `Justfile` content is retained and only non-conflicting Agent Core module declarations are appended. Existing `AGENTS.md` content is retained and Agent Core rules are appended inside explicit markers.
+
+Existing non-identical `opencode.json`, `.automation/**`, or other Automation Core-owned paths are not silently overwritten. They block adoption until the collision is resolved intentionally.
+
+## Base Adapter
+
+The base Adapter is the minimum Project Adapter contract for unknown repositories. It provides the stable `project::*` API without inventing project-specific verification:
+
+```text
+project::doctor        PASS
+project::format-check  SKIPPED
+project::lint          SKIPPED
+project::test          SKIPPED
+project::build         SKIPPED
+project::check         PASS
+```
+
+A skipped project-specific operation remains explicitly `SKIPPED`; it is not represented as work that actually ran.
+
+After adoption, the repository contains the normal Agent Core version, Adapter marker, initialization contract, OpenCode agents, guarded Just API, and worktree lifecycle. The normal read-only `/init` contract applies immediately.
+
+## Migration to a dedicated Adapter
+
+`adapter-migrate-plan` is read-only. It compares the currently active Adapter with the requested target Adapter.
+
+A path currently owned by the active Adapter is replaceable only when the repository copy still matches that Adapter's source. If the repository modified an Adapter-owned path, migration reports a blocker instead of overwriting it.
+
+Agent Core files are not replaced by Adapter migration. Repository extensions are outside Adapter ownership and remain protected.
+
+Actual Adapter migration application is intentionally separate from planning so that future dedicated Adapters can define their ownership and migration rules without weakening the collision policy.

--- a/just/template.just
+++ b/just/template.just
@@ -22,4 +22,4 @@ adopt-apply target adapter='auto':
 
 [working-directory: root]
 adapter-migrate-plan target adapter:
-    python3 tools/adopt_repository.py migrate-plan {{quote(target)}} --adapter {{quote(adapter)}}
+    python3 tools/adapter_migration.py {{quote(target)}} --adapter {{quote(adapter)}}

--- a/just/template.just
+++ b/just/template.just
@@ -11,3 +11,15 @@ render-all:
 [working-directory: root]
 check:
     python3 tools/render_templates.py check
+
+[working-directory: root]
+adopt-plan target adapter='auto':
+    python3 tools/adopt_repository.py plan {{quote(target)}} --adapter {{quote(adapter)}}
+
+[working-directory: root]
+adopt-apply target adapter='auto':
+    python3 tools/adopt_repository.py apply {{quote(target)}} --adapter {{quote(adapter)}}
+
+[working-directory: root]
+adapter-migrate-plan target adapter:
+    python3 tools/adopt_repository.py migrate-plan {{quote(target)}} --adapter {{quote(adapter)}}

--- a/tests/test_adopt_repository.py
+++ b/tests/test_adopt_repository.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOLS = ROOT / "tools"
+sys.path.insert(0, str(TOOLS))
+
+import adopt_repository  # noqa: E402
+
+
+class AdoptRepositoryTest(unittest.TestCase):
+    def make_repo(self) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+        temporary = tempfile.TemporaryDirectory()
+        root = Path(temporary.name)
+        subprocess.run(["git", "init", "-b", "main"], cwd=root, check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+        return temporary, root
+
+    def commit_all(self, root: Path, message: str = "initial") -> str:
+        subprocess.run(["git", "add", "."], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-m", message], cwd=root, check=True, capture_output=True)
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=root, check=True, text=True, capture_output=True
+        ).stdout.strip()
+
+    def test_plan_is_read_only_and_auto_falls_back_to_base(self) -> None:
+        temporary, repo = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        (repo / "flake.nix").write_text("{ outputs = { self }: {}; }\n", encoding="utf-8")
+        self.commit_all(repo)
+        before = subprocess.run(
+            ["git", "status", "--porcelain"], cwd=repo, check=True, text=True, capture_output=True
+        ).stdout
+
+        plan = adopt_repository.build_plan(ROOT, repo, "auto")
+
+        after = subprocess.run(
+            ["git", "status", "--porcelain"], cwd=repo, check=True, text=True, capture_output=True
+        ).stdout
+        self.assertEqual(plan["selectedAdapter"], "base")
+        self.assertIn("base fallback", plan["adapterSelectionReason"])
+        self.assertEqual(before, after)
+        self.assertFalse(plan["workingTreeDirty"])
+
+    def test_base_apply_preserves_repository_files_and_does_not_commit(self) -> None:
+        temporary, repo = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        original_flake = "{ outputs = { self }: { existing = true; }; }\n"
+        (repo / "flake.nix").write_text(original_flake, encoding="utf-8")
+        (repo / "Justfile").write_text("default:\n    @echo existing\n", encoding="utf-8")
+        (repo / "AGENTS.md").write_text("# Existing Repository Rules\n", encoding="utf-8")
+        (repo / ".gitignore").write_text("result\n", encoding="utf-8")
+        head_before = self.commit_all(repo)
+
+        plan = adopt_repository.build_plan(ROOT, repo, "base")
+        self.assertTrue(plan["canApply"], plan["blockers"])
+        result = adopt_repository.apply_plan(ROOT, repo, "base")
+
+        self.assertTrue(result["applied"])
+        self.assertEqual((repo / "flake.nix").read_text(encoding="utf-8"), original_flake)
+        justfile = (repo / "Justfile").read_text(encoding="utf-8")
+        self.assertIn("default:", justfile)
+        self.assertIn("mod agent '.automation/just/agent.just'", justfile)
+        self.assertIn("mod project 'just/project/mod.just'", justfile)
+        agents = (repo / "AGENTS.md").read_text(encoding="utf-8")
+        self.assertIn("# Existing Repository Rules", agents)
+        self.assertIn("<!-- BEGIN AGENT CORE RULES -->", agents)
+        self.assertIn("/.worktrees/", (repo / ".gitignore").read_text(encoding="utf-8"))
+        self.assertEqual((repo / ".automation" / "ADAPTER").read_text().strip(), "base")
+        head_after = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo, check=True, text=True, capture_output=True
+        ).stdout.strip()
+        self.assertEqual(head_before, head_after)
+        self.assertFalse(result["commitCreated"])
+        self.assertFalse(result["pushPerformed"])
+        self.assertFalse(result["mergePerformed"])
+
+    def test_existing_opencode_collision_blocks_apply(self) -> None:
+        temporary, repo = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        (repo / "opencode.json").write_text('{"existing": true}\n', encoding="utf-8")
+        self.commit_all(repo)
+
+        plan = adopt_repository.build_plan(ROOT, repo, "base")
+
+        self.assertFalse(plan["canApply"])
+        self.assertTrue(any("opencode.json" in blocker for blocker in plan["blockers"]))
+
+    def test_dirty_repository_cannot_apply(self) -> None:
+        temporary, repo = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        (repo / "README.md").write_text("initial\n", encoding="utf-8")
+        self.commit_all(repo)
+        (repo / "README.md").write_text("dirty\n", encoding="utf-8")
+
+        plan = adopt_repository.build_plan(ROOT, repo, "base")
+
+        self.assertTrue(plan["workingTreeDirty"])
+        self.assertFalse(plan["canApply"])
+        with self.assertRaisesRegex(adopt_repository.AdoptionError, "working tree is dirty"):
+            adopt_repository.apply_plan(ROOT, repo, "base")
+
+    def test_conflicting_just_module_blocks_safe_merge(self) -> None:
+        existing = "mod agent 'custom/agent.just'\n"
+        merged, reason = adopt_repository.just_router_merge(existing)
+        self.assertIsNone(merged)
+        self.assertIn("conflicts", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/adapter_migration.py
+++ b/tools/adapter_migration.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from adopt_repository import AdoptionError, available_adapters, repository_root, select_adapter
+from render_templates import TemplateSpec, compose_entries
+
+
+def plan(source: Path, target: Path, requested: str) -> dict:
+    root = repository_root(target)
+    marker = root / ".automation" / "ADAPTER"
+    if not marker.is_file():
+        raise AdoptionError("repository is not Agent-ready: missing .automation/ADAPTER")
+    current = marker.read_text(encoding="utf-8").strip()
+    adapters = available_adapters(source)
+    if current not in adapters:
+        raise AdoptionError(f"current adapter {current!r} is unavailable in Templates")
+    selected, reason, candidates = select_adapter(source, root, requested)
+    if selected == current:
+        return {
+            "repositoryRoot": str(root),
+            "fromAdapter": current,
+            "toAdapter": selected,
+            "adapterSelectionReason": reason,
+            "adapterCandidates": candidates,
+            "actions": [],
+            "blockers": ["selected adapter is already active"],
+            "canMigrate": False,
+        }
+
+    current_entries = compose_entries(
+        source, TemplateSpec("migration-current", current, "current adapter")
+    )
+    target_entries = compose_entries(
+        source, TemplateSpec("migration-target", selected, "target adapter")
+    )
+
+    actions: list[dict] = []
+    blockers: list[str] = []
+    paths = sorted(
+        {
+            path
+            for path, entry in current_entries.items()
+            if entry.component.startswith("adapter:")
+        }
+        | {
+            path
+            for path, entry in target_entries.items()
+            if entry.component.startswith("adapter:")
+        },
+        key=lambda path: path.as_posix(),
+    )
+
+    for relative in paths:
+        rel = relative.as_posix()
+        destination = root / relative
+        current_entry = current_entries.get(relative)
+        target_entry = target_entries.get(relative)
+        current_owned = current_entry is not None and current_entry.component.startswith("adapter:")
+        target_owned = target_entry is not None and target_entry.component.startswith("adapter:")
+
+        if rel == ".automation/ADAPTER" and target_owned:
+            actions.append(
+                {
+                    "path": rel,
+                    "action": "replace-adapter",
+                    "reason": f"switch adapter marker {current} -> {selected}",
+                }
+            )
+            continue
+
+        if current_owned and destination.exists():
+            if not destination.is_file() or not current_entry.source.is_file():
+                detail = "current adapter-owned path is not a regular file"
+                blockers.append(f"{rel}: {detail}")
+                actions.append({"path": rel, "action": "blocked", "reason": detail})
+                continue
+            if destination.read_bytes() != current_entry.source.read_bytes():
+                detail = "repository modified a current adapter-owned file; automatic replacement is unsafe"
+                blockers.append(f"{rel}: {detail}")
+                actions.append({"path": rel, "action": "blocked", "reason": detail})
+                continue
+
+        if target_owned:
+            action = "replace-adapter" if destination.exists() else "create-adapter"
+            actions.append(
+                {
+                    "path": rel,
+                    "action": action,
+                    "reason": f"target adapter {selected} owns this path",
+                }
+            )
+        elif current_owned:
+            actions.append(
+                {
+                    "path": rel,
+                    "action": "remove-adapter",
+                    "reason": f"path belongs only to previous adapter {current}",
+                }
+            )
+
+    return {
+        "repositoryRoot": str(root),
+        "fromAdapter": current,
+        "toAdapter": selected,
+        "adapterSelectionReason": reason,
+        "adapterCandidates": candidates,
+        "actions": actions,
+        "blockers": blockers,
+        "canMigrate": not blockers,
+        "readOnly": True,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Plan Project Adapter migration")
+    parser.add_argument("target", type=Path)
+    parser.add_argument("--adapter", required=True)
+    args = parser.parse_args()
+    source = Path(__file__).resolve().parents[1]
+    try:
+        print(json.dumps(plan(source, args.target.resolve(), args.adapter), indent=2, sort_keys=True))
+        return 0
+    except AdoptionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/adopt_repository.py
+++ b/tools/adopt_repository.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+from render_templates import CompositionError, TemplateSpec, compose_entries
+
+
+class AdoptionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Action:
+    path: str
+    action: str
+    owner: str
+    reason: str
+
+
+def templates_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise AdoptionError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def repository_root(path: Path) -> Path:
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=path)
+    return Path(result.stdout.strip()).resolve()
+
+
+def available_adapters(source: Path) -> set[str]:
+    root = source / "components" / "adapters"
+    if not root.is_dir():
+        raise AdoptionError("missing components/adapters")
+    return {path.name for path in root.iterdir() if path.is_dir()}
+
+
+def detect_adapter(target: Path, adapters: set[str]) -> tuple[str, str, list[str]]:
+    candidates: list[tuple[str, str]] = []
+    signals = [
+        ("cpp-cmake", "CMakeLists.txt"),
+        ("python", "pyproject.toml"),
+        ("rust", "Cargo.toml"),
+        ("nix", "flake.nix"),
+    ]
+    for adapter, marker in signals:
+        if adapter in adapters and (target / marker).exists():
+            candidates.append((adapter, marker))
+    if len(candidates) == 1:
+        adapter, marker = candidates[0]
+        return adapter, f"unique known marker: {marker}", [adapter]
+    if not candidates:
+        return "base", "no dedicated adapter matched; using mandatory base fallback", []
+    names = [name for name, _ in candidates]
+    return "base", "adapter detection is ambiguous; using mandatory base fallback", names
+
+
+def select_adapter(source: Path, target: Path, requested: str) -> tuple[str, str, list[str]]:
+    adapters = available_adapters(source)
+    if "base" not in adapters:
+        raise AdoptionError("base adapter is required but missing")
+    if requested == "auto":
+        return detect_adapter(target, adapters)
+    if requested not in adapters:
+        raise AdoptionError(
+            f"unknown adapter {requested!r}; available: {', '.join(sorted(adapters))}"
+        )
+    return requested, "explicit adapter selection", [requested]
+
+
+def load_policy(source: Path, adapter: str) -> dict:
+    path = source / "components" / "adapters" / adapter / ".automation" / "adoption.toml"
+    if not path.is_file():
+        return {
+            "preserve_existing": [],
+            "line_merge": {},
+            "structured_merge": {},
+        }
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    return {
+        "preserve_existing": list(raw.get("preserve_existing", [])),
+        "line_merge": dict(raw.get("line_merge", {})),
+        "structured_merge": dict(raw.get("structured_merge", {})),
+    }
+
+
+def matches(path: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def bytes_equal(left: Path, right: Path) -> bool:
+    if not left.is_file() or not right.is_file():
+        return False
+    return left.read_bytes() == right.read_bytes()
+
+
+def just_router_merge(existing: str) -> tuple[str | None, str]:
+    required = {
+        "agent": "mod agent '.automation/just/agent.just'",
+        "integrate": "mod integrate '.automation/just/integrate.just'",
+        "project": "mod project 'just/project/mod.just'",
+        "local": "mod? local 'just/local.just'",
+    }
+    lines = existing.splitlines()
+    for name, expected in required.items():
+        conflicting = [line.strip() for line in lines if line.strip().startswith(f"mod {name} ") or line.strip().startswith(f"mod? {name} ")]
+        if conflicting and expected not in conflicting:
+            return None, f"existing Just module {name!r} conflicts with Agent Core router"
+    missing = [value for value in required.values() if value not in lines]
+    if not missing:
+        return existing, "Agent module router already present"
+    suffix = "\n" if existing.endswith("\n") or not existing else "\n\n"
+    merged = existing + suffix + "# Agent Core module router\n" + "\n".join(missing) + "\n"
+    return merged, "append non-conflicting Agent Core module router declarations"
+
+
+def agent_rules_merge(existing: str, core_rules: str) -> tuple[str | None, str]:
+    begin = "<!-- BEGIN AGENT CORE RULES -->"
+    end = "<!-- END AGENT CORE RULES -->"
+    block = f"{begin}\n{core_rules.rstrip()}\n{end}"
+    if begin in existing or end in existing:
+        if block in existing:
+            return existing, "Agent Core rules block already present"
+        return None, "existing Agent Core rules marker does not match current source"
+    suffix = "\n" if existing.endswith("\n") or not existing else "\n\n"
+    return existing + suffix + block + "\n", "append marked Agent Core rules block"
+
+
+def line_merge(existing: str, required: list[str]) -> tuple[str, list[str]]:
+    lines = existing.splitlines()
+    missing = [line for line in required if line not in lines]
+    if not missing:
+        return existing, []
+    suffix = "\n" if existing.endswith("\n") or not existing else "\n"
+    return existing + suffix + "\n".join(missing) + "\n", missing
+
+
+def materialized_bytes(source_path: Path) -> bytes:
+    if source_path.is_symlink():
+        raise AdoptionError(f"symlink adoption is not supported yet: {source_path}")
+    return source_path.read_bytes()
+
+
+def build_plan(source: Path, target: Path, requested_adapter: str) -> dict:
+    root = repository_root(target)
+    adapter, reason, detected = select_adapter(source, root, requested_adapter)
+    policy = load_policy(source, adapter)
+    spec = TemplateSpec(name="adoption", adapter=adapter, description="existing repository adoption")
+    try:
+        entries = compose_entries(source, spec)
+    except CompositionError as exc:
+        raise AdoptionError(str(exc)) from exc
+
+    actions: list[Action] = []
+    blockers: list[str] = []
+    for relative, entry in sorted(entries.items(), key=lambda item: item[0].as_posix()):
+        rel = relative.as_posix()
+        destination = root / relative
+        owner = entry.component
+
+        if not destination.exists() and not destination.is_symlink():
+            actions.append(Action(rel, "create", owner, "path does not exist"))
+            continue
+
+        if destination.is_file() and entry.source.is_file() and bytes_equal(destination, entry.source):
+            actions.append(Action(rel, "noop", owner, "existing content is identical"))
+            continue
+
+        if owner.startswith("adapter:") and matches(rel, policy["preserve_existing"]):
+            actions.append(Action(rel, "preserve", "repository", "adapter adoption policy preserves existing repository-owned file"))
+            continue
+
+        if rel in policy["line_merge"] and destination.is_file():
+            _, missing = line_merge(destination.read_text(encoding="utf-8"), policy["line_merge"][rel])
+            action = "merge" if missing else "noop"
+            actions.append(Action(rel, action, "shared", "line merge: " + (", ".join(missing) if missing else "already satisfied")))
+            continue
+
+        strategy = policy["structured_merge"].get(rel)
+        if strategy == "agent-module-router" and destination.is_file():
+            merged, detail = just_router_merge(destination.read_text(encoding="utf-8"))
+            if merged is None:
+                blockers.append(f"{rel}: {detail}")
+                actions.append(Action(rel, "blocked", "shared", detail))
+            else:
+                actions.append(Action(rel, "merge" if merged != destination.read_text(encoding="utf-8") else "noop", "shared", detail))
+            continue
+        if strategy == "agent-rules-block" and destination.is_file():
+            merged, detail = agent_rules_merge(destination.read_text(encoding="utf-8"), entry.source.read_text(encoding="utf-8"))
+            if merged is None:
+                blockers.append(f"{rel}: {detail}")
+                actions.append(Action(rel, "blocked", "shared", detail))
+            else:
+                actions.append(Action(rel, "merge" if merged != destination.read_text(encoding="utf-8") else "noop", "shared", detail))
+            continue
+
+        detail = "non-identical existing path has no safe adoption merge strategy"
+        blockers.append(f"{rel}: {detail}")
+        actions.append(Action(rel, "blocked", owner, detail))
+
+    dirty = bool(run(["git", "status", "--porcelain"], cwd=root).stdout.strip())
+    version = (source / "components" / "agent-core" / ".automation" / "VERSION")
+    version_value = version.read_text(encoding="utf-8").strip() if version.is_file() else None
+    return {
+        "repositoryRoot": str(root),
+        "requestedAdapter": requested_adapter,
+        "selectedAdapter": adapter,
+        "adapterSelectionReason": reason,
+        "adapterCandidates": detected,
+        "agentCoreVersion": version_value,
+        "workingTreeDirty": dirty,
+        "actions": [asdict(action) for action in actions],
+        "blockers": blockers,
+        "canApply": not blockers and not dirty,
+    }
+
+
+def apply_plan(source: Path, target: Path, requested_adapter: str) -> dict:
+    plan = build_plan(source, target, requested_adapter)
+    if plan["blockers"]:
+        raise AdoptionError("adoption blocked:\n- " + "\n- ".join(plan["blockers"]))
+    if plan["workingTreeDirty"]:
+        raise AdoptionError("adoption refused: target working tree is dirty")
+
+    root = Path(plan["repositoryRoot"])
+    adapter = plan["selectedAdapter"]
+    policy = load_policy(source, adapter)
+    entries = compose_entries(source, TemplateSpec("adoption", adapter, "existing repository adoption"))
+    action_by_path = {item["path"]: item for item in plan["actions"]}
+
+    for relative, entry in sorted(entries.items(), key=lambda item: item[0].as_posix()):
+        rel = relative.as_posix()
+        destination = root / relative
+        action = action_by_path[rel]["action"]
+        if action in {"noop", "preserve"}:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if action == "create":
+            if entry.source.is_symlink():
+                os.symlink(os.readlink(entry.source), destination)
+            else:
+                shutil.copy2(entry.source, destination, follow_symlinks=False)
+            continue
+        if action == "merge":
+            if rel in policy["line_merge"]:
+                merged, _ = line_merge(destination.read_text(encoding="utf-8"), policy["line_merge"][rel])
+                destination.write_text(merged, encoding="utf-8")
+                continue
+            strategy = policy["structured_merge"].get(rel)
+            if strategy == "agent-module-router":
+                merged, detail = just_router_merge(destination.read_text(encoding="utf-8"))
+            elif strategy == "agent-rules-block":
+                merged, detail = agent_rules_merge(destination.read_text(encoding="utf-8"), entry.source.read_text(encoding="utf-8"))
+            else:
+                raise AdoptionError(f"unexpected merge action for {rel}")
+            if merged is None:
+                raise AdoptionError(f"merge became unsafe for {rel}: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+            continue
+        raise AdoptionError(f"unexpected action {action!r} for {rel}")
+
+    return {
+        "applied": True,
+        "repositoryRoot": str(root),
+        "adapter": adapter,
+        "agentCoreVersion": plan["agentCoreVersion"],
+        "commitCreated": False,
+        "pushPerformed": False,
+        "mergePerformed": False,
+    }
+
+
+def migration_plan(source: Path, target: Path, adapter: str) -> dict:
+    root = repository_root(target)
+    current_path = root / ".automation" / "ADAPTER"
+    if not current_path.is_file():
+        raise AdoptionError("repository is not Agent-ready: missing .automation/ADAPTER")
+    current = current_path.read_text(encoding="utf-8").strip()
+    plan = build_plan(source, root, adapter)
+    plan["migration"] = {"from": current, "to": plan["selectedAdapter"]}
+    if current == plan["selectedAdapter"]:
+        plan["blockers"].append("selected adapter is already active")
+        plan["canApply"] = False
+    return plan
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description="Adopt Agent Core into an existing Git repository")
+    sub = result.add_subparsers(dest="command", required=True)
+    for name in ("plan", "apply"):
+        command = sub.add_parser(name)
+        command.add_argument("target", type=Path)
+        command.add_argument("--adapter", default="auto")
+    migrate = sub.add_parser("migrate-plan")
+    migrate.add_argument("target", type=Path)
+    migrate.add_argument("--adapter", required=True)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    source = templates_root()
+    try:
+        if args.command == "plan":
+            result = build_plan(source, args.target.resolve(), args.adapter)
+        elif args.command == "apply":
+            result = apply_plan(source, args.target.resolve(), args.adapter)
+        elif args.command == "migrate-plan":
+            result = migration_plan(source, args.target.resolve(), args.adapter)
+        else:  # pragma: no cover
+            raise AdoptionError(f"unsupported command: {args.command}")
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except AdoptionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements #26: collision-safe Agent Core adoption/bootstrap for existing repositories, with the `base` Project Adapter as the mandatory fallback when no dedicated Adapter is available or auto-detection is ambiguous.

This PR adds:

- repository-independent adoption planning and application tooling
- explicit / auto Adapter selection with deterministic `base` fallback
- read-only adoption dry-run with create/noop/preserve/merge/blocked classification
- Adapter-specific adoption policy support
- base Adapter preservation of existing `flake.nix` / `flake.lock`
- safe line merge for `/.worktrees/` in `.gitignore`
- safe `Justfile` merge that retains existing recipes and appends only non-conflicting Agent Core module declarations
- marked `AGENTS.md` merge that preserves existing repository instructions
- strict blocking for non-identical Automation Core files without a defined safe merge strategy
- clean-working-tree requirement for apply
- no commit, push, merge, stash, reset, or destructive rename during adoption
- read-only Project Adapter migration planning
- Just API entry points for adoption plan/apply and Adapter migration planning
- tests using temporary real Git repositories
- adoption/migration documentation

## Adapter invariant

Agent-ready repositories always have an Adapter.

```text
known dedicated Adapter -> use selected Adapter
no dedicated Adapter     -> base
ambiguous auto-detection -> base
```

There is no `Adapter = none` state.

The base Adapter remains the minimum stable `project::*` contract and does not invent project-specific verification.

## Public API

```text
just template::adopt-plan <repo> [adapter]
just template::adopt-apply <repo> [adapter]
just template::adapter-migrate-plan <repo> <adapter>
```

`adopt-plan` and `adapter-migrate-plan` are read-only.

`adopt-apply` re-runs the plan and refuses to proceed when:

- the target working tree is dirty
- unresolved collisions exist
- an existing Just module conflicts with the Agent Core router
- an existing Automation Core-owned path differs and has no explicit merge strategy

## Base Adapter adoption policy

Repository-owned environment files are preserved:

- `flake.nix`
- `flake.lock`

Safe shared merges:

- `.gitignore`: add `/.worktrees/` if absent
- `Justfile`: retain existing content and append Agent Core modules only when names do not conflict
- `AGENTS.md`: retain existing rules and append Agent Core rules inside explicit markers

Non-identical `opencode.json`, `.automation/**`, and other unclassified Agent Core collisions block adoption instead of being silently overwritten.

## Adapter migration

Migration planning is intentionally read-only.

A currently Adapter-owned path is considered replaceable only when the repository copy still matches the current Adapter source. Repository-modified Adapter files become blockers. Agent Core files and repository extensions are outside Adapter replacement ownership.

Actual migration application remains separate so dedicated Adapters can define migration ownership safely as they are introduced.

## Validation

Structural validation completed:

- #26 diff is isolated to adoption policy/runtime/Just API/tests/docs
- branch is based directly on merged #9 main
- adoption reuses the existing deterministic component composition implementation
- no adoption path invokes Git commit/push/merge/stash/reset

Repository tests added but not executable in this connector-only runtime:

- `tests/test_adopt_repository.py`: UNVERIFIED
- full `python3 -m unittest discover -s tests -v`: UNVERIFIED
- `just template::adopt-plan/apply`: UNVERIFIED against a local checkout
- post-adoption `just agent::doctor/context`, `project::doctor`, and real OpenCode `/init`: UNVERIFIED

Unexecuted checks are not reported as PASS.

## Acceptance criteria

- [x] read-only adoption dry-run is implemented
- [x] explicit `base` Adapter can be selected for an existing repository
- [x] unknown/ambiguous auto-detection falls back to `base` rather than guessing
- [x] Adapter contract is maintained; no Adapter-less state is created
- [x] Automation Core / Adapter / repository ownership collisions are classified before apply
- [x] existing files are not silently overwritten
- [x] base Adapter preserves existing repository environment files defined by policy
- [x] safe Justfile/AGENTS/.gitignore merges are explicit and bounded
- [x] adoption apply performs no commit/push/merge
- [x] dirty working tree blocks apply
- [x] read-only Adapter migration planning is implemented
- [x] repository-modified Adapter-owned files block automatic replacement
- [x] new-repository template generation remains unchanged
- [ ] real post-adoption `/init` and Just smoke tests — UNVERIFIED in this runtime

Refs #26