### PR TITLE
fix: preserve repository-owned files during Agent Core upgrade

### DIFF
--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -4,15 +4,24 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tomllib
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 
 class UpgradeError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class Action:
+    path: str
+    action: str
+    reason: str
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -64,31 +73,12 @@ def resolve_source(path: Path | None) -> Path:
     return source
 
 
-def plan(repo: Path, source: Path) -> dict:
-    local = version(repo)
-    remote = version(source / "components" / "agent-core")
-    return {
-        "currentVersion": local,
-        "upstreamVersion": remote,
-        "updateAvailable": local != remote,
-        "source": str(source),
-        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
-        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
-        "readOnly": True,
-    }
-
-
-def require_maintenance(repo: Path) -> None:
-    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
-    if not branch:
-        raise UpgradeError("detached HEAD is not supported")
-    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
-    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
-        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+def load_ownership(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "ownership.toml"
+    if not path.is_file():
+        return {}
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    return {str(key): str(value) for key, value in raw.get("paths", {}).items()}
 
 
 def managed(relative: Path) -> bool:
@@ -106,24 +96,160 @@ def managed(relative: Path) -> bool:
     return False
 
 
-def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
+    begin = "<!-- BEGIN AGENT CORE RULES -->"
+    end = "<!-- END AGENT CORE RULES -->"
+    begin_count = existing.count(begin)
+    end_count = existing.count(end)
+    if begin_count != 1 or end_count != 1:
+        return None, "managed Agent Core rules block is missing or malformed"
+    start = existing.index(begin)
+    finish = existing.index(end, start) + len(end)
+    replacement = f"{begin}\n{upstream_rules.rstrip()}\n{end}"
+    return existing[:start] + replacement + existing[finish:], "replace managed Agent Core rules block"
+
+
+def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
+    module_re = re.compile(r"^(mod\??)\s+([A-Za-z0-9_-]+)\s+(['\"])(.+?)\3\s*$")
+    required: dict[str, str] = {}
+    for line in upstream.splitlines():
+        match = module_re.match(line.strip())
+        if match:
+            required[match.group(2)] = line.strip()
+    lines = existing.splitlines()
+    by_name: dict[str, list[int]] = {}
+    for index, line in enumerate(lines):
+        match = module_re.match(line.strip())
+        if match:
+            by_name.setdefault(match.group(2), []).append(index)
+    for name, expected in required.items():
+        indices = by_name.get(name, [])
+        if len(indices) > 1:
+            return None, f"Just module {name!r} is declared more than once"
+        if indices:
+            current = lines[indices[0]].strip()
+            current_match = module_re.match(current)
+            expected_match = module_re.match(expected)
+            assert current_match and expected_match
+            if current_match.group(4) != expected_match.group(4):
+                return None, f"Just module {name!r} points to repository-owned path {current_match.group(4)!r}"
+            lines[indices[0]] = expected
+        else:
+            lines.append(expected)
+    suffix = "\n" if existing.endswith("\n") or not existing else ""
+    return "\n".join(lines) + suffix, "merge Agent Core router declarations"
+
+
+def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
+    rel = relative.as_posix()
+    destination = repo / relative
+    source = source_core / relative
+    if not destination.exists():
+        return Action(rel, "create", "Agent Core-owned path is absent")
+    if not destination.is_file() or not source.is_file():
+        return Action(rel, "blocked", "non-file collision cannot be upgraded safely")
+    if destination.read_bytes() == source.read_bytes():
+        return Action(rel, "noop", "already matches upstream")
+
+    if rel == "AGENTS.md":
+        mode = ownership.get(rel)
+        if mode == "replace":
+            return Action(rel, "replace", "ownership metadata marks generated AGENTS.md as replaceable")
+        existing = destination.read_text(encoding="utf-8")
+        merged, detail = replace_agent_rules(existing, source.read_text(encoding="utf-8"))
+        return Action(rel, "merge" if merged is not None else "blocked", detail)
+
+    if rel == "Justfile":
+        mode = ownership.get(rel)
+        if mode == "replace":
+            return Action(rel, "replace", "ownership metadata marks generated Justfile as replaceable")
+        merged, detail = merge_just_router(
+            destination.read_text(encoding="utf-8"), source.read_text(encoding="utf-8")
+        )
+        return Action(rel, "merge" if merged is not None else "blocked", detail)
+
+    return Action(rel, "replace", "Agent Core-owned path")
+
+
+def build_plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
     source_core = source / "components" / "agent-core"
-    changed: list[str] = []
+    ownership = load_ownership(repo)
+    actions: list[Action] = []
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
-        if not managed(relative):
+        if managed(relative):
+            actions.append(action_for(repo, source_core, relative, ownership))
+    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": bool(changed),
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "actions": [asdict(item) for item in actions],
+        "blockers": blockers,
+        "canApply": not blockers,
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo,
+        check=False,
+    ).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    plan = build_plan(repo, source)
+    if plan["blockers"]:
+        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+    source_core = source / "components" / "agent-core"
+    ownership = load_ownership(repo)
+    changed: list[str] = []
+    for item in plan["actions"]:
+        if item["action"] == "noop":
             continue
+        relative = Path(item["path"])
+        source_path = source_core / relative
         destination = repo / relative
-        before = destination.read_bytes() if destination.is_file() else None
-        data = path.read_bytes()
-        if before == data:
-            continue
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, destination)
-        changed.append(relative.as_posix())
+        if item["action"] in {"create", "replace"}:
+            shutil.copy2(source_path, destination)
+        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            merged, detail = replace_agent_rules(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        elif item["action"] == "merge" and item["path"] == "Justfile":
+            merged, detail = merge_just_router(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        else:
+            raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
     return {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -133,7 +259,12 @@ def apply(repo: Path, source: Path) -> dict:
         "commitCreated": False,
         "pushPerformed": False,
         "mergePerformed": False,
-        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+        "requiredNextChecks": [
+            "git diff --check",
+            "just agent::doctor",
+            "just project::check",
+            "repository CI/smoke tests",
+        ],
     }
 
 
@@ -155,7 +286,7 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = plan(repo, resolve_source(args.source))
+            result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
         else:  # pragma: no cover

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -152,21 +152,22 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
         return Action(rel, "noop", "already matches upstream")
 
     if rel == "AGENTS.md":
-        mode = ownership.get(rel)
-        if mode == "replace":
-            return Action(rel, "replace", "ownership metadata marks generated AGENTS.md as replaceable")
         existing = destination.read_text(encoding="utf-8")
-        merged, detail = replace_agent_rules(existing, source.read_text(encoding="utf-8"))
-        return Action(rel, "merge" if merged is not None else "blocked", detail)
+        has_marker = "<!-- BEGIN AGENT CORE RULES -->" in existing or "<!-- END AGENT CORE RULES -->" in existing
+        if has_marker:
+            merged, detail = replace_agent_rules(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        if ownership.get(rel) == "replace":
+            return Action(rel, "replace", "ownership metadata marks generated AGENTS.md as replaceable")
+        return Action(rel, "blocked", "AGENTS.md ownership is ambiguous and no managed block exists")
 
     if rel == "Justfile":
-        mode = ownership.get(rel)
-        if mode == "replace":
-            return Action(rel, "replace", "ownership metadata marks generated Justfile as replaceable")
-        merged, detail = merge_just_router(
-            destination.read_text(encoding="utf-8"), source.read_text(encoding="utf-8")
-        )
-        return Action(rel, "merge" if merged is not None else "blocked", detail)
+        existing = destination.read_text(encoding="utf-8")
+        adopted_router = "# Agent Core module router" in existing
+        if adopted_router or ownership.get(rel) != "replace":
+            merged, detail = merge_just_router(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        return Action(rel, "replace", "ownership metadata marks generated Justfile as replaceable")
 
     return Action(rel, "replace", "Agent Core-owned path")
 
@@ -222,7 +223,6 @@ def apply(repo: Path, source: Path) -> dict:
     if plan["blockers"]:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
-    ownership = load_ownership(repo)
     changed: list[str] = []
     for item in plan["actions"]:
         if item["action"] == "noop":

--- a/components/agent-core/.automation/ownership.toml
+++ b/components/agent-core/.automation/ownership.toml
@@ -1,0 +1,5 @@
+version = 1
+
+[paths]
+"AGENTS.md" = "replace"
+"Justfile" = "replace"

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -4,15 +4,24 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tomllib
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 
 class UpgradeError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class Action:
+    path: str
+    action: str
+    reason: str
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -64,31 +73,12 @@ def resolve_source(path: Path | None) -> Path:
     return source
 
 
-def plan(repo: Path, source: Path) -> dict:
-    local = version(repo)
-    remote = version(source / "components" / "agent-core")
-    return {
-        "currentVersion": local,
-        "upstreamVersion": remote,
-        "updateAvailable": local != remote,
-        "source": str(source),
-        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
-        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
-        "readOnly": True,
-    }
-
-
-def require_maintenance(repo: Path) -> None:
-    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
-    if not branch:
-        raise UpgradeError("detached HEAD is not supported")
-    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
-    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
-        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+def load_ownership(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "ownership.toml"
+    if not path.is_file():
+        return {}
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    return {str(key): str(value) for key, value in raw.get("paths", {}).items()}
 
 
 def managed(relative: Path) -> bool:
@@ -106,24 +96,160 @@ def managed(relative: Path) -> bool:
     return False
 
 
-def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
+    begin = "<!-- BEGIN AGENT CORE RULES -->"
+    end = "<!-- END AGENT CORE RULES -->"
+    begin_count = existing.count(begin)
+    end_count = existing.count(end)
+    if begin_count != 1 or end_count != 1:
+        return None, "managed Agent Core rules block is missing or malformed"
+    start = existing.index(begin)
+    finish = existing.index(end, start) + len(end)
+    replacement = f"{begin}\n{upstream_rules.rstrip()}\n{end}"
+    return existing[:start] + replacement + existing[finish:], "replace managed Agent Core rules block"
+
+
+def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
+    module_re = re.compile(r"^(mod\??)\s+([A-Za-z0-9_-]+)\s+(['\"])(.+?)\3\s*$")
+    required: dict[str, str] = {}
+    for line in upstream.splitlines():
+        match = module_re.match(line.strip())
+        if match:
+            required[match.group(2)] = line.strip()
+    lines = existing.splitlines()
+    by_name: dict[str, list[int]] = {}
+    for index, line in enumerate(lines):
+        match = module_re.match(line.strip())
+        if match:
+            by_name.setdefault(match.group(2), []).append(index)
+    for name, expected in required.items():
+        indices = by_name.get(name, [])
+        if len(indices) > 1:
+            return None, f"Just module {name!r} is declared more than once"
+        if indices:
+            current = lines[indices[0]].strip()
+            current_match = module_re.match(current)
+            expected_match = module_re.match(expected)
+            assert current_match and expected_match
+            if current_match.group(4) != expected_match.group(4):
+                return None, f"Just module {name!r} points to repository-owned path {current_match.group(4)!r}"
+            lines[indices[0]] = expected
+        else:
+            lines.append(expected)
+    suffix = "\n" if existing.endswith("\n") or not existing else ""
+    return "\n".join(lines) + suffix, "merge Agent Core router declarations"
+
+
+def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
+    rel = relative.as_posix()
+    destination = repo / relative
+    source = source_core / relative
+    if not destination.exists():
+        return Action(rel, "create", "Agent Core-owned path is absent")
+    if not destination.is_file() or not source.is_file():
+        return Action(rel, "blocked", "non-file collision cannot be upgraded safely")
+    if destination.read_bytes() == source.read_bytes():
+        return Action(rel, "noop", "already matches upstream")
+
+    if rel == "AGENTS.md":
+        existing = destination.read_text(encoding="utf-8")
+        has_marker = "<!-- BEGIN AGENT CORE RULES -->" in existing or "<!-- END AGENT CORE RULES -->" in existing
+        if has_marker:
+            merged, detail = replace_agent_rules(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        if ownership.get(rel) == "replace":
+            return Action(rel, "replace", "ownership metadata marks generated AGENTS.md as replaceable")
+        return Action(rel, "blocked", "AGENTS.md ownership is ambiguous and no managed block exists")
+
+    if rel == "Justfile":
+        existing = destination.read_text(encoding="utf-8")
+        adopted_router = "# Agent Core module router" in existing
+        if adopted_router or ownership.get(rel) != "replace":
+            merged, detail = merge_just_router(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        return Action(rel, "replace", "ownership metadata marks generated Justfile as replaceable")
+
+    return Action(rel, "replace", "Agent Core-owned path")
+
+
+def build_plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
     source_core = source / "components" / "agent-core"
-    changed: list[str] = []
+    ownership = load_ownership(repo)
+    actions: list[Action] = []
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
-        if not managed(relative):
+        if managed(relative):
+            actions.append(action_for(repo, source_core, relative, ownership))
+    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": bool(changed),
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "actions": [asdict(item) for item in actions],
+        "blockers": blockers,
+        "canApply": not blockers,
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo,
+        check=False,
+    ).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    plan = build_plan(repo, source)
+    if plan["blockers"]:
+        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for item in plan["actions"]:
+        if item["action"] == "noop":
             continue
+        relative = Path(item["path"])
+        source_path = source_core / relative
         destination = repo / relative
-        before = destination.read_bytes() if destination.is_file() else None
-        data = path.read_bytes()
-        if before == data:
-            continue
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, destination)
-        changed.append(relative.as_posix())
+        if item["action"] in {"create", "replace"}:
+            shutil.copy2(source_path, destination)
+        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            merged, detail = replace_agent_rules(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        elif item["action"] == "merge" and item["path"] == "Justfile":
+            merged, detail = merge_just_router(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        else:
+            raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
     return {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -133,7 +259,12 @@ def apply(repo: Path, source: Path) -> dict:
         "commitCreated": False,
         "pushPerformed": False,
         "mergePerformed": False,
-        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+        "requiredNextChecks": [
+            "git diff --check",
+            "just agent::doctor",
+            "just project::check",
+            "repository CI/smoke tests",
+        ],
     }
 
 
@@ -155,7 +286,7 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = plan(repo, resolve_source(args.source))
+            result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
         else:  # pragma: no cover

--- a/templates/agent-base/.automation/ownership.toml
+++ b/templates/agent-base/.automation/ownership.toml
@@ -1,0 +1,5 @@
+version = 1
+
+[paths]
+"AGENTS.md" = "replace"
+"Justfile" = "replace"

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -4,15 +4,24 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tomllib
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 
 class UpgradeError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class Action:
+    path: str
+    action: str
+    reason: str
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -64,31 +73,12 @@ def resolve_source(path: Path | None) -> Path:
     return source
 
 
-def plan(repo: Path, source: Path) -> dict:
-    local = version(repo)
-    remote = version(source / "components" / "agent-core")
-    return {
-        "currentVersion": local,
-        "upstreamVersion": remote,
-        "updateAvailable": local != remote,
-        "source": str(source),
-        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
-        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
-        "readOnly": True,
-    }
-
-
-def require_maintenance(repo: Path) -> None:
-    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
-    if not branch:
-        raise UpgradeError("detached HEAD is not supported")
-    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
-    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
-        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+def load_ownership(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "ownership.toml"
+    if not path.is_file():
+        return {}
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    return {str(key): str(value) for key, value in raw.get("paths", {}).items()}
 
 
 def managed(relative: Path) -> bool:
@@ -106,24 +96,160 @@ def managed(relative: Path) -> bool:
     return False
 
 
-def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
+    begin = "<!-- BEGIN AGENT CORE RULES -->"
+    end = "<!-- END AGENT CORE RULES -->"
+    begin_count = existing.count(begin)
+    end_count = existing.count(end)
+    if begin_count != 1 or end_count != 1:
+        return None, "managed Agent Core rules block is missing or malformed"
+    start = existing.index(begin)
+    finish = existing.index(end, start) + len(end)
+    replacement = f"{begin}\n{upstream_rules.rstrip()}\n{end}"
+    return existing[:start] + replacement + existing[finish:], "replace managed Agent Core rules block"
+
+
+def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
+    module_re = re.compile(r"^(mod\??)\s+([A-Za-z0-9_-]+)\s+(['\"])(.+?)\3\s*$")
+    required: dict[str, str] = {}
+    for line in upstream.splitlines():
+        match = module_re.match(line.strip())
+        if match:
+            required[match.group(2)] = line.strip()
+    lines = existing.splitlines()
+    by_name: dict[str, list[int]] = {}
+    for index, line in enumerate(lines):
+        match = module_re.match(line.strip())
+        if match:
+            by_name.setdefault(match.group(2), []).append(index)
+    for name, expected in required.items():
+        indices = by_name.get(name, [])
+        if len(indices) > 1:
+            return None, f"Just module {name!r} is declared more than once"
+        if indices:
+            current = lines[indices[0]].strip()
+            current_match = module_re.match(current)
+            expected_match = module_re.match(expected)
+            assert current_match and expected_match
+            if current_match.group(4) != expected_match.group(4):
+                return None, f"Just module {name!r} points to repository-owned path {current_match.group(4)!r}"
+            lines[indices[0]] = expected
+        else:
+            lines.append(expected)
+    suffix = "\n" if existing.endswith("\n") or not existing else ""
+    return "\n".join(lines) + suffix, "merge Agent Core router declarations"
+
+
+def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
+    rel = relative.as_posix()
+    destination = repo / relative
+    source = source_core / relative
+    if not destination.exists():
+        return Action(rel, "create", "Agent Core-owned path is absent")
+    if not destination.is_file() or not source.is_file():
+        return Action(rel, "blocked", "non-file collision cannot be upgraded safely")
+    if destination.read_bytes() == source.read_bytes():
+        return Action(rel, "noop", "already matches upstream")
+
+    if rel == "AGENTS.md":
+        existing = destination.read_text(encoding="utf-8")
+        has_marker = "<!-- BEGIN AGENT CORE RULES -->" in existing or "<!-- END AGENT CORE RULES -->" in existing
+        if has_marker:
+            merged, detail = replace_agent_rules(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        if ownership.get(rel) == "replace":
+            return Action(rel, "replace", "ownership metadata marks generated AGENTS.md as replaceable")
+        return Action(rel, "blocked", "AGENTS.md ownership is ambiguous and no managed block exists")
+
+    if rel == "Justfile":
+        existing = destination.read_text(encoding="utf-8")
+        adopted_router = "# Agent Core module router" in existing
+        if adopted_router or ownership.get(rel) != "replace":
+            merged, detail = merge_just_router(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        return Action(rel, "replace", "ownership metadata marks generated Justfile as replaceable")
+
+    return Action(rel, "replace", "Agent Core-owned path")
+
+
+def build_plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
     source_core = source / "components" / "agent-core"
-    changed: list[str] = []
+    ownership = load_ownership(repo)
+    actions: list[Action] = []
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
-        if not managed(relative):
+        if managed(relative):
+            actions.append(action_for(repo, source_core, relative, ownership))
+    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": bool(changed),
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "actions": [asdict(item) for item in actions],
+        "blockers": blockers,
+        "canApply": not blockers,
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo,
+        check=False,
+    ).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    plan = build_plan(repo, source)
+    if plan["blockers"]:
+        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for item in plan["actions"]:
+        if item["action"] == "noop":
             continue
+        relative = Path(item["path"])
+        source_path = source_core / relative
         destination = repo / relative
-        before = destination.read_bytes() if destination.is_file() else None
-        data = path.read_bytes()
-        if before == data:
-            continue
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, destination)
-        changed.append(relative.as_posix())
+        if item["action"] in {"create", "replace"}:
+            shutil.copy2(source_path, destination)
+        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            merged, detail = replace_agent_rules(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        elif item["action"] == "merge" and item["path"] == "Justfile":
+            merged, detail = merge_just_router(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        else:
+            raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
     return {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -133,7 +259,12 @@ def apply(repo: Path, source: Path) -> dict:
         "commitCreated": False,
         "pushPerformed": False,
         "mergePerformed": False,
-        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+        "requiredNextChecks": [
+            "git diff --check",
+            "just agent::doctor",
+            "just project::check",
+            "repository CI/smoke tests",
+        ],
     }
 
 
@@ -155,7 +286,7 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = plan(repo, resolve_source(args.source))
+            result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
         else:  # pragma: no cover

--- a/templates/agent-cpp-cmake/.automation/ownership.toml
+++ b/templates/agent-cpp-cmake/.automation/ownership.toml
@@ -1,0 +1,5 @@
+version = 1
+
+[paths]
+"AGENTS.md" = "replace"
+"Justfile" = "replace"

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -4,15 +4,24 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tomllib
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 
 class UpgradeError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class Action:
+    path: str
+    action: str
+    reason: str
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -64,31 +73,12 @@ def resolve_source(path: Path | None) -> Path:
     return source
 
 
-def plan(repo: Path, source: Path) -> dict:
-    local = version(repo)
-    remote = version(source / "components" / "agent-core")
-    return {
-        "currentVersion": local,
-        "upstreamVersion": remote,
-        "updateAvailable": local != remote,
-        "source": str(source),
-        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
-        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
-        "readOnly": True,
-    }
-
-
-def require_maintenance(repo: Path) -> None:
-    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
-    if not branch:
-        raise UpgradeError("detached HEAD is not supported")
-    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
-    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
-        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+def load_ownership(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "ownership.toml"
+    if not path.is_file():
+        return {}
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    return {str(key): str(value) for key, value in raw.get("paths", {}).items()}
 
 
 def managed(relative: Path) -> bool:
@@ -106,24 +96,160 @@ def managed(relative: Path) -> bool:
     return False
 
 
-def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
+    begin = "<!-- BEGIN AGENT CORE RULES -->"
+    end = "<!-- END AGENT CORE RULES -->"
+    begin_count = existing.count(begin)
+    end_count = existing.count(end)
+    if begin_count != 1 or end_count != 1:
+        return None, "managed Agent Core rules block is missing or malformed"
+    start = existing.index(begin)
+    finish = existing.index(end, start) + len(end)
+    replacement = f"{begin}\n{upstream_rules.rstrip()}\n{end}"
+    return existing[:start] + replacement + existing[finish:], "replace managed Agent Core rules block"
+
+
+def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
+    module_re = re.compile(r"^(mod\??)\s+([A-Za-z0-9_-]+)\s+(['\"])(.+?)\3\s*$")
+    required: dict[str, str] = {}
+    for line in upstream.splitlines():
+        match = module_re.match(line.strip())
+        if match:
+            required[match.group(2)] = line.strip()
+    lines = existing.splitlines()
+    by_name: dict[str, list[int]] = {}
+    for index, line in enumerate(lines):
+        match = module_re.match(line.strip())
+        if match:
+            by_name.setdefault(match.group(2), []).append(index)
+    for name, expected in required.items():
+        indices = by_name.get(name, [])
+        if len(indices) > 1:
+            return None, f"Just module {name!r} is declared more than once"
+        if indices:
+            current = lines[indices[0]].strip()
+            current_match = module_re.match(current)
+            expected_match = module_re.match(expected)
+            assert current_match and expected_match
+            if current_match.group(4) != expected_match.group(4):
+                return None, f"Just module {name!r} points to repository-owned path {current_match.group(4)!r}"
+            lines[indices[0]] = expected
+        else:
+            lines.append(expected)
+    suffix = "\n" if existing.endswith("\n") or not existing else ""
+    return "\n".join(lines) + suffix, "merge Agent Core router declarations"
+
+
+def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
+    rel = relative.as_posix()
+    destination = repo / relative
+    source = source_core / relative
+    if not destination.exists():
+        return Action(rel, "create", "Agent Core-owned path is absent")
+    if not destination.is_file() or not source.is_file():
+        return Action(rel, "blocked", "non-file collision cannot be upgraded safely")
+    if destination.read_bytes() == source.read_bytes():
+        return Action(rel, "noop", "already matches upstream")
+
+    if rel == "AGENTS.md":
+        existing = destination.read_text(encoding="utf-8")
+        has_marker = "<!-- BEGIN AGENT CORE RULES -->" in existing or "<!-- END AGENT CORE RULES -->" in existing
+        if has_marker:
+            merged, detail = replace_agent_rules(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        if ownership.get(rel) == "replace":
+            return Action(rel, "replace", "ownership metadata marks generated AGENTS.md as replaceable")
+        return Action(rel, "blocked", "AGENTS.md ownership is ambiguous and no managed block exists")
+
+    if rel == "Justfile":
+        existing = destination.read_text(encoding="utf-8")
+        adopted_router = "# Agent Core module router" in existing
+        if adopted_router or ownership.get(rel) != "replace":
+            merged, detail = merge_just_router(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        return Action(rel, "replace", "ownership metadata marks generated Justfile as replaceable")
+
+    return Action(rel, "replace", "Agent Core-owned path")
+
+
+def build_plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
     source_core = source / "components" / "agent-core"
-    changed: list[str] = []
+    ownership = load_ownership(repo)
+    actions: list[Action] = []
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
-        if not managed(relative):
+        if managed(relative):
+            actions.append(action_for(repo, source_core, relative, ownership))
+    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": bool(changed),
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "actions": [asdict(item) for item in actions],
+        "blockers": blockers,
+        "canApply": not blockers,
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo,
+        check=False,
+    ).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    plan = build_plan(repo, source)
+    if plan["blockers"]:
+        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for item in plan["actions"]:
+        if item["action"] == "noop":
             continue
+        relative = Path(item["path"])
+        source_path = source_core / relative
         destination = repo / relative
-        before = destination.read_bytes() if destination.is_file() else None
-        data = path.read_bytes()
-        if before == data:
-            continue
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, destination)
-        changed.append(relative.as_posix())
+        if item["action"] in {"create", "replace"}:
+            shutil.copy2(source_path, destination)
+        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            merged, detail = replace_agent_rules(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        elif item["action"] == "merge" and item["path"] == "Justfile":
+            merged, detail = merge_just_router(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        else:
+            raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
     return {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -133,7 +259,12 @@ def apply(repo: Path, source: Path) -> dict:
         "commitCreated": False,
         "pushPerformed": False,
         "mergePerformed": False,
-        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+        "requiredNextChecks": [
+            "git diff --check",
+            "just agent::doctor",
+            "just project::check",
+            "repository CI/smoke tests",
+        ],
     }
 
 
@@ -155,7 +286,7 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = plan(repo, resolve_source(args.source))
+            result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
         else:  # pragma: no cover

--- a/templates/agent-nix/.automation/ownership.toml
+++ b/templates/agent-nix/.automation/ownership.toml
@@ -1,0 +1,5 @@
+version = 1
+
+[paths]
+"AGENTS.md" = "replace"
+"Justfile" = "replace"

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -4,15 +4,24 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tomllib
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 
 class UpgradeError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class Action:
+    path: str
+    action: str
+    reason: str
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -64,31 +73,12 @@ def resolve_source(path: Path | None) -> Path:
     return source
 
 
-def plan(repo: Path, source: Path) -> dict:
-    local = version(repo)
-    remote = version(source / "components" / "agent-core")
-    return {
-        "currentVersion": local,
-        "upstreamVersion": remote,
-        "updateAvailable": local != remote,
-        "source": str(source),
-        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
-        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
-        "readOnly": True,
-    }
-
-
-def require_maintenance(repo: Path) -> None:
-    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
-    if not branch:
-        raise UpgradeError("detached HEAD is not supported")
-    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
-    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
-        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+def load_ownership(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "ownership.toml"
+    if not path.is_file():
+        return {}
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    return {str(key): str(value) for key, value in raw.get("paths", {}).items()}
 
 
 def managed(relative: Path) -> bool:
@@ -106,24 +96,160 @@ def managed(relative: Path) -> bool:
     return False
 
 
-def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
+    begin = "<!-- BEGIN AGENT CORE RULES -->"
+    end = "<!-- END AGENT CORE RULES -->"
+    begin_count = existing.count(begin)
+    end_count = existing.count(end)
+    if begin_count != 1 or end_count != 1:
+        return None, "managed Agent Core rules block is missing or malformed"
+    start = existing.index(begin)
+    finish = existing.index(end, start) + len(end)
+    replacement = f"{begin}\n{upstream_rules.rstrip()}\n{end}"
+    return existing[:start] + replacement + existing[finish:], "replace managed Agent Core rules block"
+
+
+def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
+    module_re = re.compile(r"^(mod\??)\s+([A-Za-z0-9_-]+)\s+(['\"])(.+?)\3\s*$")
+    required: dict[str, str] = {}
+    for line in upstream.splitlines():
+        match = module_re.match(line.strip())
+        if match:
+            required[match.group(2)] = line.strip()
+    lines = existing.splitlines()
+    by_name: dict[str, list[int]] = {}
+    for index, line in enumerate(lines):
+        match = module_re.match(line.strip())
+        if match:
+            by_name.setdefault(match.group(2), []).append(index)
+    for name, expected in required.items():
+        indices = by_name.get(name, [])
+        if len(indices) > 1:
+            return None, f"Just module {name!r} is declared more than once"
+        if indices:
+            current = lines[indices[0]].strip()
+            current_match = module_re.match(current)
+            expected_match = module_re.match(expected)
+            assert current_match and expected_match
+            if current_match.group(4) != expected_match.group(4):
+                return None, f"Just module {name!r} points to repository-owned path {current_match.group(4)!r}"
+            lines[indices[0]] = expected
+        else:
+            lines.append(expected)
+    suffix = "\n" if existing.endswith("\n") or not existing else ""
+    return "\n".join(lines) + suffix, "merge Agent Core router declarations"
+
+
+def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
+    rel = relative.as_posix()
+    destination = repo / relative
+    source = source_core / relative
+    if not destination.exists():
+        return Action(rel, "create", "Agent Core-owned path is absent")
+    if not destination.is_file() or not source.is_file():
+        return Action(rel, "blocked", "non-file collision cannot be upgraded safely")
+    if destination.read_bytes() == source.read_bytes():
+        return Action(rel, "noop", "already matches upstream")
+
+    if rel == "AGENTS.md":
+        existing = destination.read_text(encoding="utf-8")
+        has_marker = "<!-- BEGIN AGENT CORE RULES -->" in existing or "<!-- END AGENT CORE RULES -->" in existing
+        if has_marker:
+            merged, detail = replace_agent_rules(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        if ownership.get(rel) == "replace":
+            return Action(rel, "replace", "ownership metadata marks generated AGENTS.md as replaceable")
+        return Action(rel, "blocked", "AGENTS.md ownership is ambiguous and no managed block exists")
+
+    if rel == "Justfile":
+        existing = destination.read_text(encoding="utf-8")
+        adopted_router = "# Agent Core module router" in existing
+        if adopted_router or ownership.get(rel) != "replace":
+            merged, detail = merge_just_router(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        return Action(rel, "replace", "ownership metadata marks generated Justfile as replaceable")
+
+    return Action(rel, "replace", "Agent Core-owned path")
+
+
+def build_plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
     source_core = source / "components" / "agent-core"
-    changed: list[str] = []
+    ownership = load_ownership(repo)
+    actions: list[Action] = []
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
-        if not managed(relative):
+        if managed(relative):
+            actions.append(action_for(repo, source_core, relative, ownership))
+    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": bool(changed),
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "actions": [asdict(item) for item in actions],
+        "blockers": blockers,
+        "canApply": not blockers,
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo,
+        check=False,
+    ).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    plan = build_plan(repo, source)
+    if plan["blockers"]:
+        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for item in plan["actions"]:
+        if item["action"] == "noop":
             continue
+        relative = Path(item["path"])
+        source_path = source_core / relative
         destination = repo / relative
-        before = destination.read_bytes() if destination.is_file() else None
-        data = path.read_bytes()
-        if before == data:
-            continue
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, destination)
-        changed.append(relative.as_posix())
+        if item["action"] in {"create", "replace"}:
+            shutil.copy2(source_path, destination)
+        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            merged, detail = replace_agent_rules(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        elif item["action"] == "merge" and item["path"] == "Justfile":
+            merged, detail = merge_just_router(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        else:
+            raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
     return {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -133,7 +259,12 @@ def apply(repo: Path, source: Path) -> dict:
         "commitCreated": False,
         "pushPerformed": False,
         "mergePerformed": False,
-        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+        "requiredNextChecks": [
+            "git diff --check",
+            "just agent::doctor",
+            "just project::check",
+            "repository CI/smoke tests",
+        ],
     }
 
 
@@ -155,7 +286,7 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = plan(repo, resolve_source(args.source))
+            result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
         else:  # pragma: no cover

--- a/templates/agent-python/.automation/ownership.toml
+++ b/templates/agent-python/.automation/ownership.toml
@@ -1,0 +1,5 @@
+version = 1
+
+[paths]
+"AGENTS.md" = "replace"
+"Justfile" = "replace"

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -4,15 +4,24 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tomllib
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 
 class UpgradeError(RuntimeError):
     pass
+
+
+@dataclass(frozen=True)
+class Action:
+    path: str
+    action: str
+    reason: str
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -64,31 +73,12 @@ def resolve_source(path: Path | None) -> Path:
     return source
 
 
-def plan(repo: Path, source: Path) -> dict:
-    local = version(repo)
-    remote = version(source / "components" / "agent-core")
-    return {
-        "currentVersion": local,
-        "upstreamVersion": remote,
-        "updateAvailable": local != remote,
-        "source": str(source),
-        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
-        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
-        "readOnly": True,
-    }
-
-
-def require_maintenance(repo: Path) -> None:
-    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
-    if not branch:
-        raise UpgradeError("detached HEAD is not supported")
-    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
-    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
-        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+def load_ownership(repo: Path) -> dict[str, str]:
+    path = repo / ".automation" / "ownership.toml"
+    if not path.is_file():
+        return {}
+    raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    return {str(key): str(value) for key, value in raw.get("paths", {}).items()}
 
 
 def managed(relative: Path) -> bool:
@@ -106,24 +96,160 @@ def managed(relative: Path) -> bool:
     return False
 
 
-def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
+    begin = "<!-- BEGIN AGENT CORE RULES -->"
+    end = "<!-- END AGENT CORE RULES -->"
+    begin_count = existing.count(begin)
+    end_count = existing.count(end)
+    if begin_count != 1 or end_count != 1:
+        return None, "managed Agent Core rules block is missing or malformed"
+    start = existing.index(begin)
+    finish = existing.index(end, start) + len(end)
+    replacement = f"{begin}\n{upstream_rules.rstrip()}\n{end}"
+    return existing[:start] + replacement + existing[finish:], "replace managed Agent Core rules block"
+
+
+def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
+    module_re = re.compile(r"^(mod\??)\s+([A-Za-z0-9_-]+)\s+(['\"])(.+?)\3\s*$")
+    required: dict[str, str] = {}
+    for line in upstream.splitlines():
+        match = module_re.match(line.strip())
+        if match:
+            required[match.group(2)] = line.strip()
+    lines = existing.splitlines()
+    by_name: dict[str, list[int]] = {}
+    for index, line in enumerate(lines):
+        match = module_re.match(line.strip())
+        if match:
+            by_name.setdefault(match.group(2), []).append(index)
+    for name, expected in required.items():
+        indices = by_name.get(name, [])
+        if len(indices) > 1:
+            return None, f"Just module {name!r} is declared more than once"
+        if indices:
+            current = lines[indices[0]].strip()
+            current_match = module_re.match(current)
+            expected_match = module_re.match(expected)
+            assert current_match and expected_match
+            if current_match.group(4) != expected_match.group(4):
+                return None, f"Just module {name!r} points to repository-owned path {current_match.group(4)!r}"
+            lines[indices[0]] = expected
+        else:
+            lines.append(expected)
+    suffix = "\n" if existing.endswith("\n") or not existing else ""
+    return "\n".join(lines) + suffix, "merge Agent Core router declarations"
+
+
+def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
+    rel = relative.as_posix()
+    destination = repo / relative
+    source = source_core / relative
+    if not destination.exists():
+        return Action(rel, "create", "Agent Core-owned path is absent")
+    if not destination.is_file() or not source.is_file():
+        return Action(rel, "blocked", "non-file collision cannot be upgraded safely")
+    if destination.read_bytes() == source.read_bytes():
+        return Action(rel, "noop", "already matches upstream")
+
+    if rel == "AGENTS.md":
+        existing = destination.read_text(encoding="utf-8")
+        has_marker = "<!-- BEGIN AGENT CORE RULES -->" in existing or "<!-- END AGENT CORE RULES -->" in existing
+        if has_marker:
+            merged, detail = replace_agent_rules(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        if ownership.get(rel) == "replace":
+            return Action(rel, "replace", "ownership metadata marks generated AGENTS.md as replaceable")
+        return Action(rel, "blocked", "AGENTS.md ownership is ambiguous and no managed block exists")
+
+    if rel == "Justfile":
+        existing = destination.read_text(encoding="utf-8")
+        adopted_router = "# Agent Core module router" in existing
+        if adopted_router or ownership.get(rel) != "replace":
+            merged, detail = merge_just_router(existing, source.read_text(encoding="utf-8"))
+            return Action(rel, "merge" if merged is not None else "blocked", detail)
+        return Action(rel, "replace", "ownership metadata marks generated Justfile as replaceable")
+
+    return Action(rel, "replace", "Agent Core-owned path")
+
+
+def build_plan(repo: Path, source: Path) -> dict:
+    local = version(repo)
+    remote = version(source / "components" / "agent-core")
     source_core = source / "components" / "agent-core"
-    changed: list[str] = []
+    ownership = load_ownership(repo)
+    actions: list[Action] = []
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
-        if not managed(relative):
+        if managed(relative):
+            actions.append(action_for(repo, source_core, relative, ownership))
+    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+    return {
+        "currentVersion": local,
+        "upstreamVersion": remote,
+        "updateAvailable": bool(changed),
+        "source": str(source),
+        "managedPaths": [".automation/**", ".opencode/**", "AGENTS.md", "Justfile", "opencode.json"],
+        "protectedRepositoryPaths": ["just/project/**", "just/local.just", ".github/workflows/**"],
+        "actions": [asdict(item) for item in actions],
+        "blockers": blockers,
+        "canApply": not blockers,
+        "readOnly": True,
+    }
+
+
+def require_maintenance(repo: Path) -> None:
+    branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    if not branch:
+        raise UpgradeError("detached HEAD is not supported")
+    default = run(
+        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+        cwd=repo,
+        check=False,
+    ).stdout.strip().removeprefix("origin/")
+    if default and branch == default:
+        raise UpgradeError("upgrade refused on default branch")
+    if not (repo / ".task-state" / "task.md").is_file():
+        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
+        raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+
+
+def apply(repo: Path, source: Path) -> dict:
+    require_maintenance(repo)
+    plan = build_plan(repo, source)
+    if plan["blockers"]:
+        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+    source_core = source / "components" / "agent-core"
+    changed: list[str] = []
+    for item in plan["actions"]:
+        if item["action"] == "noop":
             continue
+        relative = Path(item["path"])
+        source_path = source_core / relative
         destination = repo / relative
-        before = destination.read_bytes() if destination.is_file() else None
-        data = path.read_bytes()
-        if before == data:
-            continue
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, destination)
-        changed.append(relative.as_posix())
+        if item["action"] in {"create", "replace"}:
+            shutil.copy2(source_path, destination)
+        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            merged, detail = replace_agent_rules(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        elif item["action"] == "merge" and item["path"] == "Justfile":
+            merged, detail = merge_just_router(
+                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
+            )
+            if merged is None:
+                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+            destination.write_text(merged, encoding="utf-8")
+        else:
+            raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
     return {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -133,7 +259,12 @@ def apply(repo: Path, source: Path) -> dict:
         "commitCreated": False,
         "pushPerformed": False,
         "mergePerformed": False,
-        "requiredNextChecks": ["git diff --check", "just agent::doctor", "just project::check", "repository CI/smoke tests"],
+        "requiredNextChecks": [
+            "git diff --check",
+            "just agent::doctor",
+            "just project::check",
+            "repository CI/smoke tests",
+        ],
     }
 
 
@@ -155,7 +286,7 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = plan(repo, resolve_source(args.source))
+            result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
         else:  # pragma: no cover

--- a/templates/agent-rust/.automation/ownership.toml
+++ b/templates/agent-rust/.automation/ownership.toml
@@ -1,0 +1,5 @@
+version = 1
+
+[paths]
+"AGENTS.md" = "replace"
+"Justfile" = "replace"

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -1,20 +1,37 @@
 from __future__ import annotations
 
+import importlib.util
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "components" / "agent-core" / ".automation" / "bin" / "automation_upgrade.py"
+SPEC = importlib.util.spec_from_file_location("automation_upgrade", SCRIPT)
+assert SPEC and SPEC.loader
+upgrade = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(upgrade)
 
 
 class AutomationUpgradeContractTest(unittest.TestCase):
     def test_upstream_and_generated_parity(self) -> None:
         upstream = ROOT / "components" / "agent-core" / ".automation" / "UPSTREAM"
+        ownership = ROOT / "components" / "agent-core" / ".automation" / "ownership.toml"
         self.assertIn('repository = "github:upiscium/Templates"', upstream.read_text())
+        self.assertIn('"AGENTS.md" = "replace"', ownership.read_text())
         for template in ("agent-base", "agent-python", "agent-rust", "agent-nix", "agent-cpp-cmake"):
             self.assertEqual(
                 upstream.read_bytes(),
                 (ROOT / "templates" / template / ".automation" / "UPSTREAM").read_bytes(),
+            )
+            self.assertEqual(
+                ownership.read_bytes(),
+                (ROOT / "templates" / template / ".automation" / "ownership.toml").read_bytes(),
+            )
+            self.assertEqual(
+                SCRIPT.read_bytes(),
+                (ROOT / "templates" / template / ".automation" / "bin" / "automation_upgrade.py").read_bytes(),
             )
 
     def test_root_router_and_permissions(self) -> None:
@@ -27,7 +44,7 @@ class AutomationUpgradeContractTest(unittest.TestCase):
         self.assertEqual(bash["just automation::upgrade *"], "ask")
 
     def test_upgrade_preserves_adapter_and_repository_owned_paths(self) -> None:
-        script = (ROOT / "components" / "agent-core" / ".automation" / "bin" / "automation_upgrade.py").read_text()
+        script = SCRIPT.read_text()
         readme = (ROOT / "README.md").read_text()
         for protected in (
             ".automation/ADAPTER",
@@ -42,6 +59,71 @@ class AutomationUpgradeContractTest(unittest.TestCase):
         self.assertIn("commitCreated", script)
         self.assertIn("pushPerformed", script)
         self.assertIn("mergePerformed", script)
+
+    def test_existing_repository_plan_merges_managed_surfaces(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory) / "repo"
+            repo.mkdir()
+            automation = repo / ".automation"
+            automation.mkdir()
+            (automation / "VERSION").write_text("1\n")
+            (automation / "ADAPTER").write_text("base\n")
+            (automation / "UPSTREAM").write_text(
+                'repository = "github:upiscium/Templates"\nref = "main"\ncomponent = "components/agent-core"\n'
+            )
+            # Deliberately retain generated ownership metadata: adoption markers
+            # must take precedence over the default replace mode.
+            (automation / "ownership.toml").write_text(
+                'version = 1\n\n[paths]\n"AGENTS.md" = "replace"\n"Justfile" = "replace"\n'
+            )
+            core_rules = (ROOT / "components" / "agent-core" / "AGENTS.md").read_text()
+            (repo / "AGENTS.md").write_text(
+                "# Existing Repository Rules\n\n"
+                "<!-- BEGIN AGENT CORE RULES -->\nold core rules\n<!-- END AGENT CORE RULES -->\n"
+            )
+            (repo / "Justfile").write_text(
+                "default:\n    @echo existing\n\n"
+                "# Agent Core module router\n"
+                "mod agent '.automation/just/agent.just'\n"
+                "mod integrate '.automation/just/integrate.just'\n"
+                "mod project 'just/project/mod.just'\n"
+                "mod? local 'just/local.just'\n"
+            )
+
+            plan = upgrade.build_plan(repo, ROOT)
+            actions = {item["path"]: item for item in plan["actions"]}
+            self.assertEqual(actions["AGENTS.md"]["action"], "merge")
+            self.assertEqual(actions["Justfile"]["action"], "merge")
+            self.assertTrue(plan["canApply"], plan["blockers"])
+
+            merged_agents, _ = upgrade.replace_agent_rules(
+                (repo / "AGENTS.md").read_text(), core_rules
+            )
+            assert merged_agents is not None
+            self.assertIn("# Existing Repository Rules", merged_agents)
+            self.assertIn(core_rules.rstrip(), merged_agents)
+
+            merged_just, _ = upgrade.merge_just_router(
+                (repo / "Justfile").read_text(),
+                (ROOT / "components" / "agent-core" / "Justfile").read_text(),
+            )
+            assert merged_just is not None
+            self.assertIn("@echo existing", merged_just)
+            self.assertIn("mod automation '.automation/just/automation.just'", merged_just)
+
+    def test_malformed_rules_and_conflicting_router_block_upgrade(self) -> None:
+        bad_agents, reason = upgrade.replace_agent_rules(
+            "<!-- BEGIN AGENT CORE RULES -->\nmissing end\n", "new rules\n"
+        )
+        self.assertIsNone(bad_agents)
+        self.assertIn("malformed", reason)
+
+        bad_just, reason = upgrade.merge_just_router(
+            "mod agent 'custom/agent.just'\n",
+            (ROOT / "components" / "agent-core" / "Justfile").read_text(),
+        )
+        self.assertIsNone(bad_just)
+        self.assertIn("repository-owned path", reason)
 
     def test_readme_covers_operational_entrypoints(self) -> None:
         readme = (ROOT / "README.md").read_text()

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,6 +12,7 @@ SCRIPT = ROOT / "components" / "agent-core" / ".automation" / "bin" / "automatio
 SPEC = importlib.util.spec_from_file_location("automation_upgrade", SCRIPT)
 assert SPEC and SPEC.loader
 upgrade = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = upgrade
 SPEC.loader.exec_module(upgrade)
 
 
@@ -71,8 +73,6 @@ class AutomationUpgradeContractTest(unittest.TestCase):
             (automation / "UPSTREAM").write_text(
                 'repository = "github:upiscium/Templates"\nref = "main"\ncomponent = "components/agent-core"\n'
             )
-            # Deliberately retain generated ownership metadata: adoption markers
-            # must take precedence over the default replace mode.
             (automation / "ownership.toml").write_text(
                 'version = 1\n\n[paths]\n"AGENTS.md" = "replace"\n"Justfile" = "replace"\n'
             )


### PR DESCRIPTION
## Summary

Implements #34 by making Agent Core upgrades ownership-aware for repositories that were adopted through #26.

The previous #14 upgrade path could replace `AGENTS.md` and `Justfile` wholesale even when adoption had safely merged repository-owned rules/recipes into those files.

This PR adds:

- `.automation/ownership.toml` for generated repositories
- path-level upgrade actions: create / replace / merge / noop / blocked
- managed Agent Core rules block replacement inside adopted `AGENTS.md`
- Agent Core router merge for adopted `Justfile`
- adoption markers take precedence over generated replace metadata
- malformed AGENTS markers and conflicting Just module paths block upgrade
- missing ownership metadata is handled conservatively rather than guessed
- Project Adapter, local modules, and repository CI remain outside the upgrade set
- source/generated parity for the ownership-aware runtime
- integration-style tests using an adopted-repository fixture

## Safety behavior

Generated repositories explicitly mark `AGENTS.md` and `Justfile` as replaceable.

Adopted repositories are detected through the existing #26 managed surfaces:

- `<!-- BEGIN AGENT CORE RULES -->` / `<!-- END AGENT CORE RULES -->`
- `# Agent Core module router`

For those repositories, upgrade updates only the managed Agent Core content and preserves repository-owned content byte-for-byte outside the managed area.

Ambiguous `AGENTS.md` ownership without a managed block is BLOCKED rather than overwritten.

`automation::check-update` now exposes path-level actions and blockers read-only. `automation::upgrade` still requires the #14 Automation Maintenance boundary and performs no commit, push, or merge.

## Validation

Existing Template CI will run contract tests, deterministic generated drift, and all generated Adapter smoke tests.

Refs #34