### PR TITLE
test: add repository-local OpenCode runtime diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.runtime-smoke/

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,7 @@
 set minimum-version := "1.31.0"
 
 mod template 'just/template.just'
+mod runtime 'just/runtime.just'
 
 default:
     @just --list

--- a/just/runtime.just
+++ b/just/runtime.just
@@ -1,0 +1,47 @@
+root := justfile_directory()
+runner := root / "tests/runtime/runtime_smoke.py"
+debug_runner := root / "tests/runtime/run_opencode_debug.sh"
+direct_runner := root / "tests/runtime/run_direct_leaf.sh"
+
+[working-directory: root]
+doctor:
+    python3 {{quote(runner)}} doctor
+
+[working-directory: root]
+prepare issue='issue-41' template='agent-python':
+    python3 {{quote(runner)}} prepare --issue {{quote(issue)}} --template {{quote(template)}}
+
+[working-directory: root]
+status issue='issue-41':
+    python3 {{quote(runner)}} status --issue {{quote(issue)}}
+
+[working-directory: root]
+diagnose-child-stall issue='issue-41':
+    @echo "Diagnostic control: in the TUI run /task-run SMOKE-CONTROL"
+    bash {{quote(debug_runner)}} {{quote(issue)}} child-stall
+
+[working-directory: root]
+smoke-depth2 issue='issue-41':
+    @echo "Depth-2 Ask smoke: in the TUI run /task-run SMOKE-ASK"
+    bash {{quote(debug_runner)}} {{quote(issue)}} depth2-ask
+
+[working-directory: root]
+smoke-fallback issue='issue-41':
+    @echo "Fallback observation: in the TUI run /task-run SMOKE-FALLBACK"
+    bash {{quote(debug_runner)}} {{quote(issue)}} fallback
+
+[working-directory: root]
+direct-leaf issue='issue-41':
+    bash {{quote(direct_runner)}} {{quote(issue)}}
+
+[working-directory: root]
+sessions issue='issue-41' label='manual':
+    python3 {{quote(runner)}} snapshot-sessions --issue {{quote(issue)}} --label {{quote(label)}}
+
+[working-directory: root]
+export-session session issue='issue-41':
+    python3 {{quote(runner)}} export-session --issue {{quote(issue)}} --session-id {{quote(session)}}
+
+[working-directory: root]
+report issue='issue-41':
+    python3 {{quote(runner)}} report --issue {{quote(issue)}}

--- a/tests/runtime/README.md
+++ b/tests/runtime/README.md
@@ -1,0 +1,125 @@
+# Repository-local runtime smoke harness
+
+Runtime validation is executed from the `Templates` repository root, while all generated fixtures, OpenCode logs, session snapshots, and reports live under the Git-ignored `.runtime-smoke/` directory.
+
+```text
+Templates/
+├── tests/runtime/                  # committed harness and procedures
+├── just/runtime.just              # stable operator API
+└── .runtime-smoke/                # local evidence; never committed
+    └── issue-41/
+        ├── smoke-repo/
+        ├── smoke-origin.git/
+        ├── logs/
+        ├── evidence/
+        ├── reports/REPORT.md
+        └── metadata.json
+```
+
+The harness never writes runtime evidence into tracked repository paths. Do not move logs or session exports into the repository for convenience; summarize evidence in the relevant GitHub Issue instead.
+
+## Prepare a fresh fixture
+
+From the `Templates` root:
+
+```sh
+just runtime::doctor
+just runtime::prepare issue-41 agent-python
+just runtime::status issue-41
+```
+
+`runtime::prepare` creates a fresh generated repository from the current checkout, runs the documented `project::bootstrap`, initializes a local disposable Git origin, verifies the Main repository, and creates three deterministic Task worktrees with concrete Task State contracts:
+
+- `SMOKE-CONTROL`: Ask-free nested leaf control
+- `SMOKE-ASK`: Depth-2 approval/rejection probe
+- `SMOKE-FALLBACK`: genuine usage-limit observation only
+
+Preparation refuses to overwrite an existing `.runtime-smoke/<issue>/` workspace. Preserve existing evidence or remove the directory explicitly before requesting a genuinely fresh run.
+
+## Direct leaf control
+
+Run the same configured `general` leaf directly in the `SMOKE-CONTROL` worktree:
+
+```sh
+just runtime::direct-leaf issue-41
+```
+
+This uses non-interactive `opencode run --agent general --format json`, writes event and DEBUG logs under `.runtime-smoke/issue-41/logs/`, and applies a bounded diagnostic timeout. This is a provider/agent isolation control only; it is not evidence that Depth-2 delegation works.
+
+## Ask-free nested control
+
+```sh
+just runtime::diagnose-child-stall issue-41
+```
+
+The command starts the real Main TUI with DEBUG logging. In the TUI, run:
+
+```text
+/task-run SMOKE-CONTROL
+```
+
+The Task contract requires the Task Orchestrator to delegate exactly one `general` leaf and for that leaf to run only `git status --short`.
+
+Interpretation:
+
+- direct leaf stalls: investigate provider/model or leaf-agent execution before nested orchestration
+- direct leaf passes but nested control stalls: investigate Task/subagent session execution
+- nested control passes: proceed to the Ask probe
+
+## Depth-2 Ask probe
+
+```sh
+just runtime::smoke-depth2 issue-41
+```
+
+Then run:
+
+```text
+/task-run SMOKE-ASK
+```
+
+The leaf contract requests two harmless unclassified Bash commands in sequence. Approve the first once and reject the second. Do not use auto-approval and do not change repository permissions.
+
+A child-session permission that can only be handled by navigating away from Main does not satisfy the centralized Main-TUI Ask requirement.
+
+## Model fallback observation
+
+```sh
+just runtime::smoke-fallback issue-41
+```
+
+Then run:
+
+```text
+/task-run SMOKE-FALLBACK
+```
+
+Do not manufacture a quota condition. If no genuine usage/quota/rate-limit failure occurs, runtime fallback remains `INCOMPLETE`.
+
+## Session evidence
+
+The interactive launchers automatically snapshot the session list before and after each TUI run. Additional snapshots can be requested explicitly:
+
+```sh
+just runtime::sessions issue-41 after-control
+```
+
+Export only session IDs relevant to this diagnostic, using OpenCode's sanitized export path:
+
+```sh
+just runtime::export-session ses_... issue-41
+```
+
+Exports are written under `.runtime-smoke/issue-41/evidence/` and must remain untracked.
+
+## Report
+
+```sh
+just runtime::report issue-41
+```
+
+Edit the returned `REPORT.md` in place. Record only observed evidence. An unexecuted item is `INCOMPLETE`, not `PASS`.
+
+## Sensitive data
+
+DEBUG logs are local diagnostic artifacts and may contain prompts, filesystem paths, provider errors, or other operational details. `.runtime-smoke/` is intentionally ignored. Do not commit or paste raw logs without reviewing them for credentials and sensitive content first.

--- a/tests/runtime/issue-41-child-stall.md
+++ b/tests/runtime/issue-41-child-stall.md
@@ -1,0 +1,122 @@
+# Issue #41 — OpenCode child-agent stall diagnosis
+
+This procedure diagnoses where a native OpenCode child-agent run stops without weakening the repository permission model.
+
+## Required order
+
+Run controls in this order and stop guessing once one fails:
+
+```text
+1. direct `general` leaf
+2. Main -> Task Orchestrator -> Ask-free `general` leaf
+3. Main -> Task Orchestrator -> Ask-producing `general` leaf
+```
+
+All runs use the same generated `agent-python` fixture prepared by `just runtime::prepare issue-41 agent-python`.
+
+## Stage model
+
+Classify the furthest evidence-backed stage reached:
+
+```text
+Task tool launch
+  -> child session creation
+  -> provider request start
+  -> provider response
+  -> tool request
+  -> permission.asked
+  -> Main TUI relay
+  -> tool execution
+  -> child completion
+```
+
+Do not infer an intermediate stage from a spinner or child label alone.
+
+## Control A — direct leaf
+
+```sh
+just runtime::direct-leaf issue-41
+```
+
+Expected diagnostic action: `general` runs `git status --short` once without editing.
+
+- PASS: provider responds, read-only command completes, process exits normally
+- FAIL: explicit provider/tool/agent error is observed
+- INCOMPLETE: bounded timeout expires without enough evidence
+
+If this control does not pass, do not attribute the nested stall to permission relay.
+
+## Control B — Ask-free nested leaf
+
+```sh
+just runtime::diagnose-child-stall issue-41
+```
+
+Inside Main TUI:
+
+```text
+/task-run SMOKE-CONTROL
+```
+
+Expected path:
+
+```text
+build -> task-orchestrator -> general -> git status --short -> return
+```
+
+No Ask event is required by this control.
+
+- direct PASS + nested FAIL/INCOMPLETE: prioritize nested Task/session/provider execution
+- direct PASS + nested PASS: nested provider path works; continue to Ask probe
+
+## Control C — Depth-2 Ask
+
+```sh
+just runtime::smoke-depth2 issue-41
+```
+
+Inside Main TUI:
+
+```text
+/task-run SMOKE-ASK
+```
+
+The leaf must request exactly these harmless commands in sequence:
+
+```sh
+printf 'depth2-ask-approved\n'
+printf 'depth2-ask-rejected\n'
+```
+
+Approve the first once and reject the second.
+
+If provider response and tool request are visible but `permission.asked` or Main relay is absent, prioritize permission propagation. If no provider response occurs, keep the diagnosis in the provider/session path.
+
+## Evidence collection
+
+Interactive launchers write DEBUG stderr logs locally and take pre/post session-list snapshots. Record relevant session IDs, then export only those sessions:
+
+```sh
+just runtime::export-session <session-id> issue-41
+```
+
+Use the sanitized export as supporting evidence, not as a replacement for real TUI observation.
+
+## Decision table
+
+| Direct leaf | Nested Ask-free | Ask probe | Primary suspicion |
+|---|---|---|---|
+| stall | not run | not run | provider/model/direct leaf execution |
+| pass | stall | not run | nested Task/subagent session execution |
+| pass | pass | stall before permission event | Ask-producing leaf/provider/tool request path |
+| pass | pass | permission event exists but Main cannot handle it | permission relay/UI propagation |
+| pass | pass | approve/reject both work | #7 may proceed to remaining permission-boundary checks |
+
+## Non-negotiable constraints
+
+- Do not change Ask to allow.
+- Do not use OpenCode `--auto` for the permission smoke.
+- Do not substitute configured models.
+- Do not damage credentials or deliberately exhaust quota.
+- Do not report a timeout as PASS.
+- Do not commit `.runtime-smoke/` evidence.

--- a/tests/runtime/run_direct_leaf.sh
+++ b/tests/runtime/run_direct_leaf.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+issue="${1:-issue-41}"
+root="$(git rev-parse --show-toplevel)"
+workspace="$root/.runtime-smoke/$issue"
+repo="$workspace/smoke-repo"
+task_repo="$repo/.worktrees/SMOKE-CONTROL-ask-free-control"
+logs="$workspace/logs"
+timeout_seconds="${RUNTIME_TIMEOUT_SECONDS:-180}"
+
+if [[ ! -d "$task_repo" ]]; then
+  echo "missing SMOKE-CONTROL worktree: $task_repo" >&2
+  echo "run: just runtime::prepare $issue" >&2
+  exit 2
+fi
+
+opencode_bin="$(command -v opencode || true)"
+if [[ -z "$opencode_bin" ]]; then
+  echo "opencode is not available in PATH" >&2
+  exit 2
+fi
+
+mkdir -p "$logs"
+stamp="$(date +%Y%m%dT%H%M%S)"
+events="$logs/direct-leaf-${stamp}.jsonl"
+debug="$logs/direct-leaf-${stamp}.debug.log"
+
+cd "$task_repo"
+export OPENCODE_BIN="$opencode_bin"
+export OPENCODE_DISABLE_AUTOUPDATE=1
+export RUNTIME_TIMEOUT_SECONDS="$timeout_seconds"
+
+set +e
+nix develop --command bash -c '
+  set -euo pipefail
+  export VIRTUAL_ENV="$PWD/.venv"
+  export UV_PROJECT_ENVIRONMENT="$PWD/.venv"
+  export PIP_REQUIRE_VIRTUALENV=1
+  export PATH="$PWD/.venv/bin:$PATH"
+  timeout "${RUNTIME_TIMEOUT_SECONDS}s" "$OPENCODE_BIN" --print-logs --log-level DEBUG run \
+    --agent general \
+    --format json \
+    "Diagnostic control only: run git status --short exactly once, do not edit files, and report the result."
+' >"$events" 2> >(tee "$debug" >&2)
+status=$?
+set -e
+
+echo "events: $events"
+echo "debug:  $debug"
+if [[ "$status" -eq 124 ]]; then
+  echo "direct leaf control timed out after ${timeout_seconds}s" >&2
+fi
+exit "$status"

--- a/tests/runtime/run_opencode_debug.sh
+++ b/tests/runtime/run_opencode_debug.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+issue="${1:-issue-41}"
+mode="${2:-child-stall}"
+root="$(git rev-parse --show-toplevel)"
+runner="$root/tests/runtime/runtime_smoke.py"
+workspace="$root/.runtime-smoke/$issue"
+repo="$workspace/smoke-repo"
+logs="$workspace/logs"
+
+if [[ ! -d "$repo" ]]; then
+  echo "missing prepared runtime fixture: $repo" >&2
+  echo "run: just runtime::prepare $issue" >&2
+  exit 2
+fi
+
+opencode_bin="$(command -v opencode || true)"
+if [[ -z "$opencode_bin" ]]; then
+  echo "opencode is not available in PATH" >&2
+  exit 2
+fi
+
+mkdir -p "$logs" "$workspace/evidence"
+stamp="$(date +%Y%m%dT%H%M%S)"
+log="$logs/opencode-${mode}-${stamp}.log"
+
+python3 "$runner" snapshot-sessions --issue "$issue" --label "before-$mode-$stamp" >/dev/null
+
+cd "$repo"
+export OPENCODE_BIN="$opencode_bin"
+export OPENCODE_DISABLE_AUTOUPDATE=1
+
+echo "OpenCode runtime diagnostic"
+echo "  issue: $issue"
+echo "  mode:  $mode"
+echo "  repo:  $repo"
+echo "  log:   $log"
+echo
+
+set +e
+nix develop --command bash -c '
+  set -euo pipefail
+  export VIRTUAL_ENV="$PWD/.venv"
+  export UV_PROJECT_ENVIRONMENT="$PWD/.venv"
+  export PIP_REQUIRE_VIRTUALENV=1
+  export PATH="$PWD/.venv/bin:$PATH"
+  exec "$OPENCODE_BIN" --print-logs --log-level DEBUG
+' 2> >(tee "$log" >&2)
+status=$?
+set -e
+
+python3 "$runner" snapshot-sessions --issue "$issue" --label "after-$mode-$stamp" >/dev/null || true
+
+echo
+echo "debug log: $log"
+echo "report:    $workspace/reports/REPORT.md"
+exit "$status"

--- a/tests/runtime/runtime_smoke.py
+++ b/tests/runtime/runtime_smoke.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNTIME_ROOT = ROOT / ".runtime-smoke"
+SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class RuntimeSmokeError(RuntimeError):
+    pass
+
+
+def validate_name(value: str, label: str) -> str:
+    if not SAFE_NAME.fullmatch(value):
+        raise RuntimeSmokeError(f"invalid {label}: {value!r}")
+    return value
+
+
+def workspace(issue: str) -> Path:
+    return RUNTIME_ROOT / validate_name(issue, "issue name")
+
+
+def smoke_repo(issue: str) -> Path:
+    return workspace(issue) / "smoke-repo"
+
+
+def run_capture(command: list[str], *, cwd: Path) -> str:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise RuntimeSmokeError(f"{' '.join(command)}: {detail}")
+    return result.stdout.strip()
+
+
+def tail(path: Path, count: int = 80) -> str:
+    if not path.is_file():
+        return ""
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return "\n".join(lines[-count:])
+
+
+def run_logged(command: list[str], *, cwd: Path, log: Path) -> None:
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a", encoding="utf-8") as handle:
+        handle.write(f"\n$ {' '.join(command)}\n")
+        handle.flush()
+        result = subprocess.run(command, cwd=cwd, text=True, stdout=handle, stderr=subprocess.STDOUT)
+    if result.returncode != 0:
+        raise RuntimeSmokeError(
+            f"{' '.join(command)} failed with exit {result.returncode}\n{tail(log)}"
+        )
+
+
+def required_tools() -> list[str]:
+    return ["git", "nix", "just", "python3", "opencode"]
+
+
+def doctor() -> dict:
+    missing = [tool for tool in required_tools() if shutil.which(tool) is None]
+    if missing:
+        raise RuntimeSmokeError("missing runtime tools: " + ", ".join(missing))
+    ignore = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+    if "/.runtime-smoke/" not in ignore:
+        raise RuntimeSmokeError("/.runtime-smoke/ is not ignored by the Templates repository")
+    return {
+        "status": "PASS",
+        "repositoryRoot": str(ROOT),
+        "runtimeRoot": str(RUNTIME_ROOT),
+        "opencodeVersion": run_capture(["opencode", "--version"], cwd=ROOT),
+    }
+
+
+def identity(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    result: dict[str, str] = {}
+    for label, key in (
+        ("Task ID", "task"),
+        ("Branch", "branch"),
+        ("Worktree", "worktree"),
+        ("Base branch", "base"),
+        ("Base revision", "base_revision"),
+    ):
+        match = re.search(rf"(?m)^- {re.escape(label)}: (.+)$", text)
+        if not match:
+            raise RuntimeSmokeError(f"Task State missing {label}: {path}")
+        result[key] = match.group(1).strip()
+    return result
+
+
+def write_contract(path: Path, *, purpose: str, scope: list[str], acceptance: list[str], test_plan: list[str]) -> None:
+    item = identity(path)
+    scope_text = "\n".join(f"- {entry}" for entry in scope)
+    acceptance_text = "\n".join(f"- [ ] {entry}" for entry in acceptance)
+    test_text = "\n".join(f"- {entry}" for entry in test_plan)
+    text = f"""# {item['task']}
+
+## Identity
+
+- Task ID: {item['task']}
+- Branch: {item['branch']}
+- Worktree: {item['worktree']}
+- Base branch: {item['base']}
+- Base revision: {item['base_revision']}
+
+## Purpose
+
+{purpose}
+
+## Scope
+
+{scope_text}
+
+## Coordination surfaces
+
+- OpenCode Main TUI
+- Task Orchestrator child session
+- Depth-2 leaf session when required by this Task
+
+## External resources
+
+- Local `.runtime-smoke/` evidence only
+
+## Prohibited changes
+
+- Do not modify tracked repository files.
+- Do not modify Agent Core, Project Adapter, permissions, credentials, or configured model IDs.
+- Do not commit, push, create a PR, or merge.
+- Do not weaken an Ask/deny boundary to make the diagnostic pass.
+
+## Dependencies
+
+- Main runtime initialization passed.
+- Task worktree identity and project environment checks passed.
+
+## Acceptance criteria
+
+{acceptance_text}
+
+## Test plan
+
+{test_text}
+
+## Stop conditions
+
+- A permission or configured model must be changed to continue.
+- Provider credentials would need to be modified.
+- The requested diagnostic leaves the assigned worktree.
+
+## Current state
+
+- Status: initialized
+- Blockers: none
+- Unverified: runtime observations
+
+## Work Units
+
+None yet.
+
+## Evidence
+
+### Changed files
+
+None expected.
+
+### Commands
+
+None recorded yet.
+
+### Reviews
+
+None.
+
+### Git
+
+- Commit: none
+- Remote branch: none
+- Pull request: none
+- Published head SHA: none
+
+## Follow-up Task candidates
+
+None yet.
+"""
+    path.write_text(text, encoding="utf-8")
+
+
+def task_contracts(repo: Path) -> None:
+    definitions = (
+        (
+            "SMOKE-CONTROL",
+            "ask-free-control",
+            "Diagnose whether a nested Depth-2 leaf can complete without any Ask permission event.",
+            [
+                "Task Orchestrator must delegate exactly one Work Unit to `general`.",
+                "The leaf must run only `git status --short` once and return the result.",
+                "The leaf must not edit files and must not request any unclassified Bash command.",
+            ],
+            [
+                "Task Orchestrator launches the Depth-2 leaf.",
+                "A provider response is observed for the leaf.",
+                "`git status --short` completes without a permission dialog.",
+                "The leaf returns to its parent instead of remaining busy indefinitely.",
+            ],
+            ["Run from Main TUI with `/task-run SMOKE-CONTROL` under `just runtime::diagnose-child-stall`."],
+        ),
+        (
+            "SMOKE-ASK",
+            "depth2-ask",
+            "Exercise a harmless Depth-2 Bash Ask from a leaf and observe approval/rejection relay in Main TUI.",
+            [
+                "Task Orchestrator must delegate the Ask probe to exactly one `general` leaf.",
+                "The leaf first requests `printf 'depth2-ask-approved\\n'` through Bash and waits for approval.",
+                "After the first probe resolves, the leaf requests `printf 'depth2-ask-rejected\\n'` and waits for rejection.",
+                "Do not perform unrelated implementation or repository changes.",
+            ],
+            [
+                "Depth-2 Ask is visible from the Main TUI.",
+                "Single-command approval propagates to the leaf.",
+                "Rejection propagates to the leaf without weakening permissions.",
+            ],
+            ["Run from Main TUI with `/task-run SMOKE-ASK` under `just runtime::smoke-depth2`."],
+        ),
+        (
+            "SMOKE-FALLBACK",
+            "model-fallback",
+            "Observe genuine usage/quota/rate-limit fallback behavior without manufacturing a provider failure.",
+            [
+                "Task Orchestrator may delegate one trivial read-only Work Unit to a leaf.",
+                "Do not intentionally consume quota or damage credentials/model configuration.",
+                "If no genuine usage-limit condition occurs, record runtime fallback as INCOMPLETE.",
+            ],
+            [
+                "Any genuine eligible failure is classified before fallback.",
+                "Only the configured fallback variant is selected.",
+                "No genuine trigger is reported as INCOMPLETE rather than PASS.",
+            ],
+            ["Run from Main TUI with `/task-run SMOKE-FALLBACK` under `just runtime::smoke-fallback`."],
+        ),
+    )
+    for task, slug, purpose, scope, acceptance, test_plan in definitions:
+        run_logged(
+            ["nix", "develop", "--command", "just", "agent::task-start", task, slug],
+            cwd=repo,
+            log=workspace("issue-41") / "logs" / "prepare.log" if False else repo.parent / "logs" / "prepare.log",
+        )
+        state = repo / ".worktrees" / f"{task}-{slug}" / ".task-state" / "task.md"
+        write_contract(state, purpose=purpose, scope=scope, acceptance=acceptance, test_plan=test_plan)
+
+
+def report_template(issue: str, metadata: dict) -> str:
+    return f"""# Runtime Diagnostic Report — {issue}
+
+## Environment
+
+- Templates commit: `{metadata['templatesCommit']}`
+- OpenCode version: `{metadata['opencodeVersion']}`
+- Template: `{metadata['template']}`
+- Fixture: `{metadata['smokeRepo']}`
+- Created: {metadata['createdAt']}
+
+## Preparation
+
+- `runtime::doctor`: PASS
+- fixture bootstrap: PASS
+- Main initialization: PASS
+- SMOKE-CONTROL contract: READY
+- SMOKE-ASK contract: READY
+- SMOKE-FALLBACK contract: READY
+
+## Ask-free nested control
+
+- Log:
+- Main session ID:
+- Task Orchestrator session ID:
+- Leaf session ID:
+- child session created: PASS / FAIL / INCOMPLETE
+- provider request started: PASS / FAIL / INCOMPLETE
+- provider response observed: PASS / FAIL / INCOMPLETE
+- read-only tool completed: PASS / FAIL / INCOMPLETE
+- child returned to parent: PASS / FAIL / INCOMPLETE
+- result: PASS / FAIL / INCOMPLETE
+
+## Direct leaf control
+
+- Events log:
+- Debug log:
+- `general` provider response: PASS / FAIL / INCOMPLETE
+- `git status --short` completed: PASS / FAIL / INCOMPLETE
+- result: PASS / FAIL / INCOMPLETE
+
+## Depth-2 Ask probe
+
+- Log:
+- Main session ID:
+- Task Orchestrator session ID:
+- Leaf session ID:
+- provider response before Ask: PASS / FAIL / INCOMPLETE
+- `permission.asked` observed: PASS / FAIL / INCOMPLETE
+- Ask visible in Main TUI: PASS / FAIL / INCOMPLETE
+- approval propagation: PASS / FAIL / INCOMPLETE
+- rejection propagation: PASS / FAIL / INCOMPLETE
+- result: PASS / FAIL / INCOMPLETE
+
+## Model fallback observation
+
+- deterministic preflight: PASS / FAIL / INCOMPLETE
+- genuine usage-limit observed: YES / NO
+- runtime fallback: PASS / FAIL / INCOMPLETE
+
+## Diagnosis
+
+- suspected stop stage:
+- provider/session stall vs permission relay:
+- upstream issue/version evidence:
+- repository-local config evidence:
+
+## Repository integrity
+
+- Templates checkout dirty: YES / NO
+- fixture tracked changes: YES / NO
+- commits/push/PR/merge beyond fixture setup: YES / NO
+
+## Final verdict
+
+- #41 diagnostic acceptance: PASS / FAIL / INCOMPLETE
+- #7 ready for full permission smoke: YES / NO
+- #23 runtime acceptance: PASS / FAIL / INCOMPLETE
+
+## Notes
+
+Record only evidence actually observed. Do not infer PASS from static checks.
+"""
+
+
+def prepare(issue: str, template: str) -> dict:
+    issue = validate_name(issue, "issue name")
+    template = validate_name(template, "template")
+    doctor()
+    base = workspace(issue)
+    if base.exists():
+        raise RuntimeSmokeError(
+            f"runtime workspace already exists: {base}; preserve it as evidence or remove it explicitly before a fresh run"
+        )
+    logs = base / "logs"
+    reports = base / "reports"
+    evidence = base / "evidence"
+    repo = base / "smoke-repo"
+    origin = base / "smoke-origin.git"
+    for path in (logs, reports, evidence, repo):
+        path.mkdir(parents=True, exist_ok=True)
+    prepare_log = logs / "prepare.log"
+
+    run_logged(["nix", "flake", "init", "-t", f"path:{ROOT}#{template}"], cwd=repo, log=prepare_log)
+    run_logged(["nix", "develop", "--command", "just", "project::bootstrap", "smoke-project"], cwd=repo, log=prepare_log)
+    if template == "agent-python":
+        run_logged(["nix", "develop", "--command", "just", "project::python::sync"], cwd=repo, log=prepare_log)
+
+    run_logged(["git", "init", "-b", "main"], cwd=repo, log=prepare_log)
+    run_logged(["git", "config", "user.name", "OpenCode Runtime Smoke"], cwd=repo, log=prepare_log)
+    run_logged(["git", "config", "user.email", "opencode-runtime-smoke@example.invalid"], cwd=repo, log=prepare_log)
+    run_logged(["git", "add", "."], cwd=repo, log=prepare_log)
+    run_logged(["git", "commit", "-m", "Initialize runtime smoke fixture"], cwd=repo, log=prepare_log)
+    run_logged(["git", "init", "--bare", str(origin)], cwd=ROOT, log=prepare_log)
+    run_logged(["git", "remote", "add", "origin", str(origin)], cwd=repo, log=prepare_log)
+    run_logged(["git", "push", "-u", "origin", "main"], cwd=repo, log=prepare_log)
+    run_logged(["git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], cwd=repo, log=prepare_log)
+
+    for recipe in ("agent::doctor", "agent::context", "project::doctor", "project::check"):
+        run_logged(["nix", "develop", "--command", "just", recipe], cwd=repo, log=prepare_log)
+    dirty = run_capture(["git", "status", "--porcelain"], cwd=repo)
+    if dirty:
+        raise RuntimeSmokeError(f"fixture is dirty after initialization:\n{dirty}")
+
+    # Create deterministic Tasks after the clean baseline is established.
+    definitions = (
+        ("SMOKE-CONTROL", "ask-free-control", "Diagnose whether a nested Depth-2 leaf can complete without any Ask permission event.", ["Task Orchestrator must delegate exactly one Work Unit to `general`.", "The leaf must run only `git status --short` once and return the result.", "The leaf must not edit files and must not request any unclassified Bash command."], ["Task Orchestrator launches the Depth-2 leaf.", "A provider response is observed for the leaf.", "`git status --short` completes without a permission dialog.", "The leaf returns to its parent instead of remaining busy indefinitely."], ["Run from Main TUI with `/task-run SMOKE-CONTROL` under `just runtime::diagnose-child-stall`."]),
+        ("SMOKE-ASK", "depth2-ask", "Exercise a harmless Depth-2 Bash Ask from a leaf and observe approval/rejection relay in Main TUI.", ["Task Orchestrator must delegate the Ask probe to exactly one `general` leaf.", "The leaf first requests `printf 'depth2-ask-approved\\n'` through Bash and waits for approval.", "After the first probe resolves, the leaf requests `printf 'depth2-ask-rejected\\n'` and waits for rejection.", "Do not perform unrelated implementation or repository changes."], ["Depth-2 Ask is visible from the Main TUI.", "Single-command approval propagates to the leaf.", "Rejection propagates to the leaf without weakening permissions."], ["Run from Main TUI with `/task-run SMOKE-ASK` under `just runtime::smoke-depth2`."]),
+        ("SMOKE-FALLBACK", "model-fallback", "Observe genuine usage/quota/rate-limit fallback behavior without manufacturing a provider failure.", ["Task Orchestrator may delegate one trivial read-only Work Unit to a leaf.", "Do not intentionally consume quota or damage credentials/model configuration.", "If no genuine usage-limit condition occurs, record runtime fallback as INCOMPLETE."], ["Any genuine eligible failure is classified before fallback.", "Only the configured fallback variant is selected.", "No genuine trigger is reported as INCOMPLETE rather than PASS."], ["Run from Main TUI with `/task-run SMOKE-FALLBACK` under `just runtime::smoke-fallback`."]),
+    )
+    for task, slug, purpose, scope, acceptance, test_plan in definitions:
+        run_logged(["nix", "develop", "--command", "just", "agent::task-start", task, slug], cwd=repo, log=prepare_log)
+        state = repo / ".worktrees" / f"{task}-{slug}" / ".task-state" / "task.md"
+        write_contract(state, purpose=purpose, scope=scope, acceptance=acceptance, test_plan=test_plan)
+
+    metadata = {
+        "issue": issue,
+        "template": template,
+        "templatesCommit": run_capture(["git", "rev-parse", "HEAD"], cwd=ROOT),
+        "opencodeVersion": run_capture(["opencode", "--version"], cwd=ROOT),
+        "createdAt": datetime.now(timezone.utc).isoformat(),
+        "smokeRepo": str(repo),
+        "origin": str(origin),
+    }
+    (base / "metadata.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    report = reports / "REPORT.md"
+    report.write_text(report_template(issue, metadata), encoding="utf-8")
+    return {"status": "PASS", **metadata, "report": str(report), "prepareLog": str(prepare_log)}
+
+
+def status(issue: str) -> dict:
+    base = workspace(issue)
+    repo = smoke_repo(issue)
+    if not repo.is_dir():
+        raise RuntimeSmokeError(f"missing prepared smoke repository: {repo}")
+    return {
+        "issue": issue,
+        "workspace": str(base),
+        "smokeRepo": str(repo),
+        "gitStatus": run_capture(["git", "status", "--porcelain"], cwd=repo).splitlines(),
+        "worktrees": run_capture(["git", "worktree", "list", "--porcelain"], cwd=repo).splitlines(),
+        "report": str(base / "reports" / "REPORT.md"),
+        "logs": str(base / "logs"),
+        "evidence": str(base / "evidence"),
+    }
+
+
+def snapshot_sessions(issue: str, label: str) -> dict:
+    label = validate_name(label, "snapshot label")
+    repo = smoke_repo(issue)
+    if not repo.is_dir():
+        raise RuntimeSmokeError(f"missing prepared smoke repository: {repo}")
+    output = run_capture(["opencode", "session", "list", "--format", "json"], cwd=repo)
+    destination = workspace(issue) / "evidence" / f" sessions-{label}.json"
+    destination = destination.with_name(destination.name.lstrip())
+    destination.write_text(output + "\n", encoding="utf-8")
+    return {"status": "PASS", "path": str(destination)}
+
+
+def export_session(issue: str, session_id: str) -> dict:
+    validate_name(session_id, "session id")
+    repo = smoke_repo(issue)
+    if not repo.is_dir():
+        raise RuntimeSmokeError(f"missing prepared smoke repository: {repo}")
+    result = subprocess.run(
+        ["opencode", "export", "--sanitize", session_id],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise RuntimeSmokeError(f"opencode export failed: {detail}")
+    destination = workspace(issue) / "evidence" / f"session-{session_id}.json"
+    destination.write_text(result.stdout, encoding="utf-8")
+    return {"status": "PASS", "path": str(destination), "sanitized": True}
+
+
+def report(issue: str) -> dict:
+    path = workspace(issue) / "reports" / "REPORT.md"
+    if not path.is_file():
+        raise RuntimeSmokeError(f"missing runtime report: {path}")
+    return {"report": str(path)}
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description="Repository-local OpenCode runtime smoke harness")
+    sub = result.add_subparsers(dest="command", required=True)
+    sub.add_parser("doctor")
+    p = sub.add_parser("prepare")
+    p.add_argument("--issue", default="issue-41")
+    p.add_argument("--template", default="agent-python")
+    p = sub.add_parser("status")
+    p.add_argument("--issue", default="issue-41")
+    p = sub.add_parser("snapshot-sessions")
+    p.add_argument("--issue", default="issue-41")
+    p.add_argument("--label", required=True)
+    p = sub.add_parser("export-session")
+    p.add_argument("--issue", default="issue-41")
+    p.add_argument("--session-id", required=True)
+    p = sub.add_parser("report")
+    p.add_argument("--issue", default="issue-41")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        if args.command == "doctor":
+            value = doctor()
+        elif args.command == "prepare":
+            value = prepare(args.issue, args.template)
+        elif args.command == "status":
+            value = status(args.issue)
+        elif args.command == "snapshot-sessions":
+            value = snapshot_sessions(args.issue, args.label)
+        elif args.command == "export-session":
+            value = export_session(args.issue, args.session_id)
+        elif args.command == "report":
+            value = report(args.issue)
+        else:
+            raise AssertionError(args.command)
+        print(json.dumps(value, indent=2, sort_keys=True))
+        return 0
+    except RuntimeSmokeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/runtime/runtime_smoke.py
+++ b/tests/runtime/runtime_smoke.py
@@ -14,6 +14,59 @@ ROOT = Path(__file__).resolve().parents[2]
 RUNTIME_ROOT = ROOT / ".runtime-smoke"
 SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
+TASK_DEFINITIONS = (
+    (
+        "SMOKE-CONTROL",
+        "ask-free-control",
+        "Diagnose whether a nested Depth-2 leaf can complete without any Ask permission event.",
+        [
+            "Task Orchestrator must delegate exactly one Work Unit to `general`.",
+            "The leaf must run only `git status --short` once and return the result.",
+            "The leaf must not edit files and must not request any unclassified Bash command.",
+        ],
+        [
+            "Task Orchestrator launches the Depth-2 leaf.",
+            "A provider response is observed for the leaf.",
+            "`git status --short` completes without a permission dialog.",
+            "The leaf returns to its parent instead of remaining busy indefinitely.",
+        ],
+        ["Run from Main TUI with `/task-run SMOKE-CONTROL` under `just runtime::diagnose-child-stall`."],
+    ),
+    (
+        "SMOKE-ASK",
+        "depth2-ask",
+        "Exercise a harmless Depth-2 Bash Ask from a leaf and observe approval/rejection relay in Main TUI.",
+        [
+            "Task Orchestrator must delegate the Ask probe to exactly one `general` leaf.",
+            "The leaf first requests `printf 'depth2-ask-approved\\n'` through Bash and waits for approval.",
+            "After the first probe resolves, the leaf requests `printf 'depth2-ask-rejected\\n'` and waits for rejection.",
+            "Do not perform unrelated implementation or repository changes.",
+        ],
+        [
+            "Depth-2 Ask is visible from the Main TUI.",
+            "Single-command approval propagates to the leaf.",
+            "Rejection propagates to the leaf without weakening permissions.",
+        ],
+        ["Run from Main TUI with `/task-run SMOKE-ASK` under `just runtime::smoke-depth2`."],
+    ),
+    (
+        "SMOKE-FALLBACK",
+        "model-fallback",
+        "Observe genuine usage/quota/rate-limit fallback behavior without manufacturing a provider failure.",
+        [
+            "Task Orchestrator may delegate one trivial read-only Work Unit to a leaf.",
+            "Do not intentionally consume quota or damage credentials/model configuration.",
+            "If no genuine usage-limit condition occurs, record runtime fallback as INCOMPLETE.",
+        ],
+        [
+            "Any genuine eligible failure is classified before fallback.",
+            "Only the configured fallback variant is selected.",
+            "No genuine trigger is reported as INCOMPLETE rather than PASS.",
+        ],
+        ["Run from Main TUI with `/task-run SMOKE-FALLBACK` under `just runtime::smoke-fallback`."],
+    ),
+)
+
 
 class RuntimeSmokeError(RuntimeError):
     pass
@@ -53,7 +106,13 @@ def run_logged(command: list[str], *, cwd: Path, log: Path) -> None:
     with log.open("a", encoding="utf-8") as handle:
         handle.write(f"\n$ {' '.join(command)}\n")
         handle.flush()
-        result = subprocess.run(command, cwd=cwd, text=True, stdout=handle, stderr=subprocess.STDOUT)
+        result = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+        )
     if result.returncode != 0:
         raise RuntimeSmokeError(
             f"{' '.join(command)} failed with exit {result.returncode}\n{tail(log)}"
@@ -96,7 +155,14 @@ def identity(path: Path) -> dict[str, str]:
     return result
 
 
-def write_contract(path: Path, *, purpose: str, scope: list[str], acceptance: list[str], test_plan: list[str]) -> None:
+def write_contract(
+    path: Path,
+    *,
+    purpose: str,
+    scope: list[str],
+    acceptance: list[str],
+    test_plan: list[str],
+) -> None:
     item = identity(path)
     scope_text = "\n".join(f"- {entry}" for entry in scope)
     acceptance_text = "\n".join(f"- [ ] {entry}" for entry in acceptance)
@@ -193,69 +259,6 @@ None yet.
     path.write_text(text, encoding="utf-8")
 
 
-def task_contracts(repo: Path) -> None:
-    definitions = (
-        (
-            "SMOKE-CONTROL",
-            "ask-free-control",
-            "Diagnose whether a nested Depth-2 leaf can complete without any Ask permission event.",
-            [
-                "Task Orchestrator must delegate exactly one Work Unit to `general`.",
-                "The leaf must run only `git status --short` once and return the result.",
-                "The leaf must not edit files and must not request any unclassified Bash command.",
-            ],
-            [
-                "Task Orchestrator launches the Depth-2 leaf.",
-                "A provider response is observed for the leaf.",
-                "`git status --short` completes without a permission dialog.",
-                "The leaf returns to its parent instead of remaining busy indefinitely.",
-            ],
-            ["Run from Main TUI with `/task-run SMOKE-CONTROL` under `just runtime::diagnose-child-stall`."],
-        ),
-        (
-            "SMOKE-ASK",
-            "depth2-ask",
-            "Exercise a harmless Depth-2 Bash Ask from a leaf and observe approval/rejection relay in Main TUI.",
-            [
-                "Task Orchestrator must delegate the Ask probe to exactly one `general` leaf.",
-                "The leaf first requests `printf 'depth2-ask-approved\\n'` through Bash and waits for approval.",
-                "After the first probe resolves, the leaf requests `printf 'depth2-ask-rejected\\n'` and waits for rejection.",
-                "Do not perform unrelated implementation or repository changes.",
-            ],
-            [
-                "Depth-2 Ask is visible from the Main TUI.",
-                "Single-command approval propagates to the leaf.",
-                "Rejection propagates to the leaf without weakening permissions.",
-            ],
-            ["Run from Main TUI with `/task-run SMOKE-ASK` under `just runtime::smoke-depth2`."],
-        ),
-        (
-            "SMOKE-FALLBACK",
-            "model-fallback",
-            "Observe genuine usage/quota/rate-limit fallback behavior without manufacturing a provider failure.",
-            [
-                "Task Orchestrator may delegate one trivial read-only Work Unit to a leaf.",
-                "Do not intentionally consume quota or damage credentials/model configuration.",
-                "If no genuine usage-limit condition occurs, record runtime fallback as INCOMPLETE.",
-            ],
-            [
-                "Any genuine eligible failure is classified before fallback.",
-                "Only the configured fallback variant is selected.",
-                "No genuine trigger is reported as INCOMPLETE rather than PASS.",
-            ],
-            ["Run from Main TUI with `/task-run SMOKE-FALLBACK` under `just runtime::smoke-fallback`."],
-        ),
-    )
-    for task, slug, purpose, scope, acceptance, test_plan in definitions:
-        run_logged(
-            ["nix", "develop", "--command", "just", "agent::task-start", task, slug],
-            cwd=repo,
-            log=workspace("issue-41") / "logs" / "prepare.log" if False else repo.parent / "logs" / "prepare.log",
-        )
-        state = repo / ".worktrees" / f"{task}-{slug}" / ".task-state" / "task.md"
-        write_contract(state, purpose=purpose, scope=scope, acceptance=acceptance, test_plan=test_plan)
-
-
 def report_template(issue: str, metadata: dict) -> str:
     return f"""# Runtime Diagnostic Report — {issue}
 
@@ -350,6 +353,7 @@ def prepare(issue: str, template: str) -> dict:
         raise RuntimeSmokeError(
             f"runtime workspace already exists: {base}; preserve it as evidence or remove it explicitly before a fresh run"
         )
+
     logs = base / "logs"
     reports = base / "reports"
     evidence = base / "evidence"
@@ -359,37 +363,65 @@ def prepare(issue: str, template: str) -> dict:
         path.mkdir(parents=True, exist_ok=True)
     prepare_log = logs / "prepare.log"
 
-    run_logged(["nix", "flake", "init", "-t", f"path:{ROOT}#{template}"], cwd=repo, log=prepare_log)
-    run_logged(["nix", "develop", "--command", "just", "project::bootstrap", "smoke-project"], cwd=repo, log=prepare_log)
+    run_logged(
+        ["nix", "flake", "init", "-t", f"path:{ROOT}#{template}"],
+        cwd=repo,
+        log=prepare_log,
+    )
+    run_logged(
+        ["nix", "develop", "--command", "just", "project::bootstrap", "smoke-project"],
+        cwd=repo,
+        log=prepare_log,
+    )
     if template == "agent-python":
-        run_logged(["nix", "develop", "--command", "just", "project::python::sync"], cwd=repo, log=prepare_log)
+        run_logged(
+            ["nix", "develop", "--command", "just", "project::python::sync"],
+            cwd=repo,
+            log=prepare_log,
+        )
 
-    run_logged(["git", "init", "-b", "main"], cwd=repo, log=prepare_log)
-    run_logged(["git", "config", "user.name", "OpenCode Runtime Smoke"], cwd=repo, log=prepare_log)
-    run_logged(["git", "config", "user.email", "opencode-runtime-smoke@example.invalid"], cwd=repo, log=prepare_log)
-    run_logged(["git", "add", "."], cwd=repo, log=prepare_log)
-    run_logged(["git", "commit", "-m", "Initialize runtime smoke fixture"], cwd=repo, log=prepare_log)
+    for command in (
+        ["git", "init", "-b", "main"],
+        ["git", "config", "user.name", "OpenCode Runtime Smoke"],
+        ["git", "config", "user.email", "opencode-runtime-smoke@example.invalid"],
+        ["git", "add", "."],
+        ["git", "commit", "-m", "Initialize runtime smoke fixture"],
+    ):
+        run_logged(command, cwd=repo, log=prepare_log)
+
     run_logged(["git", "init", "--bare", str(origin)], cwd=ROOT, log=prepare_log)
     run_logged(["git", "remote", "add", "origin", str(origin)], cwd=repo, log=prepare_log)
     run_logged(["git", "push", "-u", "origin", "main"], cwd=repo, log=prepare_log)
-    run_logged(["git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], cwd=repo, log=prepare_log)
+    run_logged(
+        ["git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
+        cwd=repo,
+        log=prepare_log,
+    )
 
     for recipe in ("agent::doctor", "agent::context", "project::doctor", "project::check"):
-        run_logged(["nix", "develop", "--command", "just", recipe], cwd=repo, log=prepare_log)
+        run_logged(
+            ["nix", "develop", "--command", "just", recipe],
+            cwd=repo,
+            log=prepare_log,
+        )
     dirty = run_capture(["git", "status", "--porcelain"], cwd=repo)
     if dirty:
         raise RuntimeSmokeError(f"fixture is dirty after initialization:\n{dirty}")
 
-    # Create deterministic Tasks after the clean baseline is established.
-    definitions = (
-        ("SMOKE-CONTROL", "ask-free-control", "Diagnose whether a nested Depth-2 leaf can complete without any Ask permission event.", ["Task Orchestrator must delegate exactly one Work Unit to `general`.", "The leaf must run only `git status --short` once and return the result.", "The leaf must not edit files and must not request any unclassified Bash command."], ["Task Orchestrator launches the Depth-2 leaf.", "A provider response is observed for the leaf.", "`git status --short` completes without a permission dialog.", "The leaf returns to its parent instead of remaining busy indefinitely."], ["Run from Main TUI with `/task-run SMOKE-CONTROL` under `just runtime::diagnose-child-stall`."]),
-        ("SMOKE-ASK", "depth2-ask", "Exercise a harmless Depth-2 Bash Ask from a leaf and observe approval/rejection relay in Main TUI.", ["Task Orchestrator must delegate the Ask probe to exactly one `general` leaf.", "The leaf first requests `printf 'depth2-ask-approved\\n'` through Bash and waits for approval.", "After the first probe resolves, the leaf requests `printf 'depth2-ask-rejected\\n'` and waits for rejection.", "Do not perform unrelated implementation or repository changes."], ["Depth-2 Ask is visible from the Main TUI.", "Single-command approval propagates to the leaf.", "Rejection propagates to the leaf without weakening permissions."], ["Run from Main TUI with `/task-run SMOKE-ASK` under `just runtime::smoke-depth2`."]),
-        ("SMOKE-FALLBACK", "model-fallback", "Observe genuine usage/quota/rate-limit fallback behavior without manufacturing a provider failure.", ["Task Orchestrator may delegate one trivial read-only Work Unit to a leaf.", "Do not intentionally consume quota or damage credentials/model configuration.", "If no genuine usage-limit condition occurs, record runtime fallback as INCOMPLETE."], ["Any genuine eligible failure is classified before fallback.", "Only the configured fallback variant is selected.", "No genuine trigger is reported as INCOMPLETE rather than PASS."], ["Run from Main TUI with `/task-run SMOKE-FALLBACK` under `just runtime::smoke-fallback`."]),
-    )
-    for task, slug, purpose, scope, acceptance, test_plan in definitions:
-        run_logged(["nix", "develop", "--command", "just", "agent::task-start", task, slug], cwd=repo, log=prepare_log)
+    for task, slug, purpose, scope, acceptance, test_plan in TASK_DEFINITIONS:
+        run_logged(
+            ["nix", "develop", "--command", "just", "agent::task-start", task, slug],
+            cwd=repo,
+            log=prepare_log,
+        )
         state = repo / ".worktrees" / f"{task}-{slug}" / ".task-state" / "task.md"
-        write_contract(state, purpose=purpose, scope=scope, acceptance=acceptance, test_plan=test_plan)
+        write_contract(
+            state,
+            purpose=purpose,
+            scope=scope,
+            acceptance=acceptance,
+            test_plan=test_plan,
+        )
 
     metadata = {
         "issue": issue,
@@ -400,10 +432,18 @@ def prepare(issue: str, template: str) -> dict:
         "smokeRepo": str(repo),
         "origin": str(origin),
     }
-    (base / "metadata.json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    (base / "metadata.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     report = reports / "REPORT.md"
     report.write_text(report_template(issue, metadata), encoding="utf-8")
-    return {"status": "PASS", **metadata, "report": str(report), "prepareLog": str(prepare_log)}
+    return {
+        "status": "PASS",
+        **metadata,
+        "report": str(report),
+        "prepareLog": str(prepare_log),
+    }
 
 
 def status(issue: str) -> dict:
@@ -429,8 +469,7 @@ def snapshot_sessions(issue: str, label: str) -> dict:
     if not repo.is_dir():
         raise RuntimeSmokeError(f"missing prepared smoke repository: {repo}")
     output = run_capture(["opencode", "session", "list", "--format", "json"], cwd=repo)
-    destination = workspace(issue) / "evidence" / f" sessions-{label}.json"
-    destination = destination.with_name(destination.name.lstrip())
+    destination = workspace(issue) / "evidence" / f"sessions-{label}.json"
     destination.write_text(output + "\n", encoding="utf-8")
     return {"status": "PASS", "path": str(destination)}
 
@@ -465,19 +504,24 @@ def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description="Repository-local OpenCode runtime smoke harness")
     sub = result.add_subparsers(dest="command", required=True)
     sub.add_parser("doctor")
-    p = sub.add_parser("prepare")
-    p.add_argument("--issue", default="issue-41")
-    p.add_argument("--template", default="agent-python")
-    p = sub.add_parser("status")
-    p.add_argument("--issue", default="issue-41")
-    p = sub.add_parser("snapshot-sessions")
-    p.add_argument("--issue", default="issue-41")
-    p.add_argument("--label", required=True)
-    p = sub.add_parser("export-session")
-    p.add_argument("--issue", default="issue-41")
-    p.add_argument("--session-id", required=True)
-    p = sub.add_parser("report")
-    p.add_argument("--issue", default="issue-41")
+
+    command = sub.add_parser("prepare")
+    command.add_argument("--issue", default="issue-41")
+    command.add_argument("--template", default="agent-python")
+
+    command = sub.add_parser("status")
+    command.add_argument("--issue", default="issue-41")
+
+    command = sub.add_parser("snapshot-sessions")
+    command.add_argument("--issue", default="issue-41")
+    command.add_argument("--label", required=True)
+
+    command = sub.add_parser("export-session")
+    command.add_argument("--issue", default="issue-41")
+    command.add_argument("--session-id", required=True)
+
+    command = sub.add_parser("report")
+    command.add_argument("--issue", default="issue-41")
     return result
 
 

--- a/tests/test_runtime_smoke_harness.py
+++ b/tests/test_runtime_smoke_harness.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "tests" / "runtime" / "runtime_smoke.py"
+SPEC = importlib.util.spec_from_file_location("runtime_smoke", RUNNER)
+assert SPEC and SPEC.loader
+runtime = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(runtime)
+
+
+class RuntimeSmokeHarnessTest(unittest.TestCase):
+    def test_runtime_workspace_is_git_ignored_and_routed_through_just(self) -> None:
+        ignore = (ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+        self.assertIn("/.runtime-smoke/", ignore)
+        justfile = (ROOT / "Justfile").read_text(encoding="utf-8")
+        self.assertIn("mod runtime 'just/runtime.just'", justfile)
+        module = (ROOT / "just" / "runtime.just").read_text(encoding="utf-8")
+        for recipe in (
+            "prepare issue='issue-41' template='agent-python'",
+            "diagnose-child-stall issue='issue-41'",
+            "smoke-depth2 issue='issue-41'",
+            "smoke-fallback issue='issue-41'",
+            "direct-leaf issue='issue-41'",
+            "export-session session issue='issue-41'",
+        ):
+            self.assertIn(recipe, module)
+
+    def test_workspace_names_cannot_escape_runtime_root(self) -> None:
+        with self.assertRaises(runtime.RuntimeSmokeError):
+            runtime.workspace("../outside")
+        with self.assertRaises(runtime.RuntimeSmokeError):
+            runtime.validate_name("bad/name", "name")
+        resolved = runtime.workspace("issue-41")
+        self.assertEqual(resolved.parent, ROOT / ".runtime-smoke")
+
+    def test_deterministic_runtime_tasks_are_defined(self) -> None:
+        tasks = {(task, slug) for task, slug, *_ in runtime.TASK_DEFINITIONS}
+        self.assertEqual(
+            tasks,
+            {
+                ("SMOKE-CONTROL", "ask-free-control"),
+                ("SMOKE-ASK", "depth2-ask"),
+                ("SMOKE-FALLBACK", "model-fallback"),
+            },
+        )
+
+    def test_task_contract_replaces_unresolved_template_content(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "task.md"
+            path.write_text(
+                "# TEST\n\n## Identity\n\n"
+                "- Task ID: TEST\n"
+                "- Branch: task/TEST-smoke\n"
+                f"- Worktree: {Path(temporary)}\n"
+                "- Base branch: main\n"
+                "- Base revision: deadbeef\n\n"
+                "## Purpose\n\nTBD\n",
+                encoding="utf-8",
+            )
+            runtime.write_contract(
+                path,
+                purpose="Concrete runtime diagnostic.",
+                scope=["One bounded action."],
+                acceptance=["Evidence is recorded."],
+                test_plan=["Run the bounded control."],
+            )
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn("TBD", text)
+            self.assertIn("## Stop conditions", text)
+            self.assertIn("- Status: initialized", text)
+            self.assertIn("- [ ] Evidence is recorded.", text)
+
+    def test_debug_launchers_use_official_diagnostic_paths_without_auto_approval(self) -> None:
+        interactive = (ROOT / "tests" / "runtime" / "run_opencode_debug.sh").read_text(
+            encoding="utf-8"
+        )
+        direct = (ROOT / "tests" / "runtime" / "run_direct_leaf.sh").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("--print-logs --log-level DEBUG", interactive)
+        self.assertIn("snapshot-sessions", interactive)
+        self.assertNotIn(" --auto", interactive)
+        self.assertIn("--print-logs --log-level DEBUG run", direct)
+        self.assertIn("--agent general", direct)
+        self.assertIn("--format json", direct)
+        self.assertNotIn(" --auto", direct)
+
+    def test_report_template_requires_evidence_based_classification(self) -> None:
+        metadata = {
+            "templatesCommit": "abc",
+            "opencodeVersion": "1.18.4",
+            "template": "agent-python",
+            "smokeRepo": "/tmp/smoke",
+            "createdAt": "2026-08-09T00:00:00+00:00",
+        }
+        report = runtime.report_template("issue-41", metadata)
+        self.assertIn("Ask-free nested control", report)
+        self.assertIn("Direct leaf control", report)
+        self.assertIn("Depth-2 Ask probe", report)
+        self.assertIn("PASS / FAIL / INCOMPLETE", report)
+        self.assertIn("Do not infer PASS", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the repository-local diagnostic harness needed by #41 so OpenCode runtime validation no longer depends on an external scratch directory or manually uploaded reports.

This PR adds:

- `/.runtime-smoke/` as the Git-ignored local evidence root
- `just runtime::*` as the stable operator API
- `runtime::prepare` to create a fresh `agent-python` fixture, local bare origin, verified Main baseline, and deterministic SMOKE-CONTROL / SMOKE-ASK / SMOKE-FALLBACK Task worktrees
- concrete disposable Task State contracts generated during fixture preparation
- `runtime::direct-leaf` to isolate the configured `general` leaf with bounded non-interactive `opencode run`
- `runtime::diagnose-child-stall` for the Ask-free nested control in a real Main TUI
- `runtime::smoke-depth2` for the actual Depth-2 Ask probe
- `runtime::smoke-fallback` for genuine usage-limit observation without manufacturing a failure
- DEBUG logging through OpenCode's official `--print-logs --log-level DEBUG` path
- automatic pre/post `opencode session list --format json` snapshots
- explicit sanitized `opencode export --sanitize <session>` evidence collection
- local `.runtime-smoke/<issue>/reports/REPORT.md` templates
- an evidence-based #41 decision matrix separating direct provider/leaf, nested child-session, and permission-relay failures
- contract tests for path isolation, deterministic Task definitions, Just routing, Task State generation, and diagnostic launcher boundaries

## Intended workflow

```text
Templates/
  tests/runtime/**      committed harness
  just/runtime.just     operator API
  .runtime-smoke/**     local ignored fixtures/logs/reports
```

Typical #41 sequence:

```sh
just runtime::doctor
just runtime::prepare issue-41 agent-python
just runtime::direct-leaf issue-41
just runtime::diagnose-child-stall issue-41   # /task-run SMOKE-CONTROL
just runtime::smoke-depth2 issue-41           # /task-run SMOKE-ASK
just runtime::export-session <session-id> issue-41
just runtime::report issue-41
```

The runtime workspace is intentionally not committed. Raw DEBUG logs must be reviewed for sensitive content before any excerpt is shared.

## Diagnosis boundary

The controls are ordered so evidence can distinguish:

```text
direct general leaf stalls
  -> provider/model/direct leaf path

direct passes + nested Ask-free stalls
  -> nested Task/subagent session path
nested Ask-free passes + Ask probe stalls
  -> Ask-producing tool/permission path
permission event exists but Main cannot handle it
  -> permission relay/UI propagation
```

No control uses `--auto`, weakens repository permissions, substitutes models, damages credentials, or deliberately exhausts quota.

## Validation

Template CI will run the existing Python contract suite, which now includes `tests/test_runtime_smoke_harness.py`, plus generated-template drift and Adapter smoke jobs.

Refs #41
Blocks #7