### PR TITLE
feat: shift leaf workloads from Spark to Luna

### DIFF
--- a/components/agent-core/.automation/model-fallback.toml
+++ b/components/agent-core/.automation/model-fallback.toml
@@ -48,23 +48,23 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.reviewer]

--- a/components/agent-core/.opencode/agents/explore-fallback.md
+++ b/components/agent-core/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/explore.md
+++ b/components/agent-core/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/general-fallback.md
+++ b/components/agent-core/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   bash:

--- a/components/agent-core/.opencode/agents/general.md
+++ b/components/agent-core/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   bash:

--- a/components/agent-core/.opencode/agents/task-orchestrator.md
+++ b/components/agent-core/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,9 @@ permission:
 
 Before planning, editing, delegation, or project commands, load the `initialize` skill and complete `.automation/INIT.md` inside the assigned Task worktree. Stop and report BLOCKED on any initialization mismatch or `project::doctor` failure.
 
-Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+
+Route repository exploration and reference tracing to `explore`, bounded implementation to `general`, and project-standard verification to `verifier`. Do not spend long stretches executing implementation, exploration, or verification that a leaf can complete. Do not create unnecessary agent calls merely to shift model usage; preserve bounded, non-overlapping Work Unit granularity.
 
 When a leaf invocation fails because of a usage/quota/rate-limit condition listed in `.automation/model-fallback.toml`, retry the identical Work Unit once with the configured fallback agent variant. Record the failed model, classified reason, selected fallback model, and result in Task State. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Do not invent a fallback not listed in policy; when the chain is exhausted, set the Task BLOCKED.
 

--- a/components/agent-core/.opencode/agents/verifier-fallback.md
+++ b/components/agent-core/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/verifier.md
+++ b/components/agent-core/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -291,7 +291,8 @@ Owns one Task only:
 - validates initialization and Task boundaries;
 - establishes the Task Contract;
 - decomposes work into bounded Work Units;
-- delegates leaf work;
+- coordinates and delegates only needed leaf work; avoids speculative or repeated delegation when one Work Unit can be reused;
+- preserves a single-workflow focus by assigning each Work Unit once unless new evidence requires a reschedule;
 - inspects actual diffs and command output;
 - accepts or rejects returned Work Units;
 - updates Task State;
@@ -615,9 +616,11 @@ The intended initial model allocation is:
 | --- | --- | --- |
 | Main Orchestrator / planning / architecture | GPT-5.6 Sol | decomposition, orchestration, integration decisions |
 | Task Orchestrator | GPT-5.3 Codex Spark | fast bounded Task orchestration |
-| general / explore / verifier | GPT-5.3 Codex Spark | implementation, discovery, executable verification |
+| general / explore / verifier / scout | GPT-5.6 Luna | implementation, discovery, verification, external research |
 | reviewer / investigator / security-reviewer | GPT-5.6 Terra | analysis, diagnosis, review |
-| scout | GPT-5.6 Luna | external documentation research |
+
+This is the final split: `task-orchestrator` is the only Spark primary, while all listed leaf execution/research roles use Luna-first allocation.
+High-quality analysis roles remain as configured (reviewer/investigator/security-reviewer on Terra).
 
 Exact provider model IDs are validated at implementation time. Missing model IDs must not be silently substituted with similar names.
 

--- a/docs/model-fallback.md
+++ b/docs/model-fallback.md
@@ -6,7 +6,7 @@ Agent-ready repositories use an explicit role-scoped model fallback policy at `.
 
 OpenCode does not currently expose first-class cross-model failover for an active agent session. The upstream request for native model fallback is still open. OpenCode also treats some retryable provider errors as retry states, so an unbounded automatic retry loop would be unsafe.
 
-For that reason, this repository implements fallback as explicit alternate agent definitions. Each fallback agent keeps the same role and permission boundary while changing only the configured model.
+For that reason, this repository implements fallback as explicit alternate agent definitions. Each fallback agent keeps the same role, permission boundary, Work Unit, scope, and authority while changing only the configured model.
 
 ## Automatic subagent fallback
 
@@ -23,6 +23,15 @@ The following failures do not trigger automatic fallback:
 - tool execution failure
 - safety refusal
 - unclassified failures
+
+## Role-specific fallback split (Issue #47)
+
+The final role split is:
+
+- `task-orchestrator` → **Spark** primary, automatic fallback to **Sol** only for classified usage/quota/rate-limit failures.
+- `general`, `explore`, `verifier` → **Luna** primary, automatic fallback to **Spark** only for classified usage/quota/rate-limit failures.
+- `scout` → **Luna** primary, automatic fallback to **Terra** only for classified usage/quota/rate-limit failures.
+- `reviewer`, `investigator`, `security-reviewer` remain as configured (`Terra` in the baseline allocation).
 
 ## Main Orchestrator
 

--- a/templates/agent-base/.automation/model-fallback.toml
+++ b/templates/agent-base/.automation/model-fallback.toml
@@ -48,23 +48,23 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.reviewer]

--- a/templates/agent-base/.opencode/agents/explore-fallback.md
+++ b/templates/agent-base/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/explore.md
+++ b/templates/agent-base/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/general-fallback.md
+++ b/templates/agent-base/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   bash:

--- a/templates/agent-base/.opencode/agents/general.md
+++ b/templates/agent-base/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   bash:

--- a/templates/agent-base/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-base/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,9 @@ permission:
 
 Before planning, editing, delegation, or project commands, load the `initialize` skill and complete `.automation/INIT.md` inside the assigned Task worktree. Stop and report BLOCKED on any initialization mismatch or `project::doctor` failure.
 
-Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+
+Route repository exploration and reference tracing to `explore`, bounded implementation to `general`, and project-standard verification to `verifier`. Do not spend long stretches executing implementation, exploration, or verification that a leaf can complete. Do not create unnecessary agent calls merely to shift model usage; preserve bounded, non-overlapping Work Unit granularity.
 
 When a leaf invocation fails because of a usage/quota/rate-limit condition listed in `.automation/model-fallback.toml`, retry the identical Work Unit once with the configured fallback agent variant. Record the failed model, classified reason, selected fallback model, and result in Task State. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Do not invent a fallback not listed in policy; when the chain is exhausted, set the Task BLOCKED.
 

--- a/templates/agent-base/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-base/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/verifier.md
+++ b/templates/agent-base/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.automation/model-fallback.toml
+++ b/templates/agent-cpp-cmake/.automation/model-fallback.toml
@@ -48,23 +48,23 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.reviewer]

--- a/templates/agent-cpp-cmake/.opencode/agents/explore-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/explore.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/general-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   bash:

--- a/templates/agent-cpp-cmake/.opencode/agents/general.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   bash:

--- a/templates/agent-cpp-cmake/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,9 @@ permission:
 
 Before planning, editing, delegation, or project commands, load the `initialize` skill and complete `.automation/INIT.md` inside the assigned Task worktree. Stop and report BLOCKED on any initialization mismatch or `project::doctor` failure.
 
-Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+
+Route repository exploration and reference tracing to `explore`, bounded implementation to `general`, and project-standard verification to `verifier`. Do not spend long stretches executing implementation, exploration, or verification that a leaf can complete. Do not create unnecessary agent calls merely to shift model usage; preserve bounded, non-overlapping Work Unit granularity.
 
 When a leaf invocation fails because of a usage/quota/rate-limit condition listed in `.automation/model-fallback.toml`, retry the identical Work Unit once with the configured fallback agent variant. Record the failed model, classified reason, selected fallback model, and result in Task State. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Do not invent a fallback not listed in policy; when the chain is exhausted, set the Task BLOCKED.
 

--- a/templates/agent-cpp-cmake/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/verifier.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.automation/model-fallback.toml
+++ b/templates/agent-nix/.automation/model-fallback.toml
@@ -48,23 +48,23 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.reviewer]

--- a/templates/agent-nix/.opencode/agents/explore-fallback.md
+++ b/templates/agent-nix/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/explore.md
+++ b/templates/agent-nix/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/general-fallback.md
+++ b/templates/agent-nix/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   bash:

--- a/templates/agent-nix/.opencode/agents/general.md
+++ b/templates/agent-nix/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   bash:

--- a/templates/agent-nix/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-nix/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,9 @@ permission:
 
 Before planning, editing, delegation, or project commands, load the `initialize` skill and complete `.automation/INIT.md` inside the assigned Task worktree. Stop and report BLOCKED on any initialization mismatch or `project::doctor` failure.
 
-Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+
+Route repository exploration and reference tracing to `explore`, bounded implementation to `general`, and project-standard verification to `verifier`. Do not spend long stretches executing implementation, exploration, or verification that a leaf can complete. Do not create unnecessary agent calls merely to shift model usage; preserve bounded, non-overlapping Work Unit granularity.
 
 When a leaf invocation fails because of a usage/quota/rate-limit condition listed in `.automation/model-fallback.toml`, retry the identical Work Unit once with the configured fallback agent variant. Record the failed model, classified reason, selected fallback model, and result in Task State. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Do not invent a fallback not listed in policy; when the chain is exhausted, set the Task BLOCKED.
 

--- a/templates/agent-nix/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-nix/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/verifier.md
+++ b/templates/agent-nix/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.automation/model-fallback.toml
+++ b/templates/agent-python/.automation/model-fallback.toml
@@ -48,23 +48,23 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.reviewer]

--- a/templates/agent-python/.opencode/agents/explore-fallback.md
+++ b/templates/agent-python/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/explore.md
+++ b/templates/agent-python/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/general-fallback.md
+++ b/templates/agent-python/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   bash:

--- a/templates/agent-python/.opencode/agents/general.md
+++ b/templates/agent-python/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   bash:

--- a/templates/agent-python/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-python/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,9 @@ permission:
 
 Before planning, editing, delegation, or project commands, load the `initialize` skill and complete `.automation/INIT.md` inside the assigned Task worktree. Stop and report BLOCKED on any initialization mismatch or `project::doctor` failure.
 
-Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+
+Route repository exploration and reference tracing to `explore`, bounded implementation to `general`, and project-standard verification to `verifier`. Do not spend long stretches executing implementation, exploration, or verification that a leaf can complete. Do not create unnecessary agent calls merely to shift model usage; preserve bounded, non-overlapping Work Unit granularity.
 
 When a leaf invocation fails because of a usage/quota/rate-limit condition listed in `.automation/model-fallback.toml`, retry the identical Work Unit once with the configured fallback agent variant. Record the failed model, classified reason, selected fallback model, and result in Task State. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Do not invent a fallback not listed in policy; when the chain is exhausted, set the Task BLOCKED.
 

--- a/templates/agent-python/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-python/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/verifier.md
+++ b/templates/agent-python/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.automation/model-fallback.toml
+++ b/templates/agent-rust/.automation/model-fallback.toml
@@ -48,23 +48,23 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.3-codex-spark"
+primary_model = "openai/gpt-5.6-luna"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.reviewer]

--- a/templates/agent-rust/.opencode/agents/explore-fallback.md
+++ b/templates/agent-rust/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/explore.md
+++ b/templates/agent-rust/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/general-fallback.md
+++ b/templates/agent-rust/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   bash:

--- a/templates/agent-rust/.opencode/agents/general.md
+++ b/templates/agent-rust/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   bash:

--- a/templates/agent-rust/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-rust/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,9 @@ permission:
 
 Before planning, editing, delegation, or project commands, load the `initialize` skill and complete `.automation/INIT.md` inside the assigned Task worktree. Stop and report BLOCKED on any initialization mismatch or `project::doctor` failure.
 
-Own exactly one Task in its assigned worktree. Establish the Task contract, split work into bounded non-overlapping Work Units, delegate leaf work, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
+
+Route repository exploration and reference tracing to `explore`, bounded implementation to `general`, and project-standard verification to `verifier`. Do not spend long stretches executing implementation, exploration, or verification that a leaf can complete. Do not create unnecessary agent calls merely to shift model usage; preserve bounded, non-overlapping Work Unit granularity.
 
 When a leaf invocation fails because of a usage/quota/rate-limit condition listed in `.automation/model-fallback.toml`, retry the identical Work Unit once with the configured fallback agent variant. Record the failed model, classified reason, selected fallback model, and result in Task State. Do not fallback for authentication, permission, validation, context-window, tool, or safety failures. Do not invent a fallback not listed in policy; when the chain is exhausted, set the Task BLOCKED.
 

--- a/templates/agent-rust/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-rust/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/verifier.md
+++ b/templates/agent-rust/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/tests/test_model_fallback.py
+++ b/tests/test_model_fallback.py
@@ -37,6 +37,26 @@ class ModelFallbackTest(unittest.TestCase):
         self.assertEqual(result["agent"], "task-orchestrator-fallback")
         self.assertEqual(result["model"], "openai/gpt-5.6-sol")
 
+    def test_luna_roles_share_spark_fallback_chain(self) -> None:
+        for role in ("general", "explore", "verifier"):
+            result = fallback.next_fallback(role, role, self.cfg)
+            self.assertTrue(result["available"], role)
+            self.assertEqual(result["agent"], f"{role}-fallback", role)
+            self.assertEqual(result["model"], "openai/gpt-5.3-codex-spark", role)
+
+    def test_primary_and_fallback_models_in_policy(self) -> None:
+        expected = {
+            "general": ("openai/gpt-5.6-luna", "openai/gpt-5.3-codex-spark"),
+            "explore": ("openai/gpt-5.6-luna", "openai/gpt-5.3-codex-spark"),
+            "verifier": ("openai/gpt-5.6-luna", "openai/gpt-5.3-codex-spark"),
+            "task-orchestrator": ("openai/gpt-5.3-codex-spark", "openai/gpt-5.6-sol"),
+        }
+        for role, (primary_model, fallback_model) in expected.items():
+            role_cfg = self.cfg["roles"][role]
+            self.assertEqual(role_cfg["primary_model"], primary_model, role)
+            self.assertEqual(role_cfg["fallback_models"], [fallback_model], role)
+            self.assertEqual(role_cfg["fallback_agents"], [f"{role}-fallback"], role)
+
     def test_chain_exhaustion_stops(self) -> None:
         result = fallback.next_fallback("general", "general-fallback", self.cfg)
         self.assertFalse(result["available"])
@@ -57,8 +77,8 @@ class ModelFallbackTest(unittest.TestCase):
             fallback.append_evidence(
                 root,
                 "general",
+                "openai/gpt-5.6-luna",
                 "openai/gpt-5.3-codex-spark",
-                "openai/gpt-5.6-sol",
                 "usage limit",
                 "succeeded",
             )

--- a/tests/test_opencode_contract.py
+++ b/tests/test_opencode_contract.py
@@ -64,14 +64,49 @@ class OpenCodeContractTest(unittest.TestCase):
         expected = {
             "build.md": "openai/gpt-5.6-sol",
             "task-orchestrator.md": "openai/gpt-5.3-codex-spark",
-            "general.md": "openai/gpt-5.3-codex-spark",
-            "explore.md": "openai/gpt-5.3-codex-spark",
-            "verifier.md": "openai/gpt-5.3-codex-spark",
+            "general.md": "openai/gpt-5.6-luna",
+            "explore.md": "openai/gpt-5.6-luna",
+            "verifier.md": "openai/gpt-5.6-luna",
             "reviewer.md": "openai/gpt-5.6-terra",
             "investigator.md": "openai/gpt-5.6-terra",
             "security-reviewer.md": "openai/gpt-5.6-terra",
             "scout.md": "openai/gpt-5.6-luna",
             "architect.md": "openai/gpt-5.6-sol",
+        }
+        for filename, model in expected.items():
+            self.assertIn(f"model: {model}", frontmatter(AGENTS / filename), filename)
+
+    def test_task_orchestrator_is_only_spark_primary(self) -> None:
+        spark_primaries = {
+            path.name
+            for path in AGENTS.glob("*.md")
+            if not path.name.endswith("-fallback.md")
+            and "model: openai/gpt-5.3-codex-spark" in frontmatter(path)
+        }
+        self.assertEqual(spark_primaries, {"task-orchestrator.md"})
+
+    def test_luna_primary_agents(self) -> None:
+        expected_luna = {
+            "general.md",
+            "explore.md",
+            "verifier.md",
+            "scout.md",
+        }
+        for filename in expected_luna:
+            self.assertIn("model: openai/gpt-5.6-luna", frontmatter(AGENTS / filename), filename)
+
+    def test_fallback_model_assignment_is_exact(self) -> None:
+        expected = {
+            "build-fallback.md": "openai/gpt-5.6-terra",
+            "architect-fallback.md": "openai/gpt-5.6-terra",
+            "task-orchestrator-fallback.md": "openai/gpt-5.6-sol",
+            "general-fallback.md": "openai/gpt-5.3-codex-spark",
+            "explore-fallback.md": "openai/gpt-5.3-codex-spark",
+            "verifier-fallback.md": "openai/gpt-5.3-codex-spark",
+            "reviewer-fallback.md": "openai/gpt-5.6-sol",
+            "investigator-fallback.md": "openai/gpt-5.6-sol",
+            "security-reviewer-fallback.md": "openai/gpt-5.6-sol",
+            "scout-fallback.md": "openai/gpt-5.6-terra",
         }
         for filename, model in expected.items():
             self.assertIn(f"model: {model}", frontmatter(AGENTS / filename), filename)


### PR DESCRIPTION
## Summary
- move bounded implementation, repository exploration, and project verification primaries from Spark to Luna
- move their usage-limit fallback variants from Sol to Spark
- keep Spark primary for Task Orchestration only and add explicit delegation-cost guidance
- regenerate all five templates and strengthen exact model assignment contracts

## Model map

| Role | Before | After | Fallback |
| --- | --- | --- | --- |
| task-orchestrator | Spark | Spark | Sol |
| general | Spark | Luna | Spark |
| explore | Spark | Luna | Spark |
| verifier | Spark | Luna | Spark |
| scout | Luna | Luna | Terra |

High-quality roles remain unchanged: build/architect use Sol; reviewer/investigator/security-reviewer use Terra.

## Spark reduction rationale
Routine leaf implementation, discovery, and deterministic verification no longer consume Spark primary capacity. Spark remains focused on high-leverage Task orchestration and classified Luna usage-limit fallback.

## Fallback policy
Automatic fallback semantics are unchanged: only usage/quota/rate-limit failures (including HTTP 429) qualify. Authentication, permission, validation, context-window, tool, safety, quality, and unclassified failures do not. Retries preserve the identical Work Unit, scope, and authority and retain Task State evidence.

## Task Orchestrator delegation policy
The Spark Task Orchestrator focuses on Task Contracts, bounded Work Unit decomposition/delegation, evidence integration, diff inspection, Task State, guarded commit, and PR preparation. It routes exploration to `explore`, bounded implementation to `general`, and project-standard verification to `verifier`, while avoiding unnecessary model-usage-driven calls.

## Validation
- `git diff --check`: PASS
- `python3 -m unittest discover -s tests -v`: 105 PASS
- `just template::check`: PASS
- Template CI run `31309346927`: PASS
  - contracts and generated drift: PASS
  - agent-python, agent-rust, agent-nix, agent-cpp-cmake: PASS
  - Python inherited worktree environment smoke: PASS
- runtime direct `general` selection: PASS on OpenCode 1.18.4, observed `openai/gpt-5.6-luna` and one completed `git status --short`
- genuine Luna -> Spark fallback: INCOMPLETE (no natural usage-limit trigger; none manufactured)

Runtime evidence remains under the Git-ignored `.runtime-smoke/issue-47-luna-selection/` workspace.

Refs #47