### PR TITLE
fix: isolate Python project environment per Task worktree

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -79,3 +79,20 @@ jobs:
           cd "$target"
           nix develop --command just project::doctor
           nix develop --command just project::check
+      - name: Python inherited worktree environment smoke
+        if: matrix.template == 'agent-python'
+        shell: bash
+        run: |
+          set -euo pipefail
+          target="$RUNNER_TEMP/${{ matrix.template }}"
+          cd "$target"
+          nix develop --command bash -c '
+            set -euo pipefail
+            export VIRTUAL_ENV=/tmp/main-worktree/.venv
+            export UV_PROJECT_ENVIRONMENT=/tmp/main-worktree/.venv
+            export PIP_REQUIRE_VIRTUALENV=0
+            export PATH="/tmp/main-worktree/.venv/bin:$PATH"
+            just project::environment
+            just project::doctor
+            just project::check
+          '

--- a/components/adapters/python/.automation/INIT.fragment.md
+++ b/components/adapters/python/.automation/INIT.fragment.md
@@ -1,6 +1,7 @@
 ## Python Project Adapter initialization
 
-- `just project::doctor` requires `uv`, `ruff`, `mypy`, and `pytest` to be available.
-- The managed virtual environment is project-local at `.venv` through `UV_PROJECT_ENVIRONMENT=$PWD/.venv`.
-- `PIP_REQUIRE_VIRTUALENV=1` must remain enabled in the development shell.
+- `just project::environment` reports the worktree-local Python environment boundary without mutating project files.
+- `just project::doctor` requires `uv`, `ruff`, `mypy`, and `pytest` to be available through that boundary.
+- The managed virtual environment is always the current worktree's `.venv`; inherited `VIRTUAL_ENV`, `UV_PROJECT_ENVIRONMENT`, or `PATH` entries for another `.venv/bin` are not trusted.
+- `PIP_REQUIRE_VIRTUALENV=1` is enforced by Project Adapter execution rather than inherited ambient shell state.
 - Dependency synchronization is explicit through `just project::python::sync`; `/init` remains read-only and does not run it.

--- a/components/adapters/python/just/project/environment.py
+++ b/components/adapters/python/just/project/environment.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def root() -> Path:
+    return Path.cwd().resolve()
+
+
+def sanitized_environment(repo: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["UV_PROJECT_ENVIRONMENT"] = str(repo / ".venv")
+    env["PIP_REQUIRE_VIRTUALENV"] = "1"
+    entries = []
+    for entry in env.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        path = Path(entry).expanduser()
+        if path.name == "bin" and path.parent.name == ".venv":
+            continue
+        entries.append(entry)
+    env["PATH"] = os.pathsep.join(entries)
+    return env
+
+
+def report(repo: Path) -> dict:
+    env = sanitized_environment(repo)
+    inherited = {
+        "VIRTUAL_ENV": os.environ.get("VIRTUAL_ENV"),
+        "UV_PROJECT_ENVIRONMENT": os.environ.get("UV_PROJECT_ENVIRONMENT"),
+    }
+    return {
+        "repositoryRoot": str(repo),
+        "inherited": inherited,
+        "resolved": {
+            "VIRTUAL_ENV": None,
+            "UV_PROJECT_ENVIRONMENT": env["UV_PROJECT_ENVIRONMENT"],
+            "PIP_REQUIRE_VIRTUALENV": env["PIP_REQUIRE_VIRTUALENV"],
+        },
+        "crossWorktreeVenvRemovedFromPath": all(
+            not (Path(entry).name == "bin" and Path(entry).parent.name == ".venv")
+            for entry in env.get("PATH", "").split(os.pathsep)
+            if entry
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Python Project Adapter worktree-local environment boundary")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("report")
+    execute = sub.add_parser("exec")
+    execute.add_argument("argv", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    repo = root()
+    if args.command == "report":
+        print(json.dumps(report(repo), sort_keys=True))
+        return 0
+    if not args.argv:
+        parser.error("exec requires a command")
+    return subprocess.run(args.argv, cwd=repo, env=sanitized_environment(repo)).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/components/adapters/python/just/project/mod.just
+++ b/components/adapters/python/just/project/mod.just
@@ -1,5 +1,6 @@
 root := justfile_directory()
 bootstrap_script := root / ".automation/bin/project_bootstrap.py"
+environment_script := root / "just/project/environment.py"
 
 mod python 'python.just'
 mod? repository 'repository.just'
@@ -9,27 +10,29 @@ bootstrap name='':
     python3 {{quote(bootstrap_script)}} {{quote(name)}}
 
 [working-directory: root]
+environment:
+    python3 {{quote(environment_script)}} report
+
+[working-directory: root]
 doctor:
-    @command -v uv >/dev/null
-    @command -v ruff >/dev/null
-    @command -v mypy >/dev/null
-    @command -v pytest >/dev/null
-    @test "${UV_PROJECT_ENVIRONMENT:-}" = "$PWD/.venv"
-    @test "${PIP_REQUIRE_VIRTUALENV:-}" = "1"
+    python3 {{quote(environment_script)}} exec uv --version >/dev/null
+    python3 {{quote(environment_script)}} exec ruff --version >/dev/null
+    python3 {{quote(environment_script)}} exec mypy --version >/dev/null
+    python3 {{quote(environment_script)}} exec pytest --version >/dev/null
     @echo "Python Project Adapter doctor: PASS"
 
 [working-directory: root]
 format-check:
-    uv run ruff format --check src tests
+    python3 {{quote(environment_script)}} exec uv run ruff format --check src tests
 
 [working-directory: root]
 lint:
-    uv run ruff check src tests
-    uv run mypy src tests
+    python3 {{quote(environment_script)}} exec uv run ruff check src tests
+    python3 {{quote(environment_script)}} exec uv run mypy src tests
 
 [working-directory: root]
 test:
-    uv run pytest -v
+    python3 {{quote(environment_script)}} exec uv run pytest -v
 
 [working-directory: root]
 build:

--- a/components/adapters/python/just/project/python.just
+++ b/components/adapters/python/just/project/python.just
@@ -1,14 +1,15 @@
 root := justfile_directory()
+environment_script := root / "just/project/environment.py"
 
 [working-directory: root]
 sync:
-    uv sync
+    python3 {{quote(environment_script)}} exec uv sync
 
 [working-directory: root]
 format:
-    uv run ruff format src tests
-    uv run ruff check --fix src tests
+    python3 {{quote(environment_script)}} exec uv run ruff format src tests
+    python3 {{quote(environment_script)}} exec uv run ruff check --fix src tests
 
 [working-directory: root]
 typecheck:
-    uv run mypy src tests
+    python3 {{quote(environment_script)}} exec uv run mypy src tests

--- a/templates/agent-python/.automation/INIT.fragment.md
+++ b/templates/agent-python/.automation/INIT.fragment.md
@@ -1,6 +1,7 @@
 ## Python Project Adapter initialization
 
-- `just project::doctor` requires `uv`, `ruff`, `mypy`, and `pytest` to be available.
-- The managed virtual environment is project-local at `.venv` through `UV_PROJECT_ENVIRONMENT=$PWD/.venv`.
-- `PIP_REQUIRE_VIRTUALENV=1` must remain enabled in the development shell.
+- `just project::environment` reports the worktree-local Python environment boundary without mutating project files.
+- `just project::doctor` requires `uv`, `ruff`, `mypy`, and `pytest` to be available through that boundary.
+- The managed virtual environment is always the current worktree's `.venv`; inherited `VIRTUAL_ENV`, `UV_PROJECT_ENVIRONMENT`, or `PATH` entries for another `.venv/bin` are not trusted.
+- `PIP_REQUIRE_VIRTUALENV=1` is enforced by Project Adapter execution rather than inherited ambient shell state.
 - Dependency synchronization is explicit through `just project::python::sync`; `/init` remains read-only and does not run it.

--- a/templates/agent-python/just/project/environment.py
+++ b/templates/agent-python/just/project/environment.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def root() -> Path:
+    return Path.cwd().resolve()
+
+
+def sanitized_environment(repo: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    env["UV_PROJECT_ENVIRONMENT"] = str(repo / ".venv")
+    env["PIP_REQUIRE_VIRTUALENV"] = "1"
+    entries = []
+    for entry in env.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        path = Path(entry).expanduser()
+        if path.name == "bin" and path.parent.name == ".venv":
+            continue
+        entries.append(entry)
+    env["PATH"] = os.pathsep.join(entries)
+    return env
+
+
+def report(repo: Path) -> dict:
+    env = sanitized_environment(repo)
+    inherited = {
+        "VIRTUAL_ENV": os.environ.get("VIRTUAL_ENV"),
+        "UV_PROJECT_ENVIRONMENT": os.environ.get("UV_PROJECT_ENVIRONMENT"),
+    }
+    return {
+        "repositoryRoot": str(repo),
+        "inherited": inherited,
+        "resolved": {
+            "VIRTUAL_ENV": None,
+            "UV_PROJECT_ENVIRONMENT": env["UV_PROJECT_ENVIRONMENT"],
+            "PIP_REQUIRE_VIRTUALENV": env["PIP_REQUIRE_VIRTUALENV"],
+        },
+        "crossWorktreeVenvRemovedFromPath": all(
+            not (Path(entry).name == "bin" and Path(entry).parent.name == ".venv")
+            for entry in env.get("PATH", "").split(os.pathsep)
+            if entry
+        ),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Python Project Adapter worktree-local environment boundary")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("report")
+    execute = sub.add_parser("exec")
+    execute.add_argument("argv", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    repo = root()
+    if args.command == "report":
+        print(json.dumps(report(repo), sort_keys=True))
+        return 0
+    if not args.argv:
+        parser.error("exec requires a command")
+    return subprocess.run(args.argv, cwd=repo, env=sanitized_environment(repo)).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-python/just/project/mod.just
+++ b/templates/agent-python/just/project/mod.just
@@ -1,5 +1,6 @@
 root := justfile_directory()
 bootstrap_script := root / ".automation/bin/project_bootstrap.py"
+environment_script := root / "just/project/environment.py"
 
 mod python 'python.just'
 mod? repository 'repository.just'
@@ -9,27 +10,29 @@ bootstrap name='':
     python3 {{quote(bootstrap_script)}} {{quote(name)}}
 
 [working-directory: root]
+environment:
+    python3 {{quote(environment_script)}} report
+
+[working-directory: root]
 doctor:
-    @command -v uv >/dev/null
-    @command -v ruff >/dev/null
-    @command -v mypy >/dev/null
-    @command -v pytest >/dev/null
-    @test "${UV_PROJECT_ENVIRONMENT:-}" = "$PWD/.venv"
-    @test "${PIP_REQUIRE_VIRTUALENV:-}" = "1"
+    python3 {{quote(environment_script)}} exec uv --version >/dev/null
+    python3 {{quote(environment_script)}} exec ruff --version >/dev/null
+    python3 {{quote(environment_script)}} exec mypy --version >/dev/null
+    python3 {{quote(environment_script)}} exec pytest --version >/dev/null
     @echo "Python Project Adapter doctor: PASS"
 
 [working-directory: root]
 format-check:
-    uv run ruff format --check src tests
+    python3 {{quote(environment_script)}} exec uv run ruff format --check src tests
 
 [working-directory: root]
 lint:
-    uv run ruff check src tests
-    uv run mypy src tests
+    python3 {{quote(environment_script)}} exec uv run ruff check src tests
+    python3 {{quote(environment_script)}} exec uv run mypy src tests
 
 [working-directory: root]
 test:
-    uv run pytest -v
+    python3 {{quote(environment_script)}} exec uv run pytest -v
 
 [working-directory: root]
 build:

--- a/templates/agent-python/just/project/python.just
+++ b/templates/agent-python/just/project/python.just
@@ -1,14 +1,15 @@
 root := justfile_directory()
+environment_script := root / "just/project/environment.py"
 
 [working-directory: root]
 sync:
-    uv sync
+    python3 {{quote(environment_script)}} exec uv sync
 
 [working-directory: root]
 format:
-    uv run ruff format src tests
-    uv run ruff check --fix src tests
+    python3 {{quote(environment_script)}} exec uv run ruff format src tests
+    python3 {{quote(environment_script)}} exec uv run ruff check --fix src tests
 
 [working-directory: root]
 typecheck:
-    uv run mypy src tests
+    python3 {{quote(environment_script)}} exec uv run mypy src tests

--- a/tests/test_worktree_environment.py
+++ b/tests/test_worktree_environment.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "components" / "adapters" / "python" / "just" / "project" / "environment.py"
+SPEC = importlib.util.spec_from_file_location("python_environment", SCRIPT)
+assert SPEC and SPEC.loader
+python_environment = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(python_environment)
+
+
+class WorktreeEnvironmentTest(unittest.TestCase):
+    def test_python_environment_rebinds_to_current_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            main = base / "main"
+            task = base / "task"
+            main.mkdir()
+            task.mkdir()
+            old = os.environ.copy()
+            try:
+                os.environ["VIRTUAL_ENV"] = str(main / ".venv")
+                os.environ["UV_PROJECT_ENVIRONMENT"] = str(main / ".venv")
+                os.environ["PIP_REQUIRE_VIRTUALENV"] = "0"
+                os.environ["PATH"] = os.pathsep.join(
+                    [str(main / ".venv" / "bin"), "/usr/bin", str(task / ".venv" / "bin")]
+                )
+                env = python_environment.sanitized_environment(task)
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+            self.assertNotIn("VIRTUAL_ENV", env)
+            self.assertEqual(env["UV_PROJECT_ENVIRONMENT"], str(task / ".venv"))
+            self.assertEqual(env["PIP_REQUIRE_VIRTUALENV"], "1")
+            self.assertNotIn(str(main / ".venv" / "bin"), env["PATH"].split(os.pathsep))
+            self.assertNotIn(str(task / ".venv" / "bin"), env["PATH"].split(os.pathsep))
+
+    def test_python_source_and_generated_environment_boundary_match(self) -> None:
+        self.assertEqual(
+            SCRIPT.read_bytes(),
+            (ROOT / "templates" / "agent-python" / "just" / "project" / "environment.py").read_bytes(),
+        )
+        for relative in ("mod.just", "python.just"):
+            self.assertEqual(
+                (ROOT / "components" / "adapters" / "python" / "just" / "project" / relative).read_bytes(),
+                (ROOT / "templates" / "agent-python" / "just" / "project" / relative).read_bytes(),
+            )
+
+    def test_other_adapters_do_not_export_cross_worktree_stateful_paths(self) -> None:
+        rust_flake = (ROOT / "components" / "adapters" / "rust" / "flake.nix").read_text(encoding="utf-8")
+        nix_flake = (ROOT / "components" / "adapters" / "nix" / "flake.nix").read_text(encoding="utf-8")
+        cpp_flake = (ROOT / "components" / "adapters" / "cpp-cmake" / "flake.nix").read_text(encoding="utf-8")
+        self.assertNotIn("CARGO_TARGET_DIR", rust_flake)
+        self.assertNotIn("CMAKE_BUILD_DIR", cpp_flake)
+        self.assertNotIn("CMAKE_PRESET", cpp_flake)
+        self.assertNotIn("CARGO_TARGET_DIR", nix_flake)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #39 by making the Python Project Adapter independent from ambient virtualenv state inherited from the Main OpenCode session.

The real #7 TUI smoke reached Main -> Task Orchestrator, but Task initialization stopped because the Task process inherited Main worktree `.venv` state. This PR establishes a worktree-local execution boundary for Python project commands.

Changes:

- add `just project::environment` read-only environment report
- add Python adapter `environment.py` sanitizer/execution wrapper
- ignore inherited `VIRTUAL_ENV`
- force `UV_PROJECT_ENVIRONMENT=$CURRENT_WORKTREE/.venv`
- force `PIP_REQUIRE_VIRTUALENV=1`
- remove all inherited `*/.venv/bin` PATH entries before project command execution
- route `project::doctor`, format/lint/test/check and `project::python::*` through the same boundary
- document the environment boundary in the Python INIT fragment
- synchronize generated `agent-python`
- add unit regression tests that simulate Main `.venv` inheritance into another worktree
- add generated-template CI smoke that injects Main-worktree virtualenv variables inside `nix develop` and requires `project::environment`, `project::doctor`, and `project::check` to succeed
- verify Rust/Nix/C++ templates do not themselves export the analogous cross-worktree stateful path variables

## Design boundary

Agent Core remains language-agnostic. Python-specific environment repair lives entirely in the Python Project Adapter. `/init` remains read-only; `project::doctor` succeeds by executing through the worktree-local environment boundary rather than mutating repository state.

## Runtime follow-up

After merge, rerun the real OpenCode #7 Depth-2 Ask smoke. The acceptance target is that Main -> Task Orchestrator -> leaf initialization reaches the permission tests even when Main was started from the main worktree Python environment.

Refs #39
Blocks #7