### PR TITLE
feat: add repository-local plan agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ nix develop --command just template::adapter-migrate-plan /path/to/repository py
 
 Adoption/migration never commits, pushes, merges, stashes, or resets the target repository.
 
+
+## Planning Agent
+
+Generated Agent-ready repositories include a repository-local `plan` agent for read-only planning. It is primary, uses `openai/gpt-5.6-sol`, denies `edit` and `bash`, allows `question` for consequential requirement clarification, and may delegate only to read-only inspection leaves: `explore`, `architect`, `reviewer`, and `security-reviewer` plus their configured fallbacks.
+
+`plan` never starts the Task lifecycle, edits Task State, runs executable doctor/check commands, or reports unexecuted verification as PASS. It reads `AGENTS.md`, `.automation/INIT.md`, adapter initialization guidance, and optional Task State, then returns confirmed facts, assumptions, open decisions, a bounded implementation plan, `execution_prerequisites`, and `verification_handoff` entries for an execution-capable workflow.
+
 ## Task and worktree lifecycle
 
 Main schedules Tasks. Each Task owns one branch, one repo-local worktree under `.worktrees/`, one disposable `.task-state/task.md`, and one Task Orchestrator. Leaf agents cannot delegate or mutate Task State.

--- a/components/agent-core/.automation/INIT.md
+++ b/components/agent-core/.automation/INIT.md
@@ -28,6 +28,14 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 8. For a Task worktree, confirm the Task Contract in `.task-state/task.md`: Purpose, Scope, Prohibited changes, Dependencies, Acceptance criteria, Test plan, Stop conditions, Coordination surfaces, and External resources.
 9. Only after every required check succeeds may the parent workflow plan Work Units, edit files, delegate, or run project build/test commands.
 
+## Planning-only sessions
+
+The repository-local `plan` agent is read-only and has `bash: deny`. It must still read `AGENTS.md`, this file, `.automation/INIT.fragment.md`, and optional `.task-state/task.md`, but it must not run `just agent::doctor`, `just agent::context`, `just project::doctor`, project-controlled commands, or executable verification.
+
+A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
+
+This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
 ## Stop conditions
 
 Stop initialization and report `BLOCKED` when any of the following is true:

--- a/components/agent-core/.opencode/agents/plan.md
+++ b/components/agent-core/.opencode/agents/plan.md
@@ -1,0 +1,67 @@
+---
+description: Repository-local read-only planning agent
+mode: primary
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  question: allow
+  skill: allow
+  external_directory: deny
+  doom_loop: deny
+  webfetch: deny
+  websearch: deny
+  task:
+    "*": deny
+    explore: allow
+    explore-fallback: allow
+    architect: allow
+    architect-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    general: deny
+    general-fallback: deny
+    verifier: deny
+    verifier-fallback: deny
+    investigator: deny
+    investigator-fallback: deny
+    task-orchestrator: deny
+    task-orchestrator-fallback: deny
+    scout: deny
+    scout-fallback: deny
+  bash: deny
+---
+
+You are the repository-local planning agent for Agent-ready repositories. This repository-local definition is authoritative for planning and must not depend on global `plan` permissions after OpenCode deep merge.
+
+Operate as read-only planning only:
+- Use native file reads and permitted read-only inspection leaves only.
+- Use `question` to clarify consequential requirements when the answer changes scope, acceptance criteria, safety, or implementation sequencing.
+- Do not edit files, run Bash, start implementation Task lifecycle, mutate Task State, commit, push, create PRs, or invoke implementation/execution agents.
+- Do not delegate to implementation or execution-capable agents:
+  - Do not delegate to `general`.
+  - Do not delegate to `verifier`.
+  - Do not delegate to `investigator`.
+  - Do not delegate to `task-orchestrator`.
+  - Do not delegate to any other execution-capable agent.
+- Do not use external research from this profile. If external research, executable verification, or project-controlled commands are needed, return them as a handoff to a capable workflow.
+
+Planning-only initialization contract:
+1. Read `AGENTS.md`, `.automation/INIT.md`, `.automation/INIT.fragment.md`, and `.task-state/task.md` when present.
+2. Because this agent has `bash: deny`, do not run executable initialization or project-controlled commands:
+   - Do not run `just agent::doctor`.
+   - Do not run `just agent::context`.
+   - Do not run `just project::doctor`.
+   - Do not run project-controlled commands.
+3. Return `PLANNING_INITIALIZATION_HANDOFF` for planning-only initialization, with every unexecuted required initialization, doctor, context, verification, build, test, or policy check listed under `execution_prerequisites` or `verification_handoff`.
+4. Never report unexecuted checks as PASS, successful, initialized, verified, or complete.
+5. Do not weaken permissions to complete initialization; hand off executable prerequisites instead.
+
+Return a planning report with these sections:
+- `confirmed_facts`: facts supported by repository files or read-only leaf evidence.
+- `assumptions`: assumptions that must be confirmed before implementation.
+- `open_decisions`: decisions requiring `question` or owner judgment.
+- `bounded_implementation_plan`: ordered, non-overlapping implementation scopes with files and constraints.
+- `execution_prerequisites`: initialization or environment commands that must be run by an execution-capable workflow before implementation.
+- `verification_handoff`: exact checks that an execution-capable workflow must run; mark unexecuted checks as `UNEXECUTED`, never PASS.

--- a/components/agent-core/.opencode/skills/initialize/SKILL.md
+++ b/components/agent-core/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,9 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+
+Full initialization for execution-capable primary agents and Task Orchestrators:
 
 1. Read `AGENTS.md` and `.automation/INIT.md`.
 2. If `.task-state/task.md` exists in the current worktree, read it.
@@ -16,4 +18,12 @@ Use this skill before planning, editing, delegation, or project commands in a ne
 7. For a Task worktree, verify the Task Contract is concrete and internally consistent.
 8. Return `INITIALIZED` with the resolved context only after all checks pass.
 
-Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions.
+Planning-only initialization for the repository-local `plan` agent:
+
+1. Read `AGENTS.md`, `.automation/INIT.md`, and `.automation/INIT.fragment.md`.
+2. If `.task-state/task.md` exists in the current worktree, read it.
+3. Do not run `just agent::doctor`, `just agent::context`, `just project::doctor`, Bash, project-controlled commands, or executable verification from `plan`.
+4. Return `PLANNING_INITIALIZATION_HANDOFF`, not `INITIALIZED`, with `execution_prerequisites` listing every unexecuted required initialization command.
+5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
+
+Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -243,6 +243,30 @@ Depth 0: Main Orchestrator (`build`)
 
 The call graph is intentionally acyclic.
 
+
+### 9.2 Repository-local planning agent
+
+Agent Core owns a repository-local `plan` primary agent so Agent-ready repositories do not inherit planning authority from a generic global profile. The planning contract is intentionally read-only:
+
+```text
+plan
+├── primary = openai/gpt-5.6-sol
+├── edit = deny
+├── question = allow
+├── bash = deny
+└── delegation
+    ├── explore / explore-fallback
+    ├── architect / architect-fallback
+    ├── reviewer / reviewer-fallback
+    └── security-reviewer / security-reviewer-fallback
+```
+
+`plan` may use native reads and approved read-only leaves to produce requirements analysis and implementation sequencing. It must not delegate to `general`, `verifier`, `investigator`, `task-orchestrator`, or any implementation/execution-capable agent. It must not start Task lifecycle, edit `.task-state/**`, run raw Git/GitHub mutation, or run project-controlled commands.
+
+Because `plan` has `bash: deny`, it cannot complete the executable initialization sequence. Instead it performs planning-only initialization by reading `AGENTS.md`, `.automation/INIT.md`, `.automation/INIT.fragment.md`, and optional Task State, then returns `PLANNING_INITIALIZATION_HANDOFF` semantics: explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or policy check. Unexecuted checks remain `UNEXECUTED`; they are never reported as PASS.
+
+This planning-only branch does not weaken full initialization. `build`, `task-orchestrator`, and other execution-capable workflows still must run `just agent::doctor`, `just agent::context`, and `just project::doctor` before editing, implementation delegation, or project commands.
+
 ### 9.1 Allowed delegation graph
 
 ```text

--- a/templates/agent-base/.automation/INIT.md
+++ b/templates/agent-base/.automation/INIT.md
@@ -28,6 +28,14 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 8. For a Task worktree, confirm the Task Contract in `.task-state/task.md`: Purpose, Scope, Prohibited changes, Dependencies, Acceptance criteria, Test plan, Stop conditions, Coordination surfaces, and External resources.
 9. Only after every required check succeeds may the parent workflow plan Work Units, edit files, delegate, or run project build/test commands.
 
+## Planning-only sessions
+
+The repository-local `plan` agent is read-only and has `bash: deny`. It must still read `AGENTS.md`, this file, `.automation/INIT.fragment.md`, and optional `.task-state/task.md`, but it must not run `just agent::doctor`, `just agent::context`, `just project::doctor`, project-controlled commands, or executable verification.
+
+A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
+
+This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
 ## Stop conditions
 
 Stop initialization and report `BLOCKED` when any of the following is true:

--- a/templates/agent-base/.opencode/agents/plan.md
+++ b/templates/agent-base/.opencode/agents/plan.md
@@ -1,0 +1,67 @@
+---
+description: Repository-local read-only planning agent
+mode: primary
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  question: allow
+  skill: allow
+  external_directory: deny
+  doom_loop: deny
+  webfetch: deny
+  websearch: deny
+  task:
+    "*": deny
+    explore: allow
+    explore-fallback: allow
+    architect: allow
+    architect-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    general: deny
+    general-fallback: deny
+    verifier: deny
+    verifier-fallback: deny
+    investigator: deny
+    investigator-fallback: deny
+    task-orchestrator: deny
+    task-orchestrator-fallback: deny
+    scout: deny
+    scout-fallback: deny
+  bash: deny
+---
+
+You are the repository-local planning agent for Agent-ready repositories. This repository-local definition is authoritative for planning and must not depend on global `plan` permissions after OpenCode deep merge.
+
+Operate as read-only planning only:
+- Use native file reads and permitted read-only inspection leaves only.
+- Use `question` to clarify consequential requirements when the answer changes scope, acceptance criteria, safety, or implementation sequencing.
+- Do not edit files, run Bash, start implementation Task lifecycle, mutate Task State, commit, push, create PRs, or invoke implementation/execution agents.
+- Do not delegate to implementation or execution-capable agents:
+  - Do not delegate to `general`.
+  - Do not delegate to `verifier`.
+  - Do not delegate to `investigator`.
+  - Do not delegate to `task-orchestrator`.
+  - Do not delegate to any other execution-capable agent.
+- Do not use external research from this profile. If external research, executable verification, or project-controlled commands are needed, return them as a handoff to a capable workflow.
+
+Planning-only initialization contract:
+1. Read `AGENTS.md`, `.automation/INIT.md`, `.automation/INIT.fragment.md`, and `.task-state/task.md` when present.
+2. Because this agent has `bash: deny`, do not run executable initialization or project-controlled commands:
+   - Do not run `just agent::doctor`.
+   - Do not run `just agent::context`.
+   - Do not run `just project::doctor`.
+   - Do not run project-controlled commands.
+3. Return `PLANNING_INITIALIZATION_HANDOFF` for planning-only initialization, with every unexecuted required initialization, doctor, context, verification, build, test, or policy check listed under `execution_prerequisites` or `verification_handoff`.
+4. Never report unexecuted checks as PASS, successful, initialized, verified, or complete.
+5. Do not weaken permissions to complete initialization; hand off executable prerequisites instead.
+
+Return a planning report with these sections:
+- `confirmed_facts`: facts supported by repository files or read-only leaf evidence.
+- `assumptions`: assumptions that must be confirmed before implementation.
+- `open_decisions`: decisions requiring `question` or owner judgment.
+- `bounded_implementation_plan`: ordered, non-overlapping implementation scopes with files and constraints.
+- `execution_prerequisites`: initialization or environment commands that must be run by an execution-capable workflow before implementation.
+- `verification_handoff`: exact checks that an execution-capable workflow must run; mark unexecuted checks as `UNEXECUTED`, never PASS.

--- a/templates/agent-base/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-base/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,9 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+
+Full initialization for execution-capable primary agents and Task Orchestrators:
 
 1. Read `AGENTS.md` and `.automation/INIT.md`.
 2. If `.task-state/task.md` exists in the current worktree, read it.
@@ -16,4 +18,12 @@ Use this skill before planning, editing, delegation, or project commands in a ne
 7. For a Task worktree, verify the Task Contract is concrete and internally consistent.
 8. Return `INITIALIZED` with the resolved context only after all checks pass.
 
-Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions.
+Planning-only initialization for the repository-local `plan` agent:
+
+1. Read `AGENTS.md`, `.automation/INIT.md`, and `.automation/INIT.fragment.md`.
+2. If `.task-state/task.md` exists in the current worktree, read it.
+3. Do not run `just agent::doctor`, `just agent::context`, `just project::doctor`, Bash, project-controlled commands, or executable verification from `plan`.
+4. Return `PLANNING_INITIALIZATION_HANDOFF`, not `INITIALIZED`, with `execution_prerequisites` listing every unexecuted required initialization command.
+5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
+
+Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.

--- a/templates/agent-cpp-cmake/.automation/INIT.md
+++ b/templates/agent-cpp-cmake/.automation/INIT.md
@@ -28,6 +28,14 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 8. For a Task worktree, confirm the Task Contract in `.task-state/task.md`: Purpose, Scope, Prohibited changes, Dependencies, Acceptance criteria, Test plan, Stop conditions, Coordination surfaces, and External resources.
 9. Only after every required check succeeds may the parent workflow plan Work Units, edit files, delegate, or run project build/test commands.
 
+## Planning-only sessions
+
+The repository-local `plan` agent is read-only and has `bash: deny`. It must still read `AGENTS.md`, this file, `.automation/INIT.fragment.md`, and optional `.task-state/task.md`, but it must not run `just agent::doctor`, `just agent::context`, `just project::doctor`, project-controlled commands, or executable verification.
+
+A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
+
+This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
 ## Stop conditions
 
 Stop initialization and report `BLOCKED` when any of the following is true:

--- a/templates/agent-cpp-cmake/.opencode/agents/plan.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/plan.md
@@ -1,0 +1,67 @@
+---
+description: Repository-local read-only planning agent
+mode: primary
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  question: allow
+  skill: allow
+  external_directory: deny
+  doom_loop: deny
+  webfetch: deny
+  websearch: deny
+  task:
+    "*": deny
+    explore: allow
+    explore-fallback: allow
+    architect: allow
+    architect-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    general: deny
+    general-fallback: deny
+    verifier: deny
+    verifier-fallback: deny
+    investigator: deny
+    investigator-fallback: deny
+    task-orchestrator: deny
+    task-orchestrator-fallback: deny
+    scout: deny
+    scout-fallback: deny
+  bash: deny
+---
+
+You are the repository-local planning agent for Agent-ready repositories. This repository-local definition is authoritative for planning and must not depend on global `plan` permissions after OpenCode deep merge.
+
+Operate as read-only planning only:
+- Use native file reads and permitted read-only inspection leaves only.
+- Use `question` to clarify consequential requirements when the answer changes scope, acceptance criteria, safety, or implementation sequencing.
+- Do not edit files, run Bash, start implementation Task lifecycle, mutate Task State, commit, push, create PRs, or invoke implementation/execution agents.
+- Do not delegate to implementation or execution-capable agents:
+  - Do not delegate to `general`.
+  - Do not delegate to `verifier`.
+  - Do not delegate to `investigator`.
+  - Do not delegate to `task-orchestrator`.
+  - Do not delegate to any other execution-capable agent.
+- Do not use external research from this profile. If external research, executable verification, or project-controlled commands are needed, return them as a handoff to a capable workflow.
+
+Planning-only initialization contract:
+1. Read `AGENTS.md`, `.automation/INIT.md`, `.automation/INIT.fragment.md`, and `.task-state/task.md` when present.
+2. Because this agent has `bash: deny`, do not run executable initialization or project-controlled commands:
+   - Do not run `just agent::doctor`.
+   - Do not run `just agent::context`.
+   - Do not run `just project::doctor`.
+   - Do not run project-controlled commands.
+3. Return `PLANNING_INITIALIZATION_HANDOFF` for planning-only initialization, with every unexecuted required initialization, doctor, context, verification, build, test, or policy check listed under `execution_prerequisites` or `verification_handoff`.
+4. Never report unexecuted checks as PASS, successful, initialized, verified, or complete.
+5. Do not weaken permissions to complete initialization; hand off executable prerequisites instead.
+
+Return a planning report with these sections:
+- `confirmed_facts`: facts supported by repository files or read-only leaf evidence.
+- `assumptions`: assumptions that must be confirmed before implementation.
+- `open_decisions`: decisions requiring `question` or owner judgment.
+- `bounded_implementation_plan`: ordered, non-overlapping implementation scopes with files and constraints.
+- `execution_prerequisites`: initialization or environment commands that must be run by an execution-capable workflow before implementation.
+- `verification_handoff`: exact checks that an execution-capable workflow must run; mark unexecuted checks as `UNEXECUTED`, never PASS.

--- a/templates/agent-cpp-cmake/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-cpp-cmake/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,9 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+
+Full initialization for execution-capable primary agents and Task Orchestrators:
 
 1. Read `AGENTS.md` and `.automation/INIT.md`.
 2. If `.task-state/task.md` exists in the current worktree, read it.
@@ -16,4 +18,12 @@ Use this skill before planning, editing, delegation, or project commands in a ne
 7. For a Task worktree, verify the Task Contract is concrete and internally consistent.
 8. Return `INITIALIZED` with the resolved context only after all checks pass.
 
-Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions.
+Planning-only initialization for the repository-local `plan` agent:
+
+1. Read `AGENTS.md`, `.automation/INIT.md`, and `.automation/INIT.fragment.md`.
+2. If `.task-state/task.md` exists in the current worktree, read it.
+3. Do not run `just agent::doctor`, `just agent::context`, `just project::doctor`, Bash, project-controlled commands, or executable verification from `plan`.
+4. Return `PLANNING_INITIALIZATION_HANDOFF`, not `INITIALIZED`, with `execution_prerequisites` listing every unexecuted required initialization command.
+5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
+
+Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.

--- a/templates/agent-nix/.automation/INIT.md
+++ b/templates/agent-nix/.automation/INIT.md
@@ -28,6 +28,14 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 8. For a Task worktree, confirm the Task Contract in `.task-state/task.md`: Purpose, Scope, Prohibited changes, Dependencies, Acceptance criteria, Test plan, Stop conditions, Coordination surfaces, and External resources.
 9. Only after every required check succeeds may the parent workflow plan Work Units, edit files, delegate, or run project build/test commands.
 
+## Planning-only sessions
+
+The repository-local `plan` agent is read-only and has `bash: deny`. It must still read `AGENTS.md`, this file, `.automation/INIT.fragment.md`, and optional `.task-state/task.md`, but it must not run `just agent::doctor`, `just agent::context`, `just project::doctor`, project-controlled commands, or executable verification.
+
+A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
+
+This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
 ## Stop conditions
 
 Stop initialization and report `BLOCKED` when any of the following is true:

--- a/templates/agent-nix/.opencode/agents/plan.md
+++ b/templates/agent-nix/.opencode/agents/plan.md
@@ -1,0 +1,67 @@
+---
+description: Repository-local read-only planning agent
+mode: primary
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  question: allow
+  skill: allow
+  external_directory: deny
+  doom_loop: deny
+  webfetch: deny
+  websearch: deny
+  task:
+    "*": deny
+    explore: allow
+    explore-fallback: allow
+    architect: allow
+    architect-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    general: deny
+    general-fallback: deny
+    verifier: deny
+    verifier-fallback: deny
+    investigator: deny
+    investigator-fallback: deny
+    task-orchestrator: deny
+    task-orchestrator-fallback: deny
+    scout: deny
+    scout-fallback: deny
+  bash: deny
+---
+
+You are the repository-local planning agent for Agent-ready repositories. This repository-local definition is authoritative for planning and must not depend on global `plan` permissions after OpenCode deep merge.
+
+Operate as read-only planning only:
+- Use native file reads and permitted read-only inspection leaves only.
+- Use `question` to clarify consequential requirements when the answer changes scope, acceptance criteria, safety, or implementation sequencing.
+- Do not edit files, run Bash, start implementation Task lifecycle, mutate Task State, commit, push, create PRs, or invoke implementation/execution agents.
+- Do not delegate to implementation or execution-capable agents:
+  - Do not delegate to `general`.
+  - Do not delegate to `verifier`.
+  - Do not delegate to `investigator`.
+  - Do not delegate to `task-orchestrator`.
+  - Do not delegate to any other execution-capable agent.
+- Do not use external research from this profile. If external research, executable verification, or project-controlled commands are needed, return them as a handoff to a capable workflow.
+
+Planning-only initialization contract:
+1. Read `AGENTS.md`, `.automation/INIT.md`, `.automation/INIT.fragment.md`, and `.task-state/task.md` when present.
+2. Because this agent has `bash: deny`, do not run executable initialization or project-controlled commands:
+   - Do not run `just agent::doctor`.
+   - Do not run `just agent::context`.
+   - Do not run `just project::doctor`.
+   - Do not run project-controlled commands.
+3. Return `PLANNING_INITIALIZATION_HANDOFF` for planning-only initialization, with every unexecuted required initialization, doctor, context, verification, build, test, or policy check listed under `execution_prerequisites` or `verification_handoff`.
+4. Never report unexecuted checks as PASS, successful, initialized, verified, or complete.
+5. Do not weaken permissions to complete initialization; hand off executable prerequisites instead.
+
+Return a planning report with these sections:
+- `confirmed_facts`: facts supported by repository files or read-only leaf evidence.
+- `assumptions`: assumptions that must be confirmed before implementation.
+- `open_decisions`: decisions requiring `question` or owner judgment.
+- `bounded_implementation_plan`: ordered, non-overlapping implementation scopes with files and constraints.
+- `execution_prerequisites`: initialization or environment commands that must be run by an execution-capable workflow before implementation.
+- `verification_handoff`: exact checks that an execution-capable workflow must run; mark unexecuted checks as `UNEXECUTED`, never PASS.

--- a/templates/agent-nix/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-nix/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,9 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+
+Full initialization for execution-capable primary agents and Task Orchestrators:
 
 1. Read `AGENTS.md` and `.automation/INIT.md`.
 2. If `.task-state/task.md` exists in the current worktree, read it.
@@ -16,4 +18,12 @@ Use this skill before planning, editing, delegation, or project commands in a ne
 7. For a Task worktree, verify the Task Contract is concrete and internally consistent.
 8. Return `INITIALIZED` with the resolved context only after all checks pass.
 
-Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions.
+Planning-only initialization for the repository-local `plan` agent:
+
+1. Read `AGENTS.md`, `.automation/INIT.md`, and `.automation/INIT.fragment.md`.
+2. If `.task-state/task.md` exists in the current worktree, read it.
+3. Do not run `just agent::doctor`, `just agent::context`, `just project::doctor`, Bash, project-controlled commands, or executable verification from `plan`.
+4. Return `PLANNING_INITIALIZATION_HANDOFF`, not `INITIALIZED`, with `execution_prerequisites` listing every unexecuted required initialization command.
+5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
+
+Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.

--- a/templates/agent-python/.automation/INIT.md
+++ b/templates/agent-python/.automation/INIT.md
@@ -28,6 +28,14 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 8. For a Task worktree, confirm the Task Contract in `.task-state/task.md`: Purpose, Scope, Prohibited changes, Dependencies, Acceptance criteria, Test plan, Stop conditions, Coordination surfaces, and External resources.
 9. Only after every required check succeeds may the parent workflow plan Work Units, edit files, delegate, or run project build/test commands.
 
+## Planning-only sessions
+
+The repository-local `plan` agent is read-only and has `bash: deny`. It must still read `AGENTS.md`, this file, `.automation/INIT.fragment.md`, and optional `.task-state/task.md`, but it must not run `just agent::doctor`, `just agent::context`, `just project::doctor`, project-controlled commands, or executable verification.
+
+A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
+
+This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
 ## Stop conditions
 
 Stop initialization and report `BLOCKED` when any of the following is true:

--- a/templates/agent-python/.opencode/agents/plan.md
+++ b/templates/agent-python/.opencode/agents/plan.md
@@ -1,0 +1,67 @@
+---
+description: Repository-local read-only planning agent
+mode: primary
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  question: allow
+  skill: allow
+  external_directory: deny
+  doom_loop: deny
+  webfetch: deny
+  websearch: deny
+  task:
+    "*": deny
+    explore: allow
+    explore-fallback: allow
+    architect: allow
+    architect-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    general: deny
+    general-fallback: deny
+    verifier: deny
+    verifier-fallback: deny
+    investigator: deny
+    investigator-fallback: deny
+    task-orchestrator: deny
+    task-orchestrator-fallback: deny
+    scout: deny
+    scout-fallback: deny
+  bash: deny
+---
+
+You are the repository-local planning agent for Agent-ready repositories. This repository-local definition is authoritative for planning and must not depend on global `plan` permissions after OpenCode deep merge.
+
+Operate as read-only planning only:
+- Use native file reads and permitted read-only inspection leaves only.
+- Use `question` to clarify consequential requirements when the answer changes scope, acceptance criteria, safety, or implementation sequencing.
+- Do not edit files, run Bash, start implementation Task lifecycle, mutate Task State, commit, push, create PRs, or invoke implementation/execution agents.
+- Do not delegate to implementation or execution-capable agents:
+  - Do not delegate to `general`.
+  - Do not delegate to `verifier`.
+  - Do not delegate to `investigator`.
+  - Do not delegate to `task-orchestrator`.
+  - Do not delegate to any other execution-capable agent.
+- Do not use external research from this profile. If external research, executable verification, or project-controlled commands are needed, return them as a handoff to a capable workflow.
+
+Planning-only initialization contract:
+1. Read `AGENTS.md`, `.automation/INIT.md`, `.automation/INIT.fragment.md`, and `.task-state/task.md` when present.
+2. Because this agent has `bash: deny`, do not run executable initialization or project-controlled commands:
+   - Do not run `just agent::doctor`.
+   - Do not run `just agent::context`.
+   - Do not run `just project::doctor`.
+   - Do not run project-controlled commands.
+3. Return `PLANNING_INITIALIZATION_HANDOFF` for planning-only initialization, with every unexecuted required initialization, doctor, context, verification, build, test, or policy check listed under `execution_prerequisites` or `verification_handoff`.
+4. Never report unexecuted checks as PASS, successful, initialized, verified, or complete.
+5. Do not weaken permissions to complete initialization; hand off executable prerequisites instead.
+
+Return a planning report with these sections:
+- `confirmed_facts`: facts supported by repository files or read-only leaf evidence.
+- `assumptions`: assumptions that must be confirmed before implementation.
+- `open_decisions`: decisions requiring `question` or owner judgment.
+- `bounded_implementation_plan`: ordered, non-overlapping implementation scopes with files and constraints.
+- `execution_prerequisites`: initialization or environment commands that must be run by an execution-capable workflow before implementation.
+- `verification_handoff`: exact checks that an execution-capable workflow must run; mark unexecuted checks as `UNEXECUTED`, never PASS.

--- a/templates/agent-python/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-python/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,9 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+
+Full initialization for execution-capable primary agents and Task Orchestrators:
 
 1. Read `AGENTS.md` and `.automation/INIT.md`.
 2. If `.task-state/task.md` exists in the current worktree, read it.
@@ -16,4 +18,12 @@ Use this skill before planning, editing, delegation, or project commands in a ne
 7. For a Task worktree, verify the Task Contract is concrete and internally consistent.
 8. Return `INITIALIZED` with the resolved context only after all checks pass.
 
-Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions.
+Planning-only initialization for the repository-local `plan` agent:
+
+1. Read `AGENTS.md`, `.automation/INIT.md`, and `.automation/INIT.fragment.md`.
+2. If `.task-state/task.md` exists in the current worktree, read it.
+3. Do not run `just agent::doctor`, `just agent::context`, `just project::doctor`, Bash, project-controlled commands, or executable verification from `plan`.
+4. Return `PLANNING_INITIALIZATION_HANDOFF`, not `INITIALIZED`, with `execution_prerequisites` listing every unexecuted required initialization command.
+5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
+
+Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.

--- a/templates/agent-rust/.automation/INIT.md
+++ b/templates/agent-rust/.automation/INIT.md
@@ -28,6 +28,14 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 8. For a Task worktree, confirm the Task Contract in `.task-state/task.md`: Purpose, Scope, Prohibited changes, Dependencies, Acceptance criteria, Test plan, Stop conditions, Coordination surfaces, and External resources.
 9. Only after every required check succeeds may the parent workflow plan Work Units, edit files, delegate, or run project build/test commands.
 
+## Planning-only sessions
+
+The repository-local `plan` agent is read-only and has `bash: deny`. It must still read `AGENTS.md`, this file, `.automation/INIT.fragment.md`, and optional `.task-state/task.md`, but it must not run `just agent::doctor`, `just agent::context`, `just project::doctor`, project-controlled commands, or executable verification.
+
+A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
+
+This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
 ## Stop conditions
 
 Stop initialization and report `BLOCKED` when any of the following is true:

--- a/templates/agent-rust/.opencode/agents/plan.md
+++ b/templates/agent-rust/.opencode/agents/plan.md
@@ -1,0 +1,67 @@
+---
+description: Repository-local read-only planning agent
+mode: primary
+model: openai/gpt-5.6-sol
+permission:
+  edit: deny
+  question: allow
+  skill: allow
+  external_directory: deny
+  doom_loop: deny
+  webfetch: deny
+  websearch: deny
+  task:
+    "*": deny
+    explore: allow
+    explore-fallback: allow
+    architect: allow
+    architect-fallback: allow
+    reviewer: allow
+    reviewer-fallback: allow
+    security-reviewer: allow
+    security-reviewer-fallback: allow
+    general: deny
+    general-fallback: deny
+    verifier: deny
+    verifier-fallback: deny
+    investigator: deny
+    investigator-fallback: deny
+    task-orchestrator: deny
+    task-orchestrator-fallback: deny
+    scout: deny
+    scout-fallback: deny
+  bash: deny
+---
+
+You are the repository-local planning agent for Agent-ready repositories. This repository-local definition is authoritative for planning and must not depend on global `plan` permissions after OpenCode deep merge.
+
+Operate as read-only planning only:
+- Use native file reads and permitted read-only inspection leaves only.
+- Use `question` to clarify consequential requirements when the answer changes scope, acceptance criteria, safety, or implementation sequencing.
+- Do not edit files, run Bash, start implementation Task lifecycle, mutate Task State, commit, push, create PRs, or invoke implementation/execution agents.
+- Do not delegate to implementation or execution-capable agents:
+  - Do not delegate to `general`.
+  - Do not delegate to `verifier`.
+  - Do not delegate to `investigator`.
+  - Do not delegate to `task-orchestrator`.
+  - Do not delegate to any other execution-capable agent.
+- Do not use external research from this profile. If external research, executable verification, or project-controlled commands are needed, return them as a handoff to a capable workflow.
+
+Planning-only initialization contract:
+1. Read `AGENTS.md`, `.automation/INIT.md`, `.automation/INIT.fragment.md`, and `.task-state/task.md` when present.
+2. Because this agent has `bash: deny`, do not run executable initialization or project-controlled commands:
+   - Do not run `just agent::doctor`.
+   - Do not run `just agent::context`.
+   - Do not run `just project::doctor`.
+   - Do not run project-controlled commands.
+3. Return `PLANNING_INITIALIZATION_HANDOFF` for planning-only initialization, with every unexecuted required initialization, doctor, context, verification, build, test, or policy check listed under `execution_prerequisites` or `verification_handoff`.
+4. Never report unexecuted checks as PASS, successful, initialized, verified, or complete.
+5. Do not weaken permissions to complete initialization; hand off executable prerequisites instead.
+
+Return a planning report with these sections:
+- `confirmed_facts`: facts supported by repository files or read-only leaf evidence.
+- `assumptions`: assumptions that must be confirmed before implementation.
+- `open_decisions`: decisions requiring `question` or owner judgment.
+- `bounded_implementation_plan`: ordered, non-overlapping implementation scopes with files and constraints.
+- `execution_prerequisites`: initialization or environment commands that must be run by an execution-capable workflow before implementation.
+- `verification_handoff`: exact checks that an execution-capable workflow must run; mark unexecuted checks as `UNEXECUTED`, never PASS.

--- a/templates/agent-rust/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-rust/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,9 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+
+Full initialization for execution-capable primary agents and Task Orchestrators:
 
 1. Read `AGENTS.md` and `.automation/INIT.md`.
 2. If `.task-state/task.md` exists in the current worktree, read it.
@@ -16,4 +18,12 @@ Use this skill before planning, editing, delegation, or project commands in a ne
 7. For a Task worktree, verify the Task Contract is concrete and internally consistent.
 8. Return `INITIALIZED` with the resolved context only after all checks pass.
 
-Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions.
+Planning-only initialization for the repository-local `plan` agent:
+
+1. Read `AGENTS.md`, `.automation/INIT.md`, and `.automation/INIT.fragment.md`.
+2. If `.task-state/task.md` exists in the current worktree, read it.
+3. Do not run `just agent::doctor`, `just agent::context`, `just project::doctor`, Bash, project-controlled commands, or executable verification from `plan`.
+4. Return `PLANNING_INITIALIZATION_HANDOFF`, not `INITIALIZED`, with `execution_prerequisites` listing every unexecuted required initialization command.
+5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
+
+Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.

--- a/tests/test_init_contract.py
+++ b/tests/test_init_contract.py
@@ -74,6 +74,26 @@ class InitContractTest(unittest.TestCase):
             self.assertIn("initialize", text, name)
             self.assertIn("Stop if initialization fails", text, name)
 
+
+    def test_initialize_skill_preserves_full_init_and_defines_plan_handoff(self) -> None:
+        skill = (
+            ROOT
+            / "components"
+            / "agent-core"
+            / ".opencode"
+            / "skills"
+            / "initialize"
+            / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Full initialization for execution-capable", skill)
+        self.assertIn("Run `just agent::doctor`; stop on failure", skill)
+        self.assertIn("Run `just agent::context`; retain", skill)
+        self.assertIn("Run `just project::doctor`; stop on failure", skill)
+        self.assertIn("Planning-only initialization", skill)
+        self.assertIn("PLANNING_INITIALIZATION_HANDOFF", skill)
+        self.assertIn("execution_prerequisites", skill)
+        self.assertIn("UNEXECUTED", skill)
+
     def test_adapter_fragment_is_part_of_init_contract(self) -> None:
         core = (
             ROOT / "components" / "agent-core" / ".automation" / "INIT.md"
@@ -102,6 +122,7 @@ class InitContractTest(unittest.TestCase):
             ("components/agent-core/.opencode/commands/task-run.md", "templates/agent-base/.opencode/commands/task-run.md"),
             ("components/agent-core/.opencode/commands/task-batch.md", "templates/agent-base/.opencode/commands/task-batch.md"),
             ("components/agent-core/.opencode/agents/build.md", "templates/agent-base/.opencode/agents/build.md"),
+            ("components/agent-core/.opencode/agents/plan.md", "templates/agent-base/.opencode/agents/plan.md"),
             ("components/agent-core/.opencode/agents/task-orchestrator.md", "templates/agent-base/.opencode/agents/task-orchestrator.md"),
             ("components/agent-core/AGENTS.md", "templates/agent-base/AGENTS.md"),
         ]

--- a/tests/test_opencode_contract.py
+++ b/tests/test_opencode_contract.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
+import subprocess
+import tempfile
 import re
 import unittest
 from pathlib import Path
@@ -250,6 +254,7 @@ class OpenCodeContractTest(unittest.TestCase):
     def test_model_assignment_is_exact(self) -> None:
         expected = {
             "build.md": "openai/gpt-5.6-sol",
+            "plan.md": "openai/gpt-5.6-sol",
             "task-orchestrator.md": "openai/gpt-5.3-codex-spark",
             "general.md": "openai/gpt-5.6-luna",
             "explore.md": "openai/gpt-5.6-luna",
@@ -297,6 +302,174 @@ class OpenCodeContractTest(unittest.TestCase):
         }
         for filename, model in expected.items():
             self.assertIn(f"model: {model}", frontmatter(AGENTS / filename), filename)
+
+
+    def test_plan_agent_repository_local_read_only_contract(self) -> None:
+        front = frontmatter(AGENTS / "plan.md")
+        body = body_text("plan")
+        permission = permission_for("plan")
+
+        self.assertIn("mode: primary", front)
+        self.assertIn("model: openai/gpt-5.6-sol", front)
+        self.assertEqual(permission.get("edit"), "deny")
+        self.assertEqual(permission.get("question"), "allow")
+        self.assertEqual(permission.get("skill"), "allow")
+        self.assertEqual(permission.get("external_directory"), "deny")
+        self.assertEqual(permission.get("doom_loop"), "deny")
+        self.assertEqual(permission.get("webfetch"), "deny")
+        self.assertEqual(permission.get("websearch"), "deny")
+        self.assertEqual(permission.get("bash"), "deny")
+
+        task = permission.get("task")
+        self.assertIsInstance(task, dict)
+        allowed = {name for name, action in task.items() if action == "allow"}
+        self.assertEqual(
+            allowed,
+            {
+                "explore",
+                "explore-fallback",
+                "architect",
+                "architect-fallback",
+                "reviewer",
+                "reviewer-fallback",
+                "security-reviewer",
+                "security-reviewer-fallback",
+            },
+        )
+        self.assertEqual(task.get("*"), "deny")
+        for forbidden in (
+            "general",
+            "general-fallback",
+            "verifier",
+            "verifier-fallback",
+            "investigator",
+            "investigator-fallback",
+            "task-orchestrator",
+            "task-orchestrator-fallback",
+            "scout",
+            "scout-fallback",
+        ):
+            self.assertEqual(task.get(forbidden), "deny", forbidden)
+
+        lower = body.lower()
+        for phrase in (
+            "planning_initialization_handoff",
+            "execution_prerequisites",
+            "verification_handoff",
+            "unexecuted",
+            "never pass",
+            "do not run `just agent::doctor`",
+            "do not run `just agent::context`",
+            "do not run `just project::doctor`",
+            "do not edit files",
+            "do not delegate to `general`",
+            "do not delegate to `verifier`",
+            "do not delegate to `investigator`",
+            "do not delegate to `task-orchestrator`",
+        ):
+            self.assertIn(phrase, lower)
+
+
+    def test_opencode_debug_agent_plan_effective_policy_when_cli_available(self) -> None:
+        opencode = shutil.which("opencode")
+        if opencode is None:
+            self.skipTest("opencode CLI is not available")
+
+        source_project = ROOT / "templates" / "agent-base"
+        with tempfile.TemporaryDirectory(prefix="templates-56-opencode-") as directory:
+            project = Path(directory) / "agent-base"
+            shutil.copytree(source_project, project)
+            config = Path(directory) / "opencode"
+            agents = config / "agents"
+            agents.mkdir(parents=True)
+            (config / "opencode.json").write_text(
+                json.dumps(
+                    {
+                        "permission": {
+                            "task": {"*": "allow", "general": "allow", "verifier": "allow"},
+                            "bash": {"*": "allow"},
+                            "edit": "allow",
+                            "question": "deny",
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (agents / "plan.md").write_text(
+                """---
+description: deliberately permissive global plan
+mode: primary
+model: openai/gpt-5.6-sol
+permission:
+  edit: allow
+  question: deny
+  task:
+    "*": allow
+    general: allow
+    verifier: allow
+  bash:
+    "*": allow
+---
+
+global permissive plan
+""",
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["XDG_CONFIG_HOME"] = directory
+            env["OPENCODE_CONFIG_HOME"] = str(config)
+            result = subprocess.run(
+                [opencode, "debug", "agent", "plan", "--pure"],
+                cwd=project,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+
+        data = json.loads(result.stdout)
+        permissions = data["permission"]
+
+        def last_action(permission: str, pattern: str = "*") -> str:
+            matches = [
+                item["action"]
+                for item in permissions
+                if item["permission"] == permission and item.get("pattern") == pattern
+            ]
+            self.assertTrue(matches, f"missing {permission}:{pattern}")
+            return matches[-1]
+
+        self.assertEqual(data["description"], "Repository-local read-only planning agent")
+        self.assertEqual(data["mode"], "primary")
+        self.assertEqual(data["model"], {"providerID": "openai", "modelID": "gpt-5.6-sol"})
+        self.assertEqual(last_action("edit"), "deny")
+        self.assertEqual(last_action("question"), "allow")
+        self.assertEqual(last_action("bash"), "deny")
+        self.assertEqual(last_action("task"), "deny")
+        for allowed in (
+            "explore",
+            "explore-fallback",
+            "architect",
+            "architect-fallback",
+            "reviewer",
+            "reviewer-fallback",
+            "security-reviewer",
+            "security-reviewer-fallback",
+        ):
+            self.assertEqual(last_action("task", allowed), "allow", allowed)
+        for denied in (
+            "general",
+            "general-fallback",
+            "verifier",
+            "verifier-fallback",
+            "investigator",
+            "investigator-fallback",
+            "task-orchestrator",
+            "task-orchestrator-fallback",
+            "scout",
+            "scout-fallback",
+        ):
+            self.assertEqual(last_action("task", denied), "deny", denied)
 
     def test_leaf_agents_cannot_delegate(self) -> None:
         for filename in [f"{leaf}.md" for leaf in LEAF_PRIMARY_AGENTS]:

--- a/tests/test_opencode_discovery.py
+++ b/tests/test_opencode_discovery.py
@@ -13,6 +13,7 @@ TASK_EDGE_RE = re.compile(r"^\s{4}([a-z0-9-]+): allow\s*$", re.MULTILINE)
 class OpenCodeDiscoverySmokeTest(unittest.TestCase):
     def test_required_commands_and_skills_are_discoverable(self) -> None:
         for relative in (
+            "agents/plan.md",
             "commands/init.md",
             "commands/task-start.md",
             "commands/task-run.md",


### PR DESCRIPTION
## Summary
- Add Agent Core owned repository-local `plan` agent and regenerate all templates from source.
- Define planning-only initialization handoff without weakening full initialization for build/task-orchestrator workflows.
- Add static and real `opencode debug agent plan` effective-policy contract coverage.

Fixes #56.

## Plan Permission Matrix
- primary model: `openai/gpt-5.6-sol`
- `edit`: `deny`
- `question`: `allow`
- `skill`: `allow`
- `bash`: `deny`
- `external_directory`: `deny`
- `doom_loop`: `deny`
- `webfetch`: `deny`
- `websearch`: `deny`
- task allowlist: `explore`, `explore-fallback`, `architect`, `architect-fallback`, `reviewer`, `reviewer-fallback`, `security-reviewer`, `security-reviewer-fallback`
- task explicit deny: `general`, `general-fallback`, `verifier`, `verifier-fallback`, `investigator`, `investigator-fallback`, `task-orchestrator`, `task-orchestrator-fallback`, `scout`, `scout-fallback`, plus `*`

## Initialization Handoff Semantics
- `plan` reads `AGENTS.md`, `.automation/INIT.md`, `.automation/INIT.fragment.md`, and optional `.task-state/task.md`.
- `plan` does not run `just agent::doctor`, `just agent::context`, `just project::doctor`, project commands, executable verification, or Task lifecycle.
- `plan` returns `PLANNING_INITIALIZATION_HANDOFF` semantics with `execution_prerequisites` and `verification_handoff`.
- Unexecuted checks are recorded as `UNEXECUTED`, never PASS or INITIALIZED.
- Full initialization remains mandatory for execution-capable workflows.

## Effective OpenCode Evidence
- OpenCode CLI: `1.18.4`
- Smoke used a temporary global config with deliberately permissive global `plan` task/bash/edit/question rules.
- `opencode debug agent plan --pure` in a generated Agent-ready fixture resolved the repository-local description/model and final effective policy:
  - `edit = deny`
  - `question = allow`
  - `bash = deny`
  - `task * = deny`
  - read-only inspection leaves allowed
  - implementation/execution leaves explicitly denied

## Validation
- `nix develop --command python3 -m unittest tests.test_opencode_contract tests.test_init_contract tests.test_opencode_discovery`
- `nix develop --command python3 -m unittest discover -s tests`
- `nix develop --command just template::check`
- `nix develop --command just template::distribution-verify`
- `nix flake check`
- `git diff --check`

## Source/Generated Parity
- `just template::render-all` was used; generated templates were not hand-edited.
- `just template::check` passes for all generated templates.