### PR TITLE
feat: publish generated templates as GitHub template repositories

### DIFF
--- a/.github/workflows/publish-template-repositories.yml
+++ b/.github/workflows/publish-template-repositories.yml
@@ -1,0 +1,112 @@
+name: Publish Template Repositories
+
+on:
+  workflow_run:
+    workflows: ["Template CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      vars.TEMPLATE_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      is_current_main: ${{ steps.current.outputs.is_current_main }}
+    steps:
+      - name: Checkout verified Templates revision
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify distribution manifest
+        run: python3 tools/template_distribution.py verify
+
+      - name: Build fixed publish matrix
+        id: matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          matrix="$(python3 tools/template_distribution.py matrix)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+      - name: Refuse stale verified-main publication
+        id: current
+        shell: bash
+        env:
+          VERIFIED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          current_main="$(git ls-remote https://github.com/${GITHUB_REPOSITORY}.git refs/heads/main | awk '{print $1}')"
+          if [ "$current_main" = "$VERIFIED_SHA" ]; then
+            echo "is_current_main=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Verified SHA $VERIFIED_SHA is no longer current main ($current_main); skipping publication."
+            echo "is_current_main=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  publish:
+    needs: prepare
+    if: needs.prepare.outputs.is_current_main == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Checkout verified Templates revision
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          path: source
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout allowlisted distribution repository
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ matrix.repository }}
+          ref: ${{ matrix.default_branch }}
+          token: ${{ secrets.TEMPLATE_PUBLISH_TOKEN }}
+          path: distribution
+          fetch-depth: 1
+
+      - name: Detect pre-sync distribution drift
+        id: drift
+        continue-on-error: true
+        shell: bash
+        run: |
+          python3 source/tools/template_distribution.py check \
+            "${{ matrix.template }}" distribution
+
+      - name: Materialize exact generated template
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 source/tools/template_distribution.py materialize \
+            "${{ matrix.template }}" distribution
+          python3 source/tools/template_distribution.py check \
+            "${{ matrix.template }}" distribution
+
+      - name: Commit and publish changed snapshot
+        shell: bash
+        env:
+          VERIFIED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          cd distribution
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Distribution repository already matches $VERIFIED_SHA."
+            exit 0
+          fi
+          git config user.name "Templates Publisher"
+          git config user.email "templates-publisher@users.noreply.github.com"
+          git commit -m "Sync from upiscium/Templates@$VERIFIED_SHA"
+          git push origin "HEAD:${{ matrix.default_branch }}"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,20 @@ Nix flake templates for reproducible, Agent-ready development environments.
 
 ## Start a new repository
 
-Published templates:
+There are two new-repository distribution channels. Use a GitHub Template Repository when creating the repository on GitHub, or use the Nix flake template when initializing a local directory.
+
+GitHub Template Repository targets:
+
+```text
+agent-python     -> upiscium/Template-Agent-Python
+agent-rust       -> upiscium/Template-Agent-Rust
+agent-nix        -> upiscium/Template-Agent-Nix
+agent-cpp-cmake  -> upiscium/Template-Agent-Cpp-CMake
+```
+
+The GitHub distribution repositories are generated artifacts synchronized from this repository; they are not independent sources of truth. See `docs/github-template-distribution.md` for setup, publishing, and ownership details.
+
+Local Nix templates remain available:
 
 ```sh
 nix flake init -t github:upiscium/Templates#agent-base
@@ -190,9 +203,10 @@ just template::render agent-nix
 just template::render agent-cpp-cmake
 just template::render-all
 just template::check
+just template::distribution-verify
 ```
 
-`template::check` detects generated drift, path collisions, dotfile/mode drift, and unregistered generated directories.
+`template::check` detects generated drift, path collisions, dotfile/mode drift, and unregistered generated directories. `template::distribution-verify` validates the fixed GitHub distribution allowlist; publication itself is CI-only after a successful Template CI run on current `main`.
 
 ## OpenCode hierarchy
 

--- a/distribution/template-repositories.json
+++ b/distribution/template-repositories.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "owner": "upiscium",
+  "templates": {
+    "agent-base": {
+      "published": false,
+      "reason": "agent-base is the minimum/fallback contract for local Nix initialization and repository adoption; GitHub new-repository users should choose a concrete language/toolchain template."
+    },
+    "agent-cpp-cmake": {
+      "published": true,
+      "repository": "Template-Agent-Cpp-CMake",
+      "default_branch": "main",
+      "description": "Generated Agent-ready C++/CMake template. Source: upiscium/Templates; do not edit directly."
+    },
+    "agent-nix": {
+      "published": true,
+      "repository": "Template-Agent-Nix",
+      "default_branch": "main",
+      "description": "Generated Agent-ready Nix template. Source: upiscium/Templates; do not edit directly."
+    },
+    "agent-python": {
+      "published": true,
+      "repository": "Template-Agent-Python",
+      "default_branch": "main",
+      "description": "Generated Agent-ready Python + uv template. Source: upiscium/Templates; do not edit directly."
+    },
+    "agent-rust": {
+      "published": true,
+      "repository": "Template-Agent-Rust",
+      "default_branch": "main",
+      "description": "Generated Agent-ready Rust template. Source: upiscium/Templates; do not edit directly."
+    }
+  }
+}

--- a/docs/github-template-distribution.md
+++ b/docs/github-template-distribution.md
@@ -1,0 +1,180 @@
+# GitHub Template Repository distribution
+
+`upiscium/Templates` is the only source of truth. Published GitHub Template Repositories are generated distribution artifacts and must not be edited directly.
+
+## Channels
+
+| Intent | Channel |
+|---|---|
+| Create a new repository on GitHub | GitHub Template Repository |
+| Initialize a local directory | Nix flake template |
+| Make an existing repository Agent-ready | adoption workflow |
+| Update an existing Agent-ready repository | Agent Core upgrade workflow |
+
+Published targets are defined only in `distribution/template-repositories.json`:
+
+```text
+agent-python     -> upiscium/Template-Agent-Python
+agent-rust       -> upiscium/Template-Agent-Rust
+agent-nix        -> upiscium/Template-Agent-Nix
+agent-cpp-cmake  -> upiscium/Template-Agent-Cpp-CMake
+```
+
+`agent-base` is intentionally not published as a GitHub Template Repository. It is the minimum/fallback contract used for local Nix initialization and repository adoption; GitHub new-repository users should select a concrete language/toolchain template.
+
+## One-time repository setup
+
+The distribution repositories are external artifacts, so their initial creation is an explicit operator action. Do not grant the recurring publisher repository-administration permission just to automate this one-time step.
+
+Create the four public repositories with an initial branch, using the descriptions from `distribution/template-repositories.json`. For example:
+
+```sh
+gh repo create upiscium/Template-Agent-Python \
+  --public --add-readme --disable-issues --disable-wiki \
+  --description 'Generated Agent-ready Python + uv template. Source: upiscium/Templates; do not edit directly.'
+```
+
+Repeat for Rust, Nix, and C++/CMake. Confirm every repository has `main` as its default branch before enabling publication. If the account's new-repository default differs, rename the initial branch to `main` through GitHub before continuing.
+
+Enable each repository as a Template Repository once:
+
+```sh
+gh repo edit upiscium/Template-Agent-Python --template
+gh repo edit upiscium/Template-Agent-Rust --template
+gh repo edit upiscium/Template-Agent-Nix --template
+gh repo edit upiscium/Template-Agent-Cpp-CMake --template
+```
+
+Verify the settings:
+
+```sh
+for repo in \
+  Template-Agent-Python \
+  Template-Agent-Rust \
+  Template-Agent-Nix \
+  Template-Agent-Cpp-CMake
+do
+  gh api "repos/upiscium/$repo" --jq '{full_name,default_branch,is_template,description}'
+done
+```
+
+Expected for each target:
+
+```text
+default_branch = main
+is_template = true
+```
+
+## Publisher credential
+
+Create a fine-grained personal access token scoped to exactly these four distribution repositories. The recurring publisher requires only repository **Contents: Read and write**. Do not grant Administration permission to this token.
+
+Store it only as an Actions secret on `upiscium/Templates`:
+
+```sh
+gh secret set TEMPLATE_PUBLISH_TOKEN --repo upiscium/Templates
+```
+
+Publication is disabled unless the repository variable is explicitly enabled:
+
+```sh
+gh variable set TEMPLATE_PUBLISH_ENABLED \
+  --repo upiscium/Templates \
+  --body true
+```
+
+To stop publication without deleting the credential:
+
+```sh
+gh variable set TEMPLATE_PUBLISH_ENABLED \
+  --repo upiscium/Templates \
+  --body false
+```
+
+## Publication contract
+
+`.github/workflows/publish-template-repositories.yml` runs only after `Template CI` completes successfully for `main`.
+
+The workflow:
+
+1. checks out the exact `workflow_run.head_sha` that passed Template CI;
+2. verifies the distribution manifest;
+3. verifies that the successful SHA is still the current `main` HEAD, preventing a stale successful run from rolling distribution repositories backwards;
+4. derives the target matrix from the fixed manifest allowlist;
+5. checks out each target using `TEMPLATE_PUBLISH_TOKEN`;
+6. records whether the target drifted from the expected generated snapshot;
+7. replaces every tracked/worktree file except `.git` with the exact `templates/agent-*` snapshot;
+8. verifies content, dotfiles, symlinks, stale-file deletion, and executable mode equivalence;
+9. commits and pushes only when the snapshot changed.
+
+There is intentionally no `workflow_dispatch` publication path and no local `distribution-publish` Just recipe. Arbitrary input must not select a publish repository.
+
+## Local verification API
+
+Read-only manifest verification:
+
+```sh
+just template::distribution-verify
+just template::distribution-matrix
+```
+
+To inspect a local checkout of an allowlisted distribution repository:
+
+```sh
+just template::distribution-check agent-python /path/to/Template-Agent-Python
+```
+
+To reproduce the exact synchronizer against a disposable/local checkout:
+
+```sh
+just template::distribution-materialize agent-python /path/to/disposable-checkout
+just template::distribution-check agent-python /path/to/disposable-checkout
+```
+
+`distribution-materialize` deletes every destination file except `.git`; use it only on a disposable or generated distribution checkout.
+
+## User workflow
+
+### GitHub UI
+
+Use **Use this template** on the corresponding distribution repository, then clone the newly created repository and run:
+
+```sh
+nix develop --command just project::bootstrap
+opencode
+```
+
+Use `/init` after bootstrap for normal read-only session validation.
+
+### GitHub CLI
+
+Example:
+
+```sh
+gh repo create my-project \
+  --template upiscium/Template-Agent-Python \
+  --private --clone
+cd my-project
+nix develop --command just project::bootstrap
+opencode
+```
+
+### Nix flake template
+
+The existing local path remains supported independently:
+
+```sh
+mkdir my-project
+cd my-project
+nix flake init -t github:upiscium/Templates#agent-python
+nix develop --command just project::bootstrap
+```
+
+## Ownership and failure policy
+
+- Changes belong in `components/agent-core/**` or `components/adapters/**`, followed by normal rendering and review in `upiscium/Templates`.
+- Never fix a distribution repository directly.
+- A distribution drift is evidence of manual/out-of-band mutation; the next verified publication replaces it from the source of truth.
+- Publish failures must remain visible as failed Actions jobs.
+- Do not force-push distribution branches.
+- User-created repositories are independent and are never automatically rewritten by this publisher.

--- a/just/template.just
+++ b/just/template.just
@@ -13,6 +13,22 @@ check:
     python3 tools/render_templates.py check
 
 [working-directory: root]
+distribution-verify:
+    python3 tools/template_distribution.py verify
+
+[working-directory: root]
+distribution-matrix:
+    python3 tools/template_distribution.py matrix
+
+[working-directory: root]
+distribution-materialize template target:
+    python3 tools/template_distribution.py materialize {{quote(template)}} {{quote(target)}}
+
+[working-directory: root]
+distribution-check template target:
+    python3 tools/template_distribution.py check {{quote(template)}} {{quote(target)}}
+
+[working-directory: root]
 adopt-plan target adapter='auto':
     python3 tools/adopt_repository.py plan {{quote(target)}} --adapter {{quote(adapter)}}
 

--- a/tests/test_template_distribution.py
+++ b/tests/test_template_distribution.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "template_distribution.py"
+SPEC = importlib.util.spec_from_file_location("template_distribution", SCRIPT)
+assert SPEC and SPEC.loader
+distribution = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(distribution)
+
+
+class TemplateDistributionTest(unittest.TestCase):
+    def test_manifest_is_complete_and_allowlisted(self) -> None:
+        targets, excluded = distribution.load_distribution(ROOT)
+        self.assertEqual(
+            {target.full_name for target in targets.values()},
+            {
+                "upiscium/Template-Agent-Cpp-CMake",
+                "upiscium/Template-Agent-Nix",
+                "upiscium/Template-Agent-Python",
+                "upiscium/Template-Agent-Rust",
+            },
+        )
+        self.assertEqual(set(excluded), {"agent-base"})
+        self.assertIn("minimum/fallback", excluded["agent-base"])
+        for target in targets.values():
+            self.assertEqual(target.default_branch, "main")
+            self.assertIn("do not edit directly", target.description)
+
+    def test_matrix_is_derived_from_manifest(self) -> None:
+        targets, _ = distribution.load_distribution(ROOT)
+        expected = {
+            "include": [
+                {
+                    "template": target.template,
+                    "repository": target.full_name,
+                    "default_branch": target.default_branch,
+                }
+                for target in sorted(targets.values(), key=lambda item: item.template)
+            ]
+        }
+        actual = json.loads(
+            os.popen(f"python3 {SCRIPT} matrix").read()
+        )
+        self.assertEqual(actual, expected)
+
+    def test_materialize_is_exact_and_removes_stale_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            destination = Path(temporary) / "distribution"
+            destination.mkdir()
+            (destination / ".git").mkdir()
+            (destination / "stale.txt").write_text("stale\n", encoding="utf-8")
+            (destination / ".stale-dotfile").write_text("stale\n", encoding="utf-8")
+
+            distribution.materialize(ROOT, "agent-python", destination)
+            differences = distribution.check(ROOT, "agent-python", destination)
+            self.assertEqual(differences, [])
+            self.assertFalse((destination / "stale.txt").exists())
+            self.assertFalse((destination / ".stale-dotfile").exists())
+            self.assertTrue((destination / ".gitignore").is_file())
+
+            source_mode = (ROOT / "templates" / "agent-python" / ".automation" / "bin" / "agent_core.py").stat().st_mode
+            target_mode = (destination / ".automation" / "bin" / "agent_core.py").stat().st_mode
+            self.assertEqual(bool(source_mode & 0o111), bool(target_mode & 0o111))
+
+    def test_check_detects_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            destination = Path(temporary) / "distribution"
+            destination.mkdir()
+            (destination / ".git").mkdir()
+            distribution.materialize(ROOT, "agent-rust", destination)
+            (destination / "unexpected.txt").write_text("drift\n", encoding="utf-8")
+            self.assertIn("unexpected: unexpected.txt", distribution.check(ROOT, "agent-rust", destination))
+
+    def test_materialize_rejects_non_repository_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            destination = Path(temporary) / "not-a-repo"
+            destination.mkdir()
+            with self.assertRaises(distribution.DistributionError):
+                distribution.materialize(ROOT, "agent-python", destination)
+
+    def test_unpublished_base_cannot_be_materialized(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            destination = Path(temporary) / "distribution"
+            destination.mkdir()
+            (destination / ".git").mkdir()
+            with self.assertRaises(distribution.DistributionError):
+                distribution.materialize(ROOT, "agent-base", destination)
+
+    def test_workflow_only_publishes_verified_current_main(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "publish-template-repositories.yml").read_text(encoding="utf-8")
+        self.assertIn('workflows: ["Template CI"]', workflow)
+        self.assertIn("branches: [main]", workflow)
+        self.assertIn("workflow_run.conclusion == 'success'", workflow)
+        self.assertIn("TEMPLATE_PUBLISH_ENABLED", workflow)
+        self.assertIn("github.event.workflow_run.head_sha", workflow)
+        self.assertIn("git ls-remote", workflow)
+        self.assertIn("TEMPLATE_PUBLISH_TOKEN", workflow)
+        self.assertIn("template_distribution.py materialize", workflow)
+        self.assertIn("template_distribution.py check", workflow)
+        self.assertNotIn("workflow_dispatch:", workflow)
+        self.assertNotIn("git push --force", workflow)
+
+    def test_operator_api_exposes_distribution_checks_not_publish(self) -> None:
+        justfile = (ROOT / "just" / "template.just").read_text(encoding="utf-8")
+        self.assertIn("distribution-verify", justfile)
+        self.assertIn("distribution-matrix", justfile)
+        self.assertIn("distribution-materialize", justfile)
+        self.assertIn("distribution-check", justfile)
+        self.assertNotIn("distribution-publish", justfile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_template_distribution.py
+++ b/tests/test_template_distribution.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import importlib.util
 import json
-import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -12,6 +13,7 @@ SCRIPT = ROOT / "tools" / "template_distribution.py"
 SPEC = importlib.util.spec_from_file_location("template_distribution", SCRIPT)
 assert SPEC and SPEC.loader
 distribution = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = distribution
 SPEC.loader.exec_module(distribution)
 
 
@@ -45,10 +47,14 @@ class TemplateDistributionTest(unittest.TestCase):
                 for target in sorted(targets.values(), key=lambda item: item.template)
             ]
         }
-        actual = json.loads(
-            os.popen(f"python3 {SCRIPT} matrix").read()
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "matrix"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
         )
-        self.assertEqual(actual, expected)
+        self.assertEqual(json.loads(result.stdout), expected)
 
     def test_materialize_is_exact_and_removes_stale_files(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tools/template_distribution.py
+++ b/tools/template_distribution.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+IGNORED_DIRECTORY_NAMES = {"__pycache__", ".git"}
+IGNORED_FILE_SUFFIXES = {".pyc", ".pyo"}
+
+
+class DistributionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Target:
+    template: str
+    owner: str
+    repository: str
+    default_branch: str
+    description: str
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.owner}/{self.repository}"
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise DistributionError(f"missing manifest: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise DistributionError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise DistributionError(f"manifest root must be an object: {path}")
+    return data
+
+
+def load_template_names(root: Path) -> set[str]:
+    data = _read_json(root / "templates" / "manifest.json")
+    templates = data.get("templates")
+    if set(data) != {"templates"} or not isinstance(templates, dict):
+        raise DistributionError("templates/manifest.json must contain exactly 'templates'")
+    return set(templates)
+
+
+def load_distribution(root: Path) -> tuple[dict[str, Target], dict[str, str]]:
+    data = _read_json(root / "distribution" / "template-repositories.json")
+    if set(data) != {"version", "owner", "templates"}:
+        raise DistributionError("distribution manifest must contain version, owner, templates")
+    if data["version"] != 1:
+        raise DistributionError(f"unsupported distribution manifest version: {data['version']!r}")
+    owner = data["owner"]
+    if not isinstance(owner, str) or not NAME_RE.fullmatch(owner):
+        raise DistributionError(f"invalid distribution owner: {owner!r}")
+    raw_templates = data["templates"]
+    if not isinstance(raw_templates, dict):
+        raise DistributionError("distribution templates must be an object")
+
+    targets: dict[str, Target] = {}
+    excluded: dict[str, str] = {}
+    repositories: set[str] = set()
+    for template, raw in raw_templates.items():
+        if not isinstance(template, str) or not NAME_RE.fullmatch(template):
+            raise DistributionError(f"invalid template key: {template!r}")
+        if not isinstance(raw, dict) or not isinstance(raw.get("published"), bool):
+            raise DistributionError(f"template {template!r} requires boolean published")
+        if raw["published"]:
+            expected = {"published", "repository", "default_branch", "description"}
+            if set(raw) != expected:
+                raise DistributionError(
+                    f"published template {template!r} must contain exactly {sorted(expected)}"
+                )
+            repository = raw["repository"]
+            branch = raw["default_branch"]
+            description = raw["description"]
+            if not isinstance(repository, str) or not NAME_RE.fullmatch(repository):
+                raise DistributionError(f"invalid repository for {template!r}: {repository!r}")
+            if not isinstance(branch, str) or not NAME_RE.fullmatch(branch):
+                raise DistributionError(f"invalid default branch for {template!r}: {branch!r}")
+            if not isinstance(description, str) or not description.strip():
+                raise DistributionError(f"missing description for {template!r}")
+            full_name = f"{owner}/{repository}".lower()
+            if full_name in repositories:
+                raise DistributionError(f"duplicate target repository: {owner}/{repository}")
+            repositories.add(full_name)
+            targets[template] = Target(template, owner, repository, branch, description)
+        else:
+            if set(raw) != {"published", "reason"}:
+                raise DistributionError(
+                    f"unpublished template {template!r} must contain exactly published and reason"
+                )
+            reason = raw["reason"]
+            if not isinstance(reason, str) or not reason.strip():
+                raise DistributionError(f"unpublished template {template!r} requires a reason")
+            excluded[template] = reason
+
+    registered = load_template_names(root)
+    configured = set(raw_templates)
+    if registered != configured:
+        missing = sorted(registered - configured)
+        extra = sorted(configured - registered)
+        details = []
+        if missing:
+            details.append("missing: " + ", ".join(missing))
+        if extra:
+            details.append("unknown: " + ", ".join(extra))
+        raise DistributionError("distribution/template manifest mismatch: " + "; ".join(details))
+    for template in registered:
+        if not (root / "templates" / template).is_dir():
+            raise DistributionError(f"missing generated template directory: templates/{template}")
+    return targets, excluded
+
+
+def target_for(root: Path, template: str) -> Target:
+    targets, excluded = load_distribution(root)
+    if template in excluded:
+        raise DistributionError(f"template {template!r} is not published: {excluded[template]}")
+    try:
+        return targets[template]
+    except KeyError as exc:
+        raise DistributionError(f"unknown template: {template!r}") from exc
+
+
+def _iter_files(root: Path):
+    for current, directories, files in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current)
+        directories[:] = sorted(d for d in directories if d not in IGNORED_DIRECTORY_NAMES)
+        files.sort()
+        symlink_dirs = [d for d in directories if (current_path / d).is_symlink()]
+        for directory in symlink_dirs:
+            path = current_path / directory
+            yield path, path.relative_to(root), "symlink"
+            directories.remove(directory)
+        for filename in files:
+            path = current_path / filename
+            if path.suffix in IGNORED_FILE_SUFFIXES:
+                continue
+            yield path, path.relative_to(root), "symlink" if path.is_symlink() else "file"
+
+
+def _digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def snapshot(root: Path) -> dict[str, tuple[str, str, bool]]:
+    if not root.is_dir():
+        return {}
+    result: dict[str, tuple[str, str, bool]] = {}
+    for source, relative, kind in _iter_files(root):
+        key = relative.as_posix()
+        if kind == "symlink":
+            result[key] = ("symlink", os.readlink(source), False)
+        else:
+            executable = bool(stat.S_IMODE(source.stat().st_mode) & 0o111)
+            result[key] = ("file", _digest(source), executable)
+    return result
+
+
+def diff(expected: dict, actual: dict) -> list[str]:
+    differences: list[str] = []
+    expected_keys = set(expected)
+    actual_keys = set(actual)
+    for path in sorted(expected_keys - actual_keys):
+        differences.append(f"missing: {path}")
+    for path in sorted(actual_keys - expected_keys):
+        differences.append(f"unexpected: {path}")
+    for path in sorted(expected_keys & actual_keys):
+        if expected[path] != actual[path]:
+            differences.append(f"changed: {path}")
+    return differences
+
+
+def _safe_destination(root: Path, destination: Path) -> Path:
+    resolved = destination.resolve()
+    if resolved in {root.resolve(), root.resolve().parent, Path("/")}:
+        raise DistributionError(f"refusing unsafe destination: {resolved}")
+    if not (resolved / ".git").exists():
+        raise DistributionError(f"destination is not a checked-out Git repository: {resolved}")
+    return resolved
+
+
+def materialize(root: Path, template: str, destination: Path) -> None:
+    target_for(root, template)
+    source = root / "templates" / template
+    destination = _safe_destination(root, destination)
+
+    for child in destination.iterdir():
+        if child.name == ".git":
+            continue
+        if child.is_symlink() or child.is_file():
+            child.unlink()
+        else:
+            shutil.rmtree(child)
+
+    for source_path, relative, kind in _iter_files(source):
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if kind == "symlink":
+            os.symlink(os.readlink(source_path), target)
+        else:
+            shutil.copy2(source_path, target, follow_symlinks=False)
+
+
+def check(root: Path, template: str, destination: Path) -> list[str]:
+    target_for(root, template)
+    destination = _safe_destination(root, destination)
+    return diff(snapshot(root / "templates" / template), snapshot(destination))
+
+
+def command_verify(root: Path) -> int:
+    targets, excluded = load_distribution(root)
+    for name in sorted(targets):
+        target = targets[name]
+        print(f"publish: {name} -> {target.full_name}:{target.default_branch}")
+    for name in sorted(excluded):
+        print(f"excluded: {name} — {excluded[name]}")
+    return 0
+
+
+def command_matrix(root: Path) -> int:
+    targets, _ = load_distribution(root)
+    include = [
+        {
+            "template": target.template,
+            "repository": target.full_name,
+            "default_branch": target.default_branch,
+        }
+        for target in sorted(targets.values(), key=lambda item: item.template)
+    ]
+    print(json.dumps({"include": include}, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+def command_materialize(root: Path, template: str, destination: str) -> int:
+    materialize(root, template, Path(destination))
+    print(f"materialized: {template} -> {Path(destination).resolve()}")
+    return 0
+
+
+def command_check(root: Path, template: str, destination: str) -> int:
+    differences = check(root, template, Path(destination))
+    if differences:
+        print(f"distribution drift: {template}", file=sys.stderr)
+        for difference in differences:
+            print(f"  - {difference}", file=sys.stderr)
+        return 1
+    print(f"distribution match: {template}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage generated GitHub template repository distribution")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("verify")
+    subparsers.add_parser("matrix")
+    materialize_parser = subparsers.add_parser("materialize")
+    materialize_parser.add_argument("template")
+    materialize_parser.add_argument("destination")
+    check_parser = subparsers.add_parser("check")
+    check_parser.add_argument("template")
+    check_parser.add_argument("destination")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = repository_root()
+    try:
+        if args.command == "verify":
+            return command_verify(root)
+        if args.command == "matrix":
+            return command_matrix(root)
+        if args.command == "materialize":
+            return command_materialize(root, args.template, args.destination)
+        if args.command == "check":
+            return command_check(root, args.template, args.destination)
+        raise AssertionError(args.command)
+    except DistributionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the Templates-side distribution architecture for #38 while keeping `upiscium/Templates` as the only source of truth.

This PR adds:

- a fixed distribution allowlist in `distribution/template-repositories.json`
- GitHub Template Repository targets for Python, Rust, Nix, and C++/CMake
- an explicit documented decision not to publish `agent-base` as a GitHub Template Repository
- deterministic `template_distribution.py` materialize/check tooling
- stale-file deletion, dotfile/symlink preservation, and executable-mode comparison
- local read-only/operator Just APIs for distribution verification
- a `workflow_run` publisher that runs only after successful `Template CI` on `main`
- exact publication from the verified `workflow_run.head_sha`
- a current-main gate to prevent older successful CI runs from rolling distribution repositories backwards
- manifest-derived target matrix so arbitrary repository input cannot select a publish target
- pre-sync drift detection and mandatory post-sync exact-match verification
- no force push and no manual `workflow_dispatch` publish path
- recurring publisher credential design requiring only Contents read/write on the four allowlisted repositories
- one-time operator setup documentation for repository creation and `gh repo edit --template`
- documentation for GitHub UI / `gh repo create --template` / Nix / adoption / upgrade channel selection
- contract tests for allowlisting, materialization, stale deletion, mode preservation, workflow gates, and operator API boundaries

## Distribution targets

```text
agent-python     -> upiscium/Template-Agent-Python
agent-rust       -> upiscium/Template-Agent-Rust
agent-nix        -> upiscium/Template-Agent-Nix
agent-cpp-cmake  -> upiscium/Template-Agent-Cpp-CMake
```

`agent-base` remains available through Nix/local/adoption workflows and is intentionally not published as a GitHub new-repository template.

## Safety boundary

The actual external repositories do not exist yet. Their creation and one-time Template Repository setting remain explicit operator setup because repository setting changes require Administration-level authority, while the recurring publisher should not retain that permission.

After setup, `TEMPLATE_PUBLISH_TOKEN` is scoped to only the four target repositories with Contents read/write, and `TEMPLATE_PUBLISH_ENABLED=true` explicitly enables publication.

Publication is CI-only and only from a successful current `main` Template CI revision.

## Validation

Template CI will exercise the Python contract suite including the new distribution tests, generated drift, and all existing generated-template smoke jobs.

Refs #38