### PR TITLE
feat: pin OpenCodePolicy consumer check

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -17,6 +17,11 @@ jobs:
         run: python3 -m unittest discover -s tests -v
       - name: Generated template drift
         run: python3 tools/render_templates.py check
+      - uses: cachix/install-nix-action@v31
+      - name: Evaluate all flake systems
+        run: nix flake check --all-systems --no-build --no-update-lock-file
+      - name: OpenCodePolicy contract
+        run: nix build .#checks.x86_64-linux.opencode-policy --no-link --no-update-lock-file
 
   generated-template-smoke:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -226,6 +226,23 @@ Then require the repository CI/smoke suite. Automation Core changes must be revi
 
 ## Template development
 
+### OpenCodePolicy dependency
+
+The Templates source repository pins [`upiscium/OpenCodePolicy`](https://github.com/upiscium/OpenCodePolicy) through the root `flake.lock` and audits this checkout against the explicit `agent-core` profile. OpenCodePolicy owns the shared policy and compatibility contract; Templates remains the Agent Core implementation and distribution owner.
+
+The dependency is a Templates development and validation gate only. It is not rendered into generated templates, does not change `.automation/UPSTREAM`, and does not generate OpenCode configuration.
+
+Policy revisions advance only through an explicit dependency update:
+
+```sh
+nix flake update opencodePolicy
+nix flake check --no-update-lock-file
+python3 -m unittest discover -s tests -v
+just template::check
+```
+
+Review the resulting `flake.lock` diff and policy audit before merging. OpenCodePolicy `main` moving does not change Templates until this lockfile is deliberately updated.
+
 ```sh
 just template::render agent-base
 just template::render agent-python

--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,31 @@
         "type": "github"
       }
     },
+    "opencodePolicy": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786698952,
+        "narHash": "sha256-71KWm4YQV2PysPH9Np3IuMr2Fh1n0w7TuH5JfexQ6pE=",
+        "owner": "upiscium",
+        "repo": "OpenCodePolicy",
+        "rev": "e4ff446514c303fe275ba9eb3a4ab498caea7ac0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "upiscium",
+        "repo": "OpenCodePolicy",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "opencodePolicy": "opencodePolicy"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,20 +4,39 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    opencodePolicy = {
+      url = "github:upiscium/OpenCodePolicy";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, opencodePolicy }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system}; in {
-        devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
-            just
-            python3
-            git
-            gh
-          ];
-        };
-      })
+      if system == "x86_64-darwin" then { }
+      else
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          isLinux = pkgs.stdenv.hostPlatform.isLinux;
+        in {
+          devShells.default = pkgs.mkShell {
+            packages = with pkgs; [
+              just
+              python3
+              git
+              gh
+            ];
+          };
+        } // nixpkgs.lib.optionalAttrs isLinux {
+          checks.opencode-policy = pkgs.runCommand "templates-opencode-policy" {
+            nativeBuildInputs = [ opencodePolicy.packages.${system}.opencode-policy ];
+          } ''
+            opencode-policy audit-consumer \
+              --profile agent-core \
+              --consumer ${self} \
+              --strict
+            touch "$out"
+          '';
+        })
     // {
     templates = {
       python = {

--- a/tests/test_opencode_policy_integration.py
+++ b/tests/test_opencode_policy_integration.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES = (
+    "agent-base",
+    "agent-python",
+    "agent-rust",
+    "agent-nix",
+    "agent-cpp-cmake",
+)
+
+
+class OpenCodePolicyIntegrationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.flake = (ROOT / "flake.nix").read_text(encoding="utf-8")
+        cls.lock = json.loads((ROOT / "flake.lock").read_text(encoding="utf-8"))
+
+    def test_root_flake_declares_policy_input_and_nixpkgs_follow(self) -> None:
+        self.assertIn('opencodePolicy', self.flake)
+        self.assertIn('url = "github:upiscium/OpenCodePolicy";', self.flake)
+        self.assertIn('inputs.nixpkgs.follows = "nixpkgs";', self.flake)
+        self.assertRegex(self.flake, r"outputs\s*=\s*\{[^}]*\bopencodePolicy\b")
+
+    def test_lock_pins_opencode_policy_repository_and_revision(self) -> None:
+        node = self.lock["nodes"]["opencodePolicy"]
+        self.assertEqual("upiscium", node["locked"]["owner"])
+        self.assertEqual("OpenCodePolicy", node["locked"]["repo"])
+        self.assertRegex(node["locked"]["rev"], r"^[0-9a-f]{40}$")
+        self.assertEqual(["nixpkgs"], node["inputs"]["nixpkgs"])
+        self.assertEqual("opencodePolicy", self.lock["nodes"]["root"]["inputs"]["opencodePolicy"])
+
+    def test_linux_only_policy_check_uses_explicit_agent_core_profile_and_self(self) -> None:
+        self.assertIn("flake-utils.lib.eachDefaultSystem", self.flake)
+        self.assertIn('if system == "x86_64-darwin" then { }', self.flake)
+        self.assertIn("optionalAttrs isLinux", self.flake)
+        self.assertIn("checks.opencode-policy", self.flake)
+        self.assertIn("opencodePolicy.packages.${system}.opencode-policy", self.flake)
+        self.assertRegex(
+            self.flake,
+            re.compile(
+                r"opencode-policy audit-consumer\s+\\\s+"
+                r"--profile agent-core\s+\\\s+"
+                r"--consumer \$\{self\}\s+\\\s+"
+                r"--strict",
+                re.MULTILINE,
+            ),
+        )
+
+    def test_generated_template_flakes_do_not_receive_policy_input(self) -> None:
+        for template in TEMPLATES:
+            flake = ROOT / "templates" / template / "flake.nix"
+            self.assertNotIn("opencodePolicy", flake.read_text(encoding="utf-8"), template)
+
+    def test_agent_core_version_and_upstream_are_unchanged(self) -> None:
+        core = ROOT / "components" / "agent-core" / ".automation"
+        self.assertEqual("2\n", (core / "VERSION").read_text(encoding="utf-8"))
+        self.assertEqual(
+            'repository = "github:upiscium/Templates"\nref = "main"\n'
+            'component = "components/agent-core"\n',
+            (core / "UPSTREAM").read_text(encoding="utf-8"),
+        )
+
+    def test_ci_builds_locked_policy_check_without_cloning_policy(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "template-ci.yml").read_text(encoding="utf-8")
+        self.assertIn("cachix/install-nix-action@v31", workflow)
+        self.assertIn(
+            "nix flake check --all-systems --no-build --no-update-lock-file",
+            workflow,
+        )
+        self.assertIn(
+            "nix build .#checks.x86_64-linux.opencode-policy --no-link --no-update-lock-file",
+            workflow,
+        )
+        self.assertNotRegex(workflow, r"git\s+clone.*OpenCodePolicy")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Make the Templates source repository a lock-pinned OpenCodePolicy consumer and enforce the explicit `agent-core` conformity contract without propagating the dependency into generated templates.

## Dependency pin

- Adds root flake input `github:upiscium/OpenCodePolicy`.
- Makes the policy input's `nixpkgs` follow the Templates root `nixpkgs`.
- Pins OpenCodePolicy in `flake.lock` to `e4ff446514c303fe275ba9eb3a4ab498caea7ac0`.
- Existing nixpkgs, flake-utils, and systems lock nodes are unchanged.

## Nix policy check

Adds Linux-only `checks.<system>.opencode-policy` using the pinned package:

```text
opencode-policy audit-consumer --profile agent-core --consumer ${self} --strict
```

`${self}` is the read-only Nix store source. The audit does not clone dotnix, call GitHub, use a mutable checkout, or infer its profile.

## Linux and Darwin handling

- Policy package access is guarded by `optionalAttrs isLinux`.
- `x86_64-linux` and `aarch64-linux` expose the policy check.
- `aarch64-darwin` continues to evaluate its development shell without evaluating Linux-only policy packages.
- `x86_64-darwin` returns no per-system outputs because the existing pinned nixpkgs has dropped that platform; the early guard prevents all-system evaluation from failing.
- `nix flake check --all-systems --no-build --no-update-lock-file` passes and is enforced in CI.

## CI

The existing contracts job still runs:

- full Python contract tests
- generated template drift check

It now also:

- installs Nix
- evaluates all systems with the checked-in lock frozen
- builds `checks.x86_64-linux.opencode-policy` with `--no-update-lock-file`

No moving OpenCodePolicy checkout is cloned.

## Integration tests

Adds coverage for:

- root input and nixpkgs follow declaration
- exact repository identity and 40-character lock revision
- explicit `agent-core` and `${self}` check contract
- Linux-only/Darwin evaluation guards
- absence of OpenCodePolicy from all generated template flakes
- unchanged Agent Core VERSION and UPSTREAM
- frozen-lock CI gate and no OpenCodePolicy clone

## Verification

- Full Python suite: 146 tests passed
- `nix flake check --no-update-lock-file`: passed
- `nix flake check --all-systems --no-build --no-update-lock-file`: passed
- explicit policy check build: passed
- policy audit: `PASS=55 INTENTIONAL_DIFFERENCE=4 DIFF=0 MISSING=0`
- `just template::check`: passed for all five templates
- `just template::distribution-verify`: passed
- `git diff --check`: passed

## Negative drift evidence

A temporary Agent Core fixture changed `plan` from Sol to Terra. The pinned strict audit exited non-zero with:

`SUMMARY PASS=54 INTENTIONAL_DIFFERENCE=4 DIFF=1 MISSING=0`

The repository source was not modified by this test.

## Ownership and non-goals

- OpenCodePolicy owns shared policy/compatibility contracts.
- Templates remains Agent Core implementation/distribution owner.
- No generated template flake changed.
- Agent Core VERSION and `.automation/UPSTREAM` are unchanged.
- No OpenCodePolicy/dotnix changes, generation, materialization, submodule, automatic update, or runtime latest-main fetch.
- No readying or merge.