### PR TITLE
fix: make runtime leaf control executable

### DIFF
--- a/tests/runtime/README.md
+++ b/tests/runtime/README.md
@@ -44,7 +44,7 @@ Run the same configured `general` leaf directly in the `SMOKE-CONTROL` worktree:
 just runtime::direct-leaf issue-41
 ```
 
-This uses non-interactive `opencode run --agent general --format json`, writes event and DEBUG logs under `.runtime-smoke/issue-41/logs/`, and applies a bounded diagnostic timeout. This is a provider/agent isolation control only; it is not evidence that Depth-2 delegation works.
+This starts a local loopback `opencode serve` endpoint on an ephemeral port, creates a session through `/session`, and sends a synchronous `/session/{sessionID}/message` request with `agent: general`. The request does not override the configured model. The launcher verifies that exactly one completed Bash tool call ran `git status --short`, writes JSON event output and DEBUG logs under `.runtime-smoke/issue-41/logs/`, and applies a bounded diagnostic timeout. This is a provider/agent isolation control only; it is not evidence that Depth-2 delegation works.
 
 ## Ask-free nested control
 

--- a/tests/runtime/issue-41-child-stall.md
+++ b/tests/runtime/issue-41-child-stall.md
@@ -38,7 +38,7 @@ Do not infer an intermediate stage from a spinner or child label alone.
 just runtime::direct-leaf issue-41
 ```
 
-Expected diagnostic action: `general` runs `git status --short` once without editing.
+Expected diagnostic action: loopback API control sends a direct `general` session request that runs `git status --short` once without editing.
 
 - PASS: provider responds, read-only command completes, process exits normally
 - FAIL: explicit provider/tool/agent error is observed

--- a/tests/runtime/run_direct_leaf.sh
+++ b/tests/runtime/run_direct_leaf.sh
@@ -8,6 +8,7 @@ repo="$workspace/smoke-repo"
 task_repo="$repo/.worktrees/SMOKE-CONTROL-ask-free-control"
 logs="$workspace/logs"
 timeout_seconds="${RUNTIME_TIMEOUT_SECONDS:-180}"
+diagnostic_prompt='Diagnostic control only: run git status --short exactly once, do not edit files, and report the result.'
 
 if [[ ! -d "$task_repo" ]]; then
   echo "missing SMOKE-CONTROL worktree: $task_repo" >&2
@@ -25,23 +26,155 @@ mkdir -p "$logs"
 stamp="$(date +%Y%m%dT%H%M%S)"
 events="$logs/direct-leaf-${stamp}.jsonl"
 debug="$logs/direct-leaf-${stamp}.debug.log"
+server_log="$logs/direct-leaf-${stamp}.serve.log"
 
 cd "$task_repo"
 export OPENCODE_BIN="$opencode_bin"
 export OPENCODE_DISABLE_AUTOUPDATE=1
 export RUNTIME_TIMEOUT_SECONDS="$timeout_seconds"
+export RUNTIME_DIAGNOSTIC_PROMPT="$diagnostic_prompt"
+export RUNTIME_SERVE_LOG="$server_log"
 
 set +e
-nix develop --command bash -c '
+timeout --kill-after=20s "${RUNTIME_TIMEOUT_SECONDS}s" nix develop --command bash -c '
   set -euo pipefail
+
   export VIRTUAL_ENV="$PWD/.venv"
   export UV_PROJECT_ENVIRONMENT="$PWD/.venv"
   export PIP_REQUIRE_VIRTUALENV=1
   export PATH="$PWD/.venv/bin:$PATH"
-  timeout "${RUNTIME_TIMEOUT_SECONDS}s" "$OPENCODE_BIN" --print-logs --log-level DEBUG run \
-    --agent general \
-    --format json \
-    "Diagnostic control only: run git status --short exactly once, do not edit files, and report the result."
+  export OPENCODE_SERVE_LOG="$RUNTIME_SERVE_LOG"
+
+  port="$(python3 -c '\''import socket; sock = socket.socket(); sock.bind(("127.0.0.1", 0)); print(sock.getsockname()[1]); sock.close()'\'')"
+  export OPENCODE_BASE_URL="http://127.0.0.1:${port}"
+
+  cleanup() {
+    if [[ -n "${server_pid:-}" ]] && kill -0 "$server_pid" 2>/dev/null; then
+      kill "$server_pid" 2>/dev/null || true
+      for _ in $(seq 1 20); do
+        if ! kill -0 "$server_pid" 2>/dev/null; then
+          break
+        fi
+        sleep 0.25
+      done
+      if kill -0 "$server_pid" 2>/dev/null; then
+        kill -KILL "$server_pid" 2>/dev/null || true
+      fi
+      wait "$server_pid" 2>/dev/null || true
+    fi
+    if [[ -f "$OPENCODE_SERVE_LOG" ]]; then
+      cat "$OPENCODE_SERVE_LOG" >&2
+    fi
+  }
+  trap cleanup EXIT
+
+  "$OPENCODE_BIN" serve --print-logs --log-level DEBUG --hostname 127.0.0.1 --port "$port" >"$OPENCODE_SERVE_LOG" 2>&1 &
+  server_pid=$!
+
+  python3 - "${OPENCODE_BASE_URL}" "$RUNTIME_DIAGNOSTIC_PROMPT" <<'PY'
+import json
+import subprocess
+import sys
+import time
+import urllib.request
+
+
+base = sys.argv[1]
+prompt = sys.argv[2]
+
+
+def request(method: str, path: str, body=None):
+    data = None
+    if body is not None:
+        payload = json.dumps(body).encode("utf-8")
+        data = payload
+    request_obj = urllib.request.Request(
+        f"{base}{path}",
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(request_obj, timeout=30) as response:
+        payload = response.read().decode("utf-8")
+        return response.status, (json.loads(payload) if payload else None)
+
+
+def status(message: str) -> None:
+    print(json.dumps({"type": "status", "message": message}))
+
+
+for _ in range(120):
+    try:
+        _status, health = request("GET", "/global/health")
+        if health.get("healthy") is True:
+            break
+    except Exception:
+        time.sleep(0.25)
+else:
+    raise RuntimeError("opencode local API did not start")
+
+status("creating direct control session")
+_status, session = request("POST", "/session", {"title": "Direct leaf control"})
+session_id = session.get("id")
+if not session_id:
+    raise RuntimeError("session creation response did not include a session id")
+
+status("sending diagnostic prompt")
+_status, response = request(
+    "POST",
+    f"/session/{session_id}/message",
+    {
+        "agent": "general",
+        "parts": [{"type": "text", "text": prompt}],
+    },
+)
+
+info = response.get("info", {})
+actual_agent = info.get("agent")
+if actual_agent != "general":
+    raise RuntimeError(f"direct control used unexpected agent: {actual_agent!r}")
+
+status("collecting message evidence")
+_status, messages = request("GET", f"/session/{session_id}/message")
+tool_parts = [
+    part
+    for message in messages
+    for part in message.get("parts", [])
+    if part.get("type") == "tool"
+]
+if len(tool_parts) != 1:
+    raise RuntimeError("general requested an unexpected additional tool action")
+status_parts = [
+    part
+    for part in tool_parts
+    if part.get("tool") == "bash"
+    and part.get("state", {}).get("input", {}).get("command") == "git status --short"
+]
+if len(status_parts) != 1:
+    raise RuntimeError("general did not request git status --short exactly once")
+if status_parts[0].get("state", {}).get("status") != "completed":
+    raise RuntimeError("git status --short did not complete")
+worktree_status = subprocess.run(
+    ["git", "status", "--porcelain"],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout.strip()
+if worktree_status:
+    raise RuntimeError(f"direct control modified the worktree: {worktree_status}")
+
+print(
+    json.dumps(
+        {
+            "type": "diagnostic-result",
+            "sessionID": session_id,
+            "agent": "general",
+            "response": response,
+            "messages": messages,
+        }
+    )
+)
+PY
 ' >"$events" 2> >(tee "$debug" >&2)
 status=$?
 set -e

--- a/tests/runtime/runtime_smoke.py
+++ b/tests/runtime/runtime_smoke.py
@@ -368,6 +368,15 @@ def prepare(issue: str, template: str) -> dict:
         cwd=repo,
         log=prepare_log,
     )
+    for command in (
+        ["git", "init", "-b", "main"],
+        ["git", "config", "user.name", "OpenCode Runtime Smoke"],
+        ["git", "config", "user.email", "opencode-runtime-smoke@example.invalid"],
+        ["git", "add", "."],
+        ["git", "commit", "-m", "Initialize runtime smoke fixture"],
+    ):
+        run_logged(command, cwd=repo, log=prepare_log)
+
     run_logged(
         ["nix", "develop", "--command", "just", "project::bootstrap", "smoke-project"],
         cwd=repo,
@@ -379,19 +388,20 @@ def prepare(issue: str, template: str) -> dict:
             cwd=repo,
             log=prepare_log,
         )
-
-    for command in (
-        ["git", "init", "-b", "main"],
-        ["git", "config", "user.name", "OpenCode Runtime Smoke"],
-        ["git", "config", "user.email", "opencode-runtime-smoke@example.invalid"],
-        ["git", "add", "."],
-        ["git", "commit", "-m", "Initialize runtime smoke fixture"],
-    ):
-        run_logged(command, cwd=repo, log=prepare_log)
+    run_logged(["git", "add", "."], cwd=repo, log=prepare_log)
+    run_logged(
+        ["nix", "develop", "--command", "git", "commit", "-m", "Bootstrap runtime smoke fixture"],
+        cwd=repo,
+        log=prepare_log,
+    )
 
     run_logged(["git", "init", "--bare", str(origin)], cwd=ROOT, log=prepare_log)
     run_logged(["git", "remote", "add", "origin", str(origin)], cwd=repo, log=prepare_log)
-    run_logged(["git", "push", "-u", "origin", "main"], cwd=repo, log=prepare_log)
+    run_logged(
+        ["nix", "develop", "--command", "git", "push", "-u", "origin", "main"],
+        cwd=repo,
+        log=prepare_log,
+    )
     run_logged(
         ["git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"],
         cwd=repo,

--- a/tests/test_runtime_smoke_harness.py
+++ b/tests/test_runtime_smoke_harness.py
@@ -85,10 +85,102 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
         self.assertIn("--print-logs --log-level DEBUG", interactive)
         self.assertIn("snapshot-sessions", interactive)
         self.assertNotIn(" --auto", interactive)
-        self.assertIn("--print-logs --log-level DEBUG run", direct)
-        self.assertIn("--agent general", direct)
-        self.assertIn("--format json", direct)
+        self.assertIn('"$OPENCODE_BIN" serve', direct)
+        self.assertIn(
+            'request("POST", "/session", {"title": "Direct leaf control"})', direct
+        )
+        self.assertIn('f"/session/{session_id}/message"', direct)
+        self.assertIn('"agent": "general"', direct)
+        self.assertNotIn('"model":', direct)
+        self.assertIn("if len(tool_parts) != 1", direct)
+        self.assertIn('["git", "status", "--porcelain"]', direct)
+        self.assertIn("timeout --kill-after=20s", direct)
+        self.assertNotIn(" --agent general", direct)
         self.assertNotIn(" --auto", direct)
+
+    def test_prepare_commits_scaffold_before_nix_bootstrap_and_bootstraps_second_time(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary) / "issue-41"
+            calls: list[tuple[str, list[str], Path, Path]] = []
+
+            original_workspace = runtime.workspace
+            original_doctor = runtime.doctor
+            original_run_logged = runtime.run_logged
+            original_run_capture = runtime.run_capture
+            original_write_contract = runtime.write_contract
+
+            def fake_workspace(_: str) -> Path:
+                return base
+
+            def fake_doctor() -> dict:
+                return {"status": "PASS"}
+
+            def fake_run_logged(command: list[str], *, cwd: Path, log: Path) -> None:
+                calls.append(("logged", command, cwd, log))
+
+            def fake_run_capture(command: list[str], *, cwd: Path) -> str:
+                if command == ["opencode", "--version"]:
+                    return "1.18.4"
+                if command == ["git", "rev-parse", "HEAD"]:
+                    return "cafebabe"
+                if command == ["git", "status", "--porcelain"]:
+                    return ""
+                return "result"
+
+            runtime.workspace = fake_workspace
+            runtime.doctor = fake_doctor
+            runtime.run_logged = fake_run_logged
+            runtime.run_capture = fake_run_capture
+            runtime.write_contract = lambda *args, **kwargs: None
+            try:
+                runtime.prepare("issue-41", "agent-python")
+            finally:
+                runtime.workspace = original_workspace
+                runtime.doctor = original_doctor
+                runtime.run_logged = original_run_logged
+                runtime.run_capture = original_run_capture
+                runtime.write_contract = original_write_contract
+
+            commands = [command for _kind, command, *_ in calls]
+
+            def index_of(prefix: list[str]) -> int:
+                for idx, command in enumerate(commands):
+                    if command[: len(prefix)] == prefix:
+                        return idx
+                raise AssertionError(f"command {prefix} not found")
+
+            flake = index_of(["nix", "flake", "init"])
+            git_init = index_of(["git", "init", "-b", "main"])
+            bootstrap = index_of(["nix", "develop", "--command", "just", "project::bootstrap", "smoke-project"])
+            first_commit = index_of(["git", "commit", "-m", "Initialize runtime smoke fixture"])
+            second_commit = index_of(
+                [
+                    "nix",
+                    "develop",
+                    "--command",
+                    "git",
+                    "commit",
+                    "-m",
+                    "Bootstrap runtime smoke fixture",
+                ]
+            )
+            add_indices = [
+                idx for idx, command in enumerate(commands) if command == ["git", "add", "."]
+            ]
+
+            self.assertLess(git_init, bootstrap)
+            self.assertLess(first_commit, bootstrap)
+            self.assertLess(bootstrap, second_commit)
+            self.assertLess(flake, first_commit)
+            self.assertLess(flake, bootstrap)
+            self.assertEqual(2, len(add_indices))
+            self.assertLess(add_indices[0], first_commit)
+            self.assertGreater(second_commit, bootstrap)
+            self.assertGreater(add_indices[1], bootstrap)
+            self.assertIn(
+                ["nix", "develop", "--command", "git", "push", "-u", "origin", "main"],
+                commands,
+            )
 
     def test_report_template_requires_evidence_based_classification(self) -> None:
         metadata = {


### PR DESCRIPTION
## Summary
- run the configured `general` agent through OpenCode's loopback session API instead of the CLI path that falls back to `build`
- verify exactly one completed `git status --short` tool action and a clean worktree
- initialize and commit fresh runtime fixtures before the first `nix develop`, then run commit/push hooks inside the project shell
- add regression coverage and update the Issue #41 runtime procedure

## Verification
- `bash -n tests/runtime/run_direct_leaf.sh`
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 nix shell nixpkgs#python3 --command python3 -m unittest discover -s tests -v` (84 passed)
- `PYTHONDONTWRITEBYTECODE=1 nix shell nixpkgs#python3 --command python3 tools/render_templates.py check` (all templates OK)
- fresh `just runtime::prepare issue-41-fix agent-python` (PASS)
- live `just runtime::direct-leaf issue-41-fix` on OpenCode 1.18.4 (PASS; configured `general`, provider response, one completed status command, clean exit)

## Remaining runtime scope
- Formal Main-TUI nested Ask-free and Depth-2 Ask relay checks remain INCOMPLETE because they require interactive TUI observation.
- No permission or model configuration was weakened or replaced.

Closes no issue. Related to #41.