### PR TITLE
fix: align Just minimum tooling

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-set minimum-version := "1.31.0"
+set minimum-version := "1.55.0"
 
 mod template 'just/template.just'
 mod runtime 'just/runtime.just'

--- a/README.md
+++ b/README.md
@@ -106,14 +106,16 @@ Existing-repository adoption and Agent Core upgrade are separate mutating workfl
 Plan first:
 
 ```sh
-just template::adopt-plan /path/to/repository
+cd /path/to/Templates
+nix develop --command just template::adopt-plan /path/to/repository
 ```
 
 Apply with an explicit Adapter when appropriate:
 
 ```sh
-just template::adopt-apply /path/to/repository base
-just template::adopt-apply /path/to/repository python
+cd /path/to/Templates
+nix develop --command just template::adopt-apply /path/to/repository base
+nix develop --command just template::adopt-apply /path/to/repository python
 ```
 
 Auto-detection prefers CMake/Python/Rust markers; a standalone `flake.nix` selects Nix; unknown or ambiguous repositories fall back to `base`.
@@ -121,7 +123,8 @@ Auto-detection prefers CMake/Python/Rust markers; a standalone `flake.nix` selec
 Migrate a base-adopted repository by inspecting the read-only migration plan before changing Adapter-owned paths:
 
 ```sh
-just template::adapter-migrate-plan /path/to/repository python
+cd /path/to/Templates
+nix develop --command just template::adapter-migrate-plan /path/to/repository python
 ```
 
 Adoption/migration never commits, pushes, merges, stashes, or resets the target repository.

--- a/components/agent-core/Justfile
+++ b/components/agent-core/Justfile
@@ -1,4 +1,4 @@
-set minimum-version := "1.52.0"
+set minimum-version := "1.55.0"
 
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'

--- a/docs/existing-repository-adoption.md
+++ b/docs/existing-repository-adoption.md
@@ -4,13 +4,14 @@ Agent-ready repositories always have a Project Adapter. A repository without a d
 
 ## Commands
 
-From the Templates repository:
+From the Templates repository, use the root dev shell so adoption tooling parses with the declared Just version:
 
 ```sh
-just template::adopt-plan /path/to/repository
-just template::adopt-plan /path/to/repository base
-just template::adopt-apply /path/to/repository base
-just template::adapter-migrate-plan /path/to/repository cpp-cmake
+cd /path/to/Templates
+nix develop --command just template::adopt-plan /path/to/repository
+nix develop --command just template::adopt-plan /path/to/repository base
+nix develop --command just template::adopt-apply /path/to/repository base
+nix develop --command just template::adapter-migrate-plan /path/to/repository cpp-cmake
 ```
 
 `adopt-plan` is read-only. It reports the selected Adapter, selection reason, Agent Core version, dirty-state status, planned file actions, and blockers.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,24 @@
 {
   description = "upiscium's env templates";
 
-  outputs = { self }: {
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            just
+            python3
+            git
+            gh
+          ];
+        };
+      })
+    // {
     templates = {
       python = {
         path = ./templates/agent-python;

--- a/templates/agent-base/Justfile
+++ b/templates/agent-base/Justfile
@@ -1,4 +1,4 @@
-set minimum-version := "1.52.0"
+set minimum-version := "1.55.0"
 
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'

--- a/templates/agent-cpp-cmake/Justfile
+++ b/templates/agent-cpp-cmake/Justfile
@@ -1,4 +1,4 @@
-set minimum-version := "1.52.0"
+set minimum-version := "1.55.0"
 
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'

--- a/templates/agent-nix/Justfile
+++ b/templates/agent-nix/Justfile
@@ -1,4 +1,4 @@
-set minimum-version := "1.52.0"
+set minimum-version := "1.55.0"
 
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'

--- a/templates/agent-python/Justfile
+++ b/templates/agent-python/Justfile
@@ -1,4 +1,4 @@
-set minimum-version := "1.52.0"
+set minimum-version := "1.55.0"
 
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'

--- a/templates/agent-rust/Justfile
+++ b/templates/agent-rust/Justfile
@@ -1,4 +1,4 @@
-set minimum-version := "1.52.0"
+set minimum-version := "1.55.0"
 
 mod agent '.automation/just/agent.just'
 mod automation '.automation/just/automation.just'

--- a/tests/test_adopt_repository.py
+++ b/tests/test_adopt_repository.py
@@ -92,6 +92,32 @@ class AdoptRepositoryTest(unittest.TestCase):
         self.assertFalse(result["pushPerformed"])
         self.assertFalse(result["mergePerformed"])
 
+    def test_plan_reports_preserved_old_just_environment_prerequisite(self) -> None:
+        temporary, repo = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        (repo / "flake.nix").write_text(
+            '''{
+  outputs = { self, nixpkgs }: {
+    devShells.x86_64-linux.default = nixpkgs.legacyPackages.x86_64-linux.mkShell {
+      packages = [ nixpkgs.legacyPackages.x86_64-linux.just ];
+    };
+  };
+}
+''',
+            encoding="utf-8",
+        )
+        (repo / "flake.lock").write_text('{"nodes":{},"root":"root","version":7}\n', encoding="utf-8")
+        self.commit_all(repo)
+
+        plan = adopt_repository.build_plan(ROOT, repo, "base")
+
+        compatibility = plan["targetJustCompatibility"]
+        self.assertEqual(compatibility["requiredJustVersion"], "1.55.0")
+        self.assertEqual(compatibility["status"], "unknown")
+        self.assertIn("flake.nix", compatibility["reason"])
+        self.assertIn("flake.lock", compatibility["reason"])
+        self.assertIn("postAdoptionPrerequisite", compatibility)
+
     def test_existing_opencode_collision_blocks_apply(self) -> None:
         temporary, repo = self.make_repo()
         self.addCleanup(temporary.cleanup)

--- a/tests/test_render_templates.py
+++ b/tests/test_render_templates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import stat
 import tempfile
 import unittest
@@ -83,6 +84,24 @@ class RenderTemplatesTest(unittest.TestCase):
 
         (output / "core.txt").write_text("changed")
         self.assertEqual(check_template(self.root, self.spec()), ["changed: core.txt"])
+
+    def test_minimum_just_version_stays_in_sync(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        paths = [root / "Justfile", root / "components" / "agent-core" / "Justfile"]
+        paths.extend(sorted((root / "templates").glob("agent-*/Justfile")))
+
+        versions: dict[Path, str] = {}
+        for path in paths:
+            match = re.search(
+                r'^set minimum-version := "(\d+\.\d+\.\d+)"',
+                path.read_text(encoding="utf-8"),
+                re.MULTILINE,
+            )
+            self.assertIsNotNone(match, f"missing minimum-version in {path}")
+            assert match is not None
+            versions[path] = match.group(1)
+
+        self.assertEqual(set(versions.values()), {"1.55.0"})
 
 
 if __name__ == "__main__":

--- a/tests/test_template_distribution.py
+++ b/tests/test_template_distribution.py
@@ -121,6 +121,12 @@ class TemplateDistributionTest(unittest.TestCase):
         self.assertIn("distribution-check", justfile)
         self.assertNotIn("distribution-publish", justfile)
 
+    def test_root_flake_exposes_default_devshell_tooling(self) -> None:
+        flake = (ROOT / "flake.nix").read_text(encoding="utf-8")
+        self.assertIn("devShells.default", flake)
+        for tool in ["just", "python3", "git", "gh"]:
+            self.assertRegex(flake, rf"\b{tool}\b")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/adopt_repository.py
+++ b/tools/adopt_repository.py
@@ -19,6 +19,12 @@ class AdoptionError(RuntimeError):
     pass
 
 
+JUST_COMPATIBILITY_PREREQUISITE = (
+    "Before running Agent Core recipes in the target repository, enter or update "
+    "the target repository environment so `just` is at least the required version."
+)
+
+
 @dataclass(frozen=True)
 class Action:
     path: str
@@ -29,6 +35,37 @@ class Action:
 
 def templates_root() -> Path:
     return Path(__file__).resolve().parents[1]
+
+
+def required_just_version(source: Path) -> str | None:
+    justfile = source / "components" / "agent-core" / "Justfile"
+    if not justfile.is_file():
+        return None
+    for line in justfile.read_text(encoding="utf-8").splitlines():
+        prefix = 'set minimum-version := "'
+        if line.startswith(prefix) and line.endswith('"'):
+            return line[len(prefix):-1]
+    return None
+
+
+def target_just_compatibility(root: Path, required: str | None) -> dict:
+    preserved_tooling = [
+        path for path in ("flake.nix", "flake.lock") if (root / path).exists()
+    ]
+    reason = (
+        "target repository tooling was not executed during the read-only adoption plan"
+    )
+    if preserved_tooling:
+        reason = (
+            "target repository preserves existing tooling files: "
+            + ", ".join(preserved_tooling)
+        )
+    return {
+        "requiredJustVersion": required,
+        "status": "unknown",
+        "reason": reason,
+        "postAdoptionPrerequisite": JUST_COMPATIBILITY_PREREQUISITE,
+    }
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -219,6 +256,8 @@ def build_plan(source: Path, target: Path, requested_adapter: str) -> dict:
     dirty = bool(run(["git", "status", "--porcelain"], cwd=root).stdout.strip())
     version = (source / "components" / "agent-core" / ".automation" / "VERSION")
     version_value = version.read_text(encoding="utf-8").strip() if version.is_file() else None
+    just_version = required_just_version(source)
+    compatibility = target_just_compatibility(root, just_version)
     return {
         "repositoryRoot": str(root),
         "requestedAdapter": requested_adapter,
@@ -226,6 +265,7 @@ def build_plan(source: Path, target: Path, requested_adapter: str) -> dict:
         "adapterSelectionReason": reason,
         "adapterCandidates": detected,
         "agentCoreVersion": version_value,
+        "targetJustCompatibility": compatibility,
         "workingTreeDirty": dirty,
         "actions": [asdict(action) for action in actions],
         "blockers": blockers,
@@ -282,6 +322,7 @@ def apply_plan(source: Path, target: Path, requested_adapter: str) -> dict:
         "repositoryRoot": str(root),
         "adapter": adapter,
         "agentCoreVersion": plan["agentCoreVersion"],
+        "targetJustCompatibility": plan["targetJustCompatibility"],
         "commitCreated": False,
         "pushPerformed": False,
         "mergePerformed": False,


### PR DESCRIPTION
## Summary
- Align root, Agent Core source, and generated template Just minimum-version declarations to 1.55.0.
- Add a pinned root Nix devShell with Just, Python, Git, and GitHub CLI for trusted local template tooling execution.
- Update adoption docs to recommend nix develop --command just ... and add minimum-version/devShell contract tests.

Fixes #55.

## Evidence
- Old Just 1.47.x reproduction: root Justfile used set minimum-version while declaring 1.31.0, so Just 1.47.x fails parsing with Unknown setting minimum-version before recipes can run.
- Fixed root devShell parse: nix develop --command just --version -> just 1.58.0; nix develop --command just --list -> listed root recipes.
- Generated minimum parity: unittest test_minimum_just_version_stays_in_sync verifies root, component source, and generated templates all declare 1.55.0.

## Validation
- nix develop --command just --version
- nix develop --command just --list
- nix develop --command python3 -m unittest discover -s tests
- nix develop --command just template::check
- nix develop --command just template::distribution-verify
- nix flake check
- git diff --check
- nix develop --command just template::adopt-plan <temporary fixture> python