### PR TITLE
feat: add declarative GitHub repository policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,25 @@ The optional explicit project name can be supplied when the directory name is no
 nix develop --command just project::bootstrap my-project
 ```
 
-`project::bootstrap` is the explicit state-changing setup step. It resolves generated project-name placeholders and is idempotent. It does not commit, push, or merge. After bootstrap, initialize Git as needed and use `/init` or the corresponding Just checks for normal read-only session validation.
+`project::bootstrap` is the explicit state-changing setup step. It resolves generated project-name placeholders and is idempotent. It does not commit, push, merge, or change GitHub repository settings. After bootstrap, initialize Git as needed and use `/init` or the corresponding Just checks for normal read-only session validation.
+
+## Repository policy
+
+Generated Agent-ready repositories declare a GitHub repository policy in `.automation/repository-policy.json`. The policy expects `main` as the default branch and protects the default branch with a repository ruleset: every change must arrive through a pull request, approving reviews are optional (`0` required), deletion and force pushes are blocked, and no bypass actor is configured.
+
+Repository policy is deliberately separate from project bootstrap and `/init`. Inspect the current GitHub repository read-only with:
+
+```sh
+just repository::policy-check
+```
+
+Apply the declared policy explicitly with:
+
+```sh
+just repository::policy-apply
+```
+
+`repository::policy-apply` acts only on the GitHub repository resolved from the current checkout, requires GitHub Administration write permission, and is an Ask operation in OpenCode. If `main` does not exist, it refuses to invent or rename a branch; establish `main` explicitly first. Policy mutation is also refused from Task worktrees. See `.automation/REPOSITORY_POLICY.md` in generated repositories for the complete contract.
 
 ## Repository layers
 
@@ -70,15 +88,16 @@ Generated files under `templates/<name>/` are artifacts. Edit `components/agent-
 
 ## Initialization
 
-Bootstrap and initialization are intentionally separate:
+Bootstrap, GitHub repository policy setup, and session initialization are intentionally separate:
 
 ```text
 nix flake init ...
-  -> just project::bootstrap   # one-time, state-changing project setup
-  -> /init                     # every-session, read-only validation
+  -> just project::bootstrap          # one-time, state-changing project setup
+  -> just repository::policy-apply    # optional explicit GitHub repository setup
+  -> /init                            # every-session, read-only validation
 ```
 
-`/init` is read-only. It validates Agent Core version, Adapter identity, branch/worktree/Task State, tools, project doctor, HEAD, and Git status. It never bootstraps, repairs, installs packages, changes Task State, or rewrites `AGENTS.md`.
+`/init` is read-only. It validates Agent Core version, Adapter identity, branch/worktree/Task State, tools, project doctor, HEAD, and Git status. It never bootstraps, repairs, installs packages, changes Task State, rewrites `AGENTS.md`, or mutates GitHub repository settings.
 
 Existing-repository adoption and Agent Core upgrade are separate mutating workflows from generated-project bootstrap.
 

--- a/components/agent-core/.automation/REPOSITORY_POLICY.md
+++ b/components/agent-core/.automation/REPOSITORY_POLICY.md
@@ -1,0 +1,39 @@
+# Repository Policy
+
+Agent-ready repositories carry a declarative GitHub repository policy in `.automation/repository-policy.json`.
+
+The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
+
+Repository policy is separate from project bootstrap and session initialization:
+
+```text
+project::bootstrap
+  -> project files only
+
+repository::policy-check
+  -> read-only GitHub policy comparison
+
+repository::policy-apply
+  -> explicit GitHub repository mutation
+
+/init
+  -> read-only session validation
+```
+
+Check the current repository without changing it:
+
+```sh
+just repository::policy-check
+```
+
+Apply the policy explicitly:
+
+```sh
+just repository::policy-apply
+```
+
+`policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
+
+Repository policy mutation is refused from a Task worktree. In OpenCode, `repository::policy-check` is read-only and allowed; `repository::policy-apply` requires Ask.

--- a/components/agent-core/.automation/bin/repository_policy.py
+++ b/components/agent-core/.automation/bin/repository_policy.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+API_VERSION = "2026-03-10"
+RULESET_NAME = "Agent repository policy"
+PULL_REQUEST_PARAMETERS = {
+    "allowed_merge_methods": ["merge", "squash", "rebase"],
+    "dismiss_stale_reviews_on_push": False,
+    "require_code_owner_review": False,
+    "require_last_push_approval": False,
+    "required_approving_review_count": 0,
+    "required_review_thread_resolution": False,
+}
+
+
+class RepositoryPolicyError(RuntimeError):
+    pass
+
+
+def repository_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RepositoryPolicyError("not inside a Git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def load_policy(root: Path) -> dict[str, Any]:
+    path = root / ".automation" / "repository-policy.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RepositoryPolicyError(f"missing repository policy: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(f"invalid repository policy JSON: {exc}") from exc
+
+    if set(data) != {"version", "default_branch", "ruleset"}:
+        raise RepositoryPolicyError(
+            "repository policy must contain exactly version, default_branch, ruleset"
+        )
+    if data["version"] != 1:
+        raise RepositoryPolicyError(
+            f"unsupported repository policy version: {data['version']!r}"
+        )
+    if data["default_branch"] != "main":
+        raise RepositoryPolicyError("repository policy default_branch must be 'main'")
+
+    expected_ruleset = {
+        "name": RULESET_NAME,
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            }
+        },
+        "rules": [
+            {
+                "type": "pull_request",
+                "parameters": PULL_REQUEST_PARAMETERS,
+            },
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+        ],
+    }
+    if data["ruleset"] != expected_ruleset:
+        raise RepositoryPolicyError(
+            "repository policy ruleset does not match the supported Agent Core contract"
+        )
+    return data
+
+
+def _run_json(
+    command: list[str],
+    *,
+    cwd: Path,
+    stdin: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        input=None if stdin is None else json.dumps(stdin),
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if allow_not_found and ("HTTP 404" in detail or "Not Found" in detail):
+            return None
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} failed: {detail or f'exit {result.returncode}'}"
+        )
+    output = result.stdout.strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} returned invalid JSON"
+        ) from exc
+
+
+def gh_api(
+    root: Path,
+    method: str,
+    endpoint: str,
+    *,
+    body: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    command = [
+        "gh",
+        "api",
+        "--method",
+        method,
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        f"X-GitHub-Api-Version: {API_VERSION}",
+        endpoint,
+    ]
+    if body is not None:
+        command.extend(["--input", "-"])
+    return _run_json(
+        command,
+        cwd=root,
+        stdin=body,
+        allow_not_found=allow_not_found,
+    )
+
+
+def current_repository(root: Path) -> str:
+    value = _run_json(
+        ["gh", "repo", "view", "--json", "nameWithOwner"],
+        cwd=root,
+    )
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or repository.count("/") != 1:
+        raise RepositoryPolicyError(
+            "unable to resolve the current GitHub repository from this checkout"
+        )
+    return repository
+
+
+def task_worktree(root: Path) -> bool:
+    return (root / ".task-state" / "task.md").is_file()
+
+
+def branch_exists(root: Path, repository: str, branch: str) -> bool:
+    value = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/branches/{branch}",
+        allow_not_found=True,
+    )
+    return value is not None
+
+
+def desired_ruleset(policy: dict[str, Any]) -> dict[str, Any]:
+    return policy["ruleset"]
+
+
+def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
+    normalized_rules: list[dict[str, Any]] = []
+    for raw_rule in value.get("rules", []):
+        if not isinstance(raw_rule, dict):
+            continue
+        rule_type = raw_rule.get("type")
+        if not isinstance(rule_type, str):
+            continue
+        rule: dict[str, Any] = {"type": rule_type}
+        if rule_type == "pull_request":
+            parameters = raw_rule.get("parameters")
+            if isinstance(parameters, dict):
+                rule["parameters"] = {
+                    key: parameters.get(key)
+                    for key in PULL_REQUEST_PARAMETERS
+                }
+                methods = rule["parameters"]["allowed_merge_methods"]
+                if isinstance(methods, list):
+                    rule["parameters"]["allowed_merge_methods"] = sorted(methods)
+        normalized_rules.append(rule)
+    normalized_rules.sort(key=lambda item: item["type"])
+
+    bypass_actors = value.get("bypass_actors")
+    if bypass_actors is None:
+        normalized_bypass: Any = "__UNVERIFIED__"
+    elif isinstance(bypass_actors, list):
+        normalized_bypass = sorted(
+            bypass_actors,
+            key=lambda item: json.dumps(item, sort_keys=True),
+        )
+    else:
+        normalized_bypass = bypass_actors
+
+    return {
+        "name": value.get("name"),
+        "target": value.get("target"),
+        "enforcement": value.get("enforcement"),
+        "bypass_actors": normalized_bypass,
+        "conditions": value.get("conditions"),
+        "rules": normalized_rules,
+    }
+
+
+def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
+    result = normalize_ruleset(desired_ruleset(policy))
+    for rule in result["rules"]:
+        if rule["type"] == "pull_request":
+            rule["parameters"]["allowed_merge_methods"] = sorted(
+                rule["parameters"]["allowed_merge_methods"]
+            )
+    return result
+
+
+def find_managed_ruleset(
+    root: Path,
+    repository: str,
+) -> tuple[int | None, dict[str, Any] | None]:
+    values = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/rulesets?includes_parents=false&per_page=100",
+    )
+    if not isinstance(values, list):
+        raise RepositoryPolicyError("unexpected repository rulesets response")
+
+    matches = [
+        item
+        for item in values
+        if isinstance(item, dict)
+        and item.get("name") == RULESET_NAME
+        and item.get("source_type") == "Repository"
+    ]
+    if len(matches) > 1:
+        raise RepositoryPolicyError(
+            f"multiple repository rulesets named {RULESET_NAME!r} exist"
+        )
+    if not matches:
+        return None, None
+
+    ruleset_id = matches[0].get("id")
+    if not isinstance(ruleset_id, int):
+        raise RepositoryPolicyError("managed repository ruleset is missing its id")
+    detail = gh_api(root, "GET", f"repos/{repository}/rulesets/{ruleset_id}")
+    if not isinstance(detail, dict):
+        raise RepositoryPolicyError("unexpected managed repository ruleset response")
+    return ruleset_id, detail
+
+
+def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
+    repository = current_repository(root)
+    repository_data = gh_api(root, "GET", f"repos/{repository}")
+    if not isinstance(repository_data, dict):
+        raise RepositoryPolicyError("unexpected repository response")
+
+    expected_branch = policy["default_branch"]
+    actual_branch = repository_data.get("default_branch")
+    expected_branch_exists = branch_exists(root, repository, expected_branch)
+
+    ruleset_id, actual_ruleset = find_managed_ruleset(root, repository)
+    expected_ruleset = normalized_desired(policy)
+    normalized_actual = (
+        None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
+    )
+
+    drift: list[str] = []
+    if actual_branch != expected_branch:
+        drift.append(
+            f"default branch is {actual_branch!r}; expected {expected_branch!r}"
+        )
+    if actual_branch != expected_branch and not expected_branch_exists:
+        drift.append(
+            f"required branch {expected_branch!r} does not exist; "
+            "create or rename it before applying policy"
+        )
+    if actual_ruleset is None:
+        drift.append(f"missing ruleset {RULESET_NAME!r}")
+    elif normalized_actual != expected_ruleset:
+        drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    return {
+        "repository": repository,
+        "policyVersion": policy["version"],
+        "defaultBranch": {
+            "expected": expected_branch,
+            "actual": actual_branch,
+            "expectedBranchExists": expected_branch_exists,
+            "match": actual_branch == expected_branch,
+        },
+        "ruleset": {
+            "name": RULESET_NAME,
+            "id": ruleset_id,
+            "present": actual_ruleset is not None,
+            "match": normalized_actual == expected_ruleset,
+            "actual": normalized_actual,
+            "expected": expected_ruleset,
+        },
+        "drift": drift,
+    }
+
+
+def command_check(root: Path) -> int:
+    policy = load_policy(root)
+    result = inspect(root, policy)
+    result["status"] = "PASS" if not result["drift"] else "DRIFT"
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if not result["drift"] else 1
+
+
+def command_apply(root: Path) -> int:
+    if task_worktree(root):
+        raise RepositoryPolicyError(
+            "repository policy mutation is forbidden from a Task worktree"
+        )
+
+    policy = load_policy(root)
+    before = inspect(root, policy)
+    repository = before["repository"]
+    expected_branch = policy["default_branch"]
+
+    if before["defaultBranch"]["actual"] != expected_branch:
+        if not before["defaultBranch"]["expectedBranchExists"]:
+            raise RepositoryPolicyError(
+                f"cannot set default branch to {expected_branch!r}: "
+                f"branch {expected_branch!r} does not exist"
+            )
+        gh_api(
+            root,
+            "PATCH",
+            f"repos/{repository}",
+            body={"default_branch": expected_branch},
+        )
+
+    ruleset_id = before["ruleset"]["id"]
+    if ruleset_id is None:
+        gh_api(
+            root,
+            "POST",
+            f"repos/{repository}/rulesets",
+            body=desired_ruleset(policy),
+        )
+    elif not before["ruleset"]["match"]:
+        gh_api(
+            root,
+            "PUT",
+            f"repos/{repository}/rulesets/{ruleset_id}",
+            body=desired_ruleset(policy),
+        )
+
+    after = inspect(root, policy)
+    if after["drift"]:
+        raise RepositoryPolicyError(
+            "repository policy apply completed but verification still reports drift: "
+            + "; ".join(after["drift"])
+        )
+
+    after["status"] = "PASS"
+    after["changed"] = bool(before["drift"])
+    print(json.dumps(after, indent=2, sort_keys=True))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Check and apply the Agent repository GitHub policy"
+    )
+    sub = result.add_subparsers(dest="command", required=True)
+    sub.add_parser("check")
+    sub.add_parser("apply")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        root = repository_root()
+        if args.command == "check":
+            return command_check(root)
+        if args.command == "apply":
+            return command_apply(root)
+        raise AssertionError(args.command)
+    except RepositoryPolicyError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/components/agent-core/.automation/just/repository.just
+++ b/components/agent-core/.automation/just/repository.just
@@ -1,0 +1,10 @@
+root := justfile_directory()
+policy := root / ".automation/bin/repository_policy.py"
+
+[working-directory: root]
+policy-check:
+    python3 {{quote(policy)}} check
+
+[working-directory: root]
+policy-apply:
+    python3 {{quote(policy)}} apply

--- a/components/agent-core/.automation/ownership.toml
+++ b/components/agent-core/.automation/ownership.toml
@@ -3,3 +3,8 @@ version = 1
 [paths]
 "AGENTS.md" = "replace"
 "Justfile" = "replace"
+".automation/REPOSITORY_POLICY.md" = "replace"
+".automation/repository-policy.json" = "replace"
+".automation/bin/repository_policy.py" = "replace"
+".automation/just/repository.just" = "replace"
+"opencode.json" = "replace"

--- a/components/agent-core/.automation/repository-policy.json
+++ b/components/agent-core/.automation/repository-policy.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "default_branch": "main",
+  "ruleset": {
+    "name": "Agent repository policy",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "include": ["~DEFAULT_BRANCH"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      {
+        "type": "pull_request",
+        "parameters": {
+          "allowed_merge_methods": ["merge", "squash", "rebase"],
+          "dismiss_stale_reviews_on_push": false,
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_approving_review_count": 0,
+          "required_review_thread_resolution": false
+        }
+      },
+      {
+        "type": "deletion"
+      },
+      {
+        "type": "non_fast_forward"
+      }
+    ]
+  }
+}

--- a/components/agent-core/Justfile
+++ b/components/agent-core/Justfile
@@ -3,6 +3,7 @@ set minimum-version := "1.52.0"
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
+mod repository '.automation/just/repository.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'
 

--- a/components/agent-core/opencode.json
+++ b/components/agent-core/opencode.json
@@ -70,6 +70,8 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just repository::policy-check": "allow",
+      "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",

--- a/templates/agent-base/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-base/.automation/REPOSITORY_POLICY.md
@@ -1,0 +1,39 @@
+# Repository Policy
+
+Agent-ready repositories carry a declarative GitHub repository policy in `.automation/repository-policy.json`.
+
+The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
+
+Repository policy is separate from project bootstrap and session initialization:
+
+```text
+project::bootstrap
+  -> project files only
+
+repository::policy-check
+  -> read-only GitHub policy comparison
+
+repository::policy-apply
+  -> explicit GitHub repository mutation
+
+/init
+  -> read-only session validation
+```
+
+Check the current repository without changing it:
+
+```sh
+just repository::policy-check
+```
+
+Apply the policy explicitly:
+
+```sh
+just repository::policy-apply
+```
+
+`policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
+
+Repository policy mutation is refused from a Task worktree. In OpenCode, `repository::policy-check` is read-only and allowed; `repository::policy-apply` requires Ask.

--- a/templates/agent-base/.automation/bin/repository_policy.py
+++ b/templates/agent-base/.automation/bin/repository_policy.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+API_VERSION = "2026-03-10"
+RULESET_NAME = "Agent repository policy"
+PULL_REQUEST_PARAMETERS = {
+    "allowed_merge_methods": ["merge", "squash", "rebase"],
+    "dismiss_stale_reviews_on_push": False,
+    "require_code_owner_review": False,
+    "require_last_push_approval": False,
+    "required_approving_review_count": 0,
+    "required_review_thread_resolution": False,
+}
+
+
+class RepositoryPolicyError(RuntimeError):
+    pass
+
+
+def repository_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RepositoryPolicyError("not inside a Git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def load_policy(root: Path) -> dict[str, Any]:
+    path = root / ".automation" / "repository-policy.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RepositoryPolicyError(f"missing repository policy: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(f"invalid repository policy JSON: {exc}") from exc
+
+    if set(data) != {"version", "default_branch", "ruleset"}:
+        raise RepositoryPolicyError(
+            "repository policy must contain exactly version, default_branch, ruleset"
+        )
+    if data["version"] != 1:
+        raise RepositoryPolicyError(
+            f"unsupported repository policy version: {data['version']!r}"
+        )
+    if data["default_branch"] != "main":
+        raise RepositoryPolicyError("repository policy default_branch must be 'main'")
+
+    expected_ruleset = {
+        "name": RULESET_NAME,
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            }
+        },
+        "rules": [
+            {
+                "type": "pull_request",
+                "parameters": PULL_REQUEST_PARAMETERS,
+            },
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+        ],
+    }
+    if data["ruleset"] != expected_ruleset:
+        raise RepositoryPolicyError(
+            "repository policy ruleset does not match the supported Agent Core contract"
+        )
+    return data
+
+
+def _run_json(
+    command: list[str],
+    *,
+    cwd: Path,
+    stdin: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        input=None if stdin is None else json.dumps(stdin),
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if allow_not_found and ("HTTP 404" in detail or "Not Found" in detail):
+            return None
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} failed: {detail or f'exit {result.returncode}'}"
+        )
+    output = result.stdout.strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} returned invalid JSON"
+        ) from exc
+
+
+def gh_api(
+    root: Path,
+    method: str,
+    endpoint: str,
+    *,
+    body: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    command = [
+        "gh",
+        "api",
+        "--method",
+        method,
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        f"X-GitHub-Api-Version: {API_VERSION}",
+        endpoint,
+    ]
+    if body is not None:
+        command.extend(["--input", "-"])
+    return _run_json(
+        command,
+        cwd=root,
+        stdin=body,
+        allow_not_found=allow_not_found,
+    )
+
+
+def current_repository(root: Path) -> str:
+    value = _run_json(
+        ["gh", "repo", "view", "--json", "nameWithOwner"],
+        cwd=root,
+    )
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or repository.count("/") != 1:
+        raise RepositoryPolicyError(
+            "unable to resolve the current GitHub repository from this checkout"
+        )
+    return repository
+
+
+def task_worktree(root: Path) -> bool:
+    return (root / ".task-state" / "task.md").is_file()
+
+
+def branch_exists(root: Path, repository: str, branch: str) -> bool:
+    value = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/branches/{branch}",
+        allow_not_found=True,
+    )
+    return value is not None
+
+
+def desired_ruleset(policy: dict[str, Any]) -> dict[str, Any]:
+    return policy["ruleset"]
+
+
+def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
+    normalized_rules: list[dict[str, Any]] = []
+    for raw_rule in value.get("rules", []):
+        if not isinstance(raw_rule, dict):
+            continue
+        rule_type = raw_rule.get("type")
+        if not isinstance(rule_type, str):
+            continue
+        rule: dict[str, Any] = {"type": rule_type}
+        if rule_type == "pull_request":
+            parameters = raw_rule.get("parameters")
+            if isinstance(parameters, dict):
+                rule["parameters"] = {
+                    key: parameters.get(key)
+                    for key in PULL_REQUEST_PARAMETERS
+                }
+                methods = rule["parameters"]["allowed_merge_methods"]
+                if isinstance(methods, list):
+                    rule["parameters"]["allowed_merge_methods"] = sorted(methods)
+        normalized_rules.append(rule)
+    normalized_rules.sort(key=lambda item: item["type"])
+
+    bypass_actors = value.get("bypass_actors")
+    if bypass_actors is None:
+        normalized_bypass: Any = "__UNVERIFIED__"
+    elif isinstance(bypass_actors, list):
+        normalized_bypass = sorted(
+            bypass_actors,
+            key=lambda item: json.dumps(item, sort_keys=True),
+        )
+    else:
+        normalized_bypass = bypass_actors
+
+    return {
+        "name": value.get("name"),
+        "target": value.get("target"),
+        "enforcement": value.get("enforcement"),
+        "bypass_actors": normalized_bypass,
+        "conditions": value.get("conditions"),
+        "rules": normalized_rules,
+    }
+
+
+def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
+    result = normalize_ruleset(desired_ruleset(policy))
+    for rule in result["rules"]:
+        if rule["type"] == "pull_request":
+            rule["parameters"]["allowed_merge_methods"] = sorted(
+                rule["parameters"]["allowed_merge_methods"]
+            )
+    return result
+
+
+def find_managed_ruleset(
+    root: Path,
+    repository: str,
+) -> tuple[int | None, dict[str, Any] | None]:
+    values = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/rulesets?includes_parents=false&per_page=100",
+    )
+    if not isinstance(values, list):
+        raise RepositoryPolicyError("unexpected repository rulesets response")
+
+    matches = [
+        item
+        for item in values
+        if isinstance(item, dict)
+        and item.get("name") == RULESET_NAME
+        and item.get("source_type") == "Repository"
+    ]
+    if len(matches) > 1:
+        raise RepositoryPolicyError(
+            f"multiple repository rulesets named {RULESET_NAME!r} exist"
+        )
+    if not matches:
+        return None, None
+
+    ruleset_id = matches[0].get("id")
+    if not isinstance(ruleset_id, int):
+        raise RepositoryPolicyError("managed repository ruleset is missing its id")
+    detail = gh_api(root, "GET", f"repos/{repository}/rulesets/{ruleset_id}")
+    if not isinstance(detail, dict):
+        raise RepositoryPolicyError("unexpected managed repository ruleset response")
+    return ruleset_id, detail
+
+
+def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
+    repository = current_repository(root)
+    repository_data = gh_api(root, "GET", f"repos/{repository}")
+    if not isinstance(repository_data, dict):
+        raise RepositoryPolicyError("unexpected repository response")
+
+    expected_branch = policy["default_branch"]
+    actual_branch = repository_data.get("default_branch")
+    expected_branch_exists = branch_exists(root, repository, expected_branch)
+
+    ruleset_id, actual_ruleset = find_managed_ruleset(root, repository)
+    expected_ruleset = normalized_desired(policy)
+    normalized_actual = (
+        None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
+    )
+
+    drift: list[str] = []
+    if actual_branch != expected_branch:
+        drift.append(
+            f"default branch is {actual_branch!r}; expected {expected_branch!r}"
+        )
+    if actual_branch != expected_branch and not expected_branch_exists:
+        drift.append(
+            f"required branch {expected_branch!r} does not exist; "
+            "create or rename it before applying policy"
+        )
+    if actual_ruleset is None:
+        drift.append(f"missing ruleset {RULESET_NAME!r}")
+    elif normalized_actual != expected_ruleset:
+        drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    return {
+        "repository": repository,
+        "policyVersion": policy["version"],
+        "defaultBranch": {
+            "expected": expected_branch,
+            "actual": actual_branch,
+            "expectedBranchExists": expected_branch_exists,
+            "match": actual_branch == expected_branch,
+        },
+        "ruleset": {
+            "name": RULESET_NAME,
+            "id": ruleset_id,
+            "present": actual_ruleset is not None,
+            "match": normalized_actual == expected_ruleset,
+            "actual": normalized_actual,
+            "expected": expected_ruleset,
+        },
+        "drift": drift,
+    }
+
+
+def command_check(root: Path) -> int:
+    policy = load_policy(root)
+    result = inspect(root, policy)
+    result["status"] = "PASS" if not result["drift"] else "DRIFT"
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if not result["drift"] else 1
+
+
+def command_apply(root: Path) -> int:
+    if task_worktree(root):
+        raise RepositoryPolicyError(
+            "repository policy mutation is forbidden from a Task worktree"
+        )
+
+    policy = load_policy(root)
+    before = inspect(root, policy)
+    repository = before["repository"]
+    expected_branch = policy["default_branch"]
+
+    if before["defaultBranch"]["actual"] != expected_branch:
+        if not before["defaultBranch"]["expectedBranchExists"]:
+            raise RepositoryPolicyError(
+                f"cannot set default branch to {expected_branch!r}: "
+                f"branch {expected_branch!r} does not exist"
+            )
+        gh_api(
+            root,
+            "PATCH",
+            f"repos/{repository}",
+            body={"default_branch": expected_branch},
+        )
+
+    ruleset_id = before["ruleset"]["id"]
+    if ruleset_id is None:
+        gh_api(
+            root,
+            "POST",
+            f"repos/{repository}/rulesets",
+            body=desired_ruleset(policy),
+        )
+    elif not before["ruleset"]["match"]:
+        gh_api(
+            root,
+            "PUT",
+            f"repos/{repository}/rulesets/{ruleset_id}",
+            body=desired_ruleset(policy),
+        )
+
+    after = inspect(root, policy)
+    if after["drift"]:
+        raise RepositoryPolicyError(
+            "repository policy apply completed but verification still reports drift: "
+            + "; ".join(after["drift"])
+        )
+
+    after["status"] = "PASS"
+    after["changed"] = bool(before["drift"])
+    print(json.dumps(after, indent=2, sort_keys=True))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Check and apply the Agent repository GitHub policy"
+    )
+    sub = result.add_subparsers(dest="command", required=True)
+    sub.add_parser("check")
+    sub.add_parser("apply")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        root = repository_root()
+        if args.command == "check":
+            return command_check(root)
+        if args.command == "apply":
+            return command_apply(root)
+        raise AssertionError(args.command)
+    except RepositoryPolicyError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-base/.automation/just/repository.just
+++ b/templates/agent-base/.automation/just/repository.just
@@ -1,0 +1,10 @@
+root := justfile_directory()
+policy := root / ".automation/bin/repository_policy.py"
+
+[working-directory: root]
+policy-check:
+    python3 {{quote(policy)}} check
+
+[working-directory: root]
+policy-apply:
+    python3 {{quote(policy)}} apply

--- a/templates/agent-base/.automation/ownership.toml
+++ b/templates/agent-base/.automation/ownership.toml
@@ -3,3 +3,8 @@ version = 1
 [paths]
 "AGENTS.md" = "replace"
 "Justfile" = "replace"
+".automation/REPOSITORY_POLICY.md" = "replace"
+".automation/repository-policy.json" = "replace"
+".automation/bin/repository_policy.py" = "replace"
+".automation/just/repository.just" = "replace"
+"opencode.json" = "replace"

--- a/templates/agent-base/.automation/repository-policy.json
+++ b/templates/agent-base/.automation/repository-policy.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "default_branch": "main",
+  "ruleset": {
+    "name": "Agent repository policy",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "include": ["~DEFAULT_BRANCH"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      {
+        "type": "pull_request",
+        "parameters": {
+          "allowed_merge_methods": ["merge", "squash", "rebase"],
+          "dismiss_stale_reviews_on_push": false,
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_approving_review_count": 0,
+          "required_review_thread_resolution": false
+        }
+      },
+      {
+        "type": "deletion"
+      },
+      {
+        "type": "non_fast_forward"
+      }
+    ]
+  }
+}

--- a/templates/agent-base/Justfile
+++ b/templates/agent-base/Justfile
@@ -3,6 +3,7 @@ set minimum-version := "1.52.0"
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
+mod repository '.automation/just/repository.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'
 

--- a/templates/agent-base/opencode.json
+++ b/templates/agent-base/opencode.json
@@ -70,6 +70,8 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just repository::policy-check": "allow",
+      "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",

--- a/templates/agent-cpp-cmake/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-cpp-cmake/.automation/REPOSITORY_POLICY.md
@@ -1,0 +1,39 @@
+# Repository Policy
+
+Agent-ready repositories carry a declarative GitHub repository policy in `.automation/repository-policy.json`.
+
+The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
+
+Repository policy is separate from project bootstrap and session initialization:
+
+```text
+project::bootstrap
+  -> project files only
+
+repository::policy-check
+  -> read-only GitHub policy comparison
+
+repository::policy-apply
+  -> explicit GitHub repository mutation
+
+/init
+  -> read-only session validation
+```
+
+Check the current repository without changing it:
+
+```sh
+just repository::policy-check
+```
+
+Apply the policy explicitly:
+
+```sh
+just repository::policy-apply
+```
+
+`policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
+
+Repository policy mutation is refused from a Task worktree. In OpenCode, `repository::policy-check` is read-only and allowed; `repository::policy-apply` requires Ask.

--- a/templates/agent-cpp-cmake/.automation/bin/repository_policy.py
+++ b/templates/agent-cpp-cmake/.automation/bin/repository_policy.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+API_VERSION = "2026-03-10"
+RULESET_NAME = "Agent repository policy"
+PULL_REQUEST_PARAMETERS = {
+    "allowed_merge_methods": ["merge", "squash", "rebase"],
+    "dismiss_stale_reviews_on_push": False,
+    "require_code_owner_review": False,
+    "require_last_push_approval": False,
+    "required_approving_review_count": 0,
+    "required_review_thread_resolution": False,
+}
+
+
+class RepositoryPolicyError(RuntimeError):
+    pass
+
+
+def repository_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RepositoryPolicyError("not inside a Git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def load_policy(root: Path) -> dict[str, Any]:
+    path = root / ".automation" / "repository-policy.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RepositoryPolicyError(f"missing repository policy: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(f"invalid repository policy JSON: {exc}") from exc
+
+    if set(data) != {"version", "default_branch", "ruleset"}:
+        raise RepositoryPolicyError(
+            "repository policy must contain exactly version, default_branch, ruleset"
+        )
+    if data["version"] != 1:
+        raise RepositoryPolicyError(
+            f"unsupported repository policy version: {data['version']!r}"
+        )
+    if data["default_branch"] != "main":
+        raise RepositoryPolicyError("repository policy default_branch must be 'main'")
+
+    expected_ruleset = {
+        "name": RULESET_NAME,
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            }
+        },
+        "rules": [
+            {
+                "type": "pull_request",
+                "parameters": PULL_REQUEST_PARAMETERS,
+            },
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+        ],
+    }
+    if data["ruleset"] != expected_ruleset:
+        raise RepositoryPolicyError(
+            "repository policy ruleset does not match the supported Agent Core contract"
+        )
+    return data
+
+
+def _run_json(
+    command: list[str],
+    *,
+    cwd: Path,
+    stdin: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        input=None if stdin is None else json.dumps(stdin),
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if allow_not_found and ("HTTP 404" in detail or "Not Found" in detail):
+            return None
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} failed: {detail or f'exit {result.returncode}'}"
+        )
+    output = result.stdout.strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} returned invalid JSON"
+        ) from exc
+
+
+def gh_api(
+    root: Path,
+    method: str,
+    endpoint: str,
+    *,
+    body: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    command = [
+        "gh",
+        "api",
+        "--method",
+        method,
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        f"X-GitHub-Api-Version: {API_VERSION}",
+        endpoint,
+    ]
+    if body is not None:
+        command.extend(["--input", "-"])
+    return _run_json(
+        command,
+        cwd=root,
+        stdin=body,
+        allow_not_found=allow_not_found,
+    )
+
+
+def current_repository(root: Path) -> str:
+    value = _run_json(
+        ["gh", "repo", "view", "--json", "nameWithOwner"],
+        cwd=root,
+    )
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or repository.count("/") != 1:
+        raise RepositoryPolicyError(
+            "unable to resolve the current GitHub repository from this checkout"
+        )
+    return repository
+
+
+def task_worktree(root: Path) -> bool:
+    return (root / ".task-state" / "task.md").is_file()
+
+
+def branch_exists(root: Path, repository: str, branch: str) -> bool:
+    value = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/branches/{branch}",
+        allow_not_found=True,
+    )
+    return value is not None
+
+
+def desired_ruleset(policy: dict[str, Any]) -> dict[str, Any]:
+    return policy["ruleset"]
+
+
+def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
+    normalized_rules: list[dict[str, Any]] = []
+    for raw_rule in value.get("rules", []):
+        if not isinstance(raw_rule, dict):
+            continue
+        rule_type = raw_rule.get("type")
+        if not isinstance(rule_type, str):
+            continue
+        rule: dict[str, Any] = {"type": rule_type}
+        if rule_type == "pull_request":
+            parameters = raw_rule.get("parameters")
+            if isinstance(parameters, dict):
+                rule["parameters"] = {
+                    key: parameters.get(key)
+                    for key in PULL_REQUEST_PARAMETERS
+                }
+                methods = rule["parameters"]["allowed_merge_methods"]
+                if isinstance(methods, list):
+                    rule["parameters"]["allowed_merge_methods"] = sorted(methods)
+        normalized_rules.append(rule)
+    normalized_rules.sort(key=lambda item: item["type"])
+
+    bypass_actors = value.get("bypass_actors")
+    if bypass_actors is None:
+        normalized_bypass: Any = "__UNVERIFIED__"
+    elif isinstance(bypass_actors, list):
+        normalized_bypass = sorted(
+            bypass_actors,
+            key=lambda item: json.dumps(item, sort_keys=True),
+        )
+    else:
+        normalized_bypass = bypass_actors
+
+    return {
+        "name": value.get("name"),
+        "target": value.get("target"),
+        "enforcement": value.get("enforcement"),
+        "bypass_actors": normalized_bypass,
+        "conditions": value.get("conditions"),
+        "rules": normalized_rules,
+    }
+
+
+def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
+    result = normalize_ruleset(desired_ruleset(policy))
+    for rule in result["rules"]:
+        if rule["type"] == "pull_request":
+            rule["parameters"]["allowed_merge_methods"] = sorted(
+                rule["parameters"]["allowed_merge_methods"]
+            )
+    return result
+
+
+def find_managed_ruleset(
+    root: Path,
+    repository: str,
+) -> tuple[int | None, dict[str, Any] | None]:
+    values = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/rulesets?includes_parents=false&per_page=100",
+    )
+    if not isinstance(values, list):
+        raise RepositoryPolicyError("unexpected repository rulesets response")
+
+    matches = [
+        item
+        for item in values
+        if isinstance(item, dict)
+        and item.get("name") == RULESET_NAME
+        and item.get("source_type") == "Repository"
+    ]
+    if len(matches) > 1:
+        raise RepositoryPolicyError(
+            f"multiple repository rulesets named {RULESET_NAME!r} exist"
+        )
+    if not matches:
+        return None, None
+
+    ruleset_id = matches[0].get("id")
+    if not isinstance(ruleset_id, int):
+        raise RepositoryPolicyError("managed repository ruleset is missing its id")
+    detail = gh_api(root, "GET", f"repos/{repository}/rulesets/{ruleset_id}")
+    if not isinstance(detail, dict):
+        raise RepositoryPolicyError("unexpected managed repository ruleset response")
+    return ruleset_id, detail
+
+
+def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
+    repository = current_repository(root)
+    repository_data = gh_api(root, "GET", f"repos/{repository}")
+    if not isinstance(repository_data, dict):
+        raise RepositoryPolicyError("unexpected repository response")
+
+    expected_branch = policy["default_branch"]
+    actual_branch = repository_data.get("default_branch")
+    expected_branch_exists = branch_exists(root, repository, expected_branch)
+
+    ruleset_id, actual_ruleset = find_managed_ruleset(root, repository)
+    expected_ruleset = normalized_desired(policy)
+    normalized_actual = (
+        None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
+    )
+
+    drift: list[str] = []
+    if actual_branch != expected_branch:
+        drift.append(
+            f"default branch is {actual_branch!r}; expected {expected_branch!r}"
+        )
+    if actual_branch != expected_branch and not expected_branch_exists:
+        drift.append(
+            f"required branch {expected_branch!r} does not exist; "
+            "create or rename it before applying policy"
+        )
+    if actual_ruleset is None:
+        drift.append(f"missing ruleset {RULESET_NAME!r}")
+    elif normalized_actual != expected_ruleset:
+        drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    return {
+        "repository": repository,
+        "policyVersion": policy["version"],
+        "defaultBranch": {
+            "expected": expected_branch,
+            "actual": actual_branch,
+            "expectedBranchExists": expected_branch_exists,
+            "match": actual_branch == expected_branch,
+        },
+        "ruleset": {
+            "name": RULESET_NAME,
+            "id": ruleset_id,
+            "present": actual_ruleset is not None,
+            "match": normalized_actual == expected_ruleset,
+            "actual": normalized_actual,
+            "expected": expected_ruleset,
+        },
+        "drift": drift,
+    }
+
+
+def command_check(root: Path) -> int:
+    policy = load_policy(root)
+    result = inspect(root, policy)
+    result["status"] = "PASS" if not result["drift"] else "DRIFT"
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if not result["drift"] else 1
+
+
+def command_apply(root: Path) -> int:
+    if task_worktree(root):
+        raise RepositoryPolicyError(
+            "repository policy mutation is forbidden from a Task worktree"
+        )
+
+    policy = load_policy(root)
+    before = inspect(root, policy)
+    repository = before["repository"]
+    expected_branch = policy["default_branch"]
+
+    if before["defaultBranch"]["actual"] != expected_branch:
+        if not before["defaultBranch"]["expectedBranchExists"]:
+            raise RepositoryPolicyError(
+                f"cannot set default branch to {expected_branch!r}: "
+                f"branch {expected_branch!r} does not exist"
+            )
+        gh_api(
+            root,
+            "PATCH",
+            f"repos/{repository}",
+            body={"default_branch": expected_branch},
+        )
+
+    ruleset_id = before["ruleset"]["id"]
+    if ruleset_id is None:
+        gh_api(
+            root,
+            "POST",
+            f"repos/{repository}/rulesets",
+            body=desired_ruleset(policy),
+        )
+    elif not before["ruleset"]["match"]:
+        gh_api(
+            root,
+            "PUT",
+            f"repos/{repository}/rulesets/{ruleset_id}",
+            body=desired_ruleset(policy),
+        )
+
+    after = inspect(root, policy)
+    if after["drift"]:
+        raise RepositoryPolicyError(
+            "repository policy apply completed but verification still reports drift: "
+            + "; ".join(after["drift"])
+        )
+
+    after["status"] = "PASS"
+    after["changed"] = bool(before["drift"])
+    print(json.dumps(after, indent=2, sort_keys=True))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Check and apply the Agent repository GitHub policy"
+    )
+    sub = result.add_subparsers(dest="command", required=True)
+    sub.add_parser("check")
+    sub.add_parser("apply")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        root = repository_root()
+        if args.command == "check":
+            return command_check(root)
+        if args.command == "apply":
+            return command_apply(root)
+        raise AssertionError(args.command)
+    except RepositoryPolicyError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-cpp-cmake/.automation/just/repository.just
+++ b/templates/agent-cpp-cmake/.automation/just/repository.just
@@ -1,0 +1,10 @@
+root := justfile_directory()
+policy := root / ".automation/bin/repository_policy.py"
+
+[working-directory: root]
+policy-check:
+    python3 {{quote(policy)}} check
+
+[working-directory: root]
+policy-apply:
+    python3 {{quote(policy)}} apply

--- a/templates/agent-cpp-cmake/.automation/ownership.toml
+++ b/templates/agent-cpp-cmake/.automation/ownership.toml
@@ -3,3 +3,8 @@ version = 1
 [paths]
 "AGENTS.md" = "replace"
 "Justfile" = "replace"
+".automation/REPOSITORY_POLICY.md" = "replace"
+".automation/repository-policy.json" = "replace"
+".automation/bin/repository_policy.py" = "replace"
+".automation/just/repository.just" = "replace"
+"opencode.json" = "replace"

--- a/templates/agent-cpp-cmake/.automation/repository-policy.json
+++ b/templates/agent-cpp-cmake/.automation/repository-policy.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "default_branch": "main",
+  "ruleset": {
+    "name": "Agent repository policy",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "include": ["~DEFAULT_BRANCH"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      {
+        "type": "pull_request",
+        "parameters": {
+          "allowed_merge_methods": ["merge", "squash", "rebase"],
+          "dismiss_stale_reviews_on_push": false,
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_approving_review_count": 0,
+          "required_review_thread_resolution": false
+        }
+      },
+      {
+        "type": "deletion"
+      },
+      {
+        "type": "non_fast_forward"
+      }
+    ]
+  }
+}

--- a/templates/agent-cpp-cmake/Justfile
+++ b/templates/agent-cpp-cmake/Justfile
@@ -3,6 +3,7 @@ set minimum-version := "1.52.0"
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
+mod repository '.automation/just/repository.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'
 

--- a/templates/agent-cpp-cmake/opencode.json
+++ b/templates/agent-cpp-cmake/opencode.json
@@ -70,6 +70,8 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just repository::policy-check": "allow",
+      "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",

--- a/templates/agent-nix/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-nix/.automation/REPOSITORY_POLICY.md
@@ -1,0 +1,39 @@
+# Repository Policy
+
+Agent-ready repositories carry a declarative GitHub repository policy in `.automation/repository-policy.json`.
+
+The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
+
+Repository policy is separate from project bootstrap and session initialization:
+
+```text
+project::bootstrap
+  -> project files only
+
+repository::policy-check
+  -> read-only GitHub policy comparison
+
+repository::policy-apply
+  -> explicit GitHub repository mutation
+
+/init
+  -> read-only session validation
+```
+
+Check the current repository without changing it:
+
+```sh
+just repository::policy-check
+```
+
+Apply the policy explicitly:
+
+```sh
+just repository::policy-apply
+```
+
+`policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
+
+Repository policy mutation is refused from a Task worktree. In OpenCode, `repository::policy-check` is read-only and allowed; `repository::policy-apply` requires Ask.

--- a/templates/agent-nix/.automation/bin/repository_policy.py
+++ b/templates/agent-nix/.automation/bin/repository_policy.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+API_VERSION = "2026-03-10"
+RULESET_NAME = "Agent repository policy"
+PULL_REQUEST_PARAMETERS = {
+    "allowed_merge_methods": ["merge", "squash", "rebase"],
+    "dismiss_stale_reviews_on_push": False,
+    "require_code_owner_review": False,
+    "require_last_push_approval": False,
+    "required_approving_review_count": 0,
+    "required_review_thread_resolution": False,
+}
+
+
+class RepositoryPolicyError(RuntimeError):
+    pass
+
+
+def repository_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RepositoryPolicyError("not inside a Git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def load_policy(root: Path) -> dict[str, Any]:
+    path = root / ".automation" / "repository-policy.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RepositoryPolicyError(f"missing repository policy: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(f"invalid repository policy JSON: {exc}") from exc
+
+    if set(data) != {"version", "default_branch", "ruleset"}:
+        raise RepositoryPolicyError(
+            "repository policy must contain exactly version, default_branch, ruleset"
+        )
+    if data["version"] != 1:
+        raise RepositoryPolicyError(
+            f"unsupported repository policy version: {data['version']!r}"
+        )
+    if data["default_branch"] != "main":
+        raise RepositoryPolicyError("repository policy default_branch must be 'main'")
+
+    expected_ruleset = {
+        "name": RULESET_NAME,
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            }
+        },
+        "rules": [
+            {
+                "type": "pull_request",
+                "parameters": PULL_REQUEST_PARAMETERS,
+            },
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+        ],
+    }
+    if data["ruleset"] != expected_ruleset:
+        raise RepositoryPolicyError(
+            "repository policy ruleset does not match the supported Agent Core contract"
+        )
+    return data
+
+
+def _run_json(
+    command: list[str],
+    *,
+    cwd: Path,
+    stdin: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        input=None if stdin is None else json.dumps(stdin),
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if allow_not_found and ("HTTP 404" in detail or "Not Found" in detail):
+            return None
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} failed: {detail or f'exit {result.returncode}'}"
+        )
+    output = result.stdout.strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} returned invalid JSON"
+        ) from exc
+
+
+def gh_api(
+    root: Path,
+    method: str,
+    endpoint: str,
+    *,
+    body: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    command = [
+        "gh",
+        "api",
+        "--method",
+        method,
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        f"X-GitHub-Api-Version: {API_VERSION}",
+        endpoint,
+    ]
+    if body is not None:
+        command.extend(["--input", "-"])
+    return _run_json(
+        command,
+        cwd=root,
+        stdin=body,
+        allow_not_found=allow_not_found,
+    )
+
+
+def current_repository(root: Path) -> str:
+    value = _run_json(
+        ["gh", "repo", "view", "--json", "nameWithOwner"],
+        cwd=root,
+    )
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or repository.count("/") != 1:
+        raise RepositoryPolicyError(
+            "unable to resolve the current GitHub repository from this checkout"
+        )
+    return repository
+
+
+def task_worktree(root: Path) -> bool:
+    return (root / ".task-state" / "task.md").is_file()
+
+
+def branch_exists(root: Path, repository: str, branch: str) -> bool:
+    value = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/branches/{branch}",
+        allow_not_found=True,
+    )
+    return value is not None
+
+
+def desired_ruleset(policy: dict[str, Any]) -> dict[str, Any]:
+    return policy["ruleset"]
+
+
+def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
+    normalized_rules: list[dict[str, Any]] = []
+    for raw_rule in value.get("rules", []):
+        if not isinstance(raw_rule, dict):
+            continue
+        rule_type = raw_rule.get("type")
+        if not isinstance(rule_type, str):
+            continue
+        rule: dict[str, Any] = {"type": rule_type}
+        if rule_type == "pull_request":
+            parameters = raw_rule.get("parameters")
+            if isinstance(parameters, dict):
+                rule["parameters"] = {
+                    key: parameters.get(key)
+                    for key in PULL_REQUEST_PARAMETERS
+                }
+                methods = rule["parameters"]["allowed_merge_methods"]
+                if isinstance(methods, list):
+                    rule["parameters"]["allowed_merge_methods"] = sorted(methods)
+        normalized_rules.append(rule)
+    normalized_rules.sort(key=lambda item: item["type"])
+
+    bypass_actors = value.get("bypass_actors")
+    if bypass_actors is None:
+        normalized_bypass: Any = "__UNVERIFIED__"
+    elif isinstance(bypass_actors, list):
+        normalized_bypass = sorted(
+            bypass_actors,
+            key=lambda item: json.dumps(item, sort_keys=True),
+        )
+    else:
+        normalized_bypass = bypass_actors
+
+    return {
+        "name": value.get("name"),
+        "target": value.get("target"),
+        "enforcement": value.get("enforcement"),
+        "bypass_actors": normalized_bypass,
+        "conditions": value.get("conditions"),
+        "rules": normalized_rules,
+    }
+
+
+def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
+    result = normalize_ruleset(desired_ruleset(policy))
+    for rule in result["rules"]:
+        if rule["type"] == "pull_request":
+            rule["parameters"]["allowed_merge_methods"] = sorted(
+                rule["parameters"]["allowed_merge_methods"]
+            )
+    return result
+
+
+def find_managed_ruleset(
+    root: Path,
+    repository: str,
+) -> tuple[int | None, dict[str, Any] | None]:
+    values = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/rulesets?includes_parents=false&per_page=100",
+    )
+    if not isinstance(values, list):
+        raise RepositoryPolicyError("unexpected repository rulesets response")
+
+    matches = [
+        item
+        for item in values
+        if isinstance(item, dict)
+        and item.get("name") == RULESET_NAME
+        and item.get("source_type") == "Repository"
+    ]
+    if len(matches) > 1:
+        raise RepositoryPolicyError(
+            f"multiple repository rulesets named {RULESET_NAME!r} exist"
+        )
+    if not matches:
+        return None, None
+
+    ruleset_id = matches[0].get("id")
+    if not isinstance(ruleset_id, int):
+        raise RepositoryPolicyError("managed repository ruleset is missing its id")
+    detail = gh_api(root, "GET", f"repos/{repository}/rulesets/{ruleset_id}")
+    if not isinstance(detail, dict):
+        raise RepositoryPolicyError("unexpected managed repository ruleset response")
+    return ruleset_id, detail
+
+
+def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
+    repository = current_repository(root)
+    repository_data = gh_api(root, "GET", f"repos/{repository}")
+    if not isinstance(repository_data, dict):
+        raise RepositoryPolicyError("unexpected repository response")
+
+    expected_branch = policy["default_branch"]
+    actual_branch = repository_data.get("default_branch")
+    expected_branch_exists = branch_exists(root, repository, expected_branch)
+
+    ruleset_id, actual_ruleset = find_managed_ruleset(root, repository)
+    expected_ruleset = normalized_desired(policy)
+    normalized_actual = (
+        None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
+    )
+
+    drift: list[str] = []
+    if actual_branch != expected_branch:
+        drift.append(
+            f"default branch is {actual_branch!r}; expected {expected_branch!r}"
+        )
+    if actual_branch != expected_branch and not expected_branch_exists:
+        drift.append(
+            f"required branch {expected_branch!r} does not exist; "
+            "create or rename it before applying policy"
+        )
+    if actual_ruleset is None:
+        drift.append(f"missing ruleset {RULESET_NAME!r}")
+    elif normalized_actual != expected_ruleset:
+        drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    return {
+        "repository": repository,
+        "policyVersion": policy["version"],
+        "defaultBranch": {
+            "expected": expected_branch,
+            "actual": actual_branch,
+            "expectedBranchExists": expected_branch_exists,
+            "match": actual_branch == expected_branch,
+        },
+        "ruleset": {
+            "name": RULESET_NAME,
+            "id": ruleset_id,
+            "present": actual_ruleset is not None,
+            "match": normalized_actual == expected_ruleset,
+            "actual": normalized_actual,
+            "expected": expected_ruleset,
+        },
+        "drift": drift,
+    }
+
+
+def command_check(root: Path) -> int:
+    policy = load_policy(root)
+    result = inspect(root, policy)
+    result["status"] = "PASS" if not result["drift"] else "DRIFT"
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if not result["drift"] else 1
+
+
+def command_apply(root: Path) -> int:
+    if task_worktree(root):
+        raise RepositoryPolicyError(
+            "repository policy mutation is forbidden from a Task worktree"
+        )
+
+    policy = load_policy(root)
+    before = inspect(root, policy)
+    repository = before["repository"]
+    expected_branch = policy["default_branch"]
+
+    if before["defaultBranch"]["actual"] != expected_branch:
+        if not before["defaultBranch"]["expectedBranchExists"]:
+            raise RepositoryPolicyError(
+                f"cannot set default branch to {expected_branch!r}: "
+                f"branch {expected_branch!r} does not exist"
+            )
+        gh_api(
+            root,
+            "PATCH",
+            f"repos/{repository}",
+            body={"default_branch": expected_branch},
+        )
+
+    ruleset_id = before["ruleset"]["id"]
+    if ruleset_id is None:
+        gh_api(
+            root,
+            "POST",
+            f"repos/{repository}/rulesets",
+            body=desired_ruleset(policy),
+        )
+    elif not before["ruleset"]["match"]:
+        gh_api(
+            root,
+            "PUT",
+            f"repos/{repository}/rulesets/{ruleset_id}",
+            body=desired_ruleset(policy),
+        )
+
+    after = inspect(root, policy)
+    if after["drift"]:
+        raise RepositoryPolicyError(
+            "repository policy apply completed but verification still reports drift: "
+            + "; ".join(after["drift"])
+        )
+
+    after["status"] = "PASS"
+    after["changed"] = bool(before["drift"])
+    print(json.dumps(after, indent=2, sort_keys=True))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Check and apply the Agent repository GitHub policy"
+    )
+    sub = result.add_subparsers(dest="command", required=True)
+    sub.add_parser("check")
+    sub.add_parser("apply")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        root = repository_root()
+        if args.command == "check":
+            return command_check(root)
+        if args.command == "apply":
+            return command_apply(root)
+        raise AssertionError(args.command)
+    except RepositoryPolicyError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-nix/.automation/just/repository.just
+++ b/templates/agent-nix/.automation/just/repository.just
@@ -1,0 +1,10 @@
+root := justfile_directory()
+policy := root / ".automation/bin/repository_policy.py"
+
+[working-directory: root]
+policy-check:
+    python3 {{quote(policy)}} check
+
+[working-directory: root]
+policy-apply:
+    python3 {{quote(policy)}} apply

--- a/templates/agent-nix/.automation/ownership.toml
+++ b/templates/agent-nix/.automation/ownership.toml
@@ -3,3 +3,8 @@ version = 1
 [paths]
 "AGENTS.md" = "replace"
 "Justfile" = "replace"
+".automation/REPOSITORY_POLICY.md" = "replace"
+".automation/repository-policy.json" = "replace"
+".automation/bin/repository_policy.py" = "replace"
+".automation/just/repository.just" = "replace"
+"opencode.json" = "replace"

--- a/templates/agent-nix/.automation/repository-policy.json
+++ b/templates/agent-nix/.automation/repository-policy.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "default_branch": "main",
+  "ruleset": {
+    "name": "Agent repository policy",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "include": ["~DEFAULT_BRANCH"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      {
+        "type": "pull_request",
+        "parameters": {
+          "allowed_merge_methods": ["merge", "squash", "rebase"],
+          "dismiss_stale_reviews_on_push": false,
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_approving_review_count": 0,
+          "required_review_thread_resolution": false
+        }
+      },
+      {
+        "type": "deletion"
+      },
+      {
+        "type": "non_fast_forward"
+      }
+    ]
+  }
+}

--- a/templates/agent-nix/Justfile
+++ b/templates/agent-nix/Justfile
@@ -3,6 +3,7 @@ set minimum-version := "1.52.0"
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
+mod repository '.automation/just/repository.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'
 

--- a/templates/agent-nix/opencode.json
+++ b/templates/agent-nix/opencode.json
@@ -70,6 +70,8 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just repository::policy-check": "allow",
+      "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",

--- a/templates/agent-python/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-python/.automation/REPOSITORY_POLICY.md
@@ -1,0 +1,39 @@
+# Repository Policy
+
+Agent-ready repositories carry a declarative GitHub repository policy in `.automation/repository-policy.json`.
+
+The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
+
+Repository policy is separate from project bootstrap and session initialization:
+
+```text
+project::bootstrap
+  -> project files only
+
+repository::policy-check
+  -> read-only GitHub policy comparison
+
+repository::policy-apply
+  -> explicit GitHub repository mutation
+
+/init
+  -> read-only session validation
+```
+
+Check the current repository without changing it:
+
+```sh
+just repository::policy-check
+```
+
+Apply the policy explicitly:
+
+```sh
+just repository::policy-apply
+```
+
+`policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
+
+Repository policy mutation is refused from a Task worktree. In OpenCode, `repository::policy-check` is read-only and allowed; `repository::policy-apply` requires Ask.

--- a/templates/agent-python/.automation/bin/repository_policy.py
+++ b/templates/agent-python/.automation/bin/repository_policy.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+API_VERSION = "2026-03-10"
+RULESET_NAME = "Agent repository policy"
+PULL_REQUEST_PARAMETERS = {
+    "allowed_merge_methods": ["merge", "squash", "rebase"],
+    "dismiss_stale_reviews_on_push": False,
+    "require_code_owner_review": False,
+    "require_last_push_approval": False,
+    "required_approving_review_count": 0,
+    "required_review_thread_resolution": False,
+}
+
+
+class RepositoryPolicyError(RuntimeError):
+    pass
+
+
+def repository_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RepositoryPolicyError("not inside a Git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def load_policy(root: Path) -> dict[str, Any]:
+    path = root / ".automation" / "repository-policy.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RepositoryPolicyError(f"missing repository policy: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(f"invalid repository policy JSON: {exc}") from exc
+
+    if set(data) != {"version", "default_branch", "ruleset"}:
+        raise RepositoryPolicyError(
+            "repository policy must contain exactly version, default_branch, ruleset"
+        )
+    if data["version"] != 1:
+        raise RepositoryPolicyError(
+            f"unsupported repository policy version: {data['version']!r}"
+        )
+    if data["default_branch"] != "main":
+        raise RepositoryPolicyError("repository policy default_branch must be 'main'")
+
+    expected_ruleset = {
+        "name": RULESET_NAME,
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            }
+        },
+        "rules": [
+            {
+                "type": "pull_request",
+                "parameters": PULL_REQUEST_PARAMETERS,
+            },
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+        ],
+    }
+    if data["ruleset"] != expected_ruleset:
+        raise RepositoryPolicyError(
+            "repository policy ruleset does not match the supported Agent Core contract"
+        )
+    return data
+
+
+def _run_json(
+    command: list[str],
+    *,
+    cwd: Path,
+    stdin: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        input=None if stdin is None else json.dumps(stdin),
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if allow_not_found and ("HTTP 404" in detail or "Not Found" in detail):
+            return None
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} failed: {detail or f'exit {result.returncode}'}"
+        )
+    output = result.stdout.strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} returned invalid JSON"
+        ) from exc
+
+
+def gh_api(
+    root: Path,
+    method: str,
+    endpoint: str,
+    *,
+    body: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    command = [
+        "gh",
+        "api",
+        "--method",
+        method,
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        f"X-GitHub-Api-Version: {API_VERSION}",
+        endpoint,
+    ]
+    if body is not None:
+        command.extend(["--input", "-"])
+    return _run_json(
+        command,
+        cwd=root,
+        stdin=body,
+        allow_not_found=allow_not_found,
+    )
+
+
+def current_repository(root: Path) -> str:
+    value = _run_json(
+        ["gh", "repo", "view", "--json", "nameWithOwner"],
+        cwd=root,
+    )
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or repository.count("/") != 1:
+        raise RepositoryPolicyError(
+            "unable to resolve the current GitHub repository from this checkout"
+        )
+    return repository
+
+
+def task_worktree(root: Path) -> bool:
+    return (root / ".task-state" / "task.md").is_file()
+
+
+def branch_exists(root: Path, repository: str, branch: str) -> bool:
+    value = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/branches/{branch}",
+        allow_not_found=True,
+    )
+    return value is not None
+
+
+def desired_ruleset(policy: dict[str, Any]) -> dict[str, Any]:
+    return policy["ruleset"]
+
+
+def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
+    normalized_rules: list[dict[str, Any]] = []
+    for raw_rule in value.get("rules", []):
+        if not isinstance(raw_rule, dict):
+            continue
+        rule_type = raw_rule.get("type")
+        if not isinstance(rule_type, str):
+            continue
+        rule: dict[str, Any] = {"type": rule_type}
+        if rule_type == "pull_request":
+            parameters = raw_rule.get("parameters")
+            if isinstance(parameters, dict):
+                rule["parameters"] = {
+                    key: parameters.get(key)
+                    for key in PULL_REQUEST_PARAMETERS
+                }
+                methods = rule["parameters"]["allowed_merge_methods"]
+                if isinstance(methods, list):
+                    rule["parameters"]["allowed_merge_methods"] = sorted(methods)
+        normalized_rules.append(rule)
+    normalized_rules.sort(key=lambda item: item["type"])
+
+    bypass_actors = value.get("bypass_actors")
+    if bypass_actors is None:
+        normalized_bypass: Any = "__UNVERIFIED__"
+    elif isinstance(bypass_actors, list):
+        normalized_bypass = sorted(
+            bypass_actors,
+            key=lambda item: json.dumps(item, sort_keys=True),
+        )
+    else:
+        normalized_bypass = bypass_actors
+
+    return {
+        "name": value.get("name"),
+        "target": value.get("target"),
+        "enforcement": value.get("enforcement"),
+        "bypass_actors": normalized_bypass,
+        "conditions": value.get("conditions"),
+        "rules": normalized_rules,
+    }
+
+
+def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
+    result = normalize_ruleset(desired_ruleset(policy))
+    for rule in result["rules"]:
+        if rule["type"] == "pull_request":
+            rule["parameters"]["allowed_merge_methods"] = sorted(
+                rule["parameters"]["allowed_merge_methods"]
+            )
+    return result
+
+
+def find_managed_ruleset(
+    root: Path,
+    repository: str,
+) -> tuple[int | None, dict[str, Any] | None]:
+    values = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/rulesets?includes_parents=false&per_page=100",
+    )
+    if not isinstance(values, list):
+        raise RepositoryPolicyError("unexpected repository rulesets response")
+
+    matches = [
+        item
+        for item in values
+        if isinstance(item, dict)
+        and item.get("name") == RULESET_NAME
+        and item.get("source_type") == "Repository"
+    ]
+    if len(matches) > 1:
+        raise RepositoryPolicyError(
+            f"multiple repository rulesets named {RULESET_NAME!r} exist"
+        )
+    if not matches:
+        return None, None
+
+    ruleset_id = matches[0].get("id")
+    if not isinstance(ruleset_id, int):
+        raise RepositoryPolicyError("managed repository ruleset is missing its id")
+    detail = gh_api(root, "GET", f"repos/{repository}/rulesets/{ruleset_id}")
+    if not isinstance(detail, dict):
+        raise RepositoryPolicyError("unexpected managed repository ruleset response")
+    return ruleset_id, detail
+
+
+def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
+    repository = current_repository(root)
+    repository_data = gh_api(root, "GET", f"repos/{repository}")
+    if not isinstance(repository_data, dict):
+        raise RepositoryPolicyError("unexpected repository response")
+
+    expected_branch = policy["default_branch"]
+    actual_branch = repository_data.get("default_branch")
+    expected_branch_exists = branch_exists(root, repository, expected_branch)
+
+    ruleset_id, actual_ruleset = find_managed_ruleset(root, repository)
+    expected_ruleset = normalized_desired(policy)
+    normalized_actual = (
+        None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
+    )
+
+    drift: list[str] = []
+    if actual_branch != expected_branch:
+        drift.append(
+            f"default branch is {actual_branch!r}; expected {expected_branch!r}"
+        )
+    if actual_branch != expected_branch and not expected_branch_exists:
+        drift.append(
+            f"required branch {expected_branch!r} does not exist; "
+            "create or rename it before applying policy"
+        )
+    if actual_ruleset is None:
+        drift.append(f"missing ruleset {RULESET_NAME!r}")
+    elif normalized_actual != expected_ruleset:
+        drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    return {
+        "repository": repository,
+        "policyVersion": policy["version"],
+        "defaultBranch": {
+            "expected": expected_branch,
+            "actual": actual_branch,
+            "expectedBranchExists": expected_branch_exists,
+            "match": actual_branch == expected_branch,
+        },
+        "ruleset": {
+            "name": RULESET_NAME,
+            "id": ruleset_id,
+            "present": actual_ruleset is not None,
+            "match": normalized_actual == expected_ruleset,
+            "actual": normalized_actual,
+            "expected": expected_ruleset,
+        },
+        "drift": drift,
+    }
+
+
+def command_check(root: Path) -> int:
+    policy = load_policy(root)
+    result = inspect(root, policy)
+    result["status"] = "PASS" if not result["drift"] else "DRIFT"
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if not result["drift"] else 1
+
+
+def command_apply(root: Path) -> int:
+    if task_worktree(root):
+        raise RepositoryPolicyError(
+            "repository policy mutation is forbidden from a Task worktree"
+        )
+
+    policy = load_policy(root)
+    before = inspect(root, policy)
+    repository = before["repository"]
+    expected_branch = policy["default_branch"]
+
+    if before["defaultBranch"]["actual"] != expected_branch:
+        if not before["defaultBranch"]["expectedBranchExists"]:
+            raise RepositoryPolicyError(
+                f"cannot set default branch to {expected_branch!r}: "
+                f"branch {expected_branch!r} does not exist"
+            )
+        gh_api(
+            root,
+            "PATCH",
+            f"repos/{repository}",
+            body={"default_branch": expected_branch},
+        )
+
+    ruleset_id = before["ruleset"]["id"]
+    if ruleset_id is None:
+        gh_api(
+            root,
+            "POST",
+            f"repos/{repository}/rulesets",
+            body=desired_ruleset(policy),
+        )
+    elif not before["ruleset"]["match"]:
+        gh_api(
+            root,
+            "PUT",
+            f"repos/{repository}/rulesets/{ruleset_id}",
+            body=desired_ruleset(policy),
+        )
+
+    after = inspect(root, policy)
+    if after["drift"]:
+        raise RepositoryPolicyError(
+            "repository policy apply completed but verification still reports drift: "
+            + "; ".join(after["drift"])
+        )
+
+    after["status"] = "PASS"
+    after["changed"] = bool(before["drift"])
+    print(json.dumps(after, indent=2, sort_keys=True))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Check and apply the Agent repository GitHub policy"
+    )
+    sub = result.add_subparsers(dest="command", required=True)
+    sub.add_parser("check")
+    sub.add_parser("apply")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        root = repository_root()
+        if args.command == "check":
+            return command_check(root)
+        if args.command == "apply":
+            return command_apply(root)
+        raise AssertionError(args.command)
+    except RepositoryPolicyError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-python/.automation/just/repository.just
+++ b/templates/agent-python/.automation/just/repository.just
@@ -1,0 +1,10 @@
+root := justfile_directory()
+policy := root / ".automation/bin/repository_policy.py"
+
+[working-directory: root]
+policy-check:
+    python3 {{quote(policy)}} check
+
+[working-directory: root]
+policy-apply:
+    python3 {{quote(policy)}} apply

--- a/templates/agent-python/.automation/ownership.toml
+++ b/templates/agent-python/.automation/ownership.toml
@@ -3,3 +3,8 @@ version = 1
 [paths]
 "AGENTS.md" = "replace"
 "Justfile" = "replace"
+".automation/REPOSITORY_POLICY.md" = "replace"
+".automation/repository-policy.json" = "replace"
+".automation/bin/repository_policy.py" = "replace"
+".automation/just/repository.just" = "replace"
+"opencode.json" = "replace"

--- a/templates/agent-python/.automation/repository-policy.json
+++ b/templates/agent-python/.automation/repository-policy.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "default_branch": "main",
+  "ruleset": {
+    "name": "Agent repository policy",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "include": ["~DEFAULT_BRANCH"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      {
+        "type": "pull_request",
+        "parameters": {
+          "allowed_merge_methods": ["merge", "squash", "rebase"],
+          "dismiss_stale_reviews_on_push": false,
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_approving_review_count": 0,
+          "required_review_thread_resolution": false
+        }
+      },
+      {
+        "type": "deletion"
+      },
+      {
+        "type": "non_fast_forward"
+      }
+    ]
+  }
+}

--- a/templates/agent-python/Justfile
+++ b/templates/agent-python/Justfile
@@ -3,6 +3,7 @@ set minimum-version := "1.52.0"
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
+mod repository '.automation/just/repository.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'
 

--- a/templates/agent-python/opencode.json
+++ b/templates/agent-python/opencode.json
@@ -70,6 +70,8 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just repository::policy-check": "allow",
+      "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",

--- a/templates/agent-rust/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-rust/.automation/REPOSITORY_POLICY.md
@@ -1,0 +1,39 @@
+# Repository Policy
+
+Agent-ready repositories carry a declarative GitHub repository policy in `.automation/repository-policy.json`.
+
+The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
+
+Repository policy is separate from project bootstrap and session initialization:
+
+```text
+project::bootstrap
+  -> project files only
+
+repository::policy-check
+  -> read-only GitHub policy comparison
+
+repository::policy-apply
+  -> explicit GitHub repository mutation
+
+/init
+  -> read-only session validation
+```
+
+Check the current repository without changing it:
+
+```sh
+just repository::policy-check
+```
+
+Apply the policy explicitly:
+
+```sh
+just repository::policy-apply
+```
+
+`policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
+
+Repository policy mutation is refused from a Task worktree. In OpenCode, `repository::policy-check` is read-only and allowed; `repository::policy-apply` requires Ask.

--- a/templates/agent-rust/.automation/bin/repository_policy.py
+++ b/templates/agent-rust/.automation/bin/repository_policy.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+API_VERSION = "2026-03-10"
+RULESET_NAME = "Agent repository policy"
+PULL_REQUEST_PARAMETERS = {
+    "allowed_merge_methods": ["merge", "squash", "rebase"],
+    "dismiss_stale_reviews_on_push": False,
+    "require_code_owner_review": False,
+    "require_last_push_approval": False,
+    "required_approving_review_count": 0,
+    "required_review_thread_resolution": False,
+}
+
+
+class RepositoryPolicyError(RuntimeError):
+    pass
+
+
+def repository_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RepositoryPolicyError("not inside a Git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def load_policy(root: Path) -> dict[str, Any]:
+    path = root / ".automation" / "repository-policy.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise RepositoryPolicyError(f"missing repository policy: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(f"invalid repository policy JSON: {exc}") from exc
+
+    if set(data) != {"version", "default_branch", "ruleset"}:
+        raise RepositoryPolicyError(
+            "repository policy must contain exactly version, default_branch, ruleset"
+        )
+    if data["version"] != 1:
+        raise RepositoryPolicyError(
+            f"unsupported repository policy version: {data['version']!r}"
+        )
+    if data["default_branch"] != "main":
+        raise RepositoryPolicyError("repository policy default_branch must be 'main'")
+
+    expected_ruleset = {
+        "name": RULESET_NAME,
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            }
+        },
+        "rules": [
+            {
+                "type": "pull_request",
+                "parameters": PULL_REQUEST_PARAMETERS,
+            },
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+        ],
+    }
+    if data["ruleset"] != expected_ruleset:
+        raise RepositoryPolicyError(
+            "repository policy ruleset does not match the supported Agent Core contract"
+        )
+    return data
+
+
+def _run_json(
+    command: list[str],
+    *,
+    cwd: Path,
+    stdin: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        input=None if stdin is None else json.dumps(stdin),
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        if allow_not_found and ("HTTP 404" in detail or "Not Found" in detail):
+            return None
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} failed: {detail or f'exit {result.returncode}'}"
+        )
+    output = result.stdout.strip()
+    if not output:
+        return None
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise RepositoryPolicyError(
+            f"{' '.join(command)} returned invalid JSON"
+        ) from exc
+
+
+def gh_api(
+    root: Path,
+    method: str,
+    endpoint: str,
+    *,
+    body: dict[str, Any] | None = None,
+    allow_not_found: bool = False,
+) -> Any:
+    command = [
+        "gh",
+        "api",
+        "--method",
+        method,
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        f"X-GitHub-Api-Version: {API_VERSION}",
+        endpoint,
+    ]
+    if body is not None:
+        command.extend(["--input", "-"])
+    return _run_json(
+        command,
+        cwd=root,
+        stdin=body,
+        allow_not_found=allow_not_found,
+    )
+
+
+def current_repository(root: Path) -> str:
+    value = _run_json(
+        ["gh", "repo", "view", "--json", "nameWithOwner"],
+        cwd=root,
+    )
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or repository.count("/") != 1:
+        raise RepositoryPolicyError(
+            "unable to resolve the current GitHub repository from this checkout"
+        )
+    return repository
+
+
+def task_worktree(root: Path) -> bool:
+    return (root / ".task-state" / "task.md").is_file()
+
+
+def branch_exists(root: Path, repository: str, branch: str) -> bool:
+    value = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/branches/{branch}",
+        allow_not_found=True,
+    )
+    return value is not None
+
+
+def desired_ruleset(policy: dict[str, Any]) -> dict[str, Any]:
+    return policy["ruleset"]
+
+
+def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
+    normalized_rules: list[dict[str, Any]] = []
+    for raw_rule in value.get("rules", []):
+        if not isinstance(raw_rule, dict):
+            continue
+        rule_type = raw_rule.get("type")
+        if not isinstance(rule_type, str):
+            continue
+        rule: dict[str, Any] = {"type": rule_type}
+        if rule_type == "pull_request":
+            parameters = raw_rule.get("parameters")
+            if isinstance(parameters, dict):
+                rule["parameters"] = {
+                    key: parameters.get(key)
+                    for key in PULL_REQUEST_PARAMETERS
+                }
+                methods = rule["parameters"]["allowed_merge_methods"]
+                if isinstance(methods, list):
+                    rule["parameters"]["allowed_merge_methods"] = sorted(methods)
+        normalized_rules.append(rule)
+    normalized_rules.sort(key=lambda item: item["type"])
+
+    bypass_actors = value.get("bypass_actors")
+    if bypass_actors is None:
+        normalized_bypass: Any = "__UNVERIFIED__"
+    elif isinstance(bypass_actors, list):
+        normalized_bypass = sorted(
+            bypass_actors,
+            key=lambda item: json.dumps(item, sort_keys=True),
+        )
+    else:
+        normalized_bypass = bypass_actors
+
+    return {
+        "name": value.get("name"),
+        "target": value.get("target"),
+        "enforcement": value.get("enforcement"),
+        "bypass_actors": normalized_bypass,
+        "conditions": value.get("conditions"),
+        "rules": normalized_rules,
+    }
+
+
+def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
+    result = normalize_ruleset(desired_ruleset(policy))
+    for rule in result["rules"]:
+        if rule["type"] == "pull_request":
+            rule["parameters"]["allowed_merge_methods"] = sorted(
+                rule["parameters"]["allowed_merge_methods"]
+            )
+    return result
+
+
+def find_managed_ruleset(
+    root: Path,
+    repository: str,
+) -> tuple[int | None, dict[str, Any] | None]:
+    values = gh_api(
+        root,
+        "GET",
+        f"repos/{repository}/rulesets?includes_parents=false&per_page=100",
+    )
+    if not isinstance(values, list):
+        raise RepositoryPolicyError("unexpected repository rulesets response")
+
+    matches = [
+        item
+        for item in values
+        if isinstance(item, dict)
+        and item.get("name") == RULESET_NAME
+        and item.get("source_type") == "Repository"
+    ]
+    if len(matches) > 1:
+        raise RepositoryPolicyError(
+            f"multiple repository rulesets named {RULESET_NAME!r} exist"
+        )
+    if not matches:
+        return None, None
+
+    ruleset_id = matches[0].get("id")
+    if not isinstance(ruleset_id, int):
+        raise RepositoryPolicyError("managed repository ruleset is missing its id")
+    detail = gh_api(root, "GET", f"repos/{repository}/rulesets/{ruleset_id}")
+    if not isinstance(detail, dict):
+        raise RepositoryPolicyError("unexpected managed repository ruleset response")
+    return ruleset_id, detail
+
+
+def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
+    repository = current_repository(root)
+    repository_data = gh_api(root, "GET", f"repos/{repository}")
+    if not isinstance(repository_data, dict):
+        raise RepositoryPolicyError("unexpected repository response")
+
+    expected_branch = policy["default_branch"]
+    actual_branch = repository_data.get("default_branch")
+    expected_branch_exists = branch_exists(root, repository, expected_branch)
+
+    ruleset_id, actual_ruleset = find_managed_ruleset(root, repository)
+    expected_ruleset = normalized_desired(policy)
+    normalized_actual = (
+        None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
+    )
+
+    drift: list[str] = []
+    if actual_branch != expected_branch:
+        drift.append(
+            f"default branch is {actual_branch!r}; expected {expected_branch!r}"
+        )
+    if actual_branch != expected_branch and not expected_branch_exists:
+        drift.append(
+            f"required branch {expected_branch!r} does not exist; "
+            "create or rename it before applying policy"
+        )
+    if actual_ruleset is None:
+        drift.append(f"missing ruleset {RULESET_NAME!r}")
+    elif normalized_actual != expected_ruleset:
+        drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    return {
+        "repository": repository,
+        "policyVersion": policy["version"],
+        "defaultBranch": {
+            "expected": expected_branch,
+            "actual": actual_branch,
+            "expectedBranchExists": expected_branch_exists,
+            "match": actual_branch == expected_branch,
+        },
+        "ruleset": {
+            "name": RULESET_NAME,
+            "id": ruleset_id,
+            "present": actual_ruleset is not None,
+            "match": normalized_actual == expected_ruleset,
+            "actual": normalized_actual,
+            "expected": expected_ruleset,
+        },
+        "drift": drift,
+    }
+
+
+def command_check(root: Path) -> int:
+    policy = load_policy(root)
+    result = inspect(root, policy)
+    result["status"] = "PASS" if not result["drift"] else "DRIFT"
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0 if not result["drift"] else 1
+
+
+def command_apply(root: Path) -> int:
+    if task_worktree(root):
+        raise RepositoryPolicyError(
+            "repository policy mutation is forbidden from a Task worktree"
+        )
+
+    policy = load_policy(root)
+    before = inspect(root, policy)
+    repository = before["repository"]
+    expected_branch = policy["default_branch"]
+
+    if before["defaultBranch"]["actual"] != expected_branch:
+        if not before["defaultBranch"]["expectedBranchExists"]:
+            raise RepositoryPolicyError(
+                f"cannot set default branch to {expected_branch!r}: "
+                f"branch {expected_branch!r} does not exist"
+            )
+        gh_api(
+            root,
+            "PATCH",
+            f"repos/{repository}",
+            body={"default_branch": expected_branch},
+        )
+
+    ruleset_id = before["ruleset"]["id"]
+    if ruleset_id is None:
+        gh_api(
+            root,
+            "POST",
+            f"repos/{repository}/rulesets",
+            body=desired_ruleset(policy),
+        )
+    elif not before["ruleset"]["match"]:
+        gh_api(
+            root,
+            "PUT",
+            f"repos/{repository}/rulesets/{ruleset_id}",
+            body=desired_ruleset(policy),
+        )
+
+    after = inspect(root, policy)
+    if after["drift"]:
+        raise RepositoryPolicyError(
+            "repository policy apply completed but verification still reports drift: "
+            + "; ".join(after["drift"])
+        )
+
+    after["status"] = "PASS"
+    after["changed"] = bool(before["drift"])
+    print(json.dumps(after, indent=2, sort_keys=True))
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Check and apply the Agent repository GitHub policy"
+    )
+    sub = result.add_subparsers(dest="command", required=True)
+    sub.add_parser("check")
+    sub.add_parser("apply")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        root = repository_root()
+        if args.command == "check":
+            return command_check(root)
+        if args.command == "apply":
+            return command_apply(root)
+        raise AssertionError(args.command)
+    except RepositoryPolicyError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-rust/.automation/just/repository.just
+++ b/templates/agent-rust/.automation/just/repository.just
@@ -1,0 +1,10 @@
+root := justfile_directory()
+policy := root / ".automation/bin/repository_policy.py"
+
+[working-directory: root]
+policy-check:
+    python3 {{quote(policy)}} check
+
+[working-directory: root]
+policy-apply:
+    python3 {{quote(policy)}} apply

--- a/templates/agent-rust/.automation/ownership.toml
+++ b/templates/agent-rust/.automation/ownership.toml
@@ -3,3 +3,8 @@ version = 1
 [paths]
 "AGENTS.md" = "replace"
 "Justfile" = "replace"
+".automation/REPOSITORY_POLICY.md" = "replace"
+".automation/repository-policy.json" = "replace"
+".automation/bin/repository_policy.py" = "replace"
+".automation/just/repository.just" = "replace"
+"opencode.json" = "replace"

--- a/templates/agent-rust/.automation/repository-policy.json
+++ b/templates/agent-rust/.automation/repository-policy.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "default_branch": "main",
+  "ruleset": {
+    "name": "Agent repository policy",
+    "target": "branch",
+    "enforcement": "active",
+    "bypass_actors": [],
+    "conditions": {
+      "ref_name": {
+        "include": ["~DEFAULT_BRANCH"],
+        "exclude": []
+      }
+    },
+    "rules": [
+      {
+        "type": "pull_request",
+        "parameters": {
+          "allowed_merge_methods": ["merge", "squash", "rebase"],
+          "dismiss_stale_reviews_on_push": false,
+          "require_code_owner_review": false,
+          "require_last_push_approval": false,
+          "required_approving_review_count": 0,
+          "required_review_thread_resolution": false
+        }
+      },
+      {
+        "type": "deletion"
+      },
+      {
+        "type": "non_fast_forward"
+      }
+    ]
+  }
+}

--- a/templates/agent-rust/Justfile
+++ b/templates/agent-rust/Justfile
@@ -3,6 +3,7 @@ set minimum-version := "1.52.0"
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'
 mod integrate '.automation/just/integrate.just'
+mod repository '.automation/just/repository.just'
 mod project 'just/project/mod.just'
 mod? local 'just/local.just'
 

--- a/templates/agent-rust/opencode.json
+++ b/templates/agent-rust/opencode.json
@@ -70,6 +70,8 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just repository::policy-check": "allow",
+      "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",
       "just agent::state-set *": "deny",
       "just agent::batch-plan *": "deny",

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE = ROOT / "components" / "agent-core"
+SCRIPT = CORE / ".automation" / "bin" / "repository_policy.py"
+SPEC = importlib.util.spec_from_file_location("repository_policy", SCRIPT)
+assert SPEC and SPEC.loader
+policy_runtime = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = policy_runtime
+SPEC.loader.exec_module(policy_runtime)
+
+TEMPLATES = (
+    "agent-base",
+    "agent-python",
+    "agent-rust",
+    "agent-nix",
+    "agent-cpp-cmake",
+)
+
+
+class RepositoryPolicyContractTest(unittest.TestCase):
+    def test_policy_requires_main_and_pull_request_without_bypass(self) -> None:
+        policy = policy_runtime.load_policy(CORE)
+        self.assertEqual(policy["default_branch"], "main")
+        ruleset = policy["ruleset"]
+        self.assertEqual(ruleset["name"], "Agent repository policy")
+        self.assertEqual(ruleset["target"], "branch")
+        self.assertEqual(ruleset["enforcement"], "active")
+        self.assertEqual(ruleset["bypass_actors"], [])
+        self.assertEqual(
+            ruleset["conditions"],
+            {"ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []}},
+        )
+
+        rules = {rule["type"]: rule for rule in ruleset["rules"]}
+        self.assertEqual(set(rules), {"pull_request", "deletion", "non_fast_forward"})
+        pull_request = rules["pull_request"]["parameters"]
+        self.assertEqual(pull_request["required_approving_review_count"], 0)
+        self.assertEqual(
+            set(pull_request["allowed_merge_methods"]),
+            {"merge", "squash", "rebase"},
+        )
+        self.assertFalse(pull_request["require_code_owner_review"])
+        self.assertFalse(pull_request["require_last_push_approval"])
+
+    def test_generated_agent_core_policy_files_match_source(self) -> None:
+        paths = (
+            ".automation/repository-policy.json",
+            ".automation/bin/repository_policy.py",
+            ".automation/just/repository.just",
+            ".automation/REPOSITORY_POLICY.md",
+            ".automation/ownership.toml",
+            "Justfile",
+            "opencode.json",
+        )
+        for template in TEMPLATES:
+            generated = ROOT / "templates" / template
+            for relative in paths:
+                self.assertEqual(
+                    (CORE / relative).read_bytes(),
+                    (generated / relative).read_bytes(),
+                    f"generated drift: {template}/{relative}",
+                )
+
+    def test_router_and_opencode_permission_boundary(self) -> None:
+        justfile = (CORE / "Justfile").read_text(encoding="utf-8")
+        self.assertIn("mod repository '.automation/just/repository.just'", justfile)
+
+        module = (CORE / ".automation" / "just" / "repository.just").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("policy-check:", module)
+        self.assertIn("policy-apply:", module)
+
+        config = json.loads((CORE / "opencode.json").read_text(encoding="utf-8"))
+        bash = config["permission"]["bash"]
+        self.assertEqual(bash["just repository::policy-check"], "allow")
+        self.assertEqual(bash["just repository::policy-apply"], "ask")
+
+    def test_policy_apply_is_forbidden_from_task_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            state = root / ".task-state"
+            state.mkdir()
+            (state / "task.md").write_text("# Task\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                policy_runtime.RepositoryPolicyError,
+                "forbidden from a Task worktree",
+            ):
+                policy_runtime.command_apply(root)
+
+    def test_policy_apply_refuses_to_invent_missing_main_branch(self) -> None:
+        policy = {
+            "version": 1,
+            "default_branch": "main",
+            "ruleset": {},
+        }
+        before = {
+            "repository": "example/repository",
+            "defaultBranch": {
+                "actual": "master",
+                "expected": "main",
+                "expectedBranchExists": False,
+                "match": False,
+            },
+            "ruleset": {"id": None, "match": False},
+            "drift": ["default branch drift"],
+        }
+        with patch.object(policy_runtime, "task_worktree", return_value=False), patch.object(
+            policy_runtime, "load_policy", return_value=policy
+        ), patch.object(policy_runtime, "inspect", return_value=before), patch.object(
+            policy_runtime, "gh_api"
+        ) as gh_api:
+            with self.assertRaisesRegex(
+                policy_runtime.RepositoryPolicyError,
+                "branch 'main' does not exist",
+            ):
+                policy_runtime.command_apply(Path("/tmp/repository"))
+            gh_api.assert_not_called()
+
+    def test_policy_apply_sets_main_before_managing_ruleset(self) -> None:
+        policy = {
+            "version": 1,
+            "default_branch": "main",
+            "ruleset": {"name": "Agent repository policy"},
+        }
+        before = {
+            "repository": "example/repository",
+            "defaultBranch": {
+                "actual": "master",
+                "expected": "main",
+                "expectedBranchExists": True,
+                "match": False,
+            },
+            "ruleset": {"id": None, "match": False},
+            "drift": ["drift"],
+        }
+        after = {
+            "repository": "example/repository",
+            "defaultBranch": {
+                "actual": "main",
+                "expected": "main",
+                "expectedBranchExists": True,
+                "match": True,
+            },
+            "ruleset": {"id": 1, "match": True},
+            "drift": [],
+        }
+        calls: list[tuple[str, str, object]] = []
+
+        def fake_api(root, method, endpoint, *, body=None, allow_not_found=False):
+            calls.append((method, endpoint, body))
+            return {}
+
+        with patch.object(policy_runtime, "task_worktree", return_value=False), patch.object(
+            policy_runtime, "load_policy", return_value=policy
+        ), patch.object(policy_runtime, "inspect", side_effect=[before, after]), patch.object(
+            policy_runtime, "gh_api", side_effect=fake_api
+        ):
+            self.assertEqual(policy_runtime.command_apply(Path("/tmp/repository")), 0)
+
+        self.assertEqual(calls[0], ("PATCH", "repos/example/repository", {"default_branch": "main"}))
+        self.assertEqual(calls[1][0:2], ("POST", "repos/example/repository/rulesets"))
+
+    def test_repository_policy_is_current_repository_only(self) -> None:
+        parser = policy_runtime.parser()
+        check = parser.parse_args(["check"])
+        apply = parser.parse_args(["apply"])
+        self.assertEqual(check.command, "check")
+        self.assertEqual(apply.command, "apply")
+        self.assertNotIn("repository", vars(check))
+        self.assertNotIn("repository", vars(apply))
+
+    def test_ownership_and_docs_cover_policy_surfaces(self) -> None:
+        ownership = (CORE / ".automation" / "ownership.toml").read_text(encoding="utf-8")
+        for path in (
+            ".automation/REPOSITORY_POLICY.md",
+            ".automation/repository-policy.json",
+            ".automation/bin/repository_policy.py",
+            ".automation/just/repository.just",
+            "opencode.json",
+        ):
+            self.assertIn(f'"{path}" = "replace"', ownership)
+
+        docs = (CORE / ".automation" / "REPOSITORY_POLICY.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("default branch is `main`", docs)
+        self.assertIn("pull request is mandatory", docs)
+        self.assertIn("zero approving reviews", docs)
+        self.assertIn("No bypass actor", docs)
+        self.assertIn("does not create or rename branches", docs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements #45 by adding a declarative GitHub repository policy to Agent Core and every generated template.

The policy establishes:

- default branch: `main`
- repository ruleset target: `~DEFAULT_BRANCH`
- pull request required before changes reach the default branch
- required approving reviews: `0` (PR mandatory, self-merge still possible)
- no ruleset bypass actors
- default-branch deletion blocked
- non-fast-forward / force pushes blocked

## Operator API

```text
just repository::policy-check   # read-only
just repository::policy-apply   # explicit GitHub mutation / OpenCode Ask
```

`policy-apply` resolves only the repository associated with the current checkout and accepts no arbitrary repository target. It refuses Task worktrees. If the current default branch is not `main`, it switches GitHub's default branch only when `main` already exists; it never creates or renames branches implicitly.

GitHub repository policy remains separate from `project::bootstrap` and `/init` so neither existing initialization path gains hidden GitHub mutations.

## Safety

- applying the policy requires GitHub Administration write permission
- no bypass actor is created
- missing `main` blocks apply instead of guessing a migration
- no status-check/reviewer/CODEOWNERS policy is imposed by this change
- policy files are Agent Core-owned and participate in Automation Core upgrade
- OpenCode allows `policy-check` and requires Ask for `policy-apply`

## Validation

Adds contract coverage for policy semantics, source/generated parity, Task-worktree mutation rejection, missing-`main` refusal, default-branch-before-ruleset ordering, current-repository-only targeting, ownership, and OpenCode permission boundaries.

Template CI will additionally verify generated drift and all existing generated-template smoke jobs.

Refs #45
Parent #3