### PR TITLE
fix: preserve repository-owned adoption files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.runtime-smoke/
 /.worktrees/
+__pycache__/
+*.py[cod]

--- a/components/adapters/base/.automation/adoption.toml
+++ b/components/adapters/base/.automation/adoption.toml
@@ -4,6 +4,7 @@ version = 1
 # language-neutral base adapter. Agent Core remains responsible for its own
 # automation files and public Just modules.
 preserve_existing = [
+  "README.md",
   "flake.nix",
   "flake.lock",
 ]

--- a/components/adapters/cpp-cmake/.automation/adoption.toml
+++ b/components/adapters/cpp-cmake/.automation/adoption.toml
@@ -1,6 +1,8 @@
 version = 1
 
 preserve_existing = [
+  "README.md",
+  ".envrc",
   "CMakeLists.txt",
   "CMakePresets.json",
   "cmake/**",

--- a/components/adapters/nix/.automation/adoption.toml
+++ b/components/adapters/nix/.automation/adoption.toml
@@ -1,6 +1,8 @@
 version = 1
 
 preserve_existing = [
+  "README.md",
+  ".envrc",
   "flake.nix",
   "flake.lock",
 ]

--- a/components/adapters/python/.automation/adoption.toml
+++ b/components/adapters/python/.automation/adoption.toml
@@ -1,11 +1,12 @@
 version = 1
 
 preserve_existing = [
+  "README.md",
+  ".envrc",
   "pyproject.toml",
   "uv.lock",
   "flake.nix",
   "flake.lock",
-  ".envrc",
   ".pre-commit-config.yaml",
 ]
 

--- a/components/adapters/rust/.automation/adoption.toml
+++ b/components/adapters/rust/.automation/adoption.toml
@@ -1,11 +1,12 @@
 version = 1
 
 preserve_existing = [
+  "README.md",
+  ".envrc",
   "Cargo.toml",
   "Cargo.lock",
   "flake.nix",
   "flake.lock",
-  ".envrc",
   ".pre-commit-config.yaml",
 ]
 

--- a/templates/agent-base/.automation/adoption.toml
+++ b/templates/agent-base/.automation/adoption.toml
@@ -4,6 +4,7 @@ version = 1
 # language-neutral base adapter. Agent Core remains responsible for its own
 # automation files and public Just modules.
 preserve_existing = [
+  "README.md",
   "flake.nix",
   "flake.lock",
 ]

--- a/templates/agent-cpp-cmake/.automation/adoption.toml
+++ b/templates/agent-cpp-cmake/.automation/adoption.toml
@@ -1,6 +1,8 @@
 version = 1
 
 preserve_existing = [
+  "README.md",
+  ".envrc",
   "CMakeLists.txt",
   "CMakePresets.json",
   "cmake/**",

--- a/templates/agent-nix/.automation/adoption.toml
+++ b/templates/agent-nix/.automation/adoption.toml
@@ -1,6 +1,8 @@
 version = 1
 
 preserve_existing = [
+  "README.md",
+  ".envrc",
   "flake.nix",
   "flake.lock",
 ]

--- a/templates/agent-python/.automation/adoption.toml
+++ b/templates/agent-python/.automation/adoption.toml
@@ -1,11 +1,12 @@
 version = 1
 
 preserve_existing = [
+  "README.md",
+  ".envrc",
   "pyproject.toml",
   "uv.lock",
   "flake.nix",
   "flake.lock",
-  ".envrc",
   ".pre-commit-config.yaml",
 ]
 

--- a/templates/agent-rust/.automation/adoption.toml
+++ b/templates/agent-rust/.automation/adoption.toml
@@ -1,11 +1,12 @@
 version = 1
 
 preserve_existing = [
+  "README.md",
+  ".envrc",
   "Cargo.toml",
   "Cargo.lock",
   "flake.nix",
   "flake.lock",
-  ".envrc",
   ".pre-commit-config.yaml",
 ]
 

--- a/tests/test_adopt_repository.py
+++ b/tests/test_adopt_repository.py
@@ -92,6 +92,47 @@ class AdoptRepositoryTest(unittest.TestCase):
         self.assertFalse(result["pushPerformed"])
         self.assertFalse(result["mergePerformed"])
 
+    def test_cpp_cmake_apply_preserves_repository_readme_and_envrc(self) -> None:
+        temporary, repo = self.make_repo()
+        self.addCleanup(temporary.cleanup)
+        readme = "# Existing Project\n"
+        envrc = "use flake\n"
+        (repo / "CMakeLists.txt").write_text(
+            "cmake_minimum_required(VERSION 3.20)\nproject(existing)\n",
+            encoding="utf-8",
+        )
+        (repo / "README.md").write_text(readme, encoding="utf-8")
+        (repo / ".envrc").write_text(envrc, encoding="utf-8")
+        self.commit_all(repo)
+
+        plan = adopt_repository.build_plan(ROOT, repo, "cpp-cmake")
+        actions = {action["path"]: action["action"] for action in plan["actions"]}
+
+        self.assertEqual(actions["README.md"], "preserve")
+        self.assertEqual(actions[".envrc"], "preserve")
+        self.assertFalse(any("README.md" in blocker for blocker in plan["blockers"]))
+        self.assertFalse(any(".envrc" in blocker for blocker in plan["blockers"]))
+        self.assertTrue(plan["canApply"], plan["blockers"])
+
+        result = adopt_repository.apply_plan(ROOT, repo, "cpp-cmake")
+
+        self.assertTrue(result["applied"])
+        self.assertEqual((repo / "README.md").read_text(encoding="utf-8"), readme)
+        self.assertEqual((repo / ".envrc").read_text(encoding="utf-8"), envrc)
+        self.assertEqual((repo / ".automation" / "ADAPTER").read_text().strip(), "cpp-cmake")
+        self.assertTrue((repo / ".automation" / "VERSION").is_file())
+
+    def test_repository_owned_path_policy_is_consistent_across_adapters(self) -> None:
+        for adapter in ("base", "cpp-cmake", "python", "rust", "nix"):
+            with self.subTest(adapter=adapter):
+                policy = adopt_repository.load_policy(ROOT, adapter)
+                self.assertIn("README.md", policy["preserve_existing"])
+
+        for adapter in ("cpp-cmake", "python", "rust", "nix"):
+            with self.subTest(adapter=adapter):
+                policy = adopt_repository.load_policy(ROOT, adapter)
+                self.assertIn(".envrc", policy["preserve_existing"])
+
     def test_plan_reports_preserved_old_just_environment_prerequisite(self) -> None:
         temporary, repo = self.make_repo()
         self.addCleanup(temporary.cleanup)


### PR DESCRIPTION
## Summary
- preserve existing repository `README.md` files across all adapters during adoption
- preserve existing `.envrc` files for every adapter that generates one
- add cpp-cmake plan/apply regression coverage and cross-adapter policy checks
- ignore Python bytecode generated by repository tooling

## Verification
- `nix develop --command python3 -m unittest tests.test_adopt_repository` (9 tests passed)
- `nix develop --command python3 -m unittest discover -s tests` (123 tests passed)
- `nix develop --command just template::check`
- `nix develop --command just template::distribution-verify`
- `git diff --check`

## Risk
- adoption collision handling remains unchanged outside the declarative repository-owned paths
- generated template adoption policies were synchronized through `template::render-all`
