### PR TITLE
Use Spark-first OpenCode model fallbacks

### DIFF
--- a/components/agent-core/.automation/model-fallback.toml
+++ b/components/agent-core/.automation/model-fallback.toml
@@ -29,14 +29,14 @@ non_fallback_markers = [
 primary_agent = "build"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["build-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = false
 
 [roles.architect]
 primary_agent = "architect"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["architect-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.task-orchestrator]
@@ -48,49 +48,49 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.reviewer]
 primary_agent = "reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.investigator]
 primary_agent = "investigator"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["investigator-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.security-reviewer]
 primary_agent = "security-reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["security-reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.scout]
 primary_agent = "scout"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["scout-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true

--- a/components/agent-core/.opencode/agents/architect-fallback.md
+++ b/components/agent-core/.opencode/agents/architect-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for architecture analysis
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/build-fallback.md
+++ b/components/agent-core/.opencode/agents/build-fallback.md
@@ -2,7 +2,7 @@
 description: Manual usage-limit fallback for Main Orchestrator with identical authority
 mode: primary
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task:

--- a/components/agent-core/.opencode/agents/explore-fallback.md
+++ b/components/agent-core/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/explore.md
+++ b/components/agent-core/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/general-fallback.md
+++ b/components/agent-core/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   question: deny

--- a/components/agent-core/.opencode/agents/general.md
+++ b/components/agent-core/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   question: deny

--- a/components/agent-core/.opencode/agents/investigator-fallback.md
+++ b/components/agent-core/.opencode/agents/investigator-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for root-cause investigation
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/reviewer-fallback.md
+++ b/components/agent-core/.opencode/agents/reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for correctness review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/scout-fallback.md
+++ b/components/agent-core/.opencode/agents/scout-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for external primary-source research
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/scout.md
+++ b/components/agent-core/.opencode/agents/scout.md
@@ -1,7 +1,7 @@
 ---
 description: External primary-source research specialist
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/security-reviewer-fallback.md
+++ b/components/agent-core/.opencode/agents/security-reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for security-boundary review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/verifier-fallback.md
+++ b/components/agent-core/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/components/agent-core/.opencode/agents/verifier.md
+++ b/components/agent-core/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/docs/model-fallback.md
+++ b/docs/model-fallback.md
@@ -24,14 +24,16 @@ The following failures do not trigger automatic fallback:
 - safety refusal
 - unclassified failures
 
-## Role-specific fallback split (Issue #47)
+## Role-specific fallback split
 
-The final role split is:
+Fallbacks cross token-quota families. Codex 5.6 variants share quota, so a 5.6-primary role falls back to Spark rather than another 5.6 model. Spark-primary leaf roles fall back to Luna.
 
-- `task-orchestrator` → **Spark** primary, automatic fallback to **Sol** only for classified usage/quota/rate-limit failures.
-- `general`, `explore`, `verifier` → **Luna** primary, automatic fallback to **Spark** only for classified usage/quota/rate-limit failures.
-- `scout` → **Luna** primary, automatic fallback to **Terra** only for classified usage/quota/rate-limit failures.
-- `reviewer`, `investigator`, `security-reviewer` remain as configured (`Terra` in the baseline allocation).
+The role split is:
+
+- `task-orchestrator` → **Spark** primary, automatic fallback to **Sol**.
+- `general`, `explore`, `verifier`, `scout` → **Spark** primary, automatic fallback to **Luna**.
+- `architect`, `reviewer`, `investigator`, `security-reviewer` → their existing 5.6 primary, automatic fallback to **Spark**.
+- `build` → **Sol** primary, manual fallback to **Spark**.
 
 ## Main Orchestrator
 

--- a/templates/agent-base/.automation/model-fallback.toml
+++ b/templates/agent-base/.automation/model-fallback.toml
@@ -29,14 +29,14 @@ non_fallback_markers = [
 primary_agent = "build"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["build-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = false
 
 [roles.architect]
 primary_agent = "architect"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["architect-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.task-orchestrator]
@@ -48,49 +48,49 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.reviewer]
 primary_agent = "reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.investigator]
 primary_agent = "investigator"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["investigator-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.security-reviewer]
 primary_agent = "security-reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["security-reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.scout]
 primary_agent = "scout"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["scout-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true

--- a/templates/agent-base/.opencode/agents/architect-fallback.md
+++ b/templates/agent-base/.opencode/agents/architect-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for architecture analysis
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/build-fallback.md
+++ b/templates/agent-base/.opencode/agents/build-fallback.md
@@ -2,7 +2,7 @@
 description: Manual usage-limit fallback for Main Orchestrator with identical authority
 mode: primary
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task:

--- a/templates/agent-base/.opencode/agents/explore-fallback.md
+++ b/templates/agent-base/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/explore.md
+++ b/templates/agent-base/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/general-fallback.md
+++ b/templates/agent-base/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   question: deny

--- a/templates/agent-base/.opencode/agents/general.md
+++ b/templates/agent-base/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   question: deny

--- a/templates/agent-base/.opencode/agents/investigator-fallback.md
+++ b/templates/agent-base/.opencode/agents/investigator-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for root-cause investigation
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/reviewer-fallback.md
+++ b/templates/agent-base/.opencode/agents/reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for correctness review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/scout-fallback.md
+++ b/templates/agent-base/.opencode/agents/scout-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for external primary-source research
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/scout.md
+++ b/templates/agent-base/.opencode/agents/scout.md
@@ -1,7 +1,7 @@
 ---
 description: External primary-source research specialist
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/security-reviewer-fallback.md
+++ b/templates/agent-base/.opencode/agents/security-reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for security-boundary review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-base/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-base/.opencode/agents/verifier.md
+++ b/templates/agent-base/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.automation/model-fallback.toml
+++ b/templates/agent-cpp-cmake/.automation/model-fallback.toml
@@ -29,14 +29,14 @@ non_fallback_markers = [
 primary_agent = "build"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["build-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = false
 
 [roles.architect]
 primary_agent = "architect"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["architect-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.task-orchestrator]
@@ -48,49 +48,49 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.reviewer]
 primary_agent = "reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.investigator]
 primary_agent = "investigator"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["investigator-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.security-reviewer]
 primary_agent = "security-reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["security-reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.scout]
 primary_agent = "scout"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["scout-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true

--- a/templates/agent-cpp-cmake/.opencode/agents/architect-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/architect-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for architecture analysis
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/build-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/build-fallback.md
@@ -2,7 +2,7 @@
 description: Manual usage-limit fallback for Main Orchestrator with identical authority
 mode: primary
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task:

--- a/templates/agent-cpp-cmake/.opencode/agents/explore-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/explore.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/general-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   question: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/general.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   question: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/investigator-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/investigator-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for root-cause investigation
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/reviewer-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for correctness review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/scout-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/scout-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for external primary-source research
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/scout.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/scout.md
@@ -1,7 +1,7 @@
 ---
 description: External primary-source research specialist
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/security-reviewer-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/security-reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for security-boundary review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-cpp-cmake/.opencode/agents/verifier.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.automation/model-fallback.toml
+++ b/templates/agent-nix/.automation/model-fallback.toml
@@ -29,14 +29,14 @@ non_fallback_markers = [
 primary_agent = "build"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["build-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = false
 
 [roles.architect]
 primary_agent = "architect"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["architect-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.task-orchestrator]
@@ -48,49 +48,49 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.reviewer]
 primary_agent = "reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.investigator]
 primary_agent = "investigator"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["investigator-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.security-reviewer]
 primary_agent = "security-reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["security-reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.scout]
 primary_agent = "scout"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["scout-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true

--- a/templates/agent-nix/.opencode/agents/architect-fallback.md
+++ b/templates/agent-nix/.opencode/agents/architect-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for architecture analysis
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/build-fallback.md
+++ b/templates/agent-nix/.opencode/agents/build-fallback.md
@@ -2,7 +2,7 @@
 description: Manual usage-limit fallback for Main Orchestrator with identical authority
 mode: primary
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task:

--- a/templates/agent-nix/.opencode/agents/explore-fallback.md
+++ b/templates/agent-nix/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/explore.md
+++ b/templates/agent-nix/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/general-fallback.md
+++ b/templates/agent-nix/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   question: deny

--- a/templates/agent-nix/.opencode/agents/general.md
+++ b/templates/agent-nix/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   question: deny

--- a/templates/agent-nix/.opencode/agents/investigator-fallback.md
+++ b/templates/agent-nix/.opencode/agents/investigator-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for root-cause investigation
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/reviewer-fallback.md
+++ b/templates/agent-nix/.opencode/agents/reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for correctness review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/scout-fallback.md
+++ b/templates/agent-nix/.opencode/agents/scout-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for external primary-source research
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/scout.md
+++ b/templates/agent-nix/.opencode/agents/scout.md
@@ -1,7 +1,7 @@
 ---
 description: External primary-source research specialist
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/security-reviewer-fallback.md
+++ b/templates/agent-nix/.opencode/agents/security-reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for security-boundary review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-nix/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-nix/.opencode/agents/verifier.md
+++ b/templates/agent-nix/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.automation/model-fallback.toml
+++ b/templates/agent-python/.automation/model-fallback.toml
@@ -29,14 +29,14 @@ non_fallback_markers = [
 primary_agent = "build"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["build-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = false
 
 [roles.architect]
 primary_agent = "architect"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["architect-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.task-orchestrator]
@@ -48,49 +48,49 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.reviewer]
 primary_agent = "reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.investigator]
 primary_agent = "investigator"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["investigator-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.security-reviewer]
 primary_agent = "security-reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["security-reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.scout]
 primary_agent = "scout"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["scout-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true

--- a/templates/agent-python/.opencode/agents/architect-fallback.md
+++ b/templates/agent-python/.opencode/agents/architect-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for architecture analysis
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/build-fallback.md
+++ b/templates/agent-python/.opencode/agents/build-fallback.md
@@ -2,7 +2,7 @@
 description: Manual usage-limit fallback for Main Orchestrator with identical authority
 mode: primary
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task:

--- a/templates/agent-python/.opencode/agents/explore-fallback.md
+++ b/templates/agent-python/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/explore.md
+++ b/templates/agent-python/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/general-fallback.md
+++ b/templates/agent-python/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   question: deny

--- a/templates/agent-python/.opencode/agents/general.md
+++ b/templates/agent-python/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   question: deny

--- a/templates/agent-python/.opencode/agents/investigator-fallback.md
+++ b/templates/agent-python/.opencode/agents/investigator-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for root-cause investigation
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/reviewer-fallback.md
+++ b/templates/agent-python/.opencode/agents/reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for correctness review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/scout-fallback.md
+++ b/templates/agent-python/.opencode/agents/scout-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for external primary-source research
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/scout.md
+++ b/templates/agent-python/.opencode/agents/scout.md
@@ -1,7 +1,7 @@
 ---
 description: External primary-source research specialist
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/security-reviewer-fallback.md
+++ b/templates/agent-python/.opencode/agents/security-reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for security-boundary review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-python/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-python/.opencode/agents/verifier.md
+++ b/templates/agent-python/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.automation/model-fallback.toml
+++ b/templates/agent-rust/.automation/model-fallback.toml
@@ -29,14 +29,14 @@ non_fallback_markers = [
 primary_agent = "build"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["build-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = false
 
 [roles.architect]
 primary_agent = "architect"
 primary_model = "openai/gpt-5.6-sol"
 fallback_agents = ["architect-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.task-orchestrator]
@@ -48,49 +48,49 @@ automatic = true
 
 [roles.general]
 primary_agent = "general"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["general-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.explore]
 primary_agent = "explore"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["explore-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.verifier]
 primary_agent = "verifier"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["verifier-fallback"]
-fallback_models = ["openai/gpt-5.3-codex-spark"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true
 
 [roles.reviewer]
 primary_agent = "reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.investigator]
 primary_agent = "investigator"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["investigator-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.security-reviewer]
 primary_agent = "security-reviewer"
 primary_model = "openai/gpt-5.6-terra"
 fallback_agents = ["security-reviewer-fallback"]
-fallback_models = ["openai/gpt-5.6-sol"]
+fallback_models = ["openai/gpt-5.3-codex-spark"]
 automatic = true
 
 [roles.scout]
 primary_agent = "scout"
-primary_model = "openai/gpt-5.6-luna"
+primary_model = "openai/gpt-5.3-codex-spark"
 fallback_agents = ["scout-fallback"]
-fallback_models = ["openai/gpt-5.6-terra"]
+fallback_models = ["openai/gpt-5.6-luna"]
 automatic = true

--- a/templates/agent-rust/.opencode/agents/architect-fallback.md
+++ b/templates/agent-rust/.opencode/agents/architect-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for architecture analysis
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/build-fallback.md
+++ b/templates/agent-rust/.opencode/agents/build-fallback.md
@@ -2,7 +2,7 @@
 description: Manual usage-limit fallback for Main Orchestrator with identical authority
 mode: primary
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task:

--- a/templates/agent-rust/.opencode/agents/explore-fallback.md
+++ b/templates/agent-rust/.opencode/agents/explore-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for repository exploration
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/explore.md
+++ b/templates/agent-rust/.opencode/agents/explore.md
@@ -1,7 +1,7 @@
 ---
 description: Read-only repository exploration and reference tracing
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/general-fallback.md
+++ b/templates/agent-rust/.opencode/agents/general-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for bounded implementation work
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   task: deny
   question: deny

--- a/templates/agent-rust/.opencode/agents/general.md
+++ b/templates/agent-rust/.opencode/agents/general.md
@@ -1,7 +1,7 @@
 ---
 description: Bounded implementation worker for one Work Unit
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   task: deny
   question: deny

--- a/templates/agent-rust/.opencode/agents/investigator-fallback.md
+++ b/templates/agent-rust/.opencode/agents/investigator-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for root-cause investigation
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/reviewer-fallback.md
+++ b/templates/agent-rust/.opencode/agents/reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for correctness review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/scout-fallback.md
+++ b/templates/agent-rust/.opencode/agents/scout-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for external primary-source research
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-terra
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/scout.md
+++ b/templates/agent-rust/.opencode/agents/scout.md
@@ -1,7 +1,7 @@
 ---
 description: External primary-source research specialist
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/security-reviewer-fallback.md
+++ b/templates/agent-rust/.opencode/agents/security-reviewer-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for security-boundary review
 mode: subagent
 hidden: true
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/verifier-fallback.md
+++ b/templates/agent-rust/.opencode/agents/verifier-fallback.md
@@ -2,7 +2,7 @@
 description: Usage-limit fallback for project verification
 mode: subagent
 hidden: true
-model: openai/gpt-5.3-codex-spark
+model: openai/gpt-5.6-luna
 permission:
   edit: deny
   task: deny

--- a/templates/agent-rust/.opencode/agents/verifier.md
+++ b/templates/agent-rust/.opencode/agents/verifier.md
@@ -1,7 +1,7 @@
 ---
 description: Executes project-standard verification without modifying source
 mode: subagent
-model: openai/gpt-5.6-luna
+model: openai/gpt-5.3-codex-spark
 permission:
   edit: deny
   task: deny

--- a/tests/test_model_fallback.py
+++ b/tests/test_model_fallback.py
@@ -37,18 +37,21 @@ class ModelFallbackTest(unittest.TestCase):
         self.assertEqual(result["agent"], "task-orchestrator-fallback")
         self.assertEqual(result["model"], "openai/gpt-5.6-sol")
 
-    def test_luna_roles_share_spark_fallback_chain(self) -> None:
-        for role in ("general", "explore", "verifier"):
+    def test_spark_roles_share_luna_fallback_chain(self) -> None:
+        for role in ("general", "explore", "verifier", "scout"):
             result = fallback.next_fallback(role, role, self.cfg)
             self.assertTrue(result["available"], role)
             self.assertEqual(result["agent"], f"{role}-fallback", role)
-            self.assertEqual(result["model"], "openai/gpt-5.3-codex-spark", role)
+            self.assertEqual(result["model"], "openai/gpt-5.6-luna", role)
 
     def test_primary_and_fallback_models_in_policy(self) -> None:
         expected = {
-            "general": ("openai/gpt-5.6-luna", "openai/gpt-5.3-codex-spark"),
-            "explore": ("openai/gpt-5.6-luna", "openai/gpt-5.3-codex-spark"),
-            "verifier": ("openai/gpt-5.6-luna", "openai/gpt-5.3-codex-spark"),
+            "general": ("openai/gpt-5.3-codex-spark", "openai/gpt-5.6-luna"),
+            "explore": ("openai/gpt-5.3-codex-spark", "openai/gpt-5.6-luna"),
+            "verifier": ("openai/gpt-5.3-codex-spark", "openai/gpt-5.6-luna"),
+            "scout": ("openai/gpt-5.3-codex-spark", "openai/gpt-5.6-luna"),
+            "architect": ("openai/gpt-5.6-sol", "openai/gpt-5.3-codex-spark"),
+            "reviewer": ("openai/gpt-5.6-terra", "openai/gpt-5.3-codex-spark"),
             "task-orchestrator": ("openai/gpt-5.3-codex-spark", "openai/gpt-5.6-sol"),
         }
         for role, (primary_model, fallback_model) in expected.items():
@@ -56,6 +59,14 @@ class ModelFallbackTest(unittest.TestCase):
             self.assertEqual(role_cfg["primary_model"], primary_model, role)
             self.assertEqual(role_cfg["fallback_models"], [fallback_model], role)
             self.assertEqual(role_cfg["fallback_agents"], [f"{role}-fallback"], role)
+
+    def test_no_five_six_primary_falls_back_to_five_six(self) -> None:
+        for role, role_cfg in self.cfg["roles"].items():
+            if role_cfg["primary_model"].startswith("openai/gpt-5.6-"):
+                self.assertFalse(
+                    any(model.startswith("openai/gpt-5.6-") for model in role_cfg["fallback_models"]),
+                    role,
+                )
 
     def test_chain_exhaustion_stops(self) -> None:
         result = fallback.next_fallback("general", "general-fallback", self.cfg)
@@ -77,8 +88,8 @@ class ModelFallbackTest(unittest.TestCase):
             fallback.append_evidence(
                 root,
                 "general",
-                "openai/gpt-5.6-luna",
                 "openai/gpt-5.3-codex-spark",
+                "openai/gpt-5.6-luna",
                 "usage limit",
                 "succeeded",
             )

--- a/tests/test_opencode_contract.py
+++ b/tests/test_opencode_contract.py
@@ -256,49 +256,49 @@ class OpenCodeContractTest(unittest.TestCase):
             "build.md": "openai/gpt-5.6-sol",
             "plan.md": "openai/gpt-5.6-sol",
             "task-orchestrator.md": "openai/gpt-5.3-codex-spark",
-            "general.md": "openai/gpt-5.6-luna",
-            "explore.md": "openai/gpt-5.6-luna",
-            "verifier.md": "openai/gpt-5.6-luna",
+            "general.md": "openai/gpt-5.3-codex-spark",
+            "explore.md": "openai/gpt-5.3-codex-spark",
+            "verifier.md": "openai/gpt-5.3-codex-spark",
             "reviewer.md": "openai/gpt-5.6-terra",
             "investigator.md": "openai/gpt-5.6-terra",
             "security-reviewer.md": "openai/gpt-5.6-terra",
-            "scout.md": "openai/gpt-5.6-luna",
+            "scout.md": "openai/gpt-5.3-codex-spark",
             "architect.md": "openai/gpt-5.6-sol",
         }
         for filename, model in expected.items():
             self.assertIn(f"model: {model}", frontmatter(AGENTS / filename), filename)
 
-    def test_task_orchestrator_is_only_spark_primary(self) -> None:
+    def test_spark_primary_agents(self) -> None:
         spark_primaries = {
             path.name
             for path in AGENTS.glob("*.md")
             if not path.name.endswith("-fallback.md")
             and "model: openai/gpt-5.3-codex-spark" in frontmatter(path)
         }
-        self.assertEqual(spark_primaries, {"task-orchestrator.md"})
+        self.assertEqual(spark_primaries, {"task-orchestrator.md", "general.md", "explore.md", "verifier.md", "scout.md"})
 
-    def test_luna_primary_agents(self) -> None:
-        expected_luna = {
-            "general.md",
-            "explore.md",
-            "verifier.md",
-            "scout.md",
+    def test_spark_leaf_fallback_agents(self) -> None:
+        expected_luna_fallback = {
+            "general-fallback.md",
+            "explore-fallback.md",
+            "verifier-fallback.md",
+            "scout-fallback.md",
         }
-        for filename in expected_luna:
+        for filename in expected_luna_fallback:
             self.assertIn("model: openai/gpt-5.6-luna", frontmatter(AGENTS / filename), filename)
 
     def test_fallback_model_assignment_is_exact(self) -> None:
         expected = {
-            "build-fallback.md": "openai/gpt-5.6-terra",
-            "architect-fallback.md": "openai/gpt-5.6-terra",
+            "build-fallback.md": "openai/gpt-5.3-codex-spark",
+            "architect-fallback.md": "openai/gpt-5.3-codex-spark",
             "task-orchestrator-fallback.md": "openai/gpt-5.6-sol",
-            "general-fallback.md": "openai/gpt-5.3-codex-spark",
-            "explore-fallback.md": "openai/gpt-5.3-codex-spark",
-            "verifier-fallback.md": "openai/gpt-5.3-codex-spark",
-            "reviewer-fallback.md": "openai/gpt-5.6-sol",
-            "investigator-fallback.md": "openai/gpt-5.6-sol",
-            "security-reviewer-fallback.md": "openai/gpt-5.6-sol",
-            "scout-fallback.md": "openai/gpt-5.6-terra",
+            "general-fallback.md": "openai/gpt-5.6-luna",
+            "explore-fallback.md": "openai/gpt-5.6-luna",
+            "verifier-fallback.md": "openai/gpt-5.6-luna",
+            "reviewer-fallback.md": "openai/gpt-5.3-codex-spark",
+            "investigator-fallback.md": "openai/gpt-5.3-codex-spark",
+            "security-reviewer-fallback.md": "openai/gpt-5.3-codex-spark",
+            "scout-fallback.md": "openai/gpt-5.6-luna",
         }
         for filename, model in expected.items():
             self.assertIn(f"model: {model}", frontmatter(AGENTS / filename), filename)


### PR DESCRIPTION
## Summary
- route each OpenCode fallback across token-quota families instead of falling back from one GPT-5.6 model to another
- use Spark as the fallback for Sol/Terra primary roles and Luna as the fallback for Spark primary roles
- preserve the Spark-to-Sol task-orchestrator policy, permissions, workflow routing, and Task lifecycle contracts
- regenerate all five Agent-ready templates from `components/agent-core/`

## Verification
- `nix develop --command python3 -m unittest discover -s tests`: 125 passed
- focused model and OpenCode contract tests: 25 passed
- model fallback tests: 10 passed
- render drift check: all 5 templates passed
- `git diff --check`: passed

## Risk
- Model selection changes can alter latency and response quality when fallback routing activates; exact role assignments and the no-5.6-to-5.6 invariant are covered by contract tests.

## Related
- Global dotnix configuration counterpart: upiscium/dotnix#6
