### PR TITLE
feat: add Agent Core versioning and upgrade workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,51 +2,99 @@
 
 Nix flake templates for reproducible, Agent-ready development environments.
 
-## Published templates
+## Start a new repository
 
-Python and Rust keep their original public flake names, but those names now point
-to generated Agent Core + Project Adapter templates:
-
-```sh
-nix flake init -t github:upiscium/Templates#python
-nix flake init -t github:upiscium/Templates#rust
-```
-
-The explicit Agent-ready names are equivalent:
+Published templates:
 
 ```sh
+nix flake init -t github:upiscium/Templates#agent-base
 nix flake init -t github:upiscium/Templates#agent-python
 nix flake init -t github:upiscium/Templates#agent-rust
-nix flake init -t github:upiscium/Templates#agent-base
+nix flake init -t github:upiscium/Templates#agent-nix
+nix flake init -t github:upiscium/Templates#agent-cpp-cmake
 ```
 
-Compatibility mapping:
+Compatibility aliases remain available:
 
 ```text
-python       -> templates/agent-python
-agent-python -> templates/agent-python
-rust         -> templates/agent-rust
-agent-rust   -> templates/agent-rust
+python -> agent-python
+rust   -> agent-rust
 ```
 
-The historical top-level `python/` and `rust/` directories are retained temporarily
-as migration reference material, but are no longer the targets of the published
-`#python` and `#rust` flake templates.
+Every Agent-ready repository contains the shared Agent Core plus exactly one Project Adapter. Adapter-less repositories are not supported; unknown projects use `base` as the minimum contract.
 
-## Generated Agent-ready templates
-
-Generated templates are artifacts. Do not edit files under `templates/<name>/`
-directly. Their sources live under:
+## Repository layers
 
 ```text
-components/agent-core/
-components/adapters/<adapter>/
+Agent Core
+  .automation/**, .opencode/**, AGENTS.md, root Justfile, opencode.json
+
+Project Adapter
+  just/project/**, language/toolchain manifests, INIT.fragment.md, ADAPTER
+
+Repository extension
+  just/project/repository.just and repository-owned build/configuration files
+
+Local extension
+  just/local.just (optional, repository-specific convenience API)
 ```
 
-The generator fails on component path collisions instead of silently selecting an
-overwrite order. It preserves dotfiles, symlinks, and executable bits.
+Generated files under `templates/<name>/` are artifacts. Edit `components/agent-core/` or `components/adapters/<adapter>/` and regenerate instead.
 
-Project Adapters implement the same stable public API:
+## Initialization
+
+`/init` is read-only. It validates Agent Core version, Adapter identity, branch/worktree/Task State, tools, project doctor, HEAD, and Git status. It never bootstraps, repairs, installs packages, changes Task State, or rewrites `AGENTS.md`.
+
+Bootstrap/adoption and Agent Core upgrade are separate mutating workflows.
+
+## Existing repositories
+
+Plan first:
+
+```sh
+just template::adopt-plan /path/to/repository
+```
+
+Apply with an explicit Adapter when appropriate:
+
+```sh
+just template::adopt-apply /path/to/repository base
+just template::adopt-apply /path/to/repository python
+```
+
+Auto-detection prefers CMake/Python/Rust markers; a standalone `flake.nix` selects Nix; unknown or ambiguous repositories fall back to `base`.
+
+Migrate a base-adopted repository by inspecting the read-only migration plan before changing Adapter-owned paths:
+
+```sh
+just template::adapter-migrate-plan /path/to/repository python
+```
+
+Adoption/migration never commits, pushes, merges, stashes, or resets the target repository.
+
+## Task and worktree lifecycle
+
+Main schedules Tasks. Each Task owns one branch, one repo-local worktree under `.worktrees/`, one disposable `.task-state/task.md`, and one Task Orchestrator. Leaf agents cannot delegate or mutate Task State.
+
+Typical flow:
+
+```text
+Main
+  -> task-start
+  -> Task Orchestrator implements/verifies
+  -> guarded commit
+  -> Ask: push
+  -> Draft PR
+  -> integration check
+  -> Ask: merge (Main only)
+  -> cleanup
+```
+
+Raw Git/GitHub writes are denied. Stable Just APIs provide the guarded write path. Push, merge, cleanup, unknown Bash, and designated external paths require Ask.
+
+## Project Adapter API
+
+All Adapters expose:
 
 ```text
 just project::doctor
@@ -57,41 +105,72 @@ just project::build
 just project::check
 ```
 
-Python preserves the uv/Ruff/Mypy/Pytest workflow and project-local `.venv`.
-Its `project::build` is an explicit `SKIPPED` contract until a build artifact is
-configured. Rust exposes rustfmt, Clippy, cargo test, and cargo build through the
-same stable interface.
+Adapters may expose additional guarded APIs such as `project::eval` or `project::configure`, but broad raw tool commands are not automatically allowed.
 
-## Template generation API
+To add an Adapter, create `components/adapters/<id>/` with `.automation/ADAPTER`, `.automation/INIT.fragment.md`, `just/project/mod.just`, adoption policy, required project files, and a manifest entry. Add source/generated parity tests and generated-template CI smoke coverage.
 
-The Templates repository exposes generation through the `template` Just module:
+## Agent Core version and upstream
+
+Generated repositories contain:
+
+```text
+.automation/VERSION
+.automation/UPSTREAM
+```
+
+Inspect them through:
+
+```sh
+just automation::version
+```
+
+`UPSTREAM` records the canonical Templates repository/ref/component. Breaking Agent Core changes require a VERSION change and migration notes; compatible implementation/documentation changes may remain within the current version.
+
+## Read-only update check
+
+The repository never fetches or executes upstream code automatically. Check against a trusted local Templates checkout:
+
+```sh
+just automation::check-update /path/to/Templates
+```
+
+This reports current/upstream versions and the ownership boundaries without mutating the repository. Agent Core upgrades must never be silently mixed into an ordinary Task.
+
+## Agent Core upgrade
+
+Use a dedicated Task worktree. The upgrade command is an Ask operation and additionally requires an explicit maintenance marker:
+
+```sh
+export AUTOMATION_MAINTENANCE=1
+just automation::upgrade /path/to/Templates
+```
+
+It refuses the default branch and repositories without Task State. It materializes only Agent Core-owned paths and preserves Adapter-owned `.automation/ADAPTER`, `.automation/INIT.fragment.md`, `.automation/adoption.toml`, `just/project/**`, local modules, and repository CI.
+
+Upgrade does not commit, push, or merge. Before publication, inspect the diff and run at minimum:
+
+```sh
+git diff --check
+just agent::doctor
+just project::check
+```
+
+Then require the repository CI/smoke suite. Automation Core changes must be reviewed as a dedicated maintenance change.
+
+## Template development
 
 ```sh
 just template::render agent-base
 just template::render agent-python
 just template::render agent-rust
+just template::render agent-nix
+just template::render agent-cpp-cmake
 just template::render-all
 just template::check
 ```
 
-- `render` rebuilds one registered template from Agent Core plus its Adapter.
-- `render-all` rebuilds all registered generated templates deterministically.
-- `check` renders into temporary directories and fails when committed generated
-  output has drifted from component sources. It also rejects unregistered generated
-  template directories.
+`template::check` detects generated drift, path collisions, dotfile/mode drift, and unregistered generated directories.
 
-Template registrations live in `templates/manifest.json`.
+## OpenCode hierarchy
 
-## Existing repositories
-
-Existing repositories can adopt Agent Core without losing repository-owned files.
-When no dedicated Adapter is available or detection is ambiguous, the mandatory
-`base` Adapter is used instead of creating an Adapter-less repository.
-
-```sh
-just template::adopt-plan /path/to/repository
-just template::adopt-apply /path/to/repository base
-just template::adapter-migrate-plan /path/to/repository python
-```
-
-Adoption does not commit, push, merge, stash, or reset the target repository.
+The default Main agent orchestrates Tasks; Task Orchestrators own one Task; leaf agents perform bounded work and cannot re-delegate. Model fallback is role-scoped and only automatic for classified usage/quota/rate-limit failures. Depth-2 Ask behavior has a separate reproducible manual smoke procedure under `docs/opencode-depth2-ask-smoke.md` and is not represented as PASS until executed.

--- a/components/agent-core/.automation/UPSTREAM
+++ b/components/agent-core/.automation/UPSTREAM
@@ -1,0 +1,3 @@
+repository = "github:upiscium/Templates"
+ref = "main"
+component = "components/agent-core"

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tomllib
@@ -66,21 +67,13 @@ def resolve_source(path: Path | None) -> Path:
 def plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
-    core = source / "components" / "agent-core"
-    managed = [
-        ".automation",
-        ".opencode",
-        "AGENTS.md",
-        "Justfile",
-        "opencode.json",
-    ]
     return {
         "currentVersion": local,
         "upstreamVersion": remote,
         "updateAvailable": local != remote,
         "source": str(source),
-        "managedPaths": managed,
-        "protectedRepositoryPaths": ["just/project", "just/local.just", ".github/workflows"],
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
         "readOnly": True,
     }
 
@@ -89,11 +82,7 @@ def require_maintenance(repo: Path) -> None:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    default = run(
-        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
-        cwd=repo,
-        check=False,
-    ).stdout.strip().removeprefix("origin/")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
     if default and branch == default:
         raise UpgradeError("upgrade refused on default branch")
     if not (repo / ".task-state" / "task.md").is_file():
@@ -102,21 +91,49 @@ def require_maintenance(repo: Path) -> None:
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
 
 
+def managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text in {"AGENTS.md", "Justfile", "opencode.json"}:
+        return True
+    if text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+        }
+    return False
+
+
 def apply(repo: Path, source: Path) -> dict:
     require_maintenance(repo)
     source_core = source / "components" / "agent-core"
-    # Upgrade is intentionally delegated to the Templates-side adoption renderer.
-    # This command only validates the maintenance boundary and emits the exact
-    # source/target contract; it never fetches remote code or commits changes.
+    changed: list[str] = []
+    for path in sorted(source_core.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source_core)
+        if not managed(relative):
+            continue
+        destination = repo / relative
+        before = destination.read_bytes() if destination.is_file() else None
+        data = path.read_bytes()
+        if before == data:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+        changed.append(relative.as_posix())
     return {
-        "status": "READY",
+        "status": "APPLIED",
         "repositoryRoot": str(repo),
         "sourceCore": str(source_core),
         "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "changedPaths": changed,
         "commitCreated": False,
         "pushPerformed": False,
         "mergePerformed": False,
-        "next": "Apply the Templates upgrade materialization for Agent Core-owned paths, inspect the diff, then run just project::check and repository CI before publication.",
+        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
     }
 
 
@@ -125,7 +142,7 @@ def parser() -> argparse.ArgumentParser:
     sub = p.add_subparsers(dest="command", required=True)
     sub.add_parser("version")
     check = sub.add_parser("check-update")
-    check.add_argument("--source", type=Path)
+    check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
     return p

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+class UpgradeError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def root() -> Path:
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
+    return Path(result.stdout.strip()).resolve()
+
+
+def version(repo: Path) -> str:
+    path = repo / ".automation" / "VERSION"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/VERSION")
+    return path.read_text(encoding="utf-8").strip()
+
+
+def upstream(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "UPSTREAM"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/UPSTREAM")
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    required = ("repository", "ref", "component")
+    missing = [key for key in required if not isinstance(raw.get(key), str) or not raw[key]]
+    if missing:
+        raise UpgradeError("invalid UPSTREAM fields: " + ", ".join(missing))
+    return {key: raw[key] for key in required}
+
+
+def context(repo: Path) -> dict:
+    return {
+        "version": version(repo),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "upstream": upstream(repo),
+    }
+
+
+def resolve_source(path: Path | None) -> Path:
+    if path is None:
+        raise UpgradeError("update check requires --source <Templates checkout>; no remote code is fetched automatically")
+    source = path.resolve()
+    if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
+        raise UpgradeError(f"not a Templates source checkout: {source}")
+    return source
+
+
+def plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
+    core = source / "components" / "agent-core"
+    managed = [
+        ".automation",
+        ".opencode",
+        "AGENTS.md",
+        "Justfile",
+        "opencode.json",
+    ]
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": local != remote,
+        "source": str(source),
+        "managedPaths": managed,
+        "protectedRepositoryPaths": ["just/project", "just/local.just", ".github/workflows"],
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo,
+        check=False,
+    ).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    source_core = source / "components" / "agent-core"
+    # Upgrade is intentionally delegated to the Templates-side adoption renderer.
+    # This command only validates the maintenance boundary and emits the exact
+    # source/target contract; it never fetches remote code or commits changes.
+    return {
+        "status": "READY",
+        "repositoryRoot": str(repo),
+        "sourceCore": str(source_core),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "commitCreated": False,
+        "pushPerformed": False,
+        "mergePerformed": False,
+        "next": "Apply the Templates upgrade materialization for Agent Core-owned paths, inspect the diff, then run just project::check and repository CI before publication.",
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Agent Core version/update/upgrade contract")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("version")
+    check = sub.add_parser("check-update")
+    check.add_argument("--source", type=Path)
+    upgrade = sub.add_parser("upgrade")
+    upgrade.add_argument("--source", type=Path, required=True)
+    return p
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        repo = root()
+        if args.command == "version":
+            result = context(repo)
+        elif args.command == "check-update":
+            result = plan(repo, resolve_source(args.source))
+        elif args.command == "upgrade":
+            result = apply(repo, resolve_source(args.source))
+        else:  # pragma: no cover
+            raise UpgradeError(f"unsupported command: {args.command}")
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except UpgradeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/components/agent-core/.automation/just/automation.just
+++ b/components/agent-core/.automation/just/automation.just
@@ -1,0 +1,11 @@
+root := justfile_directory() / ".." / ".."
+script := root / ".automation" / "bin" / "automation_upgrade.py"
+
+version:
+    python3 '{{script}}' version
+
+check-update source:
+    python3 '{{script}}' check-update --source '{{source}}'
+
+upgrade source:
+    python3 '{{script}}' upgrade --source '{{source}}'

--- a/components/agent-core/Justfile
+++ b/components/agent-core/Justfile
@@ -1,6 +1,7 @@
 set minimum-version := "1.52.0"
 
 mod agent '.automation/just/agent.just'
+mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'

--- a/components/agent-core/opencode.json
+++ b/components/agent-core/opencode.json
@@ -34,7 +34,6 @@
     },
     "bash": {
       "*": "ask",
-
       "git status": "allow",
       "git status *": "allow",
       "git diff": "allow",
@@ -51,7 +50,6 @@
       "git branch --list *": "allow",
       "git remote -v": "allow",
       "git worktree list *": "allow",
-
       "gh pr view *": "allow",
       "gh pr list *": "allow",
       "gh pr status *": "allow",
@@ -62,7 +60,6 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
-
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",
@@ -70,6 +67,9 @@
       "just project::test": "allow",
       "just project::build": "allow",
       "just project::check": "allow",
+      "just automation::version": "allow",
+      "just automation::check-update *": "allow",
+      "just automation::upgrade *": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",
@@ -83,7 +83,6 @@
       "just agent::push *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
-
       "git add *": "deny",
       "git commit *": "deny",
       "git push *": "deny",

--- a/templates/agent-base/.automation/UPSTREAM
+++ b/templates/agent-base/.automation/UPSTREAM
@@ -1,0 +1,3 @@
+repository = "github:upiscium/Templates"
+ref = "main"
+component = "components/agent-core"

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+class UpgradeError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def root() -> Path:
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
+    return Path(result.stdout.strip()).resolve()
+
+
+def version(repo: Path) -> str:
+    path = repo / ".automation" / "VERSION"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/VERSION")
+    return path.read_text(encoding="utf-8").strip()
+
+
+def upstream(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "UPSTREAM"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/UPSTREAM")
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    required = ("repository", "ref", "component")
+    missing = [key for key in required if not isinstance(raw.get(key), str) or not raw[key]]
+    if missing:
+        raise UpgradeError("invalid UPSTREAM fields: " + ", ".join(missing))
+    return {key: raw[key] for key in required}
+
+
+def context(repo: Path) -> dict:
+    return {
+        "version": version(repo),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "upstream": upstream(repo),
+    }
+
+
+def resolve_source(path: Path | None) -> Path:
+    if path is None:
+        raise UpgradeError("update check requires --source <Templates checkout>; no remote code is fetched automatically")
+    source = path.resolve()
+    if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
+        raise UpgradeError(f"not a Templates source checkout: {source}")
+    return source
+
+
+def plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": local != remote,
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text in {"AGENTS.md", "Justfile", "opencode.json"}:
+        return True
+    if text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+        }
+    return False
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for path in sorted(source_core.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source_core)
+        if not managed(relative):
+            continue
+        destination = repo / relative
+        before = destination.read_bytes() if destination.is_file() else None
+        data = path.read_bytes()
+        if before == data:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+        changed.append(relative.as_posix())
+    return {
+        "status": "APPLIED",
+        "repositoryRoot": str(repo),
+        "sourceCore": str(source_core),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "changedPaths": changed,
+        "commitCreated": False,
+        "pushPerformed": False,
+        "mergePerformed": False,
+        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Agent Core version/update/upgrade contract")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("version")
+    check = sub.add_parser("check-update")
+    check.add_argument("--source", type=Path, required=True)
+    upgrade = sub.add_parser("upgrade")
+    upgrade.add_argument("--source", type=Path, required=True)
+    return p
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        repo = root()
+        if args.command == "version":
+            result = context(repo)
+        elif args.command == "check-update":
+            result = plan(repo, resolve_source(args.source))
+        elif args.command == "upgrade":
+            result = apply(repo, resolve_source(args.source))
+        else:  # pragma: no cover
+            raise UpgradeError(f"unsupported command: {args.command}")
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except UpgradeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-base/.automation/just/automation.just
+++ b/templates/agent-base/.automation/just/automation.just
@@ -1,0 +1,11 @@
+root := justfile_directory() / ".." / ".."
+script := root / ".automation" / "bin" / "automation_upgrade.py"
+
+version:
+    python3 '{{script}}' version
+
+check-update source:
+    python3 '{{script}}' check-update --source '{{source}}'
+
+upgrade source:
+    python3 '{{script}}' upgrade --source '{{source}}'

--- a/templates/agent-base/Justfile
+++ b/templates/agent-base/Justfile
@@ -1,6 +1,7 @@
 set minimum-version := "1.52.0"
 
 mod agent '.automation/just/agent.just'
+mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'

--- a/templates/agent-base/opencode.json
+++ b/templates/agent-base/opencode.json
@@ -34,7 +34,6 @@
     },
     "bash": {
       "*": "ask",
-
       "git status": "allow",
       "git status *": "allow",
       "git diff": "allow",
@@ -51,7 +50,6 @@
       "git branch --list *": "allow",
       "git remote -v": "allow",
       "git worktree list *": "allow",
-
       "gh pr view *": "allow",
       "gh pr list *": "allow",
       "gh pr status *": "allow",
@@ -62,7 +60,6 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
-
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",
@@ -70,6 +67,9 @@
       "just project::test": "allow",
       "just project::build": "allow",
       "just project::check": "allow",
+      "just automation::version": "allow",
+      "just automation::check-update *": "allow",
+      "just automation::upgrade *": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",
@@ -83,7 +83,6 @@
       "just agent::push *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
-
       "git add *": "deny",
       "git commit *": "deny",
       "git push *": "deny",

--- a/templates/agent-cpp-cmake/.automation/UPSTREAM
+++ b/templates/agent-cpp-cmake/.automation/UPSTREAM
@@ -1,0 +1,3 @@
+repository = "github:upiscium/Templates"
+ref = "main"
+component = "components/agent-core"

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+class UpgradeError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def root() -> Path:
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
+    return Path(result.stdout.strip()).resolve()
+
+
+def version(repo: Path) -> str:
+    path = repo / ".automation" / "VERSION"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/VERSION")
+    return path.read_text(encoding="utf-8").strip()
+
+
+def upstream(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "UPSTREAM"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/UPSTREAM")
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    required = ("repository", "ref", "component")
+    missing = [key for key in required if not isinstance(raw.get(key), str) or not raw[key]]
+    if missing:
+        raise UpgradeError("invalid UPSTREAM fields: " + ", ".join(missing))
+    return {key: raw[key] for key in required}
+
+
+def context(repo: Path) -> dict:
+    return {
+        "version": version(repo),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "upstream": upstream(repo),
+    }
+
+
+def resolve_source(path: Path | None) -> Path:
+    if path is None:
+        raise UpgradeError("update check requires --source <Templates checkout>; no remote code is fetched automatically")
+    source = path.resolve()
+    if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
+        raise UpgradeError(f"not a Templates source checkout: {source}")
+    return source
+
+
+def plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": local != remote,
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text in {"AGENTS.md", "Justfile", "opencode.json"}:
+        return True
+    if text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+        }
+    return False
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for path in sorted(source_core.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source_core)
+        if not managed(relative):
+            continue
+        destination = repo / relative
+        before = destination.read_bytes() if destination.is_file() else None
+        data = path.read_bytes()
+        if before == data:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+        changed.append(relative.as_posix())
+    return {
+        "status": "APPLIED",
+        "repositoryRoot": str(repo),
+        "sourceCore": str(source_core),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "changedPaths": changed,
+        "commitCreated": False,
+        "pushPerformed": False,
+        "mergePerformed": False,
+        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Agent Core version/update/upgrade contract")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("version")
+    check = sub.add_parser("check-update")
+    check.add_argument("--source", type=Path, required=True)
+    upgrade = sub.add_parser("upgrade")
+    upgrade.add_argument("--source", type=Path, required=True)
+    return p
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        repo = root()
+        if args.command == "version":
+            result = context(repo)
+        elif args.command == "check-update":
+            result = plan(repo, resolve_source(args.source))
+        elif args.command == "upgrade":
+            result = apply(repo, resolve_source(args.source))
+        else:  # pragma: no cover
+            raise UpgradeError(f"unsupported command: {args.command}")
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except UpgradeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-cpp-cmake/.automation/just/automation.just
+++ b/templates/agent-cpp-cmake/.automation/just/automation.just
@@ -1,0 +1,11 @@
+root := justfile_directory() / ".." / ".."
+script := root / ".automation" / "bin" / "automation_upgrade.py"
+
+version:
+    python3 '{{script}}' version
+
+check-update source:
+    python3 '{{script}}' check-update --source '{{source}}'
+
+upgrade source:
+    python3 '{{script}}' upgrade --source '{{source}}'

--- a/templates/agent-cpp-cmake/Justfile
+++ b/templates/agent-cpp-cmake/Justfile
@@ -1,6 +1,7 @@
 set minimum-version := "1.52.0"
 
 mod agent '.automation/just/agent.just'
+mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'

--- a/templates/agent-cpp-cmake/opencode.json
+++ b/templates/agent-cpp-cmake/opencode.json
@@ -34,7 +34,6 @@
     },
     "bash": {
       "*": "ask",
-
       "git status": "allow",
       "git status *": "allow",
       "git diff": "allow",
@@ -51,7 +50,6 @@
       "git branch --list *": "allow",
       "git remote -v": "allow",
       "git worktree list *": "allow",
-
       "gh pr view *": "allow",
       "gh pr list *": "allow",
       "gh pr status *": "allow",
@@ -62,7 +60,6 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
-
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",
@@ -70,6 +67,9 @@
       "just project::test": "allow",
       "just project::build": "allow",
       "just project::check": "allow",
+      "just automation::version": "allow",
+      "just automation::check-update *": "allow",
+      "just automation::upgrade *": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",
@@ -83,7 +83,6 @@
       "just agent::push *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
-
       "git add *": "deny",
       "git commit *": "deny",
       "git push *": "deny",

--- a/templates/agent-nix/.automation/UPSTREAM
+++ b/templates/agent-nix/.automation/UPSTREAM
@@ -1,0 +1,3 @@
+repository = "github:upiscium/Templates"
+ref = "main"
+component = "components/agent-core"

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+class UpgradeError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def root() -> Path:
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
+    return Path(result.stdout.strip()).resolve()
+
+
+def version(repo: Path) -> str:
+    path = repo / ".automation" / "VERSION"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/VERSION")
+    return path.read_text(encoding="utf-8").strip()
+
+
+def upstream(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "UPSTREAM"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/UPSTREAM")
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    required = ("repository", "ref", "component")
+    missing = [key for key in required if not isinstance(raw.get(key), str) or not raw[key]]
+    if missing:
+        raise UpgradeError("invalid UPSTREAM fields: " + ", ".join(missing))
+    return {key: raw[key] for key in required}
+
+
+def context(repo: Path) -> dict:
+    return {
+        "version": version(repo),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "upstream": upstream(repo),
+    }
+
+
+def resolve_source(path: Path | None) -> Path:
+    if path is None:
+        raise UpgradeError("update check requires --source <Templates checkout>; no remote code is fetched automatically")
+    source = path.resolve()
+    if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
+        raise UpgradeError(f"not a Templates source checkout: {source}")
+    return source
+
+
+def plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": local != remote,
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text in {"AGENTS.md", "Justfile", "opencode.json"}:
+        return True
+    if text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+        }
+    return False
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for path in sorted(source_core.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source_core)
+        if not managed(relative):
+            continue
+        destination = repo / relative
+        before = destination.read_bytes() if destination.is_file() else None
+        data = path.read_bytes()
+        if before == data:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+        changed.append(relative.as_posix())
+    return {
+        "status": "APPLIED",
+        "repositoryRoot": str(repo),
+        "sourceCore": str(source_core),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "changedPaths": changed,
+        "commitCreated": False,
+        "pushPerformed": False,
+        "mergePerformed": False,
+        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Agent Core version/update/upgrade contract")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("version")
+    check = sub.add_parser("check-update")
+    check.add_argument("--source", type=Path, required=True)
+    upgrade = sub.add_parser("upgrade")
+    upgrade.add_argument("--source", type=Path, required=True)
+    return p
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        repo = root()
+        if args.command == "version":
+            result = context(repo)
+        elif args.command == "check-update":
+            result = plan(repo, resolve_source(args.source))
+        elif args.command == "upgrade":
+            result = apply(repo, resolve_source(args.source))
+        else:  # pragma: no cover
+            raise UpgradeError(f"unsupported command: {args.command}")
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except UpgradeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-nix/.automation/just/automation.just
+++ b/templates/agent-nix/.automation/just/automation.just
@@ -1,0 +1,11 @@
+root := justfile_directory() / ".." / ".."
+script := root / ".automation" / "bin" / "automation_upgrade.py"
+
+version:
+    python3 '{{script}}' version
+
+check-update source:
+    python3 '{{script}}' check-update --source '{{source}}'
+
+upgrade source:
+    python3 '{{script}}' upgrade --source '{{source}}'

--- a/templates/agent-nix/Justfile
+++ b/templates/agent-nix/Justfile
@@ -1,6 +1,7 @@
 set minimum-version := "1.52.0"
 
 mod agent '.automation/just/agent.just'
+mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'

--- a/templates/agent-nix/opencode.json
+++ b/templates/agent-nix/opencode.json
@@ -34,7 +34,6 @@
     },
     "bash": {
       "*": "ask",
-
       "git status": "allow",
       "git status *": "allow",
       "git diff": "allow",
@@ -51,7 +50,6 @@
       "git branch --list *": "allow",
       "git remote -v": "allow",
       "git worktree list *": "allow",
-
       "gh pr view *": "allow",
       "gh pr list *": "allow",
       "gh pr status *": "allow",
@@ -62,7 +60,6 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
-
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",
@@ -70,6 +67,9 @@
       "just project::test": "allow",
       "just project::build": "allow",
       "just project::check": "allow",
+      "just automation::version": "allow",
+      "just automation::check-update *": "allow",
+      "just automation::upgrade *": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",
@@ -83,7 +83,6 @@
       "just agent::push *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
-
       "git add *": "deny",
       "git commit *": "deny",
       "git push *": "deny",

--- a/templates/agent-python/.automation/UPSTREAM
+++ b/templates/agent-python/.automation/UPSTREAM
@@ -1,0 +1,3 @@
+repository = "github:upiscium/Templates"
+ref = "main"
+component = "components/agent-core"

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+class UpgradeError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def root() -> Path:
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
+    return Path(result.stdout.strip()).resolve()
+
+
+def version(repo: Path) -> str:
+    path = repo / ".automation" / "VERSION"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/VERSION")
+    return path.read_text(encoding="utf-8").strip()
+
+
+def upstream(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "UPSTREAM"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/UPSTREAM")
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    required = ("repository", "ref", "component")
+    missing = [key for key in required if not isinstance(raw.get(key), str) or not raw[key]]
+    if missing:
+        raise UpgradeError("invalid UPSTREAM fields: " + ", ".join(missing))
+    return {key: raw[key] for key in required}
+
+
+def context(repo: Path) -> dict:
+    return {
+        "version": version(repo),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "upstream": upstream(repo),
+    }
+
+
+def resolve_source(path: Path | None) -> Path:
+    if path is None:
+        raise UpgradeError("update check requires --source <Templates checkout>; no remote code is fetched automatically")
+    source = path.resolve()
+    if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
+        raise UpgradeError(f"not a Templates source checkout: {source}")
+    return source
+
+
+def plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": local != remote,
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text in {"AGENTS.md", "Justfile", "opencode.json"}:
+        return True
+    if text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+        }
+    return False
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for path in sorted(source_core.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source_core)
+        if not managed(relative):
+            continue
+        destination = repo / relative
+        before = destination.read_bytes() if destination.is_file() else None
+        data = path.read_bytes()
+        if before == data:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+        changed.append(relative.as_posix())
+    return {
+        "status": "APPLIED",
+        "repositoryRoot": str(repo),
+        "sourceCore": str(source_core),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "changedPaths": changed,
+        "commitCreated": False,
+        "pushPerformed": False,
+        "mergePerformed": False,
+        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Agent Core version/update/upgrade contract")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("version")
+    check = sub.add_parser("check-update")
+    check.add_argument("--source", type=Path, required=True)
+    upgrade = sub.add_parser("upgrade")
+    upgrade.add_argument("--source", type=Path, required=True)
+    return p
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        repo = root()
+        if args.command == "version":
+            result = context(repo)
+        elif args.command == "check-update":
+            result = plan(repo, resolve_source(args.source))
+        elif args.command == "upgrade":
+            result = apply(repo, resolve_source(args.source))
+        else:  # pragma: no cover
+            raise UpgradeError(f"unsupported command: {args.command}")
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except UpgradeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-python/.automation/just/automation.just
+++ b/templates/agent-python/.automation/just/automation.just
@@ -1,0 +1,11 @@
+root := justfile_directory() / ".." / ".."
+script := root / ".automation" / "bin" / "automation_upgrade.py"
+
+version:
+    python3 '{{script}}' version
+
+check-update source:
+    python3 '{{script}}' check-update --source '{{source}}'
+
+upgrade source:
+    python3 '{{script}}' upgrade --source '{{source}}'

--- a/templates/agent-python/Justfile
+++ b/templates/agent-python/Justfile
@@ -1,6 +1,7 @@
 set minimum-version := "1.52.0"
 
 mod agent '.automation/just/agent.just'
+mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'

--- a/templates/agent-python/opencode.json
+++ b/templates/agent-python/opencode.json
@@ -34,7 +34,6 @@
     },
     "bash": {
       "*": "ask",
-
       "git status": "allow",
       "git status *": "allow",
       "git diff": "allow",
@@ -51,7 +50,6 @@
       "git branch --list *": "allow",
       "git remote -v": "allow",
       "git worktree list *": "allow",
-
       "gh pr view *": "allow",
       "gh pr list *": "allow",
       "gh pr status *": "allow",
@@ -62,7 +60,6 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
-
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",
@@ -70,6 +67,9 @@
       "just project::test": "allow",
       "just project::build": "allow",
       "just project::check": "allow",
+      "just automation::version": "allow",
+      "just automation::check-update *": "allow",
+      "just automation::upgrade *": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",
@@ -83,7 +83,6 @@
       "just agent::push *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
-
       "git add *": "deny",
       "git commit *": "deny",
       "git push *": "deny",

--- a/templates/agent-rust/.automation/UPSTREAM
+++ b/templates/agent-rust/.automation/UPSTREAM
@@ -1,0 +1,3 @@
+repository = "github:upiscium/Templates"
+ref = "main"
+component = "components/agent-core"

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+class UpgradeError(RuntimeError):
+    pass
+
+
+def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result
+
+
+def root() -> Path:
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
+    return Path(result.stdout.strip()).resolve()
+
+
+def version(repo: Path) -> str:
+    path = repo / ".automation" / "VERSION"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/VERSION")
+    return path.read_text(encoding="utf-8").strip()
+
+
+def upstream(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "UPSTREAM"
+    if not path.is_file():
+        raise UpgradeError("missing .automation/UPSTREAM")
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    required = ("repository", "ref", "component")
+    missing = [key for key in required if not isinstance(raw.get(key), str) or not raw[key]]
+    if missing:
+        raise UpgradeError("invalid UPSTREAM fields: " + ", ".join(missing))
+    return {key: raw[key] for key in required}
+
+
+def context(repo: Path) -> dict:
+    return {
+        "version": version(repo),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "upstream": upstream(repo),
+    }
+
+
+def resolve_source(path: Path | None) -> Path:
+    if path is None:
+        raise UpgradeError("update check requires --source <Templates checkout>; no remote code is fetched automatically")
+    source = path.resolve()
+    if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
+        raise UpgradeError(f"not a Templates source checkout: {source}")
+    return source
+
+
+def plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": local != remote,
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text in {"AGENTS.md", "Justfile", "opencode.json"}:
+        return True
+    if text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+        }
+    return False
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for path in sorted(source_core.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(source_core)
+        if not managed(relative):
+            continue
+        destination = repo / relative
+        before = destination.read_bytes() if destination.is_file() else None
+        data = path.read_bytes()
+        if before == data:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+        changed.append(relative.as_posix())
+    return {
+        "status": "APPLIED",
+        "repositoryRoot": str(repo),
+        "sourceCore": str(source_core),
+        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+        "changedPaths": changed,
+        "commitCreated": False,
+        "pushPerformed": False,
+        "mergePerformed": False,
+        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Agent Core version/update/upgrade contract")
+    sub = p.add_subparsers(dest="command", required=True)
+    sub.add_parser("version")
+    check = sub.add_parser("check-update")
+    check.add_argument("--source", type=Path, required=True)
+    upgrade = sub.add_parser("upgrade")
+    upgrade.add_argument("--source", type=Path, required=True)
+    return p
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        repo = root()
+        if args.command == "version":
+            result = context(repo)
+        elif args.command == "check-update":
+            result = plan(repo, resolve_source(args.source))
+        elif args.command == "upgrade":
+            result = apply(repo, resolve_source(args.source))
+        else:  # pragma: no cover
+            raise UpgradeError(f"unsupported command: {args.command}")
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except UpgradeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-rust/.automation/just/automation.just
+++ b/templates/agent-rust/.automation/just/automation.just
@@ -1,0 +1,11 @@
+root := justfile_directory() / ".." / ".."
+script := root / ".automation" / "bin" / "automation_upgrade.py"
+
+version:
+    python3 '{{script}}' version
+
+check-update source:
+    python3 '{{script}}' check-update --source '{{source}}'
+
+upgrade source:
+    python3 '{{script}}' upgrade --source '{{source}}'

--- a/templates/agent-rust/Justfile
+++ b/templates/agent-rust/Justfile
@@ -1,6 +1,7 @@
 set minimum-version := "1.52.0"
 
 mod agent '.automation/just/agent.just'
+mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'

--- a/templates/agent-rust/opencode.json
+++ b/templates/agent-rust/opencode.json
@@ -34,7 +34,6 @@
     },
     "bash": {
       "*": "ask",
-
       "git status": "allow",
       "git status *": "allow",
       "git diff": "allow",
@@ -51,7 +50,6 @@
       "git branch --list *": "allow",
       "git remote -v": "allow",
       "git worktree list *": "allow",
-
       "gh pr view *": "allow",
       "gh pr list *": "allow",
       "gh pr status *": "allow",
@@ -62,7 +60,6 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
-
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",
@@ -70,6 +67,9 @@
       "just project::test": "allow",
       "just project::build": "allow",
       "just project::check": "allow",
+      "just automation::version": "allow",
+      "just automation::check-update *": "allow",
+      "just automation::upgrade *": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",
@@ -83,7 +83,6 @@
       "just agent::push *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
-
       "git add *": "deny",
       "git commit *": "deny",
       "git push *": "deny",

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import tempfile
 import unittest
 from pathlib import Path
 
@@ -29,19 +28,20 @@ class AutomationUpgradeContractTest(unittest.TestCase):
 
     def test_upgrade_preserves_adapter_and_repository_owned_paths(self) -> None:
         script = (ROOT / "components" / "agent-core" / ".automation" / "bin" / "automation_upgrade.py").read_text()
+        readme = (ROOT / "README.md").read_text()
         for protected in (
-            '.automation/ADAPTER',
-            '.automation/INIT.fragment.md',
-            '.automation/adoption.toml',
-            'just/project/**',
-            '.github/workflows/**',
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
         ):
-            self.assertIn(protected.split('/**')[0], script if protected.startswith('.automation/') else (ROOT / "README.md").read_text())
-        self.assertIn('AUTOMATION_MAINTENANCE', script)
-        self.assertIn('upgrade refused on default branch', script)
-        self.assertIn('commitCreated', script)
-        self.assertIn('pushPerformed', script)
-        self.assertIn('mergePerformed', script)
+            self.assertIn(protected, script)
+        self.assertIn("just/project/**", readme)
+        self.assertIn("repository CI", readme)
+        self.assertIn("AUTOMATION_MAINTENANCE", script)
+        self.assertIn("upgrade refused on default branch", script)
+        self.assertIn("commitCreated", script)
+        self.assertIn("pushPerformed", script)
+        self.assertIn("mergePerformed", script)
 
     def test_readme_covers_operational_entrypoints(self) -> None:
         readme = (ROOT / "README.md").read_text()

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AutomationUpgradeContractTest(unittest.TestCase):
+    def test_upstream_and_generated_parity(self) -> None:
+        upstream = ROOT / "components" / "agent-core" / ".automation" / "UPSTREAM"
+        self.assertIn('repository = "github:upiscium/Templates"', upstream.read_text())
+        for template in ("agent-base", "agent-python", "agent-rust", "agent-nix", "agent-cpp-cmake"):
+            self.assertEqual(
+                upstream.read_bytes(),
+                (ROOT / "templates" / template / ".automation" / "UPSTREAM").read_bytes(),
+            )
+
+    def test_root_router_and_permissions(self) -> None:
+        justfile = (ROOT / "components" / "agent-core" / "Justfile").read_text()
+        self.assertIn("mod automation '.automation/just/automation.just'", justfile)
+        cfg = json.loads((ROOT / "components" / "agent-core" / "opencode.json").read_text())
+        bash = cfg["permission"]["bash"]
+        self.assertEqual(bash["just automation::version"], "allow")
+        self.assertEqual(bash["just automation::check-update *"], "allow")
+        self.assertEqual(bash["just automation::upgrade *"], "ask")
+
+    def test_upgrade_preserves_adapter_and_repository_owned_paths(self) -> None:
+        script = (ROOT / "components" / "agent-core" / ".automation" / "bin" / "automation_upgrade.py").read_text()
+        for protected in (
+            '.automation/ADAPTER',
+            '.automation/INIT.fragment.md',
+            '.automation/adoption.toml',
+            'just/project/**',
+            '.github/workflows/**',
+        ):
+            self.assertIn(protected.split('/**')[0], script if protected.startswith('.automation/') else (ROOT / "README.md").read_text())
+        self.assertIn('AUTOMATION_MAINTENANCE', script)
+        self.assertIn('upgrade refused on default branch', script)
+        self.assertIn('commitCreated', script)
+        self.assertIn('pushPerformed', script)
+        self.assertIn('mergePerformed', script)
+
+    def test_readme_covers_operational_entrypoints(self) -> None:
+        readme = (ROOT / "README.md").read_text()
+        for phrase in (
+            "just automation::version",
+            "just automation::check-update",
+            "just automation::upgrade",
+            "just template::adopt-plan",
+            "base",
+            "Task Orchestrator",
+            "Ask",
+            "just project::check",
+        ):
+            self.assertIn(phrase, readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #14 by adding Agent Core upstream metadata, read-only update checks, a guarded Automation Maintenance upgrade path, and consolidated usage documentation.

Key changes:

- `.automation/UPSTREAM` records canonical Templates source/ref/component
- `just automation::version`
- `just automation::check-update <Templates checkout>` is read-only and never fetches remote code
- `just automation::upgrade <Templates checkout>` is an Ask operation
- upgrade refuses the default branch, requires Task State, and requires `AUTOMATION_MAINTENANCE=1`
- upgrade materializes only Agent Core-owned paths
- Adapter-owned ADAPTER / INIT fragment / adoption policy, `just/project/**`, local modules, and repository CI are protected
- upgrade never commits, pushes, or merges
- generated templates are synchronized with the maintenance API
- README now covers template generation, adoption, base fallback, Task/worktree lifecycle, agent hierarchy, permission boundaries, Adapter authoring, versioning, and upgrade
- contract tests cover upstream parity and maintenance permissions

## Version policy

`.automation/VERSION` remains the machine-readable Agent Core compatibility version. Breaking contract changes require a VERSION increment and migration notes. `.automation/UPSTREAM` records where update comparisons originate.

Update checks require an explicit trusted local Templates checkout; generated repositories do not fetch or execute upstream code automatically.

## Upgrade boundary

```sh
just automation::version
just automation::check-update /path/to/Templates

export AUTOMATION_MAINTENANCE=1
just automation::upgrade /path/to/Templates
```

The upgrade operation requires an explicit OpenCode Ask in addition to the runtime maintenance guard. After materialization, publication requires diff inspection, `just agent::doctor`, `just project::check`, and repository CI/smoke tests.

## Validation

This branch is directly based on the merge of #31. Existing Template CI will validate contract tests, deterministic generated drift, and all generated Project Adapter smoke tests.

Refs #14