### PR TITLE
fix: keep runtime diagnostics usable

### DIFF
--- a/tests/runtime/README.md
+++ b/tests/runtime/README.md
@@ -106,6 +106,8 @@ Then run:
 /task-run SMOKE-FALLBACK
 ```
 
+The Task Orchestrator must give `general` exactly one Work Unit: run `git status --short` once and return. Only a genuine classified usage/quota/rate-limit failure may retry that identical Work Unit with `general-fallback`. Both variants receive the same diagnostic default-deny profile and explicit status allow, so permission selection cannot contaminate the fallback observation.
+
 Do not manufacture a quota condition. If no genuine usage/quota/rate-limit failure occurs, runtime fallback remains `INCOMPLETE`.
 
 ## Session evidence

--- a/tests/runtime/README.md
+++ b/tests/runtime/README.md
@@ -58,6 +58,8 @@ The command starts the real Main TUI with DEBUG logging. In the TUI, run:
 /task-run SMOKE-CONTROL
 ```
 
+DEBUG stderr is saved to the per-run log file without being printed over the TUI. Set `OPENCODE_RUNTIME_LIVE_LOGS=1` only when live DEBUG output is explicitly needed.
+
 The Task contract requires the Task Orchestrator to delegate exactly one `general` leaf and for that leaf to run only `git status --short`.
 
 Interpretation:
@@ -78,7 +80,15 @@ Then run:
 /task-run SMOKE-ASK
 ```
 
-The leaf contract requests two harmless unclassified Bash commands in sequence. Approve the first once and reject the second. Do not use auto-approval and do not change repository permissions.
+The `SMOKE-ASK` contract requires the Task Orchestrator to pass one exact bounded Work Unit to one `general` leaf: first `printf 'depth2-ask-approved\n'`, then `printf 'depth2-ask-rejected\n'`.
+
+The leaf must call Bash for the first printf immediately, and it must wait for that permission resolution before making any second request. A `question` event before the first Bash permission means the run is non-deterministic for this harness and must be treated as **INCOMPLETE/invalid** for this diagnostic.
+
+To make that protocol enforceable, `runtime::prepare` adds a diagnostic-only `question: deny` override to the generated `general` agent before committing the fixture. This narrows the disposable fixture permission surface without changing the Bash Ask boundary or the generated template source.
+
+Approve the first request once and reject the second. If the run is incomplete due to ordering/classification mismatch, stop and re-run `/task-run SMOKE-ASK` (new session) to collect a fresh, retryable observation.
+
+Do not use auto-approval and do not change repository permissions.
 
 A child-session permission that can only be handled by navigating away from Main does not satisfy the centralized Main-TUI Ask requirement.
 

--- a/tests/runtime/README.md
+++ b/tests/runtime/README.md
@@ -66,9 +66,9 @@ Interpretation:
 
 - direct leaf stalls: investigate provider/model or leaf-agent execution before nested orchestration
 - direct leaf passes but nested control stalls: investigate Task/subagent session execution
-- nested control passes: proceed to the Ask probe
+- nested control passes: the provider path works; the native Ask canary may be run independently
 
-## Depth-2 Ask probe
+## Depth-2 native Ask compatibility canary
 
 ```sh
 just runtime::smoke-depth2 issue-41
@@ -80,11 +80,13 @@ Then run:
 /task-run SMOKE-ASK
 ```
 
-The `SMOKE-ASK` contract requires the Task Orchestrator to pass one exact bounded Work Unit to one `general` leaf: first `printf 'depth2-ask-approved\n'`, then `printf 'depth2-ask-rejected\n'`.
+`SMOKE-ASK` is an upstream compatibility canary for descendant permission relay. It is not a Templates release gate and does not determine #7 completion; the durable release gate is Leaf -> Depth-1 escalation tracked by #51.
+
+The canary contract requires the Task Orchestrator to pass one exact bounded Work Unit to one `general` leaf: first `printf 'depth2-ask-approved\n'`, then `printf 'depth2-ask-rejected\n'`.
 
 The leaf must call Bash for the first printf immediately, and it must wait for that permission resolution before making any second request. A `question` event before the first Bash permission means the run is non-deterministic for this harness and must be treated as **INCOMPLETE/invalid** for this diagnostic.
 
-To make that protocol enforceable, `runtime::prepare` adds a diagnostic-only `question: deny` override to the generated `general` agent before committing the fixture. This narrows the disposable fixture permission surface without changing the Bash Ask boundary or the generated template source.
+To keep the canary independent from production Leaf policy, `runtime::prepare` installs a diagnostic-only profile before committing the disposable fixture: `question` is denied, Bash defaults to deny, `git status --short` remains available for controls, and only the two exact canary `printf` commands use Ask. This profile does not change generated template source or production permissions.
 
 Approve the first request once and reject the second. If the run is incomplete due to ordering/classification mismatch, stop and re-run `/task-run SMOKE-ASK` (new session) to collect a fresh, retryable observation.
 

--- a/tests/runtime/issue-41-child-stall.md
+++ b/tests/runtime/issue-41-child-stall.md
@@ -32,6 +32,18 @@ Task tool launch
 
 Do not infer an intermediate stage from a spinner or child label alone.
 
+## Ask ordering gate (retry requirement)
+
+For `Control C`, classify deterministic ordering as follows:
+
+- `permission.asked` (or equivalent) for `printf 'depth2-ask-approved\n'`
+- provider execution result for the approved first command
+- `permission.asked`/rejection for `printf 'depth2-ask-rejected\n'`
+
+The prepared diagnostic fixture sets `question: deny` on its generated `general` agent. This is a diagnostic-only restriction, not a production permission weakening, and ensures the leaf reaches the Bash Ask boundary instead of substituting a Question tool interaction.
+
+If the leaf emits a `question` event before the first Bash permission flow, treat the attempt as **INCOMPLETE/invalid** (not a relay failure), and rerun `just runtime::smoke-depth2 issue-41` + `/task-run SMOKE-ASK`.
+
 ## Control A — direct leaf
 
 ```sh
@@ -81,7 +93,7 @@ Inside Main TUI:
 /task-run SMOKE-ASK
 ```
 
-The leaf must request exactly these harmless commands in sequence:
+The leaf must request exactly these harmless commands in sequence, with the first command sent to Bash before any other tool and before any permission relay:
 
 ```sh
 printf 'depth2-ask-approved\n'
@@ -89,6 +101,8 @@ printf 'depth2-ask-rejected\n'
 ```
 
 Approve the first once and reject the second.
+
+Do not mark this as permission-relay failure when `question` appears before the first Bash permission event; it should be recorded as INCOMPLETE and retried once for a clean ordering sample.
 
 If provider response and tool request are visible but `permission.asked` or Main relay is absent, prioritize permission propagation. If no provider response occurs, keep the diagnosis in the provider/session path.
 
@@ -108,6 +122,7 @@ Use the sanitized export as supporting evidence, not as a replacement for real T
 |---|---|---|---|
 | stall | not run | not run | provider/model/direct leaf execution |
 | pass | stall | not run | nested Task/subagent session execution |
+| pass | pass | question before Bash permission | protocol mismatch → treat as INCOMPLETE/invalid and retry |
 | pass | pass | stall before permission event | Ask-producing leaf/provider/tool request path |
 | pass | pass | permission event exists but Main cannot handle it | permission relay/UI propagation |
 | pass | pass | approve/reject both work | #7 may proceed to remaining permission-boundary checks |

--- a/tests/runtime/issue-41-child-stall.md
+++ b/tests/runtime/issue-41-child-stall.md
@@ -40,7 +40,7 @@ For `Control C`, classify deterministic ordering as follows:
 - provider execution result for the approved first command
 - `permission.asked`/rejection for `printf 'depth2-ask-rejected\n'`
 
-The prepared diagnostic fixture uses an explicit canary profile for its generated `general` agent: `question` is denied, Bash defaults to deny, the read-only status control is allowed, and only the two exact canary `printf` commands use Ask. This is independent from production Leaf policy and ensures future non-interactive Leaf changes do not disable the upstream compatibility check.
+The prepared diagnostic fixture applies the same explicit profile to its generated `general` and `general-fallback` agents: `question` is denied, Bash defaults to deny, the read-only status control is allowed, and only the two exact canary `printf` commands use Ask. This is independent from production Leaf policy, preserves fallback authority, and ensures future non-interactive Leaf changes do not disable the upstream compatibility check.
 
 If the leaf emits a `question` event before the first Bash permission flow, treat the attempt as **INCOMPLETE/invalid** (not a relay failure), and rerun `just runtime::smoke-depth2 issue-41` + `/task-run SMOKE-ASK`.
 

--- a/tests/runtime/issue-41-child-stall.md
+++ b/tests/runtime/issue-41-child-stall.md
@@ -32,7 +32,7 @@ Task tool launch
 
 Do not infer an intermediate stage from a spinner or child label alone.
 
-## Ask ordering gate (retry requirement)
+## Native Ask canary ordering gate (retry requirement)
 
 For `Control C`, classify deterministic ordering as follows:
 
@@ -40,7 +40,7 @@ For `Control C`, classify deterministic ordering as follows:
 - provider execution result for the approved first command
 - `permission.asked`/rejection for `printf 'depth2-ask-rejected\n'`
 
-The prepared diagnostic fixture sets `question: deny` on its generated `general` agent. This is a diagnostic-only restriction, not a production permission weakening, and ensures the leaf reaches the Bash Ask boundary instead of substituting a Question tool interaction.
+The prepared diagnostic fixture uses an explicit canary profile for its generated `general` agent: `question` is denied, Bash defaults to deny, the read-only status control is allowed, and only the two exact canary `printf` commands use Ask. This is independent from production Leaf policy and ensures future non-interactive Leaf changes do not disable the upstream compatibility check.
 
 If the leaf emits a `question` event before the first Bash permission flow, treat the attempt as **INCOMPLETE/invalid** (not a relay failure), and rerun `just runtime::smoke-depth2 issue-41` + `/task-run SMOKE-ASK`.
 
@@ -81,7 +81,9 @@ No Ask event is required by this control.
 - direct PASS + nested FAIL/INCOMPLETE: prioritize nested Task/session/provider execution
 - direct PASS + nested PASS: nested provider path works; continue to Ask probe
 
-## Control C — Depth-2 Ask
+## Control C — Depth-2 native Ask compatibility canary
+
+This control observes upstream compatibility only. It is not a release blocker and does not determine #7 completion; Leaf -> Depth-1 escalation in #51 is the durable release gate.
 
 ```sh
 just runtime::smoke-depth2 issue-41
@@ -125,7 +127,7 @@ Use the sanitized export as supporting evidence, not as a replacement for real T
 | pass | pass | question before Bash permission | protocol mismatch → treat as INCOMPLETE/invalid and retry |
 | pass | pass | stall before permission event | Ask-producing leaf/provider/tool request path |
 | pass | pass | permission event exists but Main cannot handle it | permission relay/UI propagation |
-| pass | pass | approve/reject both work | #7 may proceed to remaining permission-boundary checks |
+| pass | pass | approve/reject both work | upstream compatibility restored; #7 remains gated by Leaf -> Depth-1 escalation |
 
 ## Non-negotiable constraints
 

--- a/tests/runtime/run_opencode_debug.sh
+++ b/tests/runtime/run_opencode_debug.sh
@@ -39,14 +39,22 @@ echo "  log:   $log"
 echo
 
 set +e
-nix develop --command bash -c '
-  set -euo pipefail
-  export VIRTUAL_ENV="$PWD/.venv"
-  export UV_PROJECT_ENVIRONMENT="$PWD/.venv"
-  export PIP_REQUIRE_VIRTUALENV=1
-  export PATH="$PWD/.venv/bin:$PATH"
-  exec "$OPENCODE_BIN" --print-logs --log-level DEBUG
-' 2> >(tee "$log" >&2)
+run_opencode_debug() {
+  nix develop --command bash -c '
+    set -euo pipefail
+    export VIRTUAL_ENV="$PWD/.venv"
+    export UV_PROJECT_ENVIRONMENT="$PWD/.venv"
+    export PIP_REQUIRE_VIRTUALENV=1
+    export PATH="$PWD/.venv/bin:$PATH"
+    exec "$OPENCODE_BIN" --print-logs --log-level DEBUG
+  '
+}
+
+if [[ "${OPENCODE_RUNTIME_LIVE_LOGS:-}" == "1" ]]; then
+  run_opencode_debug 2> >(tee "$log" >&2)
+else
+  run_opencode_debug 2>"$log"
+fi
 status=$?
 set -e
 

--- a/tests/runtime/runtime_smoke.py
+++ b/tests/runtime/runtime_smoke.py
@@ -35,7 +35,7 @@ TASK_DEFINITIONS = (
     (
         "SMOKE-ASK",
         "depth2-ask",
-        "Exercise a deterministic Depth-2 Bash Ask from a leaf and observe explicit approval/rejection relay in Main TUI without permission weakening.",
+        "Run a deterministic Depth-2 native Ask compatibility canary for upstream descendant permission relay without making it a release gate.",
         [
             "Task Orchestrator must delegate a single bounded Work Unit to exactly one `general` leaf.",
             "Task Orchestrator must pass this exact Work Unit instruction: \"Immediately call the Bash tool with `printf 'depth2-ask-approved\\n'`; do not call `question` or any other tool first. Wait for that permission result, then call the Bash tool with `printf 'depth2-ask-rejected\\n'`. Do not perform any other action.\"",
@@ -87,14 +87,51 @@ def harden_runtime_leaf_permissions(repo: Path) -> None:
         raise RuntimeSmokeError(f"missing generated general agent: {agent}") from exc
 
     permission = "permission:\n  task: deny\n"
-    hardened = "permission:\n  task: deny\n  question: deny\n"
-    if hardened in text:
-        return
-    if text.count(permission) != 1:
-        raise RuntimeSmokeError(
-            "generated general agent does not contain the expected permission block"
+    if "  question: deny\n" not in text:
+        if re.search(r"(?m)^  question:", text) is not None:
+            raise RuntimeSmokeError(
+                "generated general agent has a non-deny question permission"
+            )
+        if text.count(permission) != 1:
+            raise RuntimeSmokeError(
+                "generated general agent does not contain the expected permission block"
+            )
+        text = text.replace(
+            permission,
+            permission + "  question: deny\n",
+            1,
         )
-    agent.write_text(text.replace(permission, hardened, 1), encoding="utf-8")
+    elif text.count("  question: deny\n") != 1:
+        raise RuntimeSmokeError(
+            "generated general agent contains duplicate question deny rules"
+        )
+
+    bash = re.search(r"(?m)^  bash:\n(?P<rules>(?:    .*\n)*)", text)
+    if bash is None:
+        raise RuntimeSmokeError("generated general agent is missing its Bash rules")
+    rules = bash.group("rules")
+    default_deny = '    "*": deny\n'
+    conflicting_default = re.search(r'^    "\*": (?!deny$).+$', rules, re.MULTILINE)
+    if conflicting_default is not None:
+        raise RuntimeSmokeError(
+            "generated general agent has a non-deny default Bash permission"
+        )
+    if default_deny not in rules:
+        rules = default_deny + rules
+
+    diagnostic_rules = (
+        '    "git status --short": allow\n',
+        '    "printf \'depth2-ask-approved\\\\n\'": ask\n',
+        '    "printf \'depth2-ask-rejected\\\\n\'": ask\n',
+    )
+    insertion = rules.index(default_deny) + len(default_deny)
+    for rule in diagnostic_rules:
+        if rule not in rules:
+            rules = rules[:insertion] + rule + rules[insertion:]
+            insertion += len(rule)
+
+    text = text[: bash.start("rules")] + rules + text[bash.end("rules") :]
+    agent.write_text(text, encoding="utf-8")
 
 
 def workspace(issue: str) -> Path:
@@ -319,7 +356,10 @@ def report_template(issue: str, metadata: dict) -> str:
 - `git status --short` completed: PASS / FAIL / INCOMPLETE
 - result: PASS / FAIL / INCOMPLETE
 
-## Depth-2 Ask probe
+## Depth-2 native Ask compatibility canary
+
+- release blocker: NO
+- upstream compatibility canary: YES
 
 - Log:
 - Main session ID:
@@ -354,7 +394,8 @@ def report_template(issue: str, metadata: dict) -> str:
 ## Final verdict
 
 - #41 diagnostic acceptance: PASS / FAIL / INCOMPLETE
-- #7 ready for full permission smoke: YES / NO
+- Depth-2 native Ask upstream compatibility: PASS / FAIL / INCOMPLETE
+- #7 release gate: Leaf -> Depth-1 escalation tracked by #51
 - #23 runtime acceptance: PASS / FAIL / INCOMPLETE
 
 ## Notes

--- a/tests/runtime/runtime_smoke.py
+++ b/tests/runtime/runtime_smoke.py
@@ -35,17 +35,18 @@ TASK_DEFINITIONS = (
     (
         "SMOKE-ASK",
         "depth2-ask",
-        "Exercise a harmless Depth-2 Bash Ask from a leaf and observe approval/rejection relay in Main TUI.",
+        "Exercise a deterministic Depth-2 Bash Ask from a leaf and observe explicit approval/rejection relay in Main TUI without permission weakening.",
         [
-            "Task Orchestrator must delegate the Ask probe to exactly one `general` leaf.",
-            "The leaf first requests `printf 'depth2-ask-approved\\n'` through Bash and waits for approval.",
-            "After the first probe resolves, the leaf requests `printf 'depth2-ask-rejected\\n'` and waits for rejection.",
+            "Task Orchestrator must delegate a single bounded Work Unit to exactly one `general` leaf.",
+            "Task Orchestrator must pass this exact Work Unit instruction: \"Immediately call the Bash tool with `printf 'depth2-ask-approved\\n'`; do not call `question` or any other tool first. Wait for that permission result, then call the Bash tool with `printf 'depth2-ask-rejected\\n'`. Do not perform any other action.\"",
             "Do not perform unrelated implementation or repository changes.",
         ],
         [
             "Depth-2 Ask is visible from the Main TUI.",
-            "Single-command approval propagates to the leaf.",
-            "Rejection propagates to the leaf without weakening permissions.",
+            "The first provider response is for one approved `printf 'depth2-ask-approved\\n'` Bash request in the child and propagates to Main.",
+            "The second request is a rejected `printf 'depth2-ask-rejected\\n'` Bash command in the same leaf and propagates to Main.",
+            "No `question` tool call may precede the first Bash permission event; if it does, classify the run INCOMPLETE/invalid and retry.",
+            "No permission boundaries are weakened; approval and rejection remain real semantics.",
         ],
         ["Run from Main TUI with `/task-run SMOKE-ASK` under `just runtime::smoke-depth2`."],
     ),
@@ -76,6 +77,24 @@ def validate_name(value: str, label: str) -> str:
     if not SAFE_NAME.fullmatch(value):
         raise RuntimeSmokeError(f"invalid {label}: {value!r}")
     return value
+
+
+def harden_runtime_leaf_permissions(repo: Path) -> None:
+    agent = repo / ".opencode" / "agents" / "general.md"
+    try:
+        text = agent.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise RuntimeSmokeError(f"missing generated general agent: {agent}") from exc
+
+    permission = "permission:\n  task: deny\n"
+    hardened = "permission:\n  task: deny\n  question: deny\n"
+    if hardened in text:
+        return
+    if text.count(permission) != 1:
+        raise RuntimeSmokeError(
+            "generated general agent does not contain the expected permission block"
+        )
+    agent.write_text(text.replace(permission, hardened, 1), encoding="utf-8")
 
 
 def workspace(issue: str) -> Path:
@@ -388,6 +407,7 @@ def prepare(issue: str, template: str) -> dict:
             cwd=repo,
             log=prepare_log,
         )
+    harden_runtime_leaf_permissions(repo)
     run_logged(["git", "add", "."], cwd=repo, log=prepare_log)
     run_logged(
         ["nix", "develop", "--command", "git", "commit", "-m", "Bootstrap runtime smoke fixture"],

--- a/tests/runtime/runtime_smoke.py
+++ b/tests/runtime/runtime_smoke.py
@@ -13,6 +13,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 RUNTIME_ROOT = ROOT / ".runtime-smoke"
 SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+RUNTIME_GENERAL_AGENTS = ("general.md", "general-fallback.md")
 
 TASK_DEFINITIONS = (
     (
@@ -55,13 +56,17 @@ TASK_DEFINITIONS = (
         "model-fallback",
         "Observe genuine usage/quota/rate-limit fallback behavior without manufacturing a provider failure.",
         [
-            "Task Orchestrator may delegate one trivial read-only Work Unit to a leaf.",
+            "Task Orchestrator must delegate exactly one Work Unit to `general`: run only `git status --short` once and return the result.",
+            "If and only if `general` has a classified eligible usage-limit failure, retry the identical `git status --short` Work Unit once with `general-fallback`.",
+            "Neither primary nor fallback may choose another command or operation.",
             "Do not intentionally consume quota or damage credentials/model configuration.",
             "If no genuine usage-limit condition occurs, record runtime fallback as INCOMPLETE.",
         ],
         [
             "Any genuine eligible failure is classified before fallback.",
             "Only the configured fallback variant is selected.",
+            "Primary and fallback use the same diagnostic permission profile and exact Work Unit.",
+            "`git status --short` completes without a permission denial on whichever variant runs.",
             "No genuine trigger is reported as INCOMPLETE rather than PASS.",
         ],
         ["Run from Main TUI with `/task-run SMOKE-FALLBACK` under `just runtime::smoke-fallback`."],
@@ -79,8 +84,7 @@ def validate_name(value: str, label: str) -> str:
     return value
 
 
-def harden_runtime_leaf_permissions(repo: Path) -> None:
-    agent = repo / ".opencode" / "agents" / "general.md"
+def harden_runtime_leaf_agent(agent: Path) -> None:
     try:
         text = agent.read_text(encoding="utf-8")
     except FileNotFoundError as exc:
@@ -132,6 +136,12 @@ def harden_runtime_leaf_permissions(repo: Path) -> None:
 
     text = text[: bash.start("rules")] + rules + text[bash.end("rules") :]
     agent.write_text(text, encoding="utf-8")
+
+
+def harden_runtime_leaf_permissions(repo: Path) -> None:
+    agents = repo / ".opencode" / "agents"
+    for name in RUNTIME_GENERAL_AGENTS:
+        harden_runtime_leaf_agent(agents / name)
 
 
 def workspace(issue: str) -> Path:
@@ -375,6 +385,8 @@ def report_template(issue: str, metadata: dict) -> str:
 ## Model fallback observation
 
 - deterministic preflight: PASS / FAIL / INCOMPLETE
+- primary/fallback diagnostic permission parity: PASS / FAIL / INCOMPLETE
+- exact `git status --short` Work Unit preserved: PASS / FAIL / INCOMPLETE
 - genuine usage-limit observed: YES / NO
 - runtime fallback: PASS / FAIL / INCOMPLETE
 

--- a/tests/test_runtime_smoke_harness.py
+++ b/tests/test_runtime_smoke_harness.py
@@ -88,7 +88,7 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
             self.assertIn("- Status: initialized", text)
             self.assertIn("- [ ] Evidence is recorded.", text)
 
-    def test_runtime_fixture_denies_question_only_for_general_leaf(self) -> None:
+    def test_runtime_fixture_installs_explicit_native_ask_canary_profile(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             repo = Path(temporary)
             agent = repo / ".opencode" / "agents" / "general.md"
@@ -106,6 +106,52 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
             self.assertEqual(1, text.count("  question: deny\n"))
             self.assertIn("  task: deny\n", text)
             self.assertIn("  bash:\n", text)
+            self.assertEqual(1, text.count('    "*": deny\n'))
+            self.assertIn('    "git status --short": allow\n', text)
+            self.assertIn(
+                '    "printf \'depth2-ask-approved\\\\n\'": ask\n', text
+            )
+            self.assertIn(
+                '    "printf \'depth2-ask-rejected\\\\n\'": ask\n', text
+            )
+
+    def test_runtime_canary_extends_future_noninteractive_leaf_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            agent = repo / ".opencode" / "agents" / "general.md"
+            agent.parent.mkdir(parents=True)
+            agent.write_text(
+                "---\npermission:\n  task: deny\n  question: deny\n  bash:\n"
+                '    "*": deny\n'
+                '    "just project::check": allow\n---\n',
+                encoding="utf-8",
+            )
+
+            runtime.harden_runtime_leaf_permissions(repo)
+
+            text = agent.read_text(encoding="utf-8")
+            self.assertEqual(1, text.count('    "*": deny\n'))
+            self.assertIn('    "just project::check": allow\n', text)
+            self.assertIn(
+                '    "printf \'depth2-ask-approved\\\\n\'": ask\n', text
+            )
+
+    def test_runtime_canary_rejects_interactive_leaf_profile(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            agent = repo / ".opencode" / "agents" / "general.md"
+            agent.parent.mkdir(parents=True)
+            agent.write_text(
+                "---\npermission:\n  task: deny\n  question: allow\n  bash:\n"
+                '    "*": ask\n---\n',
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                runtime.RuntimeSmokeError,
+                "non-deny question permission",
+            ):
+                runtime.harden_runtime_leaf_permissions(repo)
 
     def test_debug_launchers_use_official_diagnostic_paths_without_auto_approval(self) -> None:
         interactive = (ROOT / "tests" / "runtime" / "run_opencode_debug.sh").read_text(
@@ -324,7 +370,9 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
         report = runtime.report_template("issue-41", metadata)
         self.assertIn("Ask-free nested control", report)
         self.assertIn("Direct leaf control", report)
-        self.assertIn("Depth-2 Ask probe", report)
+        self.assertIn("Depth-2 native Ask compatibility canary", report)
+        self.assertIn("release blocker: NO", report)
+        self.assertIn("#7 release gate: Leaf -> Depth-1 escalation", report)
         self.assertIn("PASS / FAIL / INCOMPLETE", report)
         self.assertIn("Do not infer PASS", report)
 

--- a/tests/test_runtime_smoke_harness.py
+++ b/tests/test_runtime_smoke_harness.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -49,6 +51,17 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
             },
         )
 
+        smoke_ask = next(
+            definition
+            for definition in runtime.TASK_DEFINITIONS
+            if definition[0] == "SMOKE-ASK"
+        )
+        scope = " ".join(smoke_ask[3])
+        self.assertIn("must pass this exact Work Unit instruction", scope)
+        self.assertIn("do not call `question` or any other tool first", scope)
+        self.assertIn("printf 'depth2-ask-approved\\n'", scope)
+        self.assertIn("printf 'depth2-ask-rejected\\n'", scope)
+
     def test_task_contract_replaces_unresolved_template_content(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             path = Path(temporary) / "task.md"
@@ -75,6 +88,25 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
             self.assertIn("- Status: initialized", text)
             self.assertIn("- [ ] Evidence is recorded.", text)
 
+    def test_runtime_fixture_denies_question_only_for_general_leaf(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            agent = repo / ".opencode" / "agents" / "general.md"
+            agent.parent.mkdir(parents=True)
+            agent.write_text(
+                "---\npermission:\n  task: deny\n  bash:\n"
+                '    "git status*": allow\n---\n',
+                encoding="utf-8",
+            )
+
+            runtime.harden_runtime_leaf_permissions(repo)
+            runtime.harden_runtime_leaf_permissions(repo)
+
+            text = agent.read_text(encoding="utf-8")
+            self.assertEqual(1, text.count("  question: deny\n"))
+            self.assertIn("  task: deny\n", text)
+            self.assertIn("  bash:\n", text)
+
     def test_debug_launchers_use_official_diagnostic_paths_without_auto_approval(self) -> None:
         interactive = (ROOT / "tests" / "runtime" / "run_opencode_debug.sh").read_text(
             encoding="utf-8"
@@ -98,6 +130,102 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
         self.assertNotIn(" --agent general", direct)
         self.assertNotIn(" --auto", direct)
 
+    def test_debug_launcher_defaults_stderr_to_per_run_log_file(self) -> None:
+        interactive = (ROOT / "tests" / "runtime" / "run_opencode_debug.sh").read_text(
+            encoding="utf-8"
+        )
+
+        marker = 'if [[ "${OPENCODE_RUNTIME_LIVE_LOGS:-}" == "1" ]]; then'
+        self.assertIn(marker, interactive)
+
+        block_start = interactive.index(marker)
+        block = interactive[
+            block_start : interactive.index("\nfi", block_start)
+        ]
+        self.assertIn('2> >(tee "$log" >&2)', block)
+        self.assertIn('2>"$log"', block)
+        self.assertIn("else", block)
+        self.assertGreater(block.index("else"), block.index('2> >(tee "$log" >&2)'))
+        self.assertGreater(block.index('2>"$log"'), block.index("else"))
+
+    def test_debug_launcher_opt_in_env_var_restores_live_stderr(self) -> None:
+        interactive = (ROOT / "tests" / "runtime" / "run_opencode_debug.sh").read_text(
+            encoding="utf-8"
+        )
+
+        marker = 'if [[ "${OPENCODE_RUNTIME_LIVE_LOGS:-}" == "1" ]]; then'
+        self.assertIn(marker, interactive)
+        self.assertIn("OPENCODE_RUNTIME_LIVE_LOGS", interactive)
+
+        branch_block = interactive.split(marker, 1)[1]
+        branch_block = branch_block.split("fi", 1)[0]
+        self.assertIn("run_opencode_debug", branch_block)
+        self.assertIn('2> >(tee "$log" >&2)', branch_block)
+        self.assertIn("else", branch_block)
+        self.assertIn('2>"$log"', branch_block)
+
+    def test_debug_launcher_routes_stderr_and_preserves_exit_status(self) -> None:
+        launcher = ROOT / "tests" / "runtime" / "run_opencode_debug.sh"
+        with tempfile.TemporaryDirectory() as temporary:
+            fake_root = Path(temporary)
+            fake_bin = fake_root / "bin"
+            fake_bin.mkdir()
+            (fake_root / "tests" / "runtime").mkdir(parents=True)
+            (fake_root / ".runtime-smoke" / "test" / "smoke-repo").mkdir(
+                parents=True
+            )
+
+            def executable(name: str, body: str) -> None:
+                path = fake_bin / name
+                path.write_text(f"#!/bin/sh\n{body}\n", encoding="utf-8")
+                path.chmod(0o755)
+
+            executable("git", 'printf "%s\\n" "$FAKE_ROOT"')
+            executable("python3", "exit 0")
+            executable("opencode", "exit 0")
+            executable("nix", 'printf "debug-marker\\n" >&2\nexit 7')
+
+            environment = os.environ.copy()
+            environment["FAKE_ROOT"] = str(fake_root)
+            environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+
+            default = subprocess.run(
+                ["bash", str(launcher), "test", "depth2-ask"],
+                cwd=ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(7, default.returncode)
+            self.assertEqual("", default.stderr)
+            logs = list(
+                (fake_root / ".runtime-smoke" / "test" / "logs").glob(
+                    "opencode-depth2-ask-*.log"
+                )
+            )
+            self.assertEqual(1, len(logs))
+            self.assertEqual("debug-marker\n", logs[0].read_text(encoding="utf-8"))
+
+            environment["OPENCODE_RUNTIME_LIVE_LOGS"] = "1"
+            live = subprocess.run(
+                ["bash", str(launcher), "test", "child-stall"],
+                cwd=ROOT,
+                env=environment,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(7, live.returncode)
+            self.assertEqual("debug-marker\n", live.stderr)
+            live_logs = list(
+                (fake_root / ".runtime-smoke" / "test" / "logs").glob(
+                    "opencode-child-stall-*.log"
+                )
+            )
+            self.assertEqual(1, len(live_logs))
+            self.assertEqual(
+                "debug-marker\n", live_logs[0].read_text(encoding="utf-8")
+            )
+
     def test_prepare_commits_scaffold_before_nix_bootstrap_and_bootstraps_second_time(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             base = Path(temporary) / "issue-41"
@@ -108,6 +236,7 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
             original_run_logged = runtime.run_logged
             original_run_capture = runtime.run_capture
             original_write_contract = runtime.write_contract
+            original_harden_permissions = runtime.harden_runtime_leaf_permissions
 
             def fake_workspace(_: str) -> Path:
                 return base
@@ -132,6 +261,7 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
             runtime.run_logged = fake_run_logged
             runtime.run_capture = fake_run_capture
             runtime.write_contract = lambda *args, **kwargs: None
+            runtime.harden_runtime_leaf_permissions = lambda *args, **kwargs: None
             try:
                 runtime.prepare("issue-41", "agent-python")
             finally:
@@ -140,6 +270,7 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
                 runtime.run_logged = original_run_logged
                 runtime.run_capture = original_run_capture
                 runtime.write_contract = original_write_contract
+                runtime.harden_runtime_leaf_permissions = original_harden_permissions
 
             commands = [command for _kind, command, *_ in calls]
 

--- a/tests/test_runtime_smoke_harness.py
+++ b/tests/test_runtime_smoke_harness.py
@@ -62,6 +62,20 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
         self.assertIn("printf 'depth2-ask-approved\\n'", scope)
         self.assertIn("printf 'depth2-ask-rejected\\n'", scope)
 
+        smoke_fallback = next(
+            definition
+            for definition in runtime.TASK_DEFINITIONS
+            if definition[0] == "SMOKE-FALLBACK"
+        )
+        fallback_scope = " ".join(smoke_fallback[3])
+        fallback_acceptance = " ".join(smoke_fallback[4])
+        self.assertIn("run only `git status --short` once", fallback_scope)
+        self.assertIn(
+            "retry the identical `git status --short` Work Unit",
+            fallback_scope,
+        )
+        self.assertIn("same diagnostic permission profile", fallback_acceptance)
+
     def test_task_contract_replaces_unresolved_template_content(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             path = Path(temporary) / "task.md"
@@ -91,59 +105,95 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
     def test_runtime_fixture_installs_explicit_native_ask_canary_profile(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             repo = Path(temporary)
-            agent = repo / ".opencode" / "agents" / "general.md"
-            agent.parent.mkdir(parents=True)
-            agent.write_text(
-                "---\npermission:\n  task: deny\n  bash:\n"
-                '    "git status*": allow\n---\n',
-                encoding="utf-8",
-            )
+            agents = repo / ".opencode" / "agents"
+            agents.mkdir(parents=True)
+            for name in runtime.RUNTIME_GENERAL_AGENTS:
+                (agents / name).write_text(
+                    "---\npermission:\n  task: deny\n  bash:\n"
+                    '    "git status*": allow\n---\n',
+                    encoding="utf-8",
+                )
 
             runtime.harden_runtime_leaf_permissions(repo)
             runtime.harden_runtime_leaf_permissions(repo)
 
-            text = agent.read_text(encoding="utf-8")
-            self.assertEqual(1, text.count("  question: deny\n"))
-            self.assertIn("  task: deny\n", text)
-            self.assertIn("  bash:\n", text)
-            self.assertEqual(1, text.count('    "*": deny\n'))
-            self.assertIn('    "git status --short": allow\n', text)
-            self.assertIn(
-                '    "printf \'depth2-ask-approved\\\\n\'": ask\n', text
-            )
-            self.assertIn(
-                '    "printf \'depth2-ask-rejected\\\\n\'": ask\n', text
-            )
+            profiles = []
+            for name in runtime.RUNTIME_GENERAL_AGENTS:
+                text = (agents / name).read_text(encoding="utf-8")
+                self.assertEqual(1, text.count("  question: deny\n"), name)
+                self.assertIn("  task: deny\n", text, name)
+                self.assertIn("  bash:\n", text, name)
+                self.assertEqual(1, text.count('    "*": deny\n'), name)
+                self.assertIn('    "git status --short": allow\n', text, name)
+                self.assertIn(
+                    '    "printf \'depth2-ask-approved\\\\n\'": ask\n',
+                    text,
+                    name,
+                )
+                self.assertIn(
+                    '    "printf \'depth2-ask-rejected\\\\n\'": ask\n',
+                    text,
+                    name,
+                )
+                profiles.append(
+                    tuple(
+                        line
+                        for line in text.splitlines()
+                        if line
+                        in {
+                            '    "*": deny',
+                            '    "git status --short": allow',
+                            '    "printf \'depth2-ask-approved\\\\n\'": ask',
+                            '    "printf \'depth2-ask-rejected\\\\n\'": ask',
+                        }
+                    )
+                )
+            self.assertEqual(profiles[0], profiles[1])
 
     def test_runtime_canary_extends_future_noninteractive_leaf_profile(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             repo = Path(temporary)
-            agent = repo / ".opencode" / "agents" / "general.md"
-            agent.parent.mkdir(parents=True)
-            agent.write_text(
+            agents = repo / ".opencode" / "agents"
+            agents.mkdir(parents=True)
+            (agents / "general.md").write_text(
                 "---\npermission:\n  task: deny\n  question: deny\n  bash:\n"
                 '    "*": deny\n'
                 '    "just project::check": allow\n---\n',
                 encoding="utf-8",
             )
+            (agents / "general-fallback.md").write_text(
+                "---\npermission:\n  task: deny\n  question: deny\n  bash:\n"
+                '    "*": deny\n'
+                '    "just agent::fallback-record *": deny\n---\n',
+                encoding="utf-8",
+            )
 
             runtime.harden_runtime_leaf_permissions(repo)
 
-            text = agent.read_text(encoding="utf-8")
-            self.assertEqual(1, text.count('    "*": deny\n'))
-            self.assertIn('    "just project::check": allow\n', text)
-            self.assertIn(
-                '    "printf \'depth2-ask-approved\\\\n\'": ask\n', text
-            )
+            primary = (agents / "general.md").read_text(encoding="utf-8")
+            fallback = (agents / "general-fallback.md").read_text(encoding="utf-8")
+            for name, text in (("primary", primary), ("fallback", fallback)):
+                self.assertEqual(1, text.count('    "*": deny\n'), name)
+                self.assertIn(
+                    '    "printf \'depth2-ask-approved\\\\n\'": ask\n',
+                    text,
+                    name,
+                )
+            self.assertIn('    "just project::check": allow\n', primary)
+            self.assertIn('    "just agent::fallback-record *": deny\n', fallback)
 
     def test_runtime_canary_rejects_interactive_leaf_profile(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             repo = Path(temporary)
-            agent = repo / ".opencode" / "agents" / "general.md"
-            agent.parent.mkdir(parents=True)
-            agent.write_text(
+            agents = repo / ".opencode" / "agents"
+            agents.mkdir(parents=True)
+            (agents / "general.md").write_text(
                 "---\npermission:\n  task: deny\n  question: allow\n  bash:\n"
                 '    "*": ask\n---\n',
+                encoding="utf-8",
+            )
+            (agents / "general-fallback.md").write_text(
+                "---\npermission:\n  task: deny\n  bash:\n---\n",
                 encoding="utf-8",
             )
 
@@ -373,6 +423,7 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
         self.assertIn("Depth-2 native Ask compatibility canary", report)
         self.assertIn("release blocker: NO", report)
         self.assertIn("#7 release gate: Leaf -> Depth-1 escalation", report)
+        self.assertIn("primary/fallback diagnostic permission parity", report)
         self.assertIn("PASS / FAIL / INCOMPLETE", report)
         self.assertIn("Do not infer PASS", report)
 


### PR DESCRIPTION
## Summary
- keep OpenCode DEBUG stderr in the per-run log by default so native TUI diagnostics remain usable
- provide `OPENCODE_RUNTIME_LIVE_LOGS=1` as an explicit live-log opt-in
- keep the Depth-2 native Ask canary independent from production Leaf policy with a disposable fixture-only profile
- apply the same diagnostic authority to `general` and `general-fallback`, and pin fallback observation to one exact read-only Work Unit
- preserve launcher exit status, before/after session snapshots, and diagnostic log paths

## Verification
- `bash -n tests/runtime/run_opencode_debug.sh`
- focused runtime harness tests: 13 passed
- full unittest discovery: 111 passed
- `python3 tools/render_templates.py check`
- `python3 tools/template_distribution.py verify`
- `git diff --check`
- independent correctness and security reviews: no findings

## Runtime evidence
- fresh `agent-python` fixture gives both `general` and `general-fallback` the same diagnostic wildcard deny, status allow, and exact two printf Ask rules
- generated `SMOKE-FALLBACK` contract requires the identical `git status --short` Work Unit before and after an eligible usage-limit fallback
- DEBUG output is retained in the workspace log instead of being printed over the TUI
- the native Depth-2 Ask remains an upstream compatibility canary, not a release gate; #7 is gated by Leaf -> Depth-1 escalation in #51

Closes #50
Related: #41, #7, #23, #51