### PR TITLE
fix: verify effective repository rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,25 @@ nix develop --command just project::bootstrap my-project
 
 Generated Agent-ready repositories declare a GitHub repository policy in `.automation/repository-policy.json`. The policy expects `main` as the default branch and protects the default branch with a repository ruleset: every change must arrive through a pull request, approving reviews are optional (`0` required), deletion and force pushes are blocked, and no bypass actor is configured.
 
+`policy-check` and `policy-apply` validate both configured policy equality and effective rules on `main` via GitHub's branch rules API. A ruleset that is configured but not effective is reported as drift.
+
 Repository policy is deliberately separate from project bootstrap and `/init`. Inspect the current GitHub repository read-only with:
 
 ```sh
 just repository::policy-check
 ```
 
+`policy-check` fails as `DRIFT` when effective policy does not match, even when configured rules match. If GitHub plan/feature availability or visibility affects enforcement, it is diagnosed as `DRIFT` rather than `PASS`.
+
 Apply the declared policy explicitly with:
 
 ```sh
 just repository::policy-apply
 ```
+
+`policy-apply` performs final effective verification after configuration changes and errors if policy is configured but not effective.
+
+API errors (including permission, transport, and unexpected response schema issues) are reported as errors, not silently mapped to empty/no-effective-rules.
 
 `repository::policy-apply` acts only on the GitHub repository resolved from the current checkout, requires GitHub Administration write permission, and is an Ask operation in OpenCode. If `main` does not exist, it refuses to invent or rename a branch; establish `main` explicitly first. Policy mutation is also refused from Task worktrees. See `.automation/REPOSITORY_POLICY.md` in generated repositories for the complete contract.
 

--- a/components/agent-core/.automation/REPOSITORY_POLICY.md
+++ b/components/agent-core/.automation/REPOSITORY_POLICY.md
@@ -4,6 +4,8 @@ Agent-ready repositories carry a declarative GitHub repository policy in `.autom
 
 The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
 
+`policy-check` and `policy-apply` require both configured ruleset equality and effective rules on `main` (via GitHub’s branch rules API). A matching configured ruleset alone is insufficient.
+
 Repository policy is separate from project bootstrap and session initialization:
 
 ```text
@@ -26,6 +28,10 @@ Check the current repository without changing it:
 just repository::policy-check
 ```
 
+`policy-check` is `DRIFT` when configured rules differ or when effective rules on `main` do not match. When the effective-rules API returns `required_approving_review_count`, it must be `0`; an omitted parameter is not inferred. If repository visibility or GitHub plan/feature availability limits enforcement, this is reported diagnostically and is still `DRIFT`.
+
+API unavailability, permission issues, or unexpected schema responses are treated as command errors, not as an absence of effective rules.
+
 Apply the policy explicitly:
 
 ```sh
@@ -33,6 +39,8 @@ just repository::policy-apply
 ```
 
 `policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+After applying configured changes, `policy-apply` performs final effective verification; it fails if the policy is configured but not effective on `main`.
 
 If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
 

--- a/components/agent-core/.automation/bin/repository_policy.py
+++ b/components/agent-core/.automation/bin/repository_policy.py
@@ -18,6 +18,7 @@ PULL_REQUEST_PARAMETERS = {
     "required_approving_review_count": 0,
     "required_review_thread_resolution": False,
 }
+EFFECTIVE_RULE_TYPES = ("deletion", "non_fast_forward", "pull_request")
 
 
 class RepositoryPolicyError(RuntimeError):
@@ -217,6 +218,135 @@ def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _normalized_effective_expected(ruleset: dict[str, Any]) -> list[dict[str, Any]]:
+    expected: list[dict[str, Any]] = []
+    for rule in ruleset.get("rules", []):
+        if not isinstance(rule, dict) or rule.get("type") not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = {"type": rule["type"]}
+        if rule["type"] == "pull_request":
+            normalized["parameters"] = {
+                "required_approving_review_count": PULL_REQUEST_PARAMETERS[
+                    "required_approving_review_count"
+                ]
+            }
+        expected.append(normalized)
+    return expected
+
+
+def _normalize_effective_rule(value: dict[str, Any]) -> dict[str, Any]:
+    rule_type = value.get("type")
+    rule: dict[str, Any] = {"type": rule_type}
+
+    if rule_type == "pull_request":
+        parameters = value.get("parameters")
+        if (
+            isinstance(parameters, dict)
+            and "required_approving_review_count" in parameters
+        ):
+            rule["parameters"] = {
+                "required_approving_review_count": parameters[
+                    "required_approving_review_count"
+                ]
+            }
+
+    for key in (
+        "ruleset_id",
+        "ruleset_source_type",
+        "ruleset_source",
+    ):
+        if key in value:
+            rule[key] = value[key]
+
+    return rule
+
+
+def _find_effective_rules(
+    values: list[Any], managed_ruleset_id: int | None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str], bool]:
+    matching: list[dict[str, Any]] = []
+    source_rules: list[dict[str, Any]] = []
+    by_type: dict[str, list[dict[str, Any]]] = {
+        rule_type: [] for rule_type in EFFECTIVE_RULE_TYPES
+    }
+
+    for index, item in enumerate(values):
+        if not isinstance(item, dict):
+            raise RepositoryPolicyError(
+                f"unexpected branch effective rule at index {index}"
+            )
+        rule_type = item.get("type")
+        if not isinstance(rule_type, str):
+            raise RepositoryPolicyError(
+                f"branch effective rule at index {index} is missing its type"
+            )
+        if rule_type not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = _normalize_effective_rule(item)
+        source_rules.append(normalized)
+        by_type[rule_type].append(normalized)
+        if (
+            managed_ruleset_id is not None
+            and normalized.get("ruleset_id") == managed_ruleset_id
+        ):
+            matching.append(normalized)
+
+    source_rules.sort(key=lambda item: item["type"])
+    matching.sort(key=lambda item: item["type"])
+
+    drift: list[str] = []
+    if managed_ruleset_id is None:
+        drift.append(
+            "managed ruleset id is missing, so effective rules cannot be attributed"
+        )
+        return source_rules, matching, drift, False
+
+    existing_types = {rule["type"] for rule in matching}
+    for rule_type in EFFECTIVE_RULE_TYPES:
+        if rule_type not in existing_types:
+            conflicting = by_type[rule_type]
+            if conflicting:
+                ids = sorted(
+                    {
+                        rule.get("ruleset_id")
+                        for rule in conflicting
+                        if isinstance(rule.get("ruleset_id"), int)
+                    }
+                )
+                if ids:
+                    drift.append(
+                        f"{rule_type} rule is not enforced by managed ruleset "
+                        f"{managed_ruleset_id}; found source ruleset IDs={ids}"
+                    )
+                else:
+                    drift.append(
+                        f"{rule_type} rule is missing for managed ruleset "
+                        f"{managed_ruleset_id}"
+                    )
+            else:
+                drift.append(
+                    f"{rule_type} rule is missing for managed ruleset "
+                    f"{managed_ruleset_id}"
+                )
+
+    for rule in matching:
+        if rule["type"] != "pull_request":
+            continue
+        actual_parameters = rule.get("parameters")
+        if not isinstance(actual_parameters, dict):
+            continue
+        if "required_approving_review_count" in actual_parameters:
+            actual_count = actual_parameters.get("required_approving_review_count")
+            if actual_count != PULL_REQUEST_PARAMETERS["required_approving_review_count"]:
+                drift.append(
+                    "effective pull_request rule reports "
+                    f"required_approving_review_count={actual_count!r}; expected 0"
+                )
+
+    match = not drift
+    return source_rules, matching, drift, match
+
+
 def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
     result = normalize_ruleset(desired_ruleset(policy))
     for rule in result["rules"]:
@@ -277,6 +407,39 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
     normalized_actual = (
         None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
     )
+    configured_match = normalized_actual == expected_ruleset
+    expected_effective_rules = _normalized_effective_expected(expected_ruleset)
+    expected_effective_rules = sorted(
+        expected_effective_rules, key=lambda rule: rule["type"]
+    )
+
+    effective_rules: list[dict[str, Any]]
+    matching_effective_rules: list[dict[str, Any]]
+    effective_drift: list[str]
+    effective_match: bool
+
+    if expected_branch_exists:
+        branch_rules_value = gh_api(
+            root,
+            "GET",
+            f"repos/{repository}/rules/branches/{expected_branch}",
+        )
+        if not isinstance(branch_rules_value, list):
+            raise RepositoryPolicyError("unexpected branch effective rules response")
+        (
+            effective_rules,
+            matching_effective_rules,
+            effective_drift,
+            effective_match,
+        ) = _find_effective_rules(branch_rules_value, ruleset_id)
+    else:
+        effective_rules = []
+        matching_effective_rules = []
+        effective_drift = [
+            f"effective rules for {expected_branch!r} cannot be verified because "
+            "the branch does not exist"
+        ]
+        effective_match = False
 
     drift: list[str] = []
     if actual_branch != expected_branch:
@@ -290,11 +453,35 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
         )
     if actual_ruleset is None:
         drift.append(f"missing ruleset {RULESET_NAME!r}")
-    elif normalized_actual != expected_ruleset:
+    elif not configured_match:
         drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    if not effective_match:
+        if configured_match:
+            if effective_drift:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    f"main: {'; '.join(effective_drift)}"
+                )
+            else:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    "main"
+                )
+        else:
+            if expected_branch_exists:
+                drift.append(
+                    "effective rules on main do not match expected policy: "
+                    + "; ".join(effective_drift)
+                )
+            else:
+                drift.append(
+                    "effective rules on main are not verifiable because main is missing"
+                )
 
     return {
         "repository": repository,
+        "visibility": repository_data.get("visibility"),
         "policyVersion": policy["version"],
         "defaultBranch": {
             "expected": expected_branch,
@@ -306,9 +493,17 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
             "name": RULESET_NAME,
             "id": ruleset_id,
             "present": actual_ruleset is not None,
-            "match": normalized_actual == expected_ruleset,
+            "match": configured_match,
             "actual": normalized_actual,
             "expected": expected_ruleset,
+        },
+        "effectiveRules": {
+            "expected": expected_effective_rules,
+            "actual": matching_effective_rules,
+            "match": effective_match,
+            "managedRulesetId": ruleset_id,
+            "drift": effective_drift,
+            "rulesFromBranch": effective_rules,
         },
         "drift": drift,
     }
@@ -333,12 +528,12 @@ def command_apply(root: Path) -> int:
     repository = before["repository"]
     expected_branch = policy["default_branch"]
 
+    if not before["defaultBranch"]["expectedBranchExists"]:
+        raise RepositoryPolicyError(
+            f"cannot apply repository policy: branch {expected_branch!r} does not exist"
+        )
+
     if before["defaultBranch"]["actual"] != expected_branch:
-        if not before["defaultBranch"]["expectedBranchExists"]:
-            raise RepositoryPolicyError(
-                f"cannot set default branch to {expected_branch!r}: "
-                f"branch {expected_branch!r} does not exist"
-            )
         gh_api(
             root,
             "PATCH",

--- a/templates/agent-base/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-base/.automation/REPOSITORY_POLICY.md
@@ -4,6 +4,8 @@ Agent-ready repositories carry a declarative GitHub repository policy in `.autom
 
 The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
 
+`policy-check` and `policy-apply` require both configured ruleset equality and effective rules on `main` (via GitHub’s branch rules API). A matching configured ruleset alone is insufficient.
+
 Repository policy is separate from project bootstrap and session initialization:
 
 ```text
@@ -26,6 +28,10 @@ Check the current repository without changing it:
 just repository::policy-check
 ```
 
+`policy-check` is `DRIFT` when configured rules differ or when effective rules on `main` do not match. When the effective-rules API returns `required_approving_review_count`, it must be `0`; an omitted parameter is not inferred. If repository visibility or GitHub plan/feature availability limits enforcement, this is reported diagnostically and is still `DRIFT`.
+
+API unavailability, permission issues, or unexpected schema responses are treated as command errors, not as an absence of effective rules.
+
 Apply the policy explicitly:
 
 ```sh
@@ -33,6 +39,8 @@ just repository::policy-apply
 ```
 
 `policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+After applying configured changes, `policy-apply` performs final effective verification; it fails if the policy is configured but not effective on `main`.
 
 If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
 

--- a/templates/agent-base/.automation/bin/repository_policy.py
+++ b/templates/agent-base/.automation/bin/repository_policy.py
@@ -18,6 +18,7 @@ PULL_REQUEST_PARAMETERS = {
     "required_approving_review_count": 0,
     "required_review_thread_resolution": False,
 }
+EFFECTIVE_RULE_TYPES = ("deletion", "non_fast_forward", "pull_request")
 
 
 class RepositoryPolicyError(RuntimeError):
@@ -217,6 +218,135 @@ def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _normalized_effective_expected(ruleset: dict[str, Any]) -> list[dict[str, Any]]:
+    expected: list[dict[str, Any]] = []
+    for rule in ruleset.get("rules", []):
+        if not isinstance(rule, dict) or rule.get("type") not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = {"type": rule["type"]}
+        if rule["type"] == "pull_request":
+            normalized["parameters"] = {
+                "required_approving_review_count": PULL_REQUEST_PARAMETERS[
+                    "required_approving_review_count"
+                ]
+            }
+        expected.append(normalized)
+    return expected
+
+
+def _normalize_effective_rule(value: dict[str, Any]) -> dict[str, Any]:
+    rule_type = value.get("type")
+    rule: dict[str, Any] = {"type": rule_type}
+
+    if rule_type == "pull_request":
+        parameters = value.get("parameters")
+        if (
+            isinstance(parameters, dict)
+            and "required_approving_review_count" in parameters
+        ):
+            rule["parameters"] = {
+                "required_approving_review_count": parameters[
+                    "required_approving_review_count"
+                ]
+            }
+
+    for key in (
+        "ruleset_id",
+        "ruleset_source_type",
+        "ruleset_source",
+    ):
+        if key in value:
+            rule[key] = value[key]
+
+    return rule
+
+
+def _find_effective_rules(
+    values: list[Any], managed_ruleset_id: int | None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str], bool]:
+    matching: list[dict[str, Any]] = []
+    source_rules: list[dict[str, Any]] = []
+    by_type: dict[str, list[dict[str, Any]]] = {
+        rule_type: [] for rule_type in EFFECTIVE_RULE_TYPES
+    }
+
+    for index, item in enumerate(values):
+        if not isinstance(item, dict):
+            raise RepositoryPolicyError(
+                f"unexpected branch effective rule at index {index}"
+            )
+        rule_type = item.get("type")
+        if not isinstance(rule_type, str):
+            raise RepositoryPolicyError(
+                f"branch effective rule at index {index} is missing its type"
+            )
+        if rule_type not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = _normalize_effective_rule(item)
+        source_rules.append(normalized)
+        by_type[rule_type].append(normalized)
+        if (
+            managed_ruleset_id is not None
+            and normalized.get("ruleset_id") == managed_ruleset_id
+        ):
+            matching.append(normalized)
+
+    source_rules.sort(key=lambda item: item["type"])
+    matching.sort(key=lambda item: item["type"])
+
+    drift: list[str] = []
+    if managed_ruleset_id is None:
+        drift.append(
+            "managed ruleset id is missing, so effective rules cannot be attributed"
+        )
+        return source_rules, matching, drift, False
+
+    existing_types = {rule["type"] for rule in matching}
+    for rule_type in EFFECTIVE_RULE_TYPES:
+        if rule_type not in existing_types:
+            conflicting = by_type[rule_type]
+            if conflicting:
+                ids = sorted(
+                    {
+                        rule.get("ruleset_id")
+                        for rule in conflicting
+                        if isinstance(rule.get("ruleset_id"), int)
+                    }
+                )
+                if ids:
+                    drift.append(
+                        f"{rule_type} rule is not enforced by managed ruleset "
+                        f"{managed_ruleset_id}; found source ruleset IDs={ids}"
+                    )
+                else:
+                    drift.append(
+                        f"{rule_type} rule is missing for managed ruleset "
+                        f"{managed_ruleset_id}"
+                    )
+            else:
+                drift.append(
+                    f"{rule_type} rule is missing for managed ruleset "
+                    f"{managed_ruleset_id}"
+                )
+
+    for rule in matching:
+        if rule["type"] != "pull_request":
+            continue
+        actual_parameters = rule.get("parameters")
+        if not isinstance(actual_parameters, dict):
+            continue
+        if "required_approving_review_count" in actual_parameters:
+            actual_count = actual_parameters.get("required_approving_review_count")
+            if actual_count != PULL_REQUEST_PARAMETERS["required_approving_review_count"]:
+                drift.append(
+                    "effective pull_request rule reports "
+                    f"required_approving_review_count={actual_count!r}; expected 0"
+                )
+
+    match = not drift
+    return source_rules, matching, drift, match
+
+
 def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
     result = normalize_ruleset(desired_ruleset(policy))
     for rule in result["rules"]:
@@ -277,6 +407,39 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
     normalized_actual = (
         None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
     )
+    configured_match = normalized_actual == expected_ruleset
+    expected_effective_rules = _normalized_effective_expected(expected_ruleset)
+    expected_effective_rules = sorted(
+        expected_effective_rules, key=lambda rule: rule["type"]
+    )
+
+    effective_rules: list[dict[str, Any]]
+    matching_effective_rules: list[dict[str, Any]]
+    effective_drift: list[str]
+    effective_match: bool
+
+    if expected_branch_exists:
+        branch_rules_value = gh_api(
+            root,
+            "GET",
+            f"repos/{repository}/rules/branches/{expected_branch}",
+        )
+        if not isinstance(branch_rules_value, list):
+            raise RepositoryPolicyError("unexpected branch effective rules response")
+        (
+            effective_rules,
+            matching_effective_rules,
+            effective_drift,
+            effective_match,
+        ) = _find_effective_rules(branch_rules_value, ruleset_id)
+    else:
+        effective_rules = []
+        matching_effective_rules = []
+        effective_drift = [
+            f"effective rules for {expected_branch!r} cannot be verified because "
+            "the branch does not exist"
+        ]
+        effective_match = False
 
     drift: list[str] = []
     if actual_branch != expected_branch:
@@ -290,11 +453,35 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
         )
     if actual_ruleset is None:
         drift.append(f"missing ruleset {RULESET_NAME!r}")
-    elif normalized_actual != expected_ruleset:
+    elif not configured_match:
         drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    if not effective_match:
+        if configured_match:
+            if effective_drift:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    f"main: {'; '.join(effective_drift)}"
+                )
+            else:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    "main"
+                )
+        else:
+            if expected_branch_exists:
+                drift.append(
+                    "effective rules on main do not match expected policy: "
+                    + "; ".join(effective_drift)
+                )
+            else:
+                drift.append(
+                    "effective rules on main are not verifiable because main is missing"
+                )
 
     return {
         "repository": repository,
+        "visibility": repository_data.get("visibility"),
         "policyVersion": policy["version"],
         "defaultBranch": {
             "expected": expected_branch,
@@ -306,9 +493,17 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
             "name": RULESET_NAME,
             "id": ruleset_id,
             "present": actual_ruleset is not None,
-            "match": normalized_actual == expected_ruleset,
+            "match": configured_match,
             "actual": normalized_actual,
             "expected": expected_ruleset,
+        },
+        "effectiveRules": {
+            "expected": expected_effective_rules,
+            "actual": matching_effective_rules,
+            "match": effective_match,
+            "managedRulesetId": ruleset_id,
+            "drift": effective_drift,
+            "rulesFromBranch": effective_rules,
         },
         "drift": drift,
     }
@@ -333,12 +528,12 @@ def command_apply(root: Path) -> int:
     repository = before["repository"]
     expected_branch = policy["default_branch"]
 
+    if not before["defaultBranch"]["expectedBranchExists"]:
+        raise RepositoryPolicyError(
+            f"cannot apply repository policy: branch {expected_branch!r} does not exist"
+        )
+
     if before["defaultBranch"]["actual"] != expected_branch:
-        if not before["defaultBranch"]["expectedBranchExists"]:
-            raise RepositoryPolicyError(
-                f"cannot set default branch to {expected_branch!r}: "
-                f"branch {expected_branch!r} does not exist"
-            )
         gh_api(
             root,
             "PATCH",

--- a/templates/agent-cpp-cmake/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-cpp-cmake/.automation/REPOSITORY_POLICY.md
@@ -4,6 +4,8 @@ Agent-ready repositories carry a declarative GitHub repository policy in `.autom
 
 The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
 
+`policy-check` and `policy-apply` require both configured ruleset equality and effective rules on `main` (via GitHub’s branch rules API). A matching configured ruleset alone is insufficient.
+
 Repository policy is separate from project bootstrap and session initialization:
 
 ```text
@@ -26,6 +28,10 @@ Check the current repository without changing it:
 just repository::policy-check
 ```
 
+`policy-check` is `DRIFT` when configured rules differ or when effective rules on `main` do not match. When the effective-rules API returns `required_approving_review_count`, it must be `0`; an omitted parameter is not inferred. If repository visibility or GitHub plan/feature availability limits enforcement, this is reported diagnostically and is still `DRIFT`.
+
+API unavailability, permission issues, or unexpected schema responses are treated as command errors, not as an absence of effective rules.
+
 Apply the policy explicitly:
 
 ```sh
@@ -33,6 +39,8 @@ just repository::policy-apply
 ```
 
 `policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+After applying configured changes, `policy-apply` performs final effective verification; it fails if the policy is configured but not effective on `main`.
 
 If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
 

--- a/templates/agent-cpp-cmake/.automation/bin/repository_policy.py
+++ b/templates/agent-cpp-cmake/.automation/bin/repository_policy.py
@@ -18,6 +18,7 @@ PULL_REQUEST_PARAMETERS = {
     "required_approving_review_count": 0,
     "required_review_thread_resolution": False,
 }
+EFFECTIVE_RULE_TYPES = ("deletion", "non_fast_forward", "pull_request")
 
 
 class RepositoryPolicyError(RuntimeError):
@@ -217,6 +218,135 @@ def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _normalized_effective_expected(ruleset: dict[str, Any]) -> list[dict[str, Any]]:
+    expected: list[dict[str, Any]] = []
+    for rule in ruleset.get("rules", []):
+        if not isinstance(rule, dict) or rule.get("type") not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = {"type": rule["type"]}
+        if rule["type"] == "pull_request":
+            normalized["parameters"] = {
+                "required_approving_review_count": PULL_REQUEST_PARAMETERS[
+                    "required_approving_review_count"
+                ]
+            }
+        expected.append(normalized)
+    return expected
+
+
+def _normalize_effective_rule(value: dict[str, Any]) -> dict[str, Any]:
+    rule_type = value.get("type")
+    rule: dict[str, Any] = {"type": rule_type}
+
+    if rule_type == "pull_request":
+        parameters = value.get("parameters")
+        if (
+            isinstance(parameters, dict)
+            and "required_approving_review_count" in parameters
+        ):
+            rule["parameters"] = {
+                "required_approving_review_count": parameters[
+                    "required_approving_review_count"
+                ]
+            }
+
+    for key in (
+        "ruleset_id",
+        "ruleset_source_type",
+        "ruleset_source",
+    ):
+        if key in value:
+            rule[key] = value[key]
+
+    return rule
+
+
+def _find_effective_rules(
+    values: list[Any], managed_ruleset_id: int | None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str], bool]:
+    matching: list[dict[str, Any]] = []
+    source_rules: list[dict[str, Any]] = []
+    by_type: dict[str, list[dict[str, Any]]] = {
+        rule_type: [] for rule_type in EFFECTIVE_RULE_TYPES
+    }
+
+    for index, item in enumerate(values):
+        if not isinstance(item, dict):
+            raise RepositoryPolicyError(
+                f"unexpected branch effective rule at index {index}"
+            )
+        rule_type = item.get("type")
+        if not isinstance(rule_type, str):
+            raise RepositoryPolicyError(
+                f"branch effective rule at index {index} is missing its type"
+            )
+        if rule_type not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = _normalize_effective_rule(item)
+        source_rules.append(normalized)
+        by_type[rule_type].append(normalized)
+        if (
+            managed_ruleset_id is not None
+            and normalized.get("ruleset_id") == managed_ruleset_id
+        ):
+            matching.append(normalized)
+
+    source_rules.sort(key=lambda item: item["type"])
+    matching.sort(key=lambda item: item["type"])
+
+    drift: list[str] = []
+    if managed_ruleset_id is None:
+        drift.append(
+            "managed ruleset id is missing, so effective rules cannot be attributed"
+        )
+        return source_rules, matching, drift, False
+
+    existing_types = {rule["type"] for rule in matching}
+    for rule_type in EFFECTIVE_RULE_TYPES:
+        if rule_type not in existing_types:
+            conflicting = by_type[rule_type]
+            if conflicting:
+                ids = sorted(
+                    {
+                        rule.get("ruleset_id")
+                        for rule in conflicting
+                        if isinstance(rule.get("ruleset_id"), int)
+                    }
+                )
+                if ids:
+                    drift.append(
+                        f"{rule_type} rule is not enforced by managed ruleset "
+                        f"{managed_ruleset_id}; found source ruleset IDs={ids}"
+                    )
+                else:
+                    drift.append(
+                        f"{rule_type} rule is missing for managed ruleset "
+                        f"{managed_ruleset_id}"
+                    )
+            else:
+                drift.append(
+                    f"{rule_type} rule is missing for managed ruleset "
+                    f"{managed_ruleset_id}"
+                )
+
+    for rule in matching:
+        if rule["type"] != "pull_request":
+            continue
+        actual_parameters = rule.get("parameters")
+        if not isinstance(actual_parameters, dict):
+            continue
+        if "required_approving_review_count" in actual_parameters:
+            actual_count = actual_parameters.get("required_approving_review_count")
+            if actual_count != PULL_REQUEST_PARAMETERS["required_approving_review_count"]:
+                drift.append(
+                    "effective pull_request rule reports "
+                    f"required_approving_review_count={actual_count!r}; expected 0"
+                )
+
+    match = not drift
+    return source_rules, matching, drift, match
+
+
 def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
     result = normalize_ruleset(desired_ruleset(policy))
     for rule in result["rules"]:
@@ -277,6 +407,39 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
     normalized_actual = (
         None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
     )
+    configured_match = normalized_actual == expected_ruleset
+    expected_effective_rules = _normalized_effective_expected(expected_ruleset)
+    expected_effective_rules = sorted(
+        expected_effective_rules, key=lambda rule: rule["type"]
+    )
+
+    effective_rules: list[dict[str, Any]]
+    matching_effective_rules: list[dict[str, Any]]
+    effective_drift: list[str]
+    effective_match: bool
+
+    if expected_branch_exists:
+        branch_rules_value = gh_api(
+            root,
+            "GET",
+            f"repos/{repository}/rules/branches/{expected_branch}",
+        )
+        if not isinstance(branch_rules_value, list):
+            raise RepositoryPolicyError("unexpected branch effective rules response")
+        (
+            effective_rules,
+            matching_effective_rules,
+            effective_drift,
+            effective_match,
+        ) = _find_effective_rules(branch_rules_value, ruleset_id)
+    else:
+        effective_rules = []
+        matching_effective_rules = []
+        effective_drift = [
+            f"effective rules for {expected_branch!r} cannot be verified because "
+            "the branch does not exist"
+        ]
+        effective_match = False
 
     drift: list[str] = []
     if actual_branch != expected_branch:
@@ -290,11 +453,35 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
         )
     if actual_ruleset is None:
         drift.append(f"missing ruleset {RULESET_NAME!r}")
-    elif normalized_actual != expected_ruleset:
+    elif not configured_match:
         drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    if not effective_match:
+        if configured_match:
+            if effective_drift:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    f"main: {'; '.join(effective_drift)}"
+                )
+            else:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    "main"
+                )
+        else:
+            if expected_branch_exists:
+                drift.append(
+                    "effective rules on main do not match expected policy: "
+                    + "; ".join(effective_drift)
+                )
+            else:
+                drift.append(
+                    "effective rules on main are not verifiable because main is missing"
+                )
 
     return {
         "repository": repository,
+        "visibility": repository_data.get("visibility"),
         "policyVersion": policy["version"],
         "defaultBranch": {
             "expected": expected_branch,
@@ -306,9 +493,17 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
             "name": RULESET_NAME,
             "id": ruleset_id,
             "present": actual_ruleset is not None,
-            "match": normalized_actual == expected_ruleset,
+            "match": configured_match,
             "actual": normalized_actual,
             "expected": expected_ruleset,
+        },
+        "effectiveRules": {
+            "expected": expected_effective_rules,
+            "actual": matching_effective_rules,
+            "match": effective_match,
+            "managedRulesetId": ruleset_id,
+            "drift": effective_drift,
+            "rulesFromBranch": effective_rules,
         },
         "drift": drift,
     }
@@ -333,12 +528,12 @@ def command_apply(root: Path) -> int:
     repository = before["repository"]
     expected_branch = policy["default_branch"]
 
+    if not before["defaultBranch"]["expectedBranchExists"]:
+        raise RepositoryPolicyError(
+            f"cannot apply repository policy: branch {expected_branch!r} does not exist"
+        )
+
     if before["defaultBranch"]["actual"] != expected_branch:
-        if not before["defaultBranch"]["expectedBranchExists"]:
-            raise RepositoryPolicyError(
-                f"cannot set default branch to {expected_branch!r}: "
-                f"branch {expected_branch!r} does not exist"
-            )
         gh_api(
             root,
             "PATCH",

--- a/templates/agent-nix/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-nix/.automation/REPOSITORY_POLICY.md
@@ -4,6 +4,8 @@ Agent-ready repositories carry a declarative GitHub repository policy in `.autom
 
 The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
 
+`policy-check` and `policy-apply` require both configured ruleset equality and effective rules on `main` (via GitHub’s branch rules API). A matching configured ruleset alone is insufficient.
+
 Repository policy is separate from project bootstrap and session initialization:
 
 ```text
@@ -26,6 +28,10 @@ Check the current repository without changing it:
 just repository::policy-check
 ```
 
+`policy-check` is `DRIFT` when configured rules differ or when effective rules on `main` do not match. When the effective-rules API returns `required_approving_review_count`, it must be `0`; an omitted parameter is not inferred. If repository visibility or GitHub plan/feature availability limits enforcement, this is reported diagnostically and is still `DRIFT`.
+
+API unavailability, permission issues, or unexpected schema responses are treated as command errors, not as an absence of effective rules.
+
 Apply the policy explicitly:
 
 ```sh
@@ -33,6 +39,8 @@ just repository::policy-apply
 ```
 
 `policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+After applying configured changes, `policy-apply` performs final effective verification; it fails if the policy is configured but not effective on `main`.
 
 If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
 

--- a/templates/agent-nix/.automation/bin/repository_policy.py
+++ b/templates/agent-nix/.automation/bin/repository_policy.py
@@ -18,6 +18,7 @@ PULL_REQUEST_PARAMETERS = {
     "required_approving_review_count": 0,
     "required_review_thread_resolution": False,
 }
+EFFECTIVE_RULE_TYPES = ("deletion", "non_fast_forward", "pull_request")
 
 
 class RepositoryPolicyError(RuntimeError):
@@ -217,6 +218,135 @@ def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _normalized_effective_expected(ruleset: dict[str, Any]) -> list[dict[str, Any]]:
+    expected: list[dict[str, Any]] = []
+    for rule in ruleset.get("rules", []):
+        if not isinstance(rule, dict) or rule.get("type") not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = {"type": rule["type"]}
+        if rule["type"] == "pull_request":
+            normalized["parameters"] = {
+                "required_approving_review_count": PULL_REQUEST_PARAMETERS[
+                    "required_approving_review_count"
+                ]
+            }
+        expected.append(normalized)
+    return expected
+
+
+def _normalize_effective_rule(value: dict[str, Any]) -> dict[str, Any]:
+    rule_type = value.get("type")
+    rule: dict[str, Any] = {"type": rule_type}
+
+    if rule_type == "pull_request":
+        parameters = value.get("parameters")
+        if (
+            isinstance(parameters, dict)
+            and "required_approving_review_count" in parameters
+        ):
+            rule["parameters"] = {
+                "required_approving_review_count": parameters[
+                    "required_approving_review_count"
+                ]
+            }
+
+    for key in (
+        "ruleset_id",
+        "ruleset_source_type",
+        "ruleset_source",
+    ):
+        if key in value:
+            rule[key] = value[key]
+
+    return rule
+
+
+def _find_effective_rules(
+    values: list[Any], managed_ruleset_id: int | None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str], bool]:
+    matching: list[dict[str, Any]] = []
+    source_rules: list[dict[str, Any]] = []
+    by_type: dict[str, list[dict[str, Any]]] = {
+        rule_type: [] for rule_type in EFFECTIVE_RULE_TYPES
+    }
+
+    for index, item in enumerate(values):
+        if not isinstance(item, dict):
+            raise RepositoryPolicyError(
+                f"unexpected branch effective rule at index {index}"
+            )
+        rule_type = item.get("type")
+        if not isinstance(rule_type, str):
+            raise RepositoryPolicyError(
+                f"branch effective rule at index {index} is missing its type"
+            )
+        if rule_type not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = _normalize_effective_rule(item)
+        source_rules.append(normalized)
+        by_type[rule_type].append(normalized)
+        if (
+            managed_ruleset_id is not None
+            and normalized.get("ruleset_id") == managed_ruleset_id
+        ):
+            matching.append(normalized)
+
+    source_rules.sort(key=lambda item: item["type"])
+    matching.sort(key=lambda item: item["type"])
+
+    drift: list[str] = []
+    if managed_ruleset_id is None:
+        drift.append(
+            "managed ruleset id is missing, so effective rules cannot be attributed"
+        )
+        return source_rules, matching, drift, False
+
+    existing_types = {rule["type"] for rule in matching}
+    for rule_type in EFFECTIVE_RULE_TYPES:
+        if rule_type not in existing_types:
+            conflicting = by_type[rule_type]
+            if conflicting:
+                ids = sorted(
+                    {
+                        rule.get("ruleset_id")
+                        for rule in conflicting
+                        if isinstance(rule.get("ruleset_id"), int)
+                    }
+                )
+                if ids:
+                    drift.append(
+                        f"{rule_type} rule is not enforced by managed ruleset "
+                        f"{managed_ruleset_id}; found source ruleset IDs={ids}"
+                    )
+                else:
+                    drift.append(
+                        f"{rule_type} rule is missing for managed ruleset "
+                        f"{managed_ruleset_id}"
+                    )
+            else:
+                drift.append(
+                    f"{rule_type} rule is missing for managed ruleset "
+                    f"{managed_ruleset_id}"
+                )
+
+    for rule in matching:
+        if rule["type"] != "pull_request":
+            continue
+        actual_parameters = rule.get("parameters")
+        if not isinstance(actual_parameters, dict):
+            continue
+        if "required_approving_review_count" in actual_parameters:
+            actual_count = actual_parameters.get("required_approving_review_count")
+            if actual_count != PULL_REQUEST_PARAMETERS["required_approving_review_count"]:
+                drift.append(
+                    "effective pull_request rule reports "
+                    f"required_approving_review_count={actual_count!r}; expected 0"
+                )
+
+    match = not drift
+    return source_rules, matching, drift, match
+
+
 def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
     result = normalize_ruleset(desired_ruleset(policy))
     for rule in result["rules"]:
@@ -277,6 +407,39 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
     normalized_actual = (
         None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
     )
+    configured_match = normalized_actual == expected_ruleset
+    expected_effective_rules = _normalized_effective_expected(expected_ruleset)
+    expected_effective_rules = sorted(
+        expected_effective_rules, key=lambda rule: rule["type"]
+    )
+
+    effective_rules: list[dict[str, Any]]
+    matching_effective_rules: list[dict[str, Any]]
+    effective_drift: list[str]
+    effective_match: bool
+
+    if expected_branch_exists:
+        branch_rules_value = gh_api(
+            root,
+            "GET",
+            f"repos/{repository}/rules/branches/{expected_branch}",
+        )
+        if not isinstance(branch_rules_value, list):
+            raise RepositoryPolicyError("unexpected branch effective rules response")
+        (
+            effective_rules,
+            matching_effective_rules,
+            effective_drift,
+            effective_match,
+        ) = _find_effective_rules(branch_rules_value, ruleset_id)
+    else:
+        effective_rules = []
+        matching_effective_rules = []
+        effective_drift = [
+            f"effective rules for {expected_branch!r} cannot be verified because "
+            "the branch does not exist"
+        ]
+        effective_match = False
 
     drift: list[str] = []
     if actual_branch != expected_branch:
@@ -290,11 +453,35 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
         )
     if actual_ruleset is None:
         drift.append(f"missing ruleset {RULESET_NAME!r}")
-    elif normalized_actual != expected_ruleset:
+    elif not configured_match:
         drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    if not effective_match:
+        if configured_match:
+            if effective_drift:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    f"main: {'; '.join(effective_drift)}"
+                )
+            else:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    "main"
+                )
+        else:
+            if expected_branch_exists:
+                drift.append(
+                    "effective rules on main do not match expected policy: "
+                    + "; ".join(effective_drift)
+                )
+            else:
+                drift.append(
+                    "effective rules on main are not verifiable because main is missing"
+                )
 
     return {
         "repository": repository,
+        "visibility": repository_data.get("visibility"),
         "policyVersion": policy["version"],
         "defaultBranch": {
             "expected": expected_branch,
@@ -306,9 +493,17 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
             "name": RULESET_NAME,
             "id": ruleset_id,
             "present": actual_ruleset is not None,
-            "match": normalized_actual == expected_ruleset,
+            "match": configured_match,
             "actual": normalized_actual,
             "expected": expected_ruleset,
+        },
+        "effectiveRules": {
+            "expected": expected_effective_rules,
+            "actual": matching_effective_rules,
+            "match": effective_match,
+            "managedRulesetId": ruleset_id,
+            "drift": effective_drift,
+            "rulesFromBranch": effective_rules,
         },
         "drift": drift,
     }
@@ -333,12 +528,12 @@ def command_apply(root: Path) -> int:
     repository = before["repository"]
     expected_branch = policy["default_branch"]
 
+    if not before["defaultBranch"]["expectedBranchExists"]:
+        raise RepositoryPolicyError(
+            f"cannot apply repository policy: branch {expected_branch!r} does not exist"
+        )
+
     if before["defaultBranch"]["actual"] != expected_branch:
-        if not before["defaultBranch"]["expectedBranchExists"]:
-            raise RepositoryPolicyError(
-                f"cannot set default branch to {expected_branch!r}: "
-                f"branch {expected_branch!r} does not exist"
-            )
         gh_api(
             root,
             "PATCH",

--- a/templates/agent-python/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-python/.automation/REPOSITORY_POLICY.md
@@ -4,6 +4,8 @@ Agent-ready repositories carry a declarative GitHub repository policy in `.autom
 
 The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
 
+`policy-check` and `policy-apply` require both configured ruleset equality and effective rules on `main` (via GitHub’s branch rules API). A matching configured ruleset alone is insufficient.
+
 Repository policy is separate from project bootstrap and session initialization:
 
 ```text
@@ -26,6 +28,10 @@ Check the current repository without changing it:
 just repository::policy-check
 ```
 
+`policy-check` is `DRIFT` when configured rules differ or when effective rules on `main` do not match. When the effective-rules API returns `required_approving_review_count`, it must be `0`; an omitted parameter is not inferred. If repository visibility or GitHub plan/feature availability limits enforcement, this is reported diagnostically and is still `DRIFT`.
+
+API unavailability, permission issues, or unexpected schema responses are treated as command errors, not as an absence of effective rules.
+
 Apply the policy explicitly:
 
 ```sh
@@ -33,6 +39,8 @@ just repository::policy-apply
 ```
 
 `policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+After applying configured changes, `policy-apply` performs final effective verification; it fails if the policy is configured but not effective on `main`.
 
 If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
 

--- a/templates/agent-python/.automation/bin/repository_policy.py
+++ b/templates/agent-python/.automation/bin/repository_policy.py
@@ -18,6 +18,7 @@ PULL_REQUEST_PARAMETERS = {
     "required_approving_review_count": 0,
     "required_review_thread_resolution": False,
 }
+EFFECTIVE_RULE_TYPES = ("deletion", "non_fast_forward", "pull_request")
 
 
 class RepositoryPolicyError(RuntimeError):
@@ -217,6 +218,135 @@ def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _normalized_effective_expected(ruleset: dict[str, Any]) -> list[dict[str, Any]]:
+    expected: list[dict[str, Any]] = []
+    for rule in ruleset.get("rules", []):
+        if not isinstance(rule, dict) or rule.get("type") not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = {"type": rule["type"]}
+        if rule["type"] == "pull_request":
+            normalized["parameters"] = {
+                "required_approving_review_count": PULL_REQUEST_PARAMETERS[
+                    "required_approving_review_count"
+                ]
+            }
+        expected.append(normalized)
+    return expected
+
+
+def _normalize_effective_rule(value: dict[str, Any]) -> dict[str, Any]:
+    rule_type = value.get("type")
+    rule: dict[str, Any] = {"type": rule_type}
+
+    if rule_type == "pull_request":
+        parameters = value.get("parameters")
+        if (
+            isinstance(parameters, dict)
+            and "required_approving_review_count" in parameters
+        ):
+            rule["parameters"] = {
+                "required_approving_review_count": parameters[
+                    "required_approving_review_count"
+                ]
+            }
+
+    for key in (
+        "ruleset_id",
+        "ruleset_source_type",
+        "ruleset_source",
+    ):
+        if key in value:
+            rule[key] = value[key]
+
+    return rule
+
+
+def _find_effective_rules(
+    values: list[Any], managed_ruleset_id: int | None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str], bool]:
+    matching: list[dict[str, Any]] = []
+    source_rules: list[dict[str, Any]] = []
+    by_type: dict[str, list[dict[str, Any]]] = {
+        rule_type: [] for rule_type in EFFECTIVE_RULE_TYPES
+    }
+
+    for index, item in enumerate(values):
+        if not isinstance(item, dict):
+            raise RepositoryPolicyError(
+                f"unexpected branch effective rule at index {index}"
+            )
+        rule_type = item.get("type")
+        if not isinstance(rule_type, str):
+            raise RepositoryPolicyError(
+                f"branch effective rule at index {index} is missing its type"
+            )
+        if rule_type not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = _normalize_effective_rule(item)
+        source_rules.append(normalized)
+        by_type[rule_type].append(normalized)
+        if (
+            managed_ruleset_id is not None
+            and normalized.get("ruleset_id") == managed_ruleset_id
+        ):
+            matching.append(normalized)
+
+    source_rules.sort(key=lambda item: item["type"])
+    matching.sort(key=lambda item: item["type"])
+
+    drift: list[str] = []
+    if managed_ruleset_id is None:
+        drift.append(
+            "managed ruleset id is missing, so effective rules cannot be attributed"
+        )
+        return source_rules, matching, drift, False
+
+    existing_types = {rule["type"] for rule in matching}
+    for rule_type in EFFECTIVE_RULE_TYPES:
+        if rule_type not in existing_types:
+            conflicting = by_type[rule_type]
+            if conflicting:
+                ids = sorted(
+                    {
+                        rule.get("ruleset_id")
+                        for rule in conflicting
+                        if isinstance(rule.get("ruleset_id"), int)
+                    }
+                )
+                if ids:
+                    drift.append(
+                        f"{rule_type} rule is not enforced by managed ruleset "
+                        f"{managed_ruleset_id}; found source ruleset IDs={ids}"
+                    )
+                else:
+                    drift.append(
+                        f"{rule_type} rule is missing for managed ruleset "
+                        f"{managed_ruleset_id}"
+                    )
+            else:
+                drift.append(
+                    f"{rule_type} rule is missing for managed ruleset "
+                    f"{managed_ruleset_id}"
+                )
+
+    for rule in matching:
+        if rule["type"] != "pull_request":
+            continue
+        actual_parameters = rule.get("parameters")
+        if not isinstance(actual_parameters, dict):
+            continue
+        if "required_approving_review_count" in actual_parameters:
+            actual_count = actual_parameters.get("required_approving_review_count")
+            if actual_count != PULL_REQUEST_PARAMETERS["required_approving_review_count"]:
+                drift.append(
+                    "effective pull_request rule reports "
+                    f"required_approving_review_count={actual_count!r}; expected 0"
+                )
+
+    match = not drift
+    return source_rules, matching, drift, match
+
+
 def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
     result = normalize_ruleset(desired_ruleset(policy))
     for rule in result["rules"]:
@@ -277,6 +407,39 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
     normalized_actual = (
         None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
     )
+    configured_match = normalized_actual == expected_ruleset
+    expected_effective_rules = _normalized_effective_expected(expected_ruleset)
+    expected_effective_rules = sorted(
+        expected_effective_rules, key=lambda rule: rule["type"]
+    )
+
+    effective_rules: list[dict[str, Any]]
+    matching_effective_rules: list[dict[str, Any]]
+    effective_drift: list[str]
+    effective_match: bool
+
+    if expected_branch_exists:
+        branch_rules_value = gh_api(
+            root,
+            "GET",
+            f"repos/{repository}/rules/branches/{expected_branch}",
+        )
+        if not isinstance(branch_rules_value, list):
+            raise RepositoryPolicyError("unexpected branch effective rules response")
+        (
+            effective_rules,
+            matching_effective_rules,
+            effective_drift,
+            effective_match,
+        ) = _find_effective_rules(branch_rules_value, ruleset_id)
+    else:
+        effective_rules = []
+        matching_effective_rules = []
+        effective_drift = [
+            f"effective rules for {expected_branch!r} cannot be verified because "
+            "the branch does not exist"
+        ]
+        effective_match = False
 
     drift: list[str] = []
     if actual_branch != expected_branch:
@@ -290,11 +453,35 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
         )
     if actual_ruleset is None:
         drift.append(f"missing ruleset {RULESET_NAME!r}")
-    elif normalized_actual != expected_ruleset:
+    elif not configured_match:
         drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    if not effective_match:
+        if configured_match:
+            if effective_drift:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    f"main: {'; '.join(effective_drift)}"
+                )
+            else:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    "main"
+                )
+        else:
+            if expected_branch_exists:
+                drift.append(
+                    "effective rules on main do not match expected policy: "
+                    + "; ".join(effective_drift)
+                )
+            else:
+                drift.append(
+                    "effective rules on main are not verifiable because main is missing"
+                )
 
     return {
         "repository": repository,
+        "visibility": repository_data.get("visibility"),
         "policyVersion": policy["version"],
         "defaultBranch": {
             "expected": expected_branch,
@@ -306,9 +493,17 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
             "name": RULESET_NAME,
             "id": ruleset_id,
             "present": actual_ruleset is not None,
-            "match": normalized_actual == expected_ruleset,
+            "match": configured_match,
             "actual": normalized_actual,
             "expected": expected_ruleset,
+        },
+        "effectiveRules": {
+            "expected": expected_effective_rules,
+            "actual": matching_effective_rules,
+            "match": effective_match,
+            "managedRulesetId": ruleset_id,
+            "drift": effective_drift,
+            "rulesFromBranch": effective_rules,
         },
         "drift": drift,
     }
@@ -333,12 +528,12 @@ def command_apply(root: Path) -> int:
     repository = before["repository"]
     expected_branch = policy["default_branch"]
 
+    if not before["defaultBranch"]["expectedBranchExists"]:
+        raise RepositoryPolicyError(
+            f"cannot apply repository policy: branch {expected_branch!r} does not exist"
+        )
+
     if before["defaultBranch"]["actual"] != expected_branch:
-        if not before["defaultBranch"]["expectedBranchExists"]:
-            raise RepositoryPolicyError(
-                f"cannot set default branch to {expected_branch!r}: "
-                f"branch {expected_branch!r} does not exist"
-            )
         gh_api(
             root,
             "PATCH",

--- a/templates/agent-rust/.automation/REPOSITORY_POLICY.md
+++ b/templates/agent-rust/.automation/REPOSITORY_POLICY.md
@@ -4,6 +4,8 @@ Agent-ready repositories carry a declarative GitHub repository policy in `.autom
 
 The expected default branch is `main`. The managed repository ruleset targets `~DEFAULT_BRANCH` and requires all changes to reach the default branch through a pull request. The ruleset requires zero approving reviews, so a pull request is mandatory while self-merge remains possible. Default-branch deletion and force pushes are also blocked. No bypass actor is configured.
 
+`policy-check` and `policy-apply` require both configured ruleset equality and effective rules on `main` (via GitHub’s branch rules API). A matching configured ruleset alone is insufficient.
+
 Repository policy is separate from project bootstrap and session initialization:
 
 ```text
@@ -26,6 +28,10 @@ Check the current repository without changing it:
 just repository::policy-check
 ```
 
+`policy-check` is `DRIFT` when configured rules differ or when effective rules on `main` do not match. When the effective-rules API returns `required_approving_review_count`, it must be `0`; an omitted parameter is not inferred. If repository visibility or GitHub plan/feature availability limits enforcement, this is reported diagnostically and is still `DRIFT`.
+
+API unavailability, permission issues, or unexpected schema responses are treated as command errors, not as an absence of effective rules.
+
 Apply the policy explicitly:
 
 ```sh
@@ -33,6 +39,8 @@ just repository::policy-apply
 ```
 
 `policy-apply` acts only on the GitHub repository resolved from the current checkout. It does not accept an arbitrary repository target. It requires GitHub Administration write permission because it may update the repository default branch and create or update a repository ruleset.
+
+After applying configured changes, `policy-apply` performs final effective verification; it fails if the policy is configured but not effective on `main`.
 
 If the current default branch is not `main`, `policy-apply` changes it only when a `main` branch already exists. It does not create or rename branches automatically. Create or rename `main` explicitly first when adopting an existing repository with another branch layout.
 

--- a/templates/agent-rust/.automation/bin/repository_policy.py
+++ b/templates/agent-rust/.automation/bin/repository_policy.py
@@ -18,6 +18,7 @@ PULL_REQUEST_PARAMETERS = {
     "required_approving_review_count": 0,
     "required_review_thread_resolution": False,
 }
+EFFECTIVE_RULE_TYPES = ("deletion", "non_fast_forward", "pull_request")
 
 
 class RepositoryPolicyError(RuntimeError):
@@ -217,6 +218,135 @@ def normalize_ruleset(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _normalized_effective_expected(ruleset: dict[str, Any]) -> list[dict[str, Any]]:
+    expected: list[dict[str, Any]] = []
+    for rule in ruleset.get("rules", []):
+        if not isinstance(rule, dict) or rule.get("type") not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = {"type": rule["type"]}
+        if rule["type"] == "pull_request":
+            normalized["parameters"] = {
+                "required_approving_review_count": PULL_REQUEST_PARAMETERS[
+                    "required_approving_review_count"
+                ]
+            }
+        expected.append(normalized)
+    return expected
+
+
+def _normalize_effective_rule(value: dict[str, Any]) -> dict[str, Any]:
+    rule_type = value.get("type")
+    rule: dict[str, Any] = {"type": rule_type}
+
+    if rule_type == "pull_request":
+        parameters = value.get("parameters")
+        if (
+            isinstance(parameters, dict)
+            and "required_approving_review_count" in parameters
+        ):
+            rule["parameters"] = {
+                "required_approving_review_count": parameters[
+                    "required_approving_review_count"
+                ]
+            }
+
+    for key in (
+        "ruleset_id",
+        "ruleset_source_type",
+        "ruleset_source",
+    ):
+        if key in value:
+            rule[key] = value[key]
+
+    return rule
+
+
+def _find_effective_rules(
+    values: list[Any], managed_ruleset_id: int | None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str], bool]:
+    matching: list[dict[str, Any]] = []
+    source_rules: list[dict[str, Any]] = []
+    by_type: dict[str, list[dict[str, Any]]] = {
+        rule_type: [] for rule_type in EFFECTIVE_RULE_TYPES
+    }
+
+    for index, item in enumerate(values):
+        if not isinstance(item, dict):
+            raise RepositoryPolicyError(
+                f"unexpected branch effective rule at index {index}"
+            )
+        rule_type = item.get("type")
+        if not isinstance(rule_type, str):
+            raise RepositoryPolicyError(
+                f"branch effective rule at index {index} is missing its type"
+            )
+        if rule_type not in EFFECTIVE_RULE_TYPES:
+            continue
+        normalized = _normalize_effective_rule(item)
+        source_rules.append(normalized)
+        by_type[rule_type].append(normalized)
+        if (
+            managed_ruleset_id is not None
+            and normalized.get("ruleset_id") == managed_ruleset_id
+        ):
+            matching.append(normalized)
+
+    source_rules.sort(key=lambda item: item["type"])
+    matching.sort(key=lambda item: item["type"])
+
+    drift: list[str] = []
+    if managed_ruleset_id is None:
+        drift.append(
+            "managed ruleset id is missing, so effective rules cannot be attributed"
+        )
+        return source_rules, matching, drift, False
+
+    existing_types = {rule["type"] for rule in matching}
+    for rule_type in EFFECTIVE_RULE_TYPES:
+        if rule_type not in existing_types:
+            conflicting = by_type[rule_type]
+            if conflicting:
+                ids = sorted(
+                    {
+                        rule.get("ruleset_id")
+                        for rule in conflicting
+                        if isinstance(rule.get("ruleset_id"), int)
+                    }
+                )
+                if ids:
+                    drift.append(
+                        f"{rule_type} rule is not enforced by managed ruleset "
+                        f"{managed_ruleset_id}; found source ruleset IDs={ids}"
+                    )
+                else:
+                    drift.append(
+                        f"{rule_type} rule is missing for managed ruleset "
+                        f"{managed_ruleset_id}"
+                    )
+            else:
+                drift.append(
+                    f"{rule_type} rule is missing for managed ruleset "
+                    f"{managed_ruleset_id}"
+                )
+
+    for rule in matching:
+        if rule["type"] != "pull_request":
+            continue
+        actual_parameters = rule.get("parameters")
+        if not isinstance(actual_parameters, dict):
+            continue
+        if "required_approving_review_count" in actual_parameters:
+            actual_count = actual_parameters.get("required_approving_review_count")
+            if actual_count != PULL_REQUEST_PARAMETERS["required_approving_review_count"]:
+                drift.append(
+                    "effective pull_request rule reports "
+                    f"required_approving_review_count={actual_count!r}; expected 0"
+                )
+
+    match = not drift
+    return source_rules, matching, drift, match
+
+
 def normalized_desired(policy: dict[str, Any]) -> dict[str, Any]:
     result = normalize_ruleset(desired_ruleset(policy))
     for rule in result["rules"]:
@@ -277,6 +407,39 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
     normalized_actual = (
         None if actual_ruleset is None else normalize_ruleset(actual_ruleset)
     )
+    configured_match = normalized_actual == expected_ruleset
+    expected_effective_rules = _normalized_effective_expected(expected_ruleset)
+    expected_effective_rules = sorted(
+        expected_effective_rules, key=lambda rule: rule["type"]
+    )
+
+    effective_rules: list[dict[str, Any]]
+    matching_effective_rules: list[dict[str, Any]]
+    effective_drift: list[str]
+    effective_match: bool
+
+    if expected_branch_exists:
+        branch_rules_value = gh_api(
+            root,
+            "GET",
+            f"repos/{repository}/rules/branches/{expected_branch}",
+        )
+        if not isinstance(branch_rules_value, list):
+            raise RepositoryPolicyError("unexpected branch effective rules response")
+        (
+            effective_rules,
+            matching_effective_rules,
+            effective_drift,
+            effective_match,
+        ) = _find_effective_rules(branch_rules_value, ruleset_id)
+    else:
+        effective_rules = []
+        matching_effective_rules = []
+        effective_drift = [
+            f"effective rules for {expected_branch!r} cannot be verified because "
+            "the branch does not exist"
+        ]
+        effective_match = False
 
     drift: list[str] = []
     if actual_branch != expected_branch:
@@ -290,11 +453,35 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
         )
     if actual_ruleset is None:
         drift.append(f"missing ruleset {RULESET_NAME!r}")
-    elif normalized_actual != expected_ruleset:
+    elif not configured_match:
         drift.append(f"ruleset {RULESET_NAME!r} differs from policy")
+
+    if not effective_match:
+        if configured_match:
+            if effective_drift:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    f"main: {'; '.join(effective_drift)}"
+                )
+            else:
+                drift.append(
+                    "configured ruleset matches policy, but it is not effective on "
+                    "main"
+                )
+        else:
+            if expected_branch_exists:
+                drift.append(
+                    "effective rules on main do not match expected policy: "
+                    + "; ".join(effective_drift)
+                )
+            else:
+                drift.append(
+                    "effective rules on main are not verifiable because main is missing"
+                )
 
     return {
         "repository": repository,
+        "visibility": repository_data.get("visibility"),
         "policyVersion": policy["version"],
         "defaultBranch": {
             "expected": expected_branch,
@@ -306,9 +493,17 @@ def inspect(root: Path, policy: dict[str, Any]) -> dict[str, Any]:
             "name": RULESET_NAME,
             "id": ruleset_id,
             "present": actual_ruleset is not None,
-            "match": normalized_actual == expected_ruleset,
+            "match": configured_match,
             "actual": normalized_actual,
             "expected": expected_ruleset,
+        },
+        "effectiveRules": {
+            "expected": expected_effective_rules,
+            "actual": matching_effective_rules,
+            "match": effective_match,
+            "managedRulesetId": ruleset_id,
+            "drift": effective_drift,
+            "rulesFromBranch": effective_rules,
         },
         "drift": drift,
     }
@@ -333,12 +528,12 @@ def command_apply(root: Path) -> int:
     repository = before["repository"]
     expected_branch = policy["default_branch"]
 
+    if not before["defaultBranch"]["expectedBranchExists"]:
+        raise RepositoryPolicyError(
+            f"cannot apply repository policy: branch {expected_branch!r} does not exist"
+        )
+
     if before["defaultBranch"]["actual"] != expected_branch:
-        if not before["defaultBranch"]["expectedBranchExists"]:
-            raise RepositoryPolicyError(
-                f"cannot set default branch to {expected_branch!r}: "
-                f"branch {expected_branch!r} does not exist"
-            )
         gh_api(
             root,
             "PATCH",

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -5,7 +5,9 @@ import json
 import sys
 import tempfile
 import unittest
+from copy import deepcopy
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -27,6 +29,32 @@ TEMPLATES = (
 
 
 class RepositoryPolicyContractTest(unittest.TestCase):
+    @staticmethod
+    def _effective_rules(ruleset_id: int, *, required_count: int | None = 0):
+        base = {
+            "ruleset_id": ruleset_id,
+            "type": "pull_request",
+            "parameters": {
+                "allowed_merge_methods": ["merge", "squash", "rebase"],
+                "dismiss_stale_reviews_on_push": False,
+                "require_code_owner_review": False,
+                "require_last_push_approval": False,
+                "required_review_thread_resolution": False,
+            },
+        }
+        if required_count is not None:
+            base["parameters"]["required_approving_review_count"] = required_count
+        return [
+            base,
+            {"type": "deletion", "ruleset_id": ruleset_id},
+            {"type": "non_fast_forward", "ruleset_id": ruleset_id},
+        ]
+
+    def _managed_ruleset_detail(self, ruleset_id: int, policy: dict[str, Any]):
+        detail = deepcopy(policy["ruleset"])
+        detail["id"] = ruleset_id
+        return detail
+
     def test_policy_requires_main_and_pull_request_without_bypass(self) -> None:
         policy = policy_runtime.load_policy(CORE)
         self.assertEqual(policy["default_branch"], "main")
@@ -126,6 +154,37 @@ class RepositoryPolicyContractTest(unittest.TestCase):
                 policy_runtime.command_apply(Path("/tmp/repository"))
             gh_api.assert_not_called()
 
+    def test_policy_apply_refuses_empty_repository_before_mutation(self) -> None:
+        policy = {
+            "version": 1,
+            "default_branch": "main",
+            "ruleset": {},
+        }
+        before = {
+            "repository": "example/repository",
+            "defaultBranch": {
+                "actual": "main",
+                "expected": "main",
+                "expectedBranchExists": False,
+                "match": True,
+            },
+            "ruleset": {"id": None, "match": False},
+            "drift": ["required branch 'main' does not exist"],
+        }
+        with patch.object(
+            policy_runtime, "task_worktree", return_value=False
+        ), patch.object(
+            policy_runtime, "load_policy", return_value=policy
+        ), patch.object(
+            policy_runtime, "inspect", return_value=before
+        ), patch.object(policy_runtime, "gh_api") as gh_api:
+            with self.assertRaisesRegex(
+                policy_runtime.RepositoryPolicyError,
+                "branch 'main' does not exist",
+            ):
+                policy_runtime.command_apply(Path("/tmp/repository"))
+            gh_api.assert_not_called()
+
     def test_policy_apply_sets_main_before_managing_ruleset(self) -> None:
         policy = {
             "version": 1,
@@ -198,6 +257,251 @@ class RepositoryPolicyContractTest(unittest.TestCase):
         self.assertIn("zero approving reviews", docs)
         self.assertIn("No bypass actor", docs)
         self.assertIn("does not create or rename branches", docs)
+
+    def test_inspect_success_when_configured_and_effective_rules_match(self) -> None:
+        policy = policy_runtime.load_policy(CORE)
+        repository = "owner/example"
+        ruleset_id = 777
+        branch_rules = self._effective_rules(ruleset_id)
+
+        with patch.object(policy_runtime, "current_repository", return_value=repository), patch.object(
+            policy_runtime, "branch_exists", return_value=True
+        ), patch.object(policy_runtime, "gh_api") as gh_api:
+            gh_api.side_effect = [
+                {"default_branch": "main", "visibility": "private"},
+                [
+                    {
+                        "name": "Agent repository policy",
+                        "source_type": "Repository",
+                        "id": ruleset_id,
+                    }
+                ],
+                self._managed_ruleset_detail(ruleset_id, policy),
+                branch_rules,
+            ]
+            result = policy_runtime.inspect(Path("/tmp/repository"), policy)
+
+        self.assertTrue(result["ruleset"]["match"])
+        self.assertTrue(result["effectiveRules"]["match"])
+        self.assertEqual(result["drift"], [])
+        self.assertEqual(result["visibility"], "private")
+        self.assertEqual(result["effectiveRules"]["actual"][0]["type"], "deletion")
+
+    def test_inspect_configured_match_without_effective_rules(self) -> None:
+        policy = policy_runtime.load_policy(CORE)
+        repository = "owner/example"
+        ruleset_id = 4
+
+        with patch.object(policy_runtime, "current_repository", return_value=repository), patch.object(
+            policy_runtime, "branch_exists", return_value=True
+        ), patch.object(policy_runtime, "gh_api") as gh_api:
+            gh_api.side_effect = [
+                {"default_branch": "main", "visibility": "public"},
+                [
+                    {
+                        "name": "Agent repository policy",
+                        "source_type": "Repository",
+                        "id": ruleset_id,
+                    }
+                ],
+                self._managed_ruleset_detail(ruleset_id, policy),
+                [],
+            ]
+            result = policy_runtime.inspect(Path("/tmp/repository"), policy)
+
+        self.assertTrue(result["ruleset"]["match"])
+        self.assertFalse(result["effectiveRules"]["match"])
+        self.assertIn(
+            "configured ruleset matches policy, but it is not effective on main",
+            result["drift"][0],
+        )
+
+    def test_inspect_reports_wrong_effective_ruleset_source(self) -> None:
+        policy = policy_runtime.load_policy(CORE)
+        repository = "owner/example"
+        ruleset_id = 10
+        wrong_ruleset_id = 11
+        branch_rules = self._effective_rules(wrong_ruleset_id)
+
+        with patch.object(policy_runtime, "current_repository", return_value=repository), patch.object(
+            policy_runtime, "branch_exists", return_value=True
+        ), patch.object(policy_runtime, "gh_api") as gh_api:
+            gh_api.side_effect = [
+                {"default_branch": "main", "visibility": "public"},
+                [
+                    {
+                        "name": "Agent repository policy",
+                        "source_type": "Repository",
+                        "id": ruleset_id,
+                    }
+                ],
+                self._managed_ruleset_detail(ruleset_id, policy),
+                branch_rules,
+            ]
+            result = policy_runtime.inspect(Path("/tmp/repository"), policy)
+
+        self.assertFalse(result["effectiveRules"]["match"])
+        self.assertIn(
+            "found source ruleset IDs=[11]",
+            " ".join(result["drift"]),
+        )
+
+    def test_inspect_effective_rules_require_pull_request_deletion_and_non_fast_forward(self) -> None:
+        policy = policy_runtime.load_policy(CORE)
+        repository = "owner/example"
+        ruleset_id = 10
+        branch_rules = [
+            self._effective_rules(ruleset_id)[0],
+        ]
+
+        with patch.object(policy_runtime, "current_repository", return_value=repository), patch.object(
+            policy_runtime, "branch_exists", return_value=True
+        ), patch.object(policy_runtime, "gh_api") as gh_api:
+            gh_api.side_effect = [
+                {"default_branch": "main", "visibility": "public"},
+                [
+                    {
+                        "name": "Agent repository policy",
+                        "source_type": "Repository",
+                        "id": ruleset_id,
+                    }
+                ],
+                self._managed_ruleset_detail(ruleset_id, policy),
+                branch_rules,
+            ]
+            result = policy_runtime.inspect(Path("/tmp/repository"), policy)
+
+        self.assertFalse(result["effectiveRules"]["match"])
+        drift = result["drift"][0]
+        self.assertIn("not effective on main", drift)
+        self.assertIn("deletion", drift)
+
+    def test_inspect_effective_pull_request_approving_review_count_match_and_absent(
+        self,
+    ) -> None:
+        policy = policy_runtime.load_policy(CORE)
+        repository = "owner/example"
+        ruleset_id = 22
+
+        for required_count in (1, None):
+            branch_rules = self._effective_rules(
+                ruleset_id, required_count=required_count
+            )
+
+            with self.subTest(required_count=required_count), patch.object(
+                policy_runtime, "current_repository", return_value=repository
+            ), patch.object(policy_runtime, "branch_exists", return_value=True), patch.object(
+                policy_runtime, "gh_api"
+            ) as gh_api:
+                gh_api.side_effect = [
+                    {"default_branch": "main", "visibility": "public"},
+                    [
+                        {
+                            "name": "Agent repository policy",
+                            "source_type": "Repository",
+                            "id": ruleset_id,
+                        }
+                    ],
+                    self._managed_ruleset_detail(ruleset_id, policy),
+                    branch_rules,
+                ]
+                result = policy_runtime.inspect(Path("/tmp/repository"), policy)
+
+            if required_count == 1:
+                self.assertFalse(result["effectiveRules"]["match"])
+                self.assertIn("required_approving_review_count=1", " ".join(result["effectiveRules"]["drift"]))
+            else:
+                self.assertTrue(result["effectiveRules"]["match"])
+                self.assertNotIn(
+                    "required_approving_review_count",
+                    " ".join(result["effectiveRules"]["drift"]),
+                )
+
+    def test_inspect_does_not_infer_unreturned_pull_request_parameters(self) -> None:
+        policy = policy_runtime.load_policy(CORE)
+        repository = "owner/example"
+        ruleset_id = 23
+        branch_rules = self._effective_rules(ruleset_id)
+        branch_rules[0].pop("parameters")
+
+        with patch.object(
+            policy_runtime, "current_repository", return_value=repository
+        ), patch.object(
+            policy_runtime, "branch_exists", return_value=True
+        ), patch.object(policy_runtime, "gh_api") as gh_api:
+            gh_api.side_effect = [
+                {"default_branch": "main", "visibility": "public"},
+                [
+                    {
+                        "name": "Agent repository policy",
+                        "source_type": "Repository",
+                        "id": ruleset_id,
+                    }
+                ],
+                self._managed_ruleset_detail(ruleset_id, policy),
+                branch_rules,
+            ]
+            result = policy_runtime.inspect(Path("/tmp/repository"), policy)
+
+        self.assertTrue(result["effectiveRules"]["match"])
+
+    def test_inspect_api_error_propagates_from_effective_rules_endpoint(self) -> None:
+        policy = policy_runtime.load_policy(CORE)
+        repository = "owner/example"
+        ruleset_id = 3
+
+        with patch.object(policy_runtime, "current_repository", return_value=repository), patch.object(
+            policy_runtime, "branch_exists", return_value=True
+        ):
+
+            def side_effect(root, method, endpoint, *, body=None, allow_not_found=False):
+                if endpoint.endswith("/rules/branches/main"):
+                    raise policy_runtime.RepositoryPolicyError("rate limited")
+                if endpoint == "repos/owner/example":
+                    return {"default_branch": "main", "visibility": "public"}
+                if endpoint == "repos/owner/example/rulesets?includes_parents=false&per_page=100":
+                    return [
+                        {
+                            "name": "Agent repository policy",
+                            "source_type": "Repository",
+                            "id": ruleset_id,
+                        }
+                    ]
+                if endpoint == "repos/owner/example/rulesets/3":
+                    return self._managed_ruleset_detail(ruleset_id, policy)
+                raise AssertionError(f"unexpected endpoint {endpoint}")
+
+            with patch.object(policy_runtime, "gh_api", side_effect=side_effect):
+                with self.assertRaisesRegex(
+                    policy_runtime.RepositoryPolicyError, "rate limited"
+                ):
+                    policy_runtime.inspect(Path("/tmp/repository"), policy)
+
+    def test_command_apply_rejects_incomplete_post_verification(self) -> None:
+        policy = policy_runtime.load_policy(CORE)
+        before = {
+            "repository": "owner/example",
+            "defaultBranch": {
+                "actual": "main",
+                "expected": "main",
+                "expectedBranchExists": True,
+                "match": True,
+            },
+            "ruleset": {"id": 1, "match": True},
+            "drift": [],
+        }
+        after = {
+            "drift": ["effective rules did not fully apply"],
+        }
+
+        with patch.object(policy_runtime, "task_worktree", return_value=False), patch.object(
+            policy_runtime, "load_policy", return_value=policy
+        ), patch.object(policy_runtime, "inspect", side_effect=[before, after]):
+            with self.assertRaisesRegex(
+                policy_runtime.RepositoryPolicyError,
+                "verification still reports drift",
+            ):
+                policy_runtime.command_apply(Path("/tmp/repository"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- require the managed repository ruleset to appear in GitHub's effective rules for `main`
- report visibility, managed ruleset attribution, missing rules, and review-count drift separately from configured ruleset drift
- fail policy apply when final effective verification is incomplete, and refuse all mutation when `main` is absent
- document the effective-policy contract and synchronize all generated templates

## Verification
- `nix shell nixpkgs#just nixpkgs#python3 --command env PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v` (114 tests)
- `nix shell nixpkgs#just nixpkgs#python3 --command env PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_repository_policy -v` (17 tests)
- `nix shell nixpkgs#just nixpkgs#python3 --command env PYTHONDONTWRITEBYTECODE=1 just template::check`
- `nix shell nixpkgs#just nixpkgs#python3 --command env PYTHONDONTWRITEBYTECODE=1 just template::distribution-verify`
- `git diff --check main...HEAD`

## Risk / diagnostics
- This verifies GitHub's reported effective branch-rule state; it does not claim that the API response independently proves push rejection.
- The private smoke repository currently reports all three managed effective rules, so the previously described empty-effective response was not reproduced in the final read-only observation.

## Related issue
- Follow-up to #45.