### PR TITLE
feat: add Agent Core v2 deletion-aware upgrade bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ just automation::upgrade /path/to/Templates
 
 It refuses the default branch and repositories without Task State. It materializes only Agent Core-owned paths and preserves Adapter-owned `.automation/ADAPTER`, `.automation/INIT.fragment.md`, `.automation/adoption.toml`, `just/project/**`, local modules, and repository CI.
 
+The upgrade system supports versioned removal migrations. Removals name explicit, exact Agent Core-managed paths; repository-owned and protected paths cannot be removed. Migration preconditions are checked before any mutation, and `.automation/VERSION` advances only after all deletion, creation, replacement, and merge actions succeed.
+
 Upgrade does not commit, push, or merge. Before publication, inspect the diff and run at minimum:
 
 ```sh

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -232,6 +232,8 @@ def migration_actions(
     for migration in migrations:
         transition = f"{migration.from_version} -> {migration.to_version}"
         for relative in migration.require_absent_paths:
+            if relative in deleted:
+                continue
             ancestor = symlink_ancestor(repo, relative)
             if ancestor is not None:
                 blockers.append(
@@ -387,7 +389,7 @@ def build_plan(repo: Path, source: Path) -> dict:
     selected = [
         migration
         for migration in migrations
-        if local_number < migration.to_version <= remote_number
+        if migration.to_version <= remote_number
     ]
     actions, blockers, deleted = migration_actions(repo, selected)
     if remote_number < local_number:

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tomllib
 from dataclasses import asdict, dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 class UpgradeError(RuntimeError):
@@ -22,6 +22,14 @@ class Action:
     path: str
     action: str
     reason: str
+
+
+@dataclass(frozen=True)
+class Migration:
+    from_version: int
+    to_version: int
+    remove_paths: tuple[Path, ...]
+    require_absent_paths: tuple[Path, ...]
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -96,6 +104,184 @@ def managed(relative: Path) -> bool:
     return False
 
 
+def deletable_managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text == "opencode.json" or text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+            ".automation/VERSION",
+        }
+    return False
+
+
+def version_number(repo: Path) -> int:
+    raw = version(repo)
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}") from exc
+    if parsed <= 0 or str(parsed) != raw:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}")
+    return parsed
+
+
+def migration_path(raw: object, *, field: str, managed_delete: bool) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise UpgradeError(f"migrations.toml {field} entries must be non-empty strings")
+    if "\\" in raw or any(character in raw for character in "*?[]{}"):
+        raise UpgradeError(f"migrations.toml {field} path must be exact repository-relative: {raw!r}")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or not pure.parts or any(part in {"", ".", ".."} for part in pure.parts):
+        raise UpgradeError(f"migrations.toml {field} path is unsafe: {raw!r}")
+    if pure.as_posix() != raw:
+        raise UpgradeError(f"migrations.toml {field} path is not normalized: {raw!r}")
+    relative = Path(*pure.parts)
+    if managed_delete and not deletable_managed(relative):
+        raise UpgradeError(f"migrations.toml remove_paths path is not Agent Core managed: {raw!r}")
+    return relative
+
+
+def load_migrations(source_core: Path) -> list[Migration]:
+    path = source_core / ".automation" / "migrations.toml"
+    if not path.is_file():
+        return []
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise UpgradeError(f"invalid migrations.toml: {exc}") from exc
+    unknown_top_level = set(raw) - {"schema_version", "migrations"}
+    if unknown_top_level:
+        raise UpgradeError(f"migrations.toml unknown top-level fields: {sorted(unknown_top_level)}")
+    if type(raw.get("schema_version")) is not int or raw["schema_version"] != 1:
+        raise UpgradeError("migrations.toml schema_version must be integer 1")
+    entries = raw.get("migrations", [])
+    if not isinstance(entries, list):
+        raise UpgradeError("migrations.toml migrations must be an array of tables")
+
+    migrations: list[Migration] = []
+    transitions: set[tuple[int, int]] = set()
+    required_fields = {"from_version", "to_version", "remove_paths", "require_absent_paths"}
+    for index, entry in enumerate(entries):
+        label = f"migrations.toml migrations[{index}]"
+        if not isinstance(entry, dict):
+            raise UpgradeError(f"{label} must be a table")
+        unknown = set(entry) - required_fields
+        missing = required_fields - set(entry)
+        if unknown:
+            raise UpgradeError(f"{label} unknown fields: {sorted(unknown)}")
+        if missing:
+            raise UpgradeError(f"{label} missing fields: {sorted(missing)}")
+        from_version = entry["from_version"]
+        to_version = entry["to_version"]
+        if type(from_version) is not int or type(to_version) is not int or from_version <= 0 or to_version <= 0:
+            raise UpgradeError(f"{label} versions must be positive integers")
+        if to_version != from_version + 1:
+            raise UpgradeError(f"{label} transition must advance exactly one version")
+        transition = (from_version, to_version)
+        if transition in transitions:
+            raise UpgradeError(f"{label} duplicates transition {from_version} -> {to_version}")
+        transitions.add(transition)
+
+        parsed_paths: dict[str, tuple[Path, ...]] = {}
+        for field, managed_delete in (("remove_paths", True), ("require_absent_paths", False)):
+            values = entry[field]
+            if not isinstance(values, list):
+                raise UpgradeError(f"{label}.{field} must be a list")
+            paths = tuple(
+                migration_path(value, field=f"{label}.{field}", managed_delete=managed_delete)
+                for value in values
+            )
+            if len(set(paths)) != len(paths):
+                raise UpgradeError(f"{label}.{field} contains duplicate paths")
+            parsed_paths[field] = paths
+        migrations.append(
+            Migration(
+                from_version=from_version,
+                to_version=to_version,
+                remove_paths=parsed_paths["remove_paths"],
+                require_absent_paths=parsed_paths["require_absent_paths"],
+            )
+        )
+    return sorted(migrations, key=lambda item: (item.to_version, item.from_version))
+
+
+def path_present(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def symlink_ancestor(repo: Path, relative: Path) -> Path | None:
+    current = repo
+    for part in relative.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            return current.relative_to(repo)
+    return None
+
+
+def migration_actions(
+    repo: Path,
+    migrations: list[Migration],
+) -> tuple[list[Action], list[str], set[Path]]:
+    actions: list[Action] = []
+    blockers: list[str] = []
+    deleted: set[Path] = set()
+    for migration in migrations:
+        transition = f"{migration.from_version} -> {migration.to_version}"
+        for relative in migration.require_absent_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: "
+                    f"symlink ancestor {ancestor.as_posix()} is unsafe; operator must remove or replace it"
+                )
+            elif path_present(repo / relative):
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: path must be absent; "
+                    "operator must resolve it before upgrading"
+                )
+        for relative in migration.remove_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "blocked",
+                        f"migration {transition} delete has symlink ancestor {ancestor.as_posix()}",
+                    )
+                )
+                continue
+            destination = repo / relative
+            if relative in deleted:
+                continue
+            if not path_present(destination):
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "noop",
+                        f"already absent for Agent Core migration {transition}",
+                    )
+                )
+                continue
+            if destination.is_symlink() or destination.is_file():
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "delete",
+                        f"removed by Agent Core migration {transition}",
+                    )
+                )
+                deleted.add(relative)
+            elif destination.is_dir():
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses directory deletion"))
+            else:
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses special-file deletion"))
+    return actions, blockers, deleted
+
+
 def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
     begin = "<!-- BEGIN AGENT CORE RULES -->"
     end = "<!-- END AGENT CORE RULES -->"
@@ -140,6 +326,24 @@ def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
     return "\n".join(lines) + suffix, "merge Agent Core router declarations"
 
 
+def write_topology_blocker(repo: Path, relative: Path, planned_deletes: set[Path]) -> str | None:
+    current = repo
+    current_relative = Path()
+    for part in relative.parts[:-1]:
+        current /= part
+        current_relative /= part
+        if current_relative in planned_deletes:
+            return None
+        if current.is_symlink():
+            return f"symlink ancestor {current_relative.as_posix()} cannot be upgraded safely"
+        if path_present(current) and not current.is_dir():
+            return f"non-directory ancestor {current_relative.as_posix()} blocks managed path"
+    destination = repo / relative
+    if relative not in planned_deletes and destination.is_symlink():
+        return "destination symlink cannot be upgraded safely"
+    return None
+
+
 def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
     rel = relative.as_posix()
     destination = repo / relative
@@ -175,17 +379,35 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
+    local_number = version_number(repo)
     source_core = source / "components" / "agent-core"
+    remote_number = version_number(source_core)
     ownership = load_ownership(repo)
-    actions: list[Action] = []
+    migrations = load_migrations(source_core)
+    selected = [
+        migration
+        for migration in migrations
+        if local_number < migration.to_version <= remote_number
+    ]
+    actions, blockers, deleted = migration_actions(repo, selected)
+    if remote_number < local_number:
+        blockers.append(
+            f"source Agent Core VERSION {remote_number} is older than local VERSION {local_number}; downgrade is forbidden"
+        )
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
         if managed(relative):
-            actions.append(action_for(repo, source_core, relative, ownership))
-    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
-    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+            topology_blocker = write_topology_blocker(repo, relative, deleted)
+            if topology_blocker:
+                actions.append(Action(relative.as_posix(), "blocked", topology_blocker))
+            elif relative in deleted:
+                actions.append(Action(relative.as_posix(), "create", "reintroduced after an Agent Core migration"))
+            else:
+                actions.append(action_for(repo, source_core, relative, ownership))
+    blockers.extend(f"{item.path}: {item.reason}" for item in actions if item.action == "blocked")
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge", "delete"}]
     return {
         "currentVersion": local,
         "upstreamVersion": remote,
@@ -224,16 +446,56 @@ def apply(repo: Path, source: Path) -> dict:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
-    for item in plan["actions"]:
-        if item["action"] == "noop":
-            continue
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    preflight_blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        destination = repo / relative
+        if item["action"] == "delete":
+            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
+                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(repo, relative, planned_deletes)
+            if blocker:
+                preflight_blockers.append(f"{item['path']}: {blocker}")
+    if preflight_blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
+
+    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
+    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered_actions = sorted(
+        ordinary_actions,
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + version_actions
+    for item in ordered_actions:
         relative = Path(item["path"])
         source_path = source_core / relative
         destination = repo / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if destination.is_symlink() or destination.is_file():
+                destination.unlink()
+            elif path_present(destination):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+            changed.append(item["path"])
+            continue
+        topology_blocker = write_topology_blocker(repo, relative, set())
+        if topology_blocker:
+            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
         destination.parent.mkdir(parents=True, exist_ok=True)
         if item["action"] in {"create", "replace"}:
+            if destination.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
             shutil.copy2(source_path, destination)
         elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            if destination.is_symlink():
+                raise UpgradeError("AGENTS.md became a symlink after planning")
             merged, detail = replace_agent_rules(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )
@@ -241,6 +503,8 @@ def apply(repo: Path, source: Path) -> dict:
                 raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
             destination.write_text(merged, encoding="utf-8")
         elif item["action"] == "merge" and item["path"] == "Justfile":
+            if destination.is_symlink():
+                raise UpgradeError("Justfile became a symlink after planning")
             merged, detail = merge_just_router(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )

--- a/components/agent-core/.automation/migrations.toml
+++ b/components/agent-core/.automation/migrations.toml
@@ -1,0 +1,1 @@
+schema_version = 1

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -232,6 +232,8 @@ def migration_actions(
     for migration in migrations:
         transition = f"{migration.from_version} -> {migration.to_version}"
         for relative in migration.require_absent_paths:
+            if relative in deleted:
+                continue
             ancestor = symlink_ancestor(repo, relative)
             if ancestor is not None:
                 blockers.append(
@@ -387,7 +389,7 @@ def build_plan(repo: Path, source: Path) -> dict:
     selected = [
         migration
         for migration in migrations
-        if local_number < migration.to_version <= remote_number
+        if migration.to_version <= remote_number
     ]
     actions, blockers, deleted = migration_actions(repo, selected)
     if remote_number < local_number:

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tomllib
 from dataclasses import asdict, dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 class UpgradeError(RuntimeError):
@@ -22,6 +22,14 @@ class Action:
     path: str
     action: str
     reason: str
+
+
+@dataclass(frozen=True)
+class Migration:
+    from_version: int
+    to_version: int
+    remove_paths: tuple[Path, ...]
+    require_absent_paths: tuple[Path, ...]
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -96,6 +104,184 @@ def managed(relative: Path) -> bool:
     return False
 
 
+def deletable_managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text == "opencode.json" or text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+            ".automation/VERSION",
+        }
+    return False
+
+
+def version_number(repo: Path) -> int:
+    raw = version(repo)
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}") from exc
+    if parsed <= 0 or str(parsed) != raw:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}")
+    return parsed
+
+
+def migration_path(raw: object, *, field: str, managed_delete: bool) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise UpgradeError(f"migrations.toml {field} entries must be non-empty strings")
+    if "\\" in raw or any(character in raw for character in "*?[]{}"):
+        raise UpgradeError(f"migrations.toml {field} path must be exact repository-relative: {raw!r}")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or not pure.parts or any(part in {"", ".", ".."} for part in pure.parts):
+        raise UpgradeError(f"migrations.toml {field} path is unsafe: {raw!r}")
+    if pure.as_posix() != raw:
+        raise UpgradeError(f"migrations.toml {field} path is not normalized: {raw!r}")
+    relative = Path(*pure.parts)
+    if managed_delete and not deletable_managed(relative):
+        raise UpgradeError(f"migrations.toml remove_paths path is not Agent Core managed: {raw!r}")
+    return relative
+
+
+def load_migrations(source_core: Path) -> list[Migration]:
+    path = source_core / ".automation" / "migrations.toml"
+    if not path.is_file():
+        return []
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise UpgradeError(f"invalid migrations.toml: {exc}") from exc
+    unknown_top_level = set(raw) - {"schema_version", "migrations"}
+    if unknown_top_level:
+        raise UpgradeError(f"migrations.toml unknown top-level fields: {sorted(unknown_top_level)}")
+    if type(raw.get("schema_version")) is not int or raw["schema_version"] != 1:
+        raise UpgradeError("migrations.toml schema_version must be integer 1")
+    entries = raw.get("migrations", [])
+    if not isinstance(entries, list):
+        raise UpgradeError("migrations.toml migrations must be an array of tables")
+
+    migrations: list[Migration] = []
+    transitions: set[tuple[int, int]] = set()
+    required_fields = {"from_version", "to_version", "remove_paths", "require_absent_paths"}
+    for index, entry in enumerate(entries):
+        label = f"migrations.toml migrations[{index}]"
+        if not isinstance(entry, dict):
+            raise UpgradeError(f"{label} must be a table")
+        unknown = set(entry) - required_fields
+        missing = required_fields - set(entry)
+        if unknown:
+            raise UpgradeError(f"{label} unknown fields: {sorted(unknown)}")
+        if missing:
+            raise UpgradeError(f"{label} missing fields: {sorted(missing)}")
+        from_version = entry["from_version"]
+        to_version = entry["to_version"]
+        if type(from_version) is not int or type(to_version) is not int or from_version <= 0 or to_version <= 0:
+            raise UpgradeError(f"{label} versions must be positive integers")
+        if to_version != from_version + 1:
+            raise UpgradeError(f"{label} transition must advance exactly one version")
+        transition = (from_version, to_version)
+        if transition in transitions:
+            raise UpgradeError(f"{label} duplicates transition {from_version} -> {to_version}")
+        transitions.add(transition)
+
+        parsed_paths: dict[str, tuple[Path, ...]] = {}
+        for field, managed_delete in (("remove_paths", True), ("require_absent_paths", False)):
+            values = entry[field]
+            if not isinstance(values, list):
+                raise UpgradeError(f"{label}.{field} must be a list")
+            paths = tuple(
+                migration_path(value, field=f"{label}.{field}", managed_delete=managed_delete)
+                for value in values
+            )
+            if len(set(paths)) != len(paths):
+                raise UpgradeError(f"{label}.{field} contains duplicate paths")
+            parsed_paths[field] = paths
+        migrations.append(
+            Migration(
+                from_version=from_version,
+                to_version=to_version,
+                remove_paths=parsed_paths["remove_paths"],
+                require_absent_paths=parsed_paths["require_absent_paths"],
+            )
+        )
+    return sorted(migrations, key=lambda item: (item.to_version, item.from_version))
+
+
+def path_present(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def symlink_ancestor(repo: Path, relative: Path) -> Path | None:
+    current = repo
+    for part in relative.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            return current.relative_to(repo)
+    return None
+
+
+def migration_actions(
+    repo: Path,
+    migrations: list[Migration],
+) -> tuple[list[Action], list[str], set[Path]]:
+    actions: list[Action] = []
+    blockers: list[str] = []
+    deleted: set[Path] = set()
+    for migration in migrations:
+        transition = f"{migration.from_version} -> {migration.to_version}"
+        for relative in migration.require_absent_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: "
+                    f"symlink ancestor {ancestor.as_posix()} is unsafe; operator must remove or replace it"
+                )
+            elif path_present(repo / relative):
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: path must be absent; "
+                    "operator must resolve it before upgrading"
+                )
+        for relative in migration.remove_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "blocked",
+                        f"migration {transition} delete has symlink ancestor {ancestor.as_posix()}",
+                    )
+                )
+                continue
+            destination = repo / relative
+            if relative in deleted:
+                continue
+            if not path_present(destination):
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "noop",
+                        f"already absent for Agent Core migration {transition}",
+                    )
+                )
+                continue
+            if destination.is_symlink() or destination.is_file():
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "delete",
+                        f"removed by Agent Core migration {transition}",
+                    )
+                )
+                deleted.add(relative)
+            elif destination.is_dir():
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses directory deletion"))
+            else:
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses special-file deletion"))
+    return actions, blockers, deleted
+
+
 def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
     begin = "<!-- BEGIN AGENT CORE RULES -->"
     end = "<!-- END AGENT CORE RULES -->"
@@ -140,6 +326,24 @@ def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
     return "\n".join(lines) + suffix, "merge Agent Core router declarations"
 
 
+def write_topology_blocker(repo: Path, relative: Path, planned_deletes: set[Path]) -> str | None:
+    current = repo
+    current_relative = Path()
+    for part in relative.parts[:-1]:
+        current /= part
+        current_relative /= part
+        if current_relative in planned_deletes:
+            return None
+        if current.is_symlink():
+            return f"symlink ancestor {current_relative.as_posix()} cannot be upgraded safely"
+        if path_present(current) and not current.is_dir():
+            return f"non-directory ancestor {current_relative.as_posix()} blocks managed path"
+    destination = repo / relative
+    if relative not in planned_deletes and destination.is_symlink():
+        return "destination symlink cannot be upgraded safely"
+    return None
+
+
 def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
     rel = relative.as_posix()
     destination = repo / relative
@@ -175,17 +379,35 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
+    local_number = version_number(repo)
     source_core = source / "components" / "agent-core"
+    remote_number = version_number(source_core)
     ownership = load_ownership(repo)
-    actions: list[Action] = []
+    migrations = load_migrations(source_core)
+    selected = [
+        migration
+        for migration in migrations
+        if local_number < migration.to_version <= remote_number
+    ]
+    actions, blockers, deleted = migration_actions(repo, selected)
+    if remote_number < local_number:
+        blockers.append(
+            f"source Agent Core VERSION {remote_number} is older than local VERSION {local_number}; downgrade is forbidden"
+        )
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
         if managed(relative):
-            actions.append(action_for(repo, source_core, relative, ownership))
-    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
-    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+            topology_blocker = write_topology_blocker(repo, relative, deleted)
+            if topology_blocker:
+                actions.append(Action(relative.as_posix(), "blocked", topology_blocker))
+            elif relative in deleted:
+                actions.append(Action(relative.as_posix(), "create", "reintroduced after an Agent Core migration"))
+            else:
+                actions.append(action_for(repo, source_core, relative, ownership))
+    blockers.extend(f"{item.path}: {item.reason}" for item in actions if item.action == "blocked")
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge", "delete"}]
     return {
         "currentVersion": local,
         "upstreamVersion": remote,
@@ -224,16 +446,56 @@ def apply(repo: Path, source: Path) -> dict:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
-    for item in plan["actions"]:
-        if item["action"] == "noop":
-            continue
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    preflight_blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        destination = repo / relative
+        if item["action"] == "delete":
+            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
+                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(repo, relative, planned_deletes)
+            if blocker:
+                preflight_blockers.append(f"{item['path']}: {blocker}")
+    if preflight_blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
+
+    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
+    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered_actions = sorted(
+        ordinary_actions,
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + version_actions
+    for item in ordered_actions:
         relative = Path(item["path"])
         source_path = source_core / relative
         destination = repo / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if destination.is_symlink() or destination.is_file():
+                destination.unlink()
+            elif path_present(destination):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+            changed.append(item["path"])
+            continue
+        topology_blocker = write_topology_blocker(repo, relative, set())
+        if topology_blocker:
+            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
         destination.parent.mkdir(parents=True, exist_ok=True)
         if item["action"] in {"create", "replace"}:
+            if destination.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
             shutil.copy2(source_path, destination)
         elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            if destination.is_symlink():
+                raise UpgradeError("AGENTS.md became a symlink after planning")
             merged, detail = replace_agent_rules(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )
@@ -241,6 +503,8 @@ def apply(repo: Path, source: Path) -> dict:
                 raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
             destination.write_text(merged, encoding="utf-8")
         elif item["action"] == "merge" and item["path"] == "Justfile":
+            if destination.is_symlink():
+                raise UpgradeError("Justfile became a symlink after planning")
             merged, detail = merge_just_router(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )

--- a/templates/agent-base/.automation/migrations.toml
+++ b/templates/agent-base/.automation/migrations.toml
@@ -1,0 +1,1 @@
+schema_version = 1

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -232,6 +232,8 @@ def migration_actions(
     for migration in migrations:
         transition = f"{migration.from_version} -> {migration.to_version}"
         for relative in migration.require_absent_paths:
+            if relative in deleted:
+                continue
             ancestor = symlink_ancestor(repo, relative)
             if ancestor is not None:
                 blockers.append(
@@ -387,7 +389,7 @@ def build_plan(repo: Path, source: Path) -> dict:
     selected = [
         migration
         for migration in migrations
-        if local_number < migration.to_version <= remote_number
+        if migration.to_version <= remote_number
     ]
     actions, blockers, deleted = migration_actions(repo, selected)
     if remote_number < local_number:

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tomllib
 from dataclasses import asdict, dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 class UpgradeError(RuntimeError):
@@ -22,6 +22,14 @@ class Action:
     path: str
     action: str
     reason: str
+
+
+@dataclass(frozen=True)
+class Migration:
+    from_version: int
+    to_version: int
+    remove_paths: tuple[Path, ...]
+    require_absent_paths: tuple[Path, ...]
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -96,6 +104,184 @@ def managed(relative: Path) -> bool:
     return False
 
 
+def deletable_managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text == "opencode.json" or text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+            ".automation/VERSION",
+        }
+    return False
+
+
+def version_number(repo: Path) -> int:
+    raw = version(repo)
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}") from exc
+    if parsed <= 0 or str(parsed) != raw:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}")
+    return parsed
+
+
+def migration_path(raw: object, *, field: str, managed_delete: bool) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise UpgradeError(f"migrations.toml {field} entries must be non-empty strings")
+    if "\\" in raw or any(character in raw for character in "*?[]{}"):
+        raise UpgradeError(f"migrations.toml {field} path must be exact repository-relative: {raw!r}")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or not pure.parts or any(part in {"", ".", ".."} for part in pure.parts):
+        raise UpgradeError(f"migrations.toml {field} path is unsafe: {raw!r}")
+    if pure.as_posix() != raw:
+        raise UpgradeError(f"migrations.toml {field} path is not normalized: {raw!r}")
+    relative = Path(*pure.parts)
+    if managed_delete and not deletable_managed(relative):
+        raise UpgradeError(f"migrations.toml remove_paths path is not Agent Core managed: {raw!r}")
+    return relative
+
+
+def load_migrations(source_core: Path) -> list[Migration]:
+    path = source_core / ".automation" / "migrations.toml"
+    if not path.is_file():
+        return []
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise UpgradeError(f"invalid migrations.toml: {exc}") from exc
+    unknown_top_level = set(raw) - {"schema_version", "migrations"}
+    if unknown_top_level:
+        raise UpgradeError(f"migrations.toml unknown top-level fields: {sorted(unknown_top_level)}")
+    if type(raw.get("schema_version")) is not int or raw["schema_version"] != 1:
+        raise UpgradeError("migrations.toml schema_version must be integer 1")
+    entries = raw.get("migrations", [])
+    if not isinstance(entries, list):
+        raise UpgradeError("migrations.toml migrations must be an array of tables")
+
+    migrations: list[Migration] = []
+    transitions: set[tuple[int, int]] = set()
+    required_fields = {"from_version", "to_version", "remove_paths", "require_absent_paths"}
+    for index, entry in enumerate(entries):
+        label = f"migrations.toml migrations[{index}]"
+        if not isinstance(entry, dict):
+            raise UpgradeError(f"{label} must be a table")
+        unknown = set(entry) - required_fields
+        missing = required_fields - set(entry)
+        if unknown:
+            raise UpgradeError(f"{label} unknown fields: {sorted(unknown)}")
+        if missing:
+            raise UpgradeError(f"{label} missing fields: {sorted(missing)}")
+        from_version = entry["from_version"]
+        to_version = entry["to_version"]
+        if type(from_version) is not int or type(to_version) is not int or from_version <= 0 or to_version <= 0:
+            raise UpgradeError(f"{label} versions must be positive integers")
+        if to_version != from_version + 1:
+            raise UpgradeError(f"{label} transition must advance exactly one version")
+        transition = (from_version, to_version)
+        if transition in transitions:
+            raise UpgradeError(f"{label} duplicates transition {from_version} -> {to_version}")
+        transitions.add(transition)
+
+        parsed_paths: dict[str, tuple[Path, ...]] = {}
+        for field, managed_delete in (("remove_paths", True), ("require_absent_paths", False)):
+            values = entry[field]
+            if not isinstance(values, list):
+                raise UpgradeError(f"{label}.{field} must be a list")
+            paths = tuple(
+                migration_path(value, field=f"{label}.{field}", managed_delete=managed_delete)
+                for value in values
+            )
+            if len(set(paths)) != len(paths):
+                raise UpgradeError(f"{label}.{field} contains duplicate paths")
+            parsed_paths[field] = paths
+        migrations.append(
+            Migration(
+                from_version=from_version,
+                to_version=to_version,
+                remove_paths=parsed_paths["remove_paths"],
+                require_absent_paths=parsed_paths["require_absent_paths"],
+            )
+        )
+    return sorted(migrations, key=lambda item: (item.to_version, item.from_version))
+
+
+def path_present(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def symlink_ancestor(repo: Path, relative: Path) -> Path | None:
+    current = repo
+    for part in relative.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            return current.relative_to(repo)
+    return None
+
+
+def migration_actions(
+    repo: Path,
+    migrations: list[Migration],
+) -> tuple[list[Action], list[str], set[Path]]:
+    actions: list[Action] = []
+    blockers: list[str] = []
+    deleted: set[Path] = set()
+    for migration in migrations:
+        transition = f"{migration.from_version} -> {migration.to_version}"
+        for relative in migration.require_absent_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: "
+                    f"symlink ancestor {ancestor.as_posix()} is unsafe; operator must remove or replace it"
+                )
+            elif path_present(repo / relative):
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: path must be absent; "
+                    "operator must resolve it before upgrading"
+                )
+        for relative in migration.remove_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "blocked",
+                        f"migration {transition} delete has symlink ancestor {ancestor.as_posix()}",
+                    )
+                )
+                continue
+            destination = repo / relative
+            if relative in deleted:
+                continue
+            if not path_present(destination):
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "noop",
+                        f"already absent for Agent Core migration {transition}",
+                    )
+                )
+                continue
+            if destination.is_symlink() or destination.is_file():
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "delete",
+                        f"removed by Agent Core migration {transition}",
+                    )
+                )
+                deleted.add(relative)
+            elif destination.is_dir():
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses directory deletion"))
+            else:
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses special-file deletion"))
+    return actions, blockers, deleted
+
+
 def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
     begin = "<!-- BEGIN AGENT CORE RULES -->"
     end = "<!-- END AGENT CORE RULES -->"
@@ -140,6 +326,24 @@ def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
     return "\n".join(lines) + suffix, "merge Agent Core router declarations"
 
 
+def write_topology_blocker(repo: Path, relative: Path, planned_deletes: set[Path]) -> str | None:
+    current = repo
+    current_relative = Path()
+    for part in relative.parts[:-1]:
+        current /= part
+        current_relative /= part
+        if current_relative in planned_deletes:
+            return None
+        if current.is_symlink():
+            return f"symlink ancestor {current_relative.as_posix()} cannot be upgraded safely"
+        if path_present(current) and not current.is_dir():
+            return f"non-directory ancestor {current_relative.as_posix()} blocks managed path"
+    destination = repo / relative
+    if relative not in planned_deletes and destination.is_symlink():
+        return "destination symlink cannot be upgraded safely"
+    return None
+
+
 def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
     rel = relative.as_posix()
     destination = repo / relative
@@ -175,17 +379,35 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
+    local_number = version_number(repo)
     source_core = source / "components" / "agent-core"
+    remote_number = version_number(source_core)
     ownership = load_ownership(repo)
-    actions: list[Action] = []
+    migrations = load_migrations(source_core)
+    selected = [
+        migration
+        for migration in migrations
+        if local_number < migration.to_version <= remote_number
+    ]
+    actions, blockers, deleted = migration_actions(repo, selected)
+    if remote_number < local_number:
+        blockers.append(
+            f"source Agent Core VERSION {remote_number} is older than local VERSION {local_number}; downgrade is forbidden"
+        )
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
         if managed(relative):
-            actions.append(action_for(repo, source_core, relative, ownership))
-    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
-    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+            topology_blocker = write_topology_blocker(repo, relative, deleted)
+            if topology_blocker:
+                actions.append(Action(relative.as_posix(), "blocked", topology_blocker))
+            elif relative in deleted:
+                actions.append(Action(relative.as_posix(), "create", "reintroduced after an Agent Core migration"))
+            else:
+                actions.append(action_for(repo, source_core, relative, ownership))
+    blockers.extend(f"{item.path}: {item.reason}" for item in actions if item.action == "blocked")
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge", "delete"}]
     return {
         "currentVersion": local,
         "upstreamVersion": remote,
@@ -224,16 +446,56 @@ def apply(repo: Path, source: Path) -> dict:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
-    for item in plan["actions"]:
-        if item["action"] == "noop":
-            continue
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    preflight_blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        destination = repo / relative
+        if item["action"] == "delete":
+            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
+                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(repo, relative, planned_deletes)
+            if blocker:
+                preflight_blockers.append(f"{item['path']}: {blocker}")
+    if preflight_blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
+
+    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
+    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered_actions = sorted(
+        ordinary_actions,
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + version_actions
+    for item in ordered_actions:
         relative = Path(item["path"])
         source_path = source_core / relative
         destination = repo / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if destination.is_symlink() or destination.is_file():
+                destination.unlink()
+            elif path_present(destination):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+            changed.append(item["path"])
+            continue
+        topology_blocker = write_topology_blocker(repo, relative, set())
+        if topology_blocker:
+            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
         destination.parent.mkdir(parents=True, exist_ok=True)
         if item["action"] in {"create", "replace"}:
+            if destination.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
             shutil.copy2(source_path, destination)
         elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            if destination.is_symlink():
+                raise UpgradeError("AGENTS.md became a symlink after planning")
             merged, detail = replace_agent_rules(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )
@@ -241,6 +503,8 @@ def apply(repo: Path, source: Path) -> dict:
                 raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
             destination.write_text(merged, encoding="utf-8")
         elif item["action"] == "merge" and item["path"] == "Justfile":
+            if destination.is_symlink():
+                raise UpgradeError("Justfile became a symlink after planning")
             merged, detail = merge_just_router(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )

--- a/templates/agent-cpp-cmake/.automation/migrations.toml
+++ b/templates/agent-cpp-cmake/.automation/migrations.toml
@@ -1,0 +1,1 @@
+schema_version = 1

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -232,6 +232,8 @@ def migration_actions(
     for migration in migrations:
         transition = f"{migration.from_version} -> {migration.to_version}"
         for relative in migration.require_absent_paths:
+            if relative in deleted:
+                continue
             ancestor = symlink_ancestor(repo, relative)
             if ancestor is not None:
                 blockers.append(
@@ -387,7 +389,7 @@ def build_plan(repo: Path, source: Path) -> dict:
     selected = [
         migration
         for migration in migrations
-        if local_number < migration.to_version <= remote_number
+        if migration.to_version <= remote_number
     ]
     actions, blockers, deleted = migration_actions(repo, selected)
     if remote_number < local_number:

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tomllib
 from dataclasses import asdict, dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 class UpgradeError(RuntimeError):
@@ -22,6 +22,14 @@ class Action:
     path: str
     action: str
     reason: str
+
+
+@dataclass(frozen=True)
+class Migration:
+    from_version: int
+    to_version: int
+    remove_paths: tuple[Path, ...]
+    require_absent_paths: tuple[Path, ...]
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -96,6 +104,184 @@ def managed(relative: Path) -> bool:
     return False
 
 
+def deletable_managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text == "opencode.json" or text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+            ".automation/VERSION",
+        }
+    return False
+
+
+def version_number(repo: Path) -> int:
+    raw = version(repo)
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}") from exc
+    if parsed <= 0 or str(parsed) != raw:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}")
+    return parsed
+
+
+def migration_path(raw: object, *, field: str, managed_delete: bool) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise UpgradeError(f"migrations.toml {field} entries must be non-empty strings")
+    if "\\" in raw or any(character in raw for character in "*?[]{}"):
+        raise UpgradeError(f"migrations.toml {field} path must be exact repository-relative: {raw!r}")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or not pure.parts or any(part in {"", ".", ".."} for part in pure.parts):
+        raise UpgradeError(f"migrations.toml {field} path is unsafe: {raw!r}")
+    if pure.as_posix() != raw:
+        raise UpgradeError(f"migrations.toml {field} path is not normalized: {raw!r}")
+    relative = Path(*pure.parts)
+    if managed_delete and not deletable_managed(relative):
+        raise UpgradeError(f"migrations.toml remove_paths path is not Agent Core managed: {raw!r}")
+    return relative
+
+
+def load_migrations(source_core: Path) -> list[Migration]:
+    path = source_core / ".automation" / "migrations.toml"
+    if not path.is_file():
+        return []
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise UpgradeError(f"invalid migrations.toml: {exc}") from exc
+    unknown_top_level = set(raw) - {"schema_version", "migrations"}
+    if unknown_top_level:
+        raise UpgradeError(f"migrations.toml unknown top-level fields: {sorted(unknown_top_level)}")
+    if type(raw.get("schema_version")) is not int or raw["schema_version"] != 1:
+        raise UpgradeError("migrations.toml schema_version must be integer 1")
+    entries = raw.get("migrations", [])
+    if not isinstance(entries, list):
+        raise UpgradeError("migrations.toml migrations must be an array of tables")
+
+    migrations: list[Migration] = []
+    transitions: set[tuple[int, int]] = set()
+    required_fields = {"from_version", "to_version", "remove_paths", "require_absent_paths"}
+    for index, entry in enumerate(entries):
+        label = f"migrations.toml migrations[{index}]"
+        if not isinstance(entry, dict):
+            raise UpgradeError(f"{label} must be a table")
+        unknown = set(entry) - required_fields
+        missing = required_fields - set(entry)
+        if unknown:
+            raise UpgradeError(f"{label} unknown fields: {sorted(unknown)}")
+        if missing:
+            raise UpgradeError(f"{label} missing fields: {sorted(missing)}")
+        from_version = entry["from_version"]
+        to_version = entry["to_version"]
+        if type(from_version) is not int or type(to_version) is not int or from_version <= 0 or to_version <= 0:
+            raise UpgradeError(f"{label} versions must be positive integers")
+        if to_version != from_version + 1:
+            raise UpgradeError(f"{label} transition must advance exactly one version")
+        transition = (from_version, to_version)
+        if transition in transitions:
+            raise UpgradeError(f"{label} duplicates transition {from_version} -> {to_version}")
+        transitions.add(transition)
+
+        parsed_paths: dict[str, tuple[Path, ...]] = {}
+        for field, managed_delete in (("remove_paths", True), ("require_absent_paths", False)):
+            values = entry[field]
+            if not isinstance(values, list):
+                raise UpgradeError(f"{label}.{field} must be a list")
+            paths = tuple(
+                migration_path(value, field=f"{label}.{field}", managed_delete=managed_delete)
+                for value in values
+            )
+            if len(set(paths)) != len(paths):
+                raise UpgradeError(f"{label}.{field} contains duplicate paths")
+            parsed_paths[field] = paths
+        migrations.append(
+            Migration(
+                from_version=from_version,
+                to_version=to_version,
+                remove_paths=parsed_paths["remove_paths"],
+                require_absent_paths=parsed_paths["require_absent_paths"],
+            )
+        )
+    return sorted(migrations, key=lambda item: (item.to_version, item.from_version))
+
+
+def path_present(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def symlink_ancestor(repo: Path, relative: Path) -> Path | None:
+    current = repo
+    for part in relative.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            return current.relative_to(repo)
+    return None
+
+
+def migration_actions(
+    repo: Path,
+    migrations: list[Migration],
+) -> tuple[list[Action], list[str], set[Path]]:
+    actions: list[Action] = []
+    blockers: list[str] = []
+    deleted: set[Path] = set()
+    for migration in migrations:
+        transition = f"{migration.from_version} -> {migration.to_version}"
+        for relative in migration.require_absent_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: "
+                    f"symlink ancestor {ancestor.as_posix()} is unsafe; operator must remove or replace it"
+                )
+            elif path_present(repo / relative):
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: path must be absent; "
+                    "operator must resolve it before upgrading"
+                )
+        for relative in migration.remove_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "blocked",
+                        f"migration {transition} delete has symlink ancestor {ancestor.as_posix()}",
+                    )
+                )
+                continue
+            destination = repo / relative
+            if relative in deleted:
+                continue
+            if not path_present(destination):
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "noop",
+                        f"already absent for Agent Core migration {transition}",
+                    )
+                )
+                continue
+            if destination.is_symlink() or destination.is_file():
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "delete",
+                        f"removed by Agent Core migration {transition}",
+                    )
+                )
+                deleted.add(relative)
+            elif destination.is_dir():
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses directory deletion"))
+            else:
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses special-file deletion"))
+    return actions, blockers, deleted
+
+
 def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
     begin = "<!-- BEGIN AGENT CORE RULES -->"
     end = "<!-- END AGENT CORE RULES -->"
@@ -140,6 +326,24 @@ def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
     return "\n".join(lines) + suffix, "merge Agent Core router declarations"
 
 
+def write_topology_blocker(repo: Path, relative: Path, planned_deletes: set[Path]) -> str | None:
+    current = repo
+    current_relative = Path()
+    for part in relative.parts[:-1]:
+        current /= part
+        current_relative /= part
+        if current_relative in planned_deletes:
+            return None
+        if current.is_symlink():
+            return f"symlink ancestor {current_relative.as_posix()} cannot be upgraded safely"
+        if path_present(current) and not current.is_dir():
+            return f"non-directory ancestor {current_relative.as_posix()} blocks managed path"
+    destination = repo / relative
+    if relative not in planned_deletes and destination.is_symlink():
+        return "destination symlink cannot be upgraded safely"
+    return None
+
+
 def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
     rel = relative.as_posix()
     destination = repo / relative
@@ -175,17 +379,35 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
+    local_number = version_number(repo)
     source_core = source / "components" / "agent-core"
+    remote_number = version_number(source_core)
     ownership = load_ownership(repo)
-    actions: list[Action] = []
+    migrations = load_migrations(source_core)
+    selected = [
+        migration
+        for migration in migrations
+        if local_number < migration.to_version <= remote_number
+    ]
+    actions, blockers, deleted = migration_actions(repo, selected)
+    if remote_number < local_number:
+        blockers.append(
+            f"source Agent Core VERSION {remote_number} is older than local VERSION {local_number}; downgrade is forbidden"
+        )
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
         if managed(relative):
-            actions.append(action_for(repo, source_core, relative, ownership))
-    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
-    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+            topology_blocker = write_topology_blocker(repo, relative, deleted)
+            if topology_blocker:
+                actions.append(Action(relative.as_posix(), "blocked", topology_blocker))
+            elif relative in deleted:
+                actions.append(Action(relative.as_posix(), "create", "reintroduced after an Agent Core migration"))
+            else:
+                actions.append(action_for(repo, source_core, relative, ownership))
+    blockers.extend(f"{item.path}: {item.reason}" for item in actions if item.action == "blocked")
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge", "delete"}]
     return {
         "currentVersion": local,
         "upstreamVersion": remote,
@@ -224,16 +446,56 @@ def apply(repo: Path, source: Path) -> dict:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
-    for item in plan["actions"]:
-        if item["action"] == "noop":
-            continue
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    preflight_blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        destination = repo / relative
+        if item["action"] == "delete":
+            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
+                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(repo, relative, planned_deletes)
+            if blocker:
+                preflight_blockers.append(f"{item['path']}: {blocker}")
+    if preflight_blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
+
+    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
+    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered_actions = sorted(
+        ordinary_actions,
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + version_actions
+    for item in ordered_actions:
         relative = Path(item["path"])
         source_path = source_core / relative
         destination = repo / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if destination.is_symlink() or destination.is_file():
+                destination.unlink()
+            elif path_present(destination):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+            changed.append(item["path"])
+            continue
+        topology_blocker = write_topology_blocker(repo, relative, set())
+        if topology_blocker:
+            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
         destination.parent.mkdir(parents=True, exist_ok=True)
         if item["action"] in {"create", "replace"}:
+            if destination.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
             shutil.copy2(source_path, destination)
         elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            if destination.is_symlink():
+                raise UpgradeError("AGENTS.md became a symlink after planning")
             merged, detail = replace_agent_rules(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )
@@ -241,6 +503,8 @@ def apply(repo: Path, source: Path) -> dict:
                 raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
             destination.write_text(merged, encoding="utf-8")
         elif item["action"] == "merge" and item["path"] == "Justfile":
+            if destination.is_symlink():
+                raise UpgradeError("Justfile became a symlink after planning")
             merged, detail = merge_just_router(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )

--- a/templates/agent-nix/.automation/migrations.toml
+++ b/templates/agent-nix/.automation/migrations.toml
@@ -1,0 +1,1 @@
+schema_version = 1

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -232,6 +232,8 @@ def migration_actions(
     for migration in migrations:
         transition = f"{migration.from_version} -> {migration.to_version}"
         for relative in migration.require_absent_paths:
+            if relative in deleted:
+                continue
             ancestor = symlink_ancestor(repo, relative)
             if ancestor is not None:
                 blockers.append(
@@ -387,7 +389,7 @@ def build_plan(repo: Path, source: Path) -> dict:
     selected = [
         migration
         for migration in migrations
-        if local_number < migration.to_version <= remote_number
+        if migration.to_version <= remote_number
     ]
     actions, blockers, deleted = migration_actions(repo, selected)
     if remote_number < local_number:

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tomllib
 from dataclasses import asdict, dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 class UpgradeError(RuntimeError):
@@ -22,6 +22,14 @@ class Action:
     path: str
     action: str
     reason: str
+
+
+@dataclass(frozen=True)
+class Migration:
+    from_version: int
+    to_version: int
+    remove_paths: tuple[Path, ...]
+    require_absent_paths: tuple[Path, ...]
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -96,6 +104,184 @@ def managed(relative: Path) -> bool:
     return False
 
 
+def deletable_managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text == "opencode.json" or text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+            ".automation/VERSION",
+        }
+    return False
+
+
+def version_number(repo: Path) -> int:
+    raw = version(repo)
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}") from exc
+    if parsed <= 0 or str(parsed) != raw:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}")
+    return parsed
+
+
+def migration_path(raw: object, *, field: str, managed_delete: bool) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise UpgradeError(f"migrations.toml {field} entries must be non-empty strings")
+    if "\\" in raw or any(character in raw for character in "*?[]{}"):
+        raise UpgradeError(f"migrations.toml {field} path must be exact repository-relative: {raw!r}")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or not pure.parts or any(part in {"", ".", ".."} for part in pure.parts):
+        raise UpgradeError(f"migrations.toml {field} path is unsafe: {raw!r}")
+    if pure.as_posix() != raw:
+        raise UpgradeError(f"migrations.toml {field} path is not normalized: {raw!r}")
+    relative = Path(*pure.parts)
+    if managed_delete and not deletable_managed(relative):
+        raise UpgradeError(f"migrations.toml remove_paths path is not Agent Core managed: {raw!r}")
+    return relative
+
+
+def load_migrations(source_core: Path) -> list[Migration]:
+    path = source_core / ".automation" / "migrations.toml"
+    if not path.is_file():
+        return []
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise UpgradeError(f"invalid migrations.toml: {exc}") from exc
+    unknown_top_level = set(raw) - {"schema_version", "migrations"}
+    if unknown_top_level:
+        raise UpgradeError(f"migrations.toml unknown top-level fields: {sorted(unknown_top_level)}")
+    if type(raw.get("schema_version")) is not int or raw["schema_version"] != 1:
+        raise UpgradeError("migrations.toml schema_version must be integer 1")
+    entries = raw.get("migrations", [])
+    if not isinstance(entries, list):
+        raise UpgradeError("migrations.toml migrations must be an array of tables")
+
+    migrations: list[Migration] = []
+    transitions: set[tuple[int, int]] = set()
+    required_fields = {"from_version", "to_version", "remove_paths", "require_absent_paths"}
+    for index, entry in enumerate(entries):
+        label = f"migrations.toml migrations[{index}]"
+        if not isinstance(entry, dict):
+            raise UpgradeError(f"{label} must be a table")
+        unknown = set(entry) - required_fields
+        missing = required_fields - set(entry)
+        if unknown:
+            raise UpgradeError(f"{label} unknown fields: {sorted(unknown)}")
+        if missing:
+            raise UpgradeError(f"{label} missing fields: {sorted(missing)}")
+        from_version = entry["from_version"]
+        to_version = entry["to_version"]
+        if type(from_version) is not int or type(to_version) is not int or from_version <= 0 or to_version <= 0:
+            raise UpgradeError(f"{label} versions must be positive integers")
+        if to_version != from_version + 1:
+            raise UpgradeError(f"{label} transition must advance exactly one version")
+        transition = (from_version, to_version)
+        if transition in transitions:
+            raise UpgradeError(f"{label} duplicates transition {from_version} -> {to_version}")
+        transitions.add(transition)
+
+        parsed_paths: dict[str, tuple[Path, ...]] = {}
+        for field, managed_delete in (("remove_paths", True), ("require_absent_paths", False)):
+            values = entry[field]
+            if not isinstance(values, list):
+                raise UpgradeError(f"{label}.{field} must be a list")
+            paths = tuple(
+                migration_path(value, field=f"{label}.{field}", managed_delete=managed_delete)
+                for value in values
+            )
+            if len(set(paths)) != len(paths):
+                raise UpgradeError(f"{label}.{field} contains duplicate paths")
+            parsed_paths[field] = paths
+        migrations.append(
+            Migration(
+                from_version=from_version,
+                to_version=to_version,
+                remove_paths=parsed_paths["remove_paths"],
+                require_absent_paths=parsed_paths["require_absent_paths"],
+            )
+        )
+    return sorted(migrations, key=lambda item: (item.to_version, item.from_version))
+
+
+def path_present(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def symlink_ancestor(repo: Path, relative: Path) -> Path | None:
+    current = repo
+    for part in relative.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            return current.relative_to(repo)
+    return None
+
+
+def migration_actions(
+    repo: Path,
+    migrations: list[Migration],
+) -> tuple[list[Action], list[str], set[Path]]:
+    actions: list[Action] = []
+    blockers: list[str] = []
+    deleted: set[Path] = set()
+    for migration in migrations:
+        transition = f"{migration.from_version} -> {migration.to_version}"
+        for relative in migration.require_absent_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: "
+                    f"symlink ancestor {ancestor.as_posix()} is unsafe; operator must remove or replace it"
+                )
+            elif path_present(repo / relative):
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: path must be absent; "
+                    "operator must resolve it before upgrading"
+                )
+        for relative in migration.remove_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "blocked",
+                        f"migration {transition} delete has symlink ancestor {ancestor.as_posix()}",
+                    )
+                )
+                continue
+            destination = repo / relative
+            if relative in deleted:
+                continue
+            if not path_present(destination):
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "noop",
+                        f"already absent for Agent Core migration {transition}",
+                    )
+                )
+                continue
+            if destination.is_symlink() or destination.is_file():
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "delete",
+                        f"removed by Agent Core migration {transition}",
+                    )
+                )
+                deleted.add(relative)
+            elif destination.is_dir():
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses directory deletion"))
+            else:
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses special-file deletion"))
+    return actions, blockers, deleted
+
+
 def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
     begin = "<!-- BEGIN AGENT CORE RULES -->"
     end = "<!-- END AGENT CORE RULES -->"
@@ -140,6 +326,24 @@ def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
     return "\n".join(lines) + suffix, "merge Agent Core router declarations"
 
 
+def write_topology_blocker(repo: Path, relative: Path, planned_deletes: set[Path]) -> str | None:
+    current = repo
+    current_relative = Path()
+    for part in relative.parts[:-1]:
+        current /= part
+        current_relative /= part
+        if current_relative in planned_deletes:
+            return None
+        if current.is_symlink():
+            return f"symlink ancestor {current_relative.as_posix()} cannot be upgraded safely"
+        if path_present(current) and not current.is_dir():
+            return f"non-directory ancestor {current_relative.as_posix()} blocks managed path"
+    destination = repo / relative
+    if relative not in planned_deletes and destination.is_symlink():
+        return "destination symlink cannot be upgraded safely"
+    return None
+
+
 def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
     rel = relative.as_posix()
     destination = repo / relative
@@ -175,17 +379,35 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
+    local_number = version_number(repo)
     source_core = source / "components" / "agent-core"
+    remote_number = version_number(source_core)
     ownership = load_ownership(repo)
-    actions: list[Action] = []
+    migrations = load_migrations(source_core)
+    selected = [
+        migration
+        for migration in migrations
+        if local_number < migration.to_version <= remote_number
+    ]
+    actions, blockers, deleted = migration_actions(repo, selected)
+    if remote_number < local_number:
+        blockers.append(
+            f"source Agent Core VERSION {remote_number} is older than local VERSION {local_number}; downgrade is forbidden"
+        )
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
         if managed(relative):
-            actions.append(action_for(repo, source_core, relative, ownership))
-    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
-    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+            topology_blocker = write_topology_blocker(repo, relative, deleted)
+            if topology_blocker:
+                actions.append(Action(relative.as_posix(), "blocked", topology_blocker))
+            elif relative in deleted:
+                actions.append(Action(relative.as_posix(), "create", "reintroduced after an Agent Core migration"))
+            else:
+                actions.append(action_for(repo, source_core, relative, ownership))
+    blockers.extend(f"{item.path}: {item.reason}" for item in actions if item.action == "blocked")
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge", "delete"}]
     return {
         "currentVersion": local,
         "upstreamVersion": remote,
@@ -224,16 +446,56 @@ def apply(repo: Path, source: Path) -> dict:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
-    for item in plan["actions"]:
-        if item["action"] == "noop":
-            continue
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    preflight_blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        destination = repo / relative
+        if item["action"] == "delete":
+            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
+                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(repo, relative, planned_deletes)
+            if blocker:
+                preflight_blockers.append(f"{item['path']}: {blocker}")
+    if preflight_blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
+
+    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
+    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered_actions = sorted(
+        ordinary_actions,
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + version_actions
+    for item in ordered_actions:
         relative = Path(item["path"])
         source_path = source_core / relative
         destination = repo / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if destination.is_symlink() or destination.is_file():
+                destination.unlink()
+            elif path_present(destination):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+            changed.append(item["path"])
+            continue
+        topology_blocker = write_topology_blocker(repo, relative, set())
+        if topology_blocker:
+            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
         destination.parent.mkdir(parents=True, exist_ok=True)
         if item["action"] in {"create", "replace"}:
+            if destination.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
             shutil.copy2(source_path, destination)
         elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            if destination.is_symlink():
+                raise UpgradeError("AGENTS.md became a symlink after planning")
             merged, detail = replace_agent_rules(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )
@@ -241,6 +503,8 @@ def apply(repo: Path, source: Path) -> dict:
                 raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
             destination.write_text(merged, encoding="utf-8")
         elif item["action"] == "merge" and item["path"] == "Justfile":
+            if destination.is_symlink():
+                raise UpgradeError("Justfile became a symlink after planning")
             merged, detail = merge_just_router(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )

--- a/templates/agent-python/.automation/migrations.toml
+++ b/templates/agent-python/.automation/migrations.toml
@@ -1,0 +1,1 @@
+schema_version = 1

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -232,6 +232,8 @@ def migration_actions(
     for migration in migrations:
         transition = f"{migration.from_version} -> {migration.to_version}"
         for relative in migration.require_absent_paths:
+            if relative in deleted:
+                continue
             ancestor = symlink_ancestor(repo, relative)
             if ancestor is not None:
                 blockers.append(
@@ -387,7 +389,7 @@ def build_plan(repo: Path, source: Path) -> dict:
     selected = [
         migration
         for migration in migrations
-        if local_number < migration.to_version <= remote_number
+        if migration.to_version <= remote_number
     ]
     actions, blockers, deleted = migration_actions(repo, selected)
     if remote_number < local_number:

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tomllib
 from dataclasses import asdict, dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 class UpgradeError(RuntimeError):
@@ -22,6 +22,14 @@ class Action:
     path: str
     action: str
     reason: str
+
+
+@dataclass(frozen=True)
+class Migration:
+    from_version: int
+    to_version: int
+    remove_paths: tuple[Path, ...]
+    require_absent_paths: tuple[Path, ...]
 
 
 def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -96,6 +104,184 @@ def managed(relative: Path) -> bool:
     return False
 
 
+def deletable_managed(relative: Path) -> bool:
+    text = relative.as_posix()
+    if text == "opencode.json" or text.startswith(".opencode/"):
+        return True
+    if text.startswith(".automation/"):
+        return text not in {
+            ".automation/ADAPTER",
+            ".automation/INIT.fragment.md",
+            ".automation/adoption.toml",
+            ".automation/VERSION",
+        }
+    return False
+
+
+def version_number(repo: Path) -> int:
+    raw = version(repo)
+    try:
+        parsed = int(raw)
+    except ValueError as exc:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}") from exc
+    if parsed <= 0 or str(parsed) != raw:
+        raise UpgradeError(f"invalid Agent Core VERSION: {raw!r}")
+    return parsed
+
+
+def migration_path(raw: object, *, field: str, managed_delete: bool) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise UpgradeError(f"migrations.toml {field} entries must be non-empty strings")
+    if "\\" in raw or any(character in raw for character in "*?[]{}"):
+        raise UpgradeError(f"migrations.toml {field} path must be exact repository-relative: {raw!r}")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or not pure.parts or any(part in {"", ".", ".."} for part in pure.parts):
+        raise UpgradeError(f"migrations.toml {field} path is unsafe: {raw!r}")
+    if pure.as_posix() != raw:
+        raise UpgradeError(f"migrations.toml {field} path is not normalized: {raw!r}")
+    relative = Path(*pure.parts)
+    if managed_delete and not deletable_managed(relative):
+        raise UpgradeError(f"migrations.toml remove_paths path is not Agent Core managed: {raw!r}")
+    return relative
+
+
+def load_migrations(source_core: Path) -> list[Migration]:
+    path = source_core / ".automation" / "migrations.toml"
+    if not path.is_file():
+        return []
+    try:
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise UpgradeError(f"invalid migrations.toml: {exc}") from exc
+    unknown_top_level = set(raw) - {"schema_version", "migrations"}
+    if unknown_top_level:
+        raise UpgradeError(f"migrations.toml unknown top-level fields: {sorted(unknown_top_level)}")
+    if type(raw.get("schema_version")) is not int or raw["schema_version"] != 1:
+        raise UpgradeError("migrations.toml schema_version must be integer 1")
+    entries = raw.get("migrations", [])
+    if not isinstance(entries, list):
+        raise UpgradeError("migrations.toml migrations must be an array of tables")
+
+    migrations: list[Migration] = []
+    transitions: set[tuple[int, int]] = set()
+    required_fields = {"from_version", "to_version", "remove_paths", "require_absent_paths"}
+    for index, entry in enumerate(entries):
+        label = f"migrations.toml migrations[{index}]"
+        if not isinstance(entry, dict):
+            raise UpgradeError(f"{label} must be a table")
+        unknown = set(entry) - required_fields
+        missing = required_fields - set(entry)
+        if unknown:
+            raise UpgradeError(f"{label} unknown fields: {sorted(unknown)}")
+        if missing:
+            raise UpgradeError(f"{label} missing fields: {sorted(missing)}")
+        from_version = entry["from_version"]
+        to_version = entry["to_version"]
+        if type(from_version) is not int or type(to_version) is not int or from_version <= 0 or to_version <= 0:
+            raise UpgradeError(f"{label} versions must be positive integers")
+        if to_version != from_version + 1:
+            raise UpgradeError(f"{label} transition must advance exactly one version")
+        transition = (from_version, to_version)
+        if transition in transitions:
+            raise UpgradeError(f"{label} duplicates transition {from_version} -> {to_version}")
+        transitions.add(transition)
+
+        parsed_paths: dict[str, tuple[Path, ...]] = {}
+        for field, managed_delete in (("remove_paths", True), ("require_absent_paths", False)):
+            values = entry[field]
+            if not isinstance(values, list):
+                raise UpgradeError(f"{label}.{field} must be a list")
+            paths = tuple(
+                migration_path(value, field=f"{label}.{field}", managed_delete=managed_delete)
+                for value in values
+            )
+            if len(set(paths)) != len(paths):
+                raise UpgradeError(f"{label}.{field} contains duplicate paths")
+            parsed_paths[field] = paths
+        migrations.append(
+            Migration(
+                from_version=from_version,
+                to_version=to_version,
+                remove_paths=parsed_paths["remove_paths"],
+                require_absent_paths=parsed_paths["require_absent_paths"],
+            )
+        )
+    return sorted(migrations, key=lambda item: (item.to_version, item.from_version))
+
+
+def path_present(path: Path) -> bool:
+    return os.path.lexists(path)
+
+
+def symlink_ancestor(repo: Path, relative: Path) -> Path | None:
+    current = repo
+    for part in relative.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            return current.relative_to(repo)
+    return None
+
+
+def migration_actions(
+    repo: Path,
+    migrations: list[Migration],
+) -> tuple[list[Action], list[str], set[Path]]:
+    actions: list[Action] = []
+    blockers: list[str] = []
+    deleted: set[Path] = set()
+    for migration in migrations:
+        transition = f"{migration.from_version} -> {migration.to_version}"
+        for relative in migration.require_absent_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: "
+                    f"symlink ancestor {ancestor.as_posix()} is unsafe; operator must remove or replace it"
+                )
+            elif path_present(repo / relative):
+                blockers.append(
+                    f"migration {transition} precondition {relative.as_posix()}: path must be absent; "
+                    "operator must resolve it before upgrading"
+                )
+        for relative in migration.remove_paths:
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "blocked",
+                        f"migration {transition} delete has symlink ancestor {ancestor.as_posix()}",
+                    )
+                )
+                continue
+            destination = repo / relative
+            if relative in deleted:
+                continue
+            if not path_present(destination):
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "noop",
+                        f"already absent for Agent Core migration {transition}",
+                    )
+                )
+                continue
+            if destination.is_symlink() or destination.is_file():
+                actions.append(
+                    Action(
+                        relative.as_posix(),
+                        "delete",
+                        f"removed by Agent Core migration {transition}",
+                    )
+                )
+                deleted.add(relative)
+            elif destination.is_dir():
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses directory deletion"))
+            else:
+                actions.append(Action(relative.as_posix(), "blocked", f"migration {transition} refuses special-file deletion"))
+    return actions, blockers, deleted
+
+
 def replace_agent_rules(existing: str, upstream_rules: str) -> tuple[str | None, str]:
     begin = "<!-- BEGIN AGENT CORE RULES -->"
     end = "<!-- END AGENT CORE RULES -->"
@@ -140,6 +326,24 @@ def merge_just_router(existing: str, upstream: str) -> tuple[str | None, str]:
     return "\n".join(lines) + suffix, "merge Agent Core router declarations"
 
 
+def write_topology_blocker(repo: Path, relative: Path, planned_deletes: set[Path]) -> str | None:
+    current = repo
+    current_relative = Path()
+    for part in relative.parts[:-1]:
+        current /= part
+        current_relative /= part
+        if current_relative in planned_deletes:
+            return None
+        if current.is_symlink():
+            return f"symlink ancestor {current_relative.as_posix()} cannot be upgraded safely"
+        if path_present(current) and not current.is_dir():
+            return f"non-directory ancestor {current_relative.as_posix()} blocks managed path"
+    destination = repo / relative
+    if relative not in planned_deletes and destination.is_symlink():
+        return "destination symlink cannot be upgraded safely"
+    return None
+
+
 def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[str, str]) -> Action:
     rel = relative.as_posix()
     destination = repo / relative
@@ -175,17 +379,35 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
+    local_number = version_number(repo)
     source_core = source / "components" / "agent-core"
+    remote_number = version_number(source_core)
     ownership = load_ownership(repo)
-    actions: list[Action] = []
+    migrations = load_migrations(source_core)
+    selected = [
+        migration
+        for migration in migrations
+        if local_number < migration.to_version <= remote_number
+    ]
+    actions, blockers, deleted = migration_actions(repo, selected)
+    if remote_number < local_number:
+        blockers.append(
+            f"source Agent Core VERSION {remote_number} is older than local VERSION {local_number}; downgrade is forbidden"
+        )
     for path in sorted(source_core.rglob("*")):
         if not path.is_file():
             continue
         relative = path.relative_to(source_core)
         if managed(relative):
-            actions.append(action_for(repo, source_core, relative, ownership))
-    blockers = [f"{item.path}: {item.reason}" for item in actions if item.action == "blocked"]
-    changed = [item.path for item in actions if item.action in {"create", "replace", "merge"}]
+            topology_blocker = write_topology_blocker(repo, relative, deleted)
+            if topology_blocker:
+                actions.append(Action(relative.as_posix(), "blocked", topology_blocker))
+            elif relative in deleted:
+                actions.append(Action(relative.as_posix(), "create", "reintroduced after an Agent Core migration"))
+            else:
+                actions.append(action_for(repo, source_core, relative, ownership))
+    blockers.extend(f"{item.path}: {item.reason}" for item in actions if item.action == "blocked")
+    changed = [item.path for item in actions if item.action in {"create", "replace", "merge", "delete"}]
     return {
         "currentVersion": local,
         "upstreamVersion": remote,
@@ -224,16 +446,56 @@ def apply(repo: Path, source: Path) -> dict:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
-    for item in plan["actions"]:
-        if item["action"] == "noop":
-            continue
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    preflight_blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        destination = repo / relative
+        if item["action"] == "delete":
+            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
+                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(repo, relative, planned_deletes)
+            if blocker:
+                preflight_blockers.append(f"{item['path']}: {blocker}")
+    if preflight_blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
+
+    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
+    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered_actions = sorted(
+        ordinary_actions,
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + version_actions
+    for item in ordered_actions:
         relative = Path(item["path"])
         source_path = source_core / relative
         destination = repo / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(repo, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if destination.is_symlink() or destination.is_file():
+                destination.unlink()
+            elif path_present(destination):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+            changed.append(item["path"])
+            continue
+        topology_blocker = write_topology_blocker(repo, relative, set())
+        if topology_blocker:
+            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
         destination.parent.mkdir(parents=True, exist_ok=True)
         if item["action"] in {"create", "replace"}:
+            if destination.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
             shutil.copy2(source_path, destination)
         elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+            if destination.is_symlink():
+                raise UpgradeError("AGENTS.md became a symlink after planning")
             merged, detail = replace_agent_rules(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )
@@ -241,6 +503,8 @@ def apply(repo: Path, source: Path) -> dict:
                 raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
             destination.write_text(merged, encoding="utf-8")
         elif item["action"] == "merge" and item["path"] == "Justfile":
+            if destination.is_symlink():
+                raise UpgradeError("Justfile became a symlink after planning")
             merged, detail = merge_just_router(
                 destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
             )

--- a/templates/agent-rust/.automation/migrations.toml
+++ b/templates/agent-rust/.automation/migrations.toml
@@ -1,0 +1,1 @@
+schema_version = 1

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -5,7 +5,10 @@ import json
 import sys
 import tempfile
 import unittest
+import os
+import shutil
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "components" / "agent-core" / ".automation" / "bin" / "automation_upgrade.py"
@@ -17,6 +20,115 @@ SPEC.loader.exec_module(upgrade)
 
 
 class AutomationUpgradeContractTest(unittest.TestCase):
+    TEMPLATE_NAMES = ("agent-base", "agent-python", "agent-rust", "agent-nix", "agent-cpp-cmake")
+
+    def _write_file(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+    def _field(self, value, name: str):
+        if isinstance(value, dict):
+            return value[name]
+        return getattr(value, name)
+
+    def _require_migration_api(self) -> None:
+        for fn in ("load_migrations", "build_plan", "apply"):
+            if not hasattr(upgrade, fn):
+                self.skipTest(f"{fn} API is not present in this checkout")
+
+    def _core_root_source(self, source_root: Path, *, version: int = 3, migrations: str | None = None) -> Path:
+        source = source_root / "components" / "agent-core"
+        auto = source / ".automation"
+        auto.mkdir(parents=True)
+
+        migration_body = migrations if migrations is not None else "schema_version = 1\n"
+        self._write_file(auto / "migrations.toml", migration_body)
+        self._write_file(auto / "VERSION", f"{version}\n")
+
+        self._write_file(
+            source / "AGENTS.md",
+            """<!-- BEGIN AGENT CORE RULES -->
+core rules
+<!-- END AGENT CORE RULES -->
+""",
+        )
+        self._write_file(
+            source / "Justfile",
+            """# Agent Core module router
+mod agent '.automation/just/agent.just'
+mod project 'just/project/mod.just'
+""",
+        )
+        self._write_file(source / "opencode.json", "{}\n")
+        self._write_file(auto / "UPSTREAM", 'repository = "github:upiscium/Templates"\nref = "main"\ncomponent = "components/agent-core"\n')
+        return source
+
+    def _destination_repo(self, repo_root: Path, *, version: int = 2) -> Path:
+        self._write_file(repo_root / ".automation" / "VERSION", f"{version}\n")
+        self._write_file(
+            repo_root / ".automation" / "ADAPTER",
+            "base\n",
+        )
+        self._write_file(
+            repo_root / ".automation" / "UPSTREAM",
+            'repository = "github:upiscium/Templates"\nref = "main"\ncomponent = "components/agent-core"\n',
+        )
+        self._write_file(
+            repo_root / ".automation" / "ownership.toml",
+            'version = 1\n\n[paths]\n"AGENTS.md" = "replace"\n"Justfile" = "replace"\n',
+        )
+
+        self._write_file(
+            repo_root / "AGENTS.md",
+            """<!-- BEGIN AGENT CORE RULES -->
+existing core rules
+<!-- END AGENT CORE RULES -->
+""",
+        )
+        self._write_file(
+            repo_root / "Justfile",
+            """# Agent Core module router
+mod agent '.automation/just/agent.just'
+mod project 'just/project/mod.just'
+""",
+        )
+        self._write_file(repo_root / "opencode.json", "{}\n")
+        return repo_root
+
+    def _plan_action(self, plan: dict, path: str):
+        for item in plan["actions"]:
+            if item["path"] == path:
+                return item
+        return None
+
+    def _manifest(self, transitions: list[str], *, extra_top: str = "") -> str:
+        body = ["schema_version = 1", ""]
+        if extra_top:
+            body.append(extra_top)
+            body.append("")
+        body.extend(transitions)
+        return "\n".join(body)
+
+    def _migration_manifest(
+        self,
+        from_version: int = 2,
+        to_version: int = 3,
+        *,
+        remove_paths: tuple[str, ...] = (),
+        require_absent_paths: tuple[str, ...] = (),
+    ) -> str:
+        def render(values: tuple[str, ...]) -> str:
+            return "[" + ", ".join(json.dumps(value) for value in values) + "]"
+
+        return (
+            "schema_version = 1\n\n"
+            "[[migrations]]\n"
+            f"from_version = {from_version}\n"
+            f"to_version = {to_version}\n"
+            f"remove_paths = {render(remove_paths)}\n"
+            f"require_absent_paths = {render(require_absent_paths)}\n"
+        )
+
     def test_upstream_and_generated_parity(self) -> None:
         upstream = ROOT / "components" / "agent-core" / ".automation" / "UPSTREAM"
         ownership = ROOT / "components" / "agent-core" / ".automation" / "ownership.toml"
@@ -138,6 +250,319 @@ class AutomationUpgradeContractTest(unittest.TestCase):
             "just project::check",
         ):
             self.assertIn(phrase, readme)
+
+    def test_load_migrations_accepts_empty_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._core_root_source(Path(directory), migrations="schema_version = 1\n")
+            self.assertEqual([], upgrade.load_migrations(source))
+
+    def test_load_migrations_accepts_valid_transition(self) -> None:
+        manifest = self._migration_manifest(
+            remove_paths=(".automation/obsolete.py",),
+            require_absent_paths=(".task-state/recovery.json",),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._core_root_source(Path(directory), version=3, migrations=manifest)
+            migrations = upgrade.load_migrations(source)
+            self.assertEqual(1, len(migrations))
+            self.assertEqual((2, 3), (migrations[0].from_version, migrations[0].to_version))
+
+    def test_load_migrations_rejects_unknown_top_level_key(self) -> None:
+        manifest = "schema_version = 1\nlegacy = true\n"
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._core_root_source(Path(directory), migrations=manifest)
+            with self.assertRaisesRegex(upgrade.UpgradeError, "unknown top-level"):
+                upgrade.load_migrations(source)
+
+    def test_load_migrations_rejects_unknown_migration_field(self) -> None:
+        manifest = self._migration_manifest() + "legacy = true\n"
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._core_root_source(Path(directory), migrations=manifest)
+            with self.assertRaisesRegex(upgrade.UpgradeError, "unknown fields"):
+                upgrade.load_migrations(source)
+
+    def test_load_migrations_rejects_non_integer_versions(self) -> None:
+        manifest = self._migration_manifest().replace("from_version = 2", 'from_version = "2"')
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._core_root_source(Path(directory), migrations=manifest)
+            with self.assertRaisesRegex(upgrade.UpgradeError, "positive integers"):
+                upgrade.load_migrations(source)
+
+    def test_load_migrations_rejects_non_consecutive_versions(self) -> None:
+        manifest = self._migration_manifest(1, 3)
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._core_root_source(Path(directory), migrations=manifest)
+            with self.assertRaisesRegex(upgrade.UpgradeError, "exactly one version"):
+                upgrade.load_migrations(source)
+
+    def test_load_migrations_rejects_duplicate_transition(self) -> None:
+        transition = self._migration_manifest().split("\n\n", 1)[1]
+        manifest = "schema_version = 1\n\n" + transition + "\n" + transition
+        with tempfile.TemporaryDirectory() as directory:
+            source = self._core_root_source(Path(directory), migrations=manifest)
+            with self.assertRaisesRegex(upgrade.UpgradeError, "duplicates transition"):
+                upgrade.load_migrations(source)
+
+    def test_remove_path_safety_rejects_absolute_traversal_and_glob(self) -> None:
+        for path in ("/tmp/escape", "../escape", ".opencode/*.md"):
+            with self.subTest(path=path), tempfile.TemporaryDirectory() as directory:
+                source = self._core_root_source(
+                    Path(directory), migrations=self._migration_manifest(remove_paths=(path,))
+                )
+                with self.assertRaisesRegex(upgrade.UpgradeError, "unsafe|exact repository-relative"):
+                    upgrade.load_migrations(source)
+
+    def test_remove_path_safety_rejects_unmanaged_and_protected_paths(self) -> None:
+        for path in (".automation/ADAPTER", "just/project/mod.just", "README.md", "AGENTS.md"):
+            with self.subTest(path=path), tempfile.TemporaryDirectory() as directory:
+                source = self._core_root_source(
+                    Path(directory), migrations=self._migration_manifest(remove_paths=(path,))
+                )
+                with self.assertRaisesRegex(upgrade.UpgradeError, "not Agent Core managed"):
+                    upgrade.load_migrations(source)
+
+    def test_build_plan_adds_delete_action_for_v2_to_v3(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            self._write_file(repo / ".automation/obsolete.py", "obsolete\n")
+            self._core_root_source(
+                root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/obsolete.py",))
+            )
+            action = self._plan_action(upgrade.build_plan(repo, root), ".automation/obsolete.py")
+            self.assertEqual("delete", action["action"])
+            self.assertEqual("removed by Agent Core migration 2 -> 3", action["reason"])
+
+    def test_build_plan_absent_obsolete_file_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            self._core_root_source(
+                root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/obsolete.py",))
+            )
+            plan = upgrade.build_plan(repo, root)
+            self.assertEqual("noop", self._plan_action(plan, ".automation/obsolete.py")["action"])
+
+    def test_build_plan_require_absent_present_is_blocker(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            self._write_file(repo / ".task-state/recovery.json", "{}\n")
+            self._core_root_source(
+                root,
+                version=3,
+                migrations=self._migration_manifest(require_absent_paths=(".task-state/recovery.json",)),
+            )
+            plan = upgrade.build_plan(repo, root)
+            self.assertFalse(plan["canApply"])
+            message = "\n".join(plan["blockers"])
+            self.assertIn("migration 2 -> 3", message)
+            self.assertIn(".task-state/recovery.json", message)
+            self.assertIn("operator must resolve", message)
+
+    def test_build_plan_require_absent_absent_can_apply(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            self._core_root_source(
+                root,
+                version=3,
+                migrations=self._migration_manifest(require_absent_paths=(".task-state/recovery.json",)),
+            )
+            self.assertTrue(upgrade.build_plan(repo, root)["canApply"])
+
+    def test_build_plan_v1_to_v3_selects_later_migrations(self) -> None:
+        first = self._migration_manifest(1, 2, remove_paths=(".automation/one",)).split("\n\n", 1)[1]
+        second = self._migration_manifest(2, 3, remove_paths=(".automation/two",)).split("\n\n", 1)[1]
+        manifest = "schema_version = 1\n\n" + first + "\n" + second
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=1)
+            self._write_file(repo / ".automation/one", "1\n")
+            self._write_file(repo / ".automation/two", "2\n")
+            self._core_root_source(root, version=3, migrations=manifest)
+            plan = upgrade.build_plan(repo, root)
+            self.assertEqual("delete", self._plan_action(plan, ".automation/one")["action"])
+            self.assertEqual("delete", self._plan_action(plan, ".automation/two")["action"])
+
+    def test_build_plan_rejects_downgrade(self) -> None:
+        self._require_migration_api()
+        with tempfile.TemporaryDirectory() as directory:
+            tmp = Path(directory)
+            repo = self._destination_repo(tmp / "repo", version=4)
+            source = self._core_root_source(tmp, version=3)
+            plan = upgrade.build_plan(repo, tmp)
+            self.assertFalse(plan["canApply"])
+            self.assertIn("downgrade", "\n".join(plan["blockers"]).lower())
+
+    def test_apply_deletes_regular_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            self._write_file(repo / ".automation/stale.py", "to delete\n")
+            self._core_root_source(
+                root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/stale.py",))
+            )
+            with mock.patch.object(upgrade, "require_maintenance"):
+                result = upgrade.apply(repo, root)
+            self.assertIn(".automation/stale.py", result["changedPaths"])
+            self.assertFalse((repo / ".automation/stale.py").exists())
+
+    def test_apply_symlink_removed_without_deleting_target(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            target = repo / "target.txt"
+            self._write_file(target, "target\n")
+            os.symlink(target, repo / ".automation/link.py")
+            self._core_root_source(
+                root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/link.py",))
+            )
+            with mock.patch.object(upgrade, "require_maintenance"):
+                upgrade.apply(repo, root)
+            self.assertFalse((repo / ".automation/link.py").exists())
+            self.assertTrue(target.exists())
+
+    def test_directory_delete_collision_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            (repo / ".automation/obsolete").mkdir()
+            self._core_root_source(
+                root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/obsolete",))
+            )
+            plan = upgrade.build_plan(repo, root)
+            self.assertFalse(plan["canApply"])
+            self.assertIn("refuses directory deletion", "\n".join(plan["blockers"]))
+
+    def test_managed_destination_symlink_blocks_without_overwriting_target(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            target = root / "external.json"
+            self._write_file(target, "external\n")
+            (repo / "opencode.json").unlink()
+            os.symlink(target, repo / "opencode.json")
+            self._core_root_source(root, version=2)
+            plan = upgrade.build_plan(repo, root)
+            self.assertFalse(plan["canApply"])
+            self.assertIn("destination symlink", "\n".join(plan["blockers"]))
+            with mock.patch.object(upgrade, "require_maintenance"):
+                with self.assertRaises(upgrade.UpgradeError):
+                    upgrade.apply(repo, root)
+            self.assertEqual("external\n", target.read_text())
+
+    def test_non_directory_managed_parent_blocks_before_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            self._write_file(repo / ".opencode", "collision\n")
+            source = self._core_root_source(root, version=3)
+            self._write_file(source / ".opencode/agents/new.md", "new\n")
+            self._write_file(repo / "opencode.json", "before\n")
+            self._write_file(source / "opencode.json", "after\n")
+            plan = upgrade.build_plan(repo, root)
+            self.assertFalse(plan["canApply"])
+            self.assertIn("non-directory ancestor .opencode", "\n".join(plan["blockers"]))
+            with mock.patch.object(upgrade, "require_maintenance"):
+                with self.assertRaises(upgrade.UpgradeError):
+                    upgrade.apply(repo, root)
+            self.assertEqual("2\n", (repo / ".automation/VERSION").read_text())
+            self.assertEqual("before\n", (repo / "opencode.json").read_text())
+
+    def test_managed_symlink_ancestor_blocks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            target = root / "external-agents"
+            target.mkdir()
+            (repo / ".opencode").symlink_to(target, target_is_directory=True)
+            source = self._core_root_source(root, version=2)
+            self._write_file(source / ".opencode/agents/new.md", "new\n")
+            plan = upgrade.build_plan(repo, root)
+            self.assertFalse(plan["canApply"])
+            self.assertIn("symlink ancestor .opencode", "\n".join(plan["blockers"]))
+            self.assertEqual([], list(target.iterdir()))
+
+    def test_apply_blocked_path_prevents_all_mutations_and_version_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=2)
+            (repo / ".automation/obsolete").mkdir()
+            self._write_file(repo / "opencode.json", "{\"before\":1}\n")
+            self._core_root_source(
+                root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/obsolete",))
+            )
+            with mock.patch.object(upgrade, "require_maintenance"):
+                with self.assertRaises(upgrade.UpgradeError):
+                    upgrade.apply(repo, root)
+            self.assertEqual((repo / ".automation" / "VERSION").read_text(), "2\n")
+            self.assertEqual((repo / "opencode.json").read_text(), "{\"before\":1}\n")
+
+    def test_apply_writes_VERSION_last_after_source_actions(self) -> None:
+        manifest = self._migration_manifest(remove_paths=(".automation/stale.py",))
+        with tempfile.TemporaryDirectory() as directory:
+            tmp = Path(directory)
+            repo = self._destination_repo(tmp / "repo", version=2)
+            self._write_file(repo / ".automation/stale.py", "stale\n")
+            self._write_file(repo / "opencode.json", "{\"before\":1}\n")
+            source = self._core_root_source(tmp, version=3, migrations=manifest)
+            self._write_file(source / "opencode.json", "{\"before\":2}\n")
+
+            calls: list[str] = []
+            original_copy2 = upgrade.shutil.copy2
+
+            def _mock_copy2(src: Path, dst: Path, *args, **kwargs):
+                if Path(dst) != repo / ".automation/VERSION":
+                    self.assertEqual("2\n", (repo / ".automation/VERSION").read_text())
+                calls.append(str(Path(dst)))
+                return original_copy2(src, dst, *args, **kwargs)
+
+            with mock.patch.object(upgrade, "require_maintenance"):
+                with mock.patch.object(upgrade.shutil, "copy2", side_effect=_mock_copy2):
+                    upgrade.apply(repo, tmp)
+            self.assertTrue(calls, calls)
+            self.assertEqual(calls[-1], str(repo / ".automation" / "VERSION"))
+            self.assertFalse((repo / ".automation/stale.py").exists())
+            self.assertEqual((repo / ".automation" / "VERSION").read_text(), "3\n")
+
+    def test_adapter_is_preserved_by_plan_and_apply(self) -> None:
+        manifest = "schema_version = 1\n"
+        with tempfile.TemporaryDirectory() as directory:
+            tmp = Path(directory)
+            repo = self._destination_repo(tmp / "repo", version=2)
+            source = self._core_root_source(tmp, version=2, migrations=manifest)
+            source_adp = source / ".automation" / "ADAPTER"
+            source_parent = source_adp.parent
+            source_parent.mkdir(parents=True, exist_ok=True)
+            self._write_file(source_adp, "python\n")
+            plan = upgrade.build_plan(repo, tmp)
+            self.assertIsNone(self._plan_action(plan, ".automation/ADAPTER"))
+            with mock.patch.object(upgrade, "require_maintenance"):
+                with mock.patch.object(upgrade.shutil, "copy2", side_effect=shutil.copy2):
+                    upgrade.apply(repo, tmp)
+            self.assertEqual((repo / ".automation" / "ADAPTER").read_text(), "base\n")
+
+    def test_current_v2_bridge_source_contains_no_delete_actions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory) / "repo"
+            shutil.copytree(ROOT / "templates/agent-base", repo, symlinks=True)
+            plan = upgrade.build_plan(repo, ROOT)
+            self.assertFalse(any(item["action"] == "delete" for item in plan["actions"]))
+            self.assertEqual([], upgrade.load_migrations(ROOT / "components/agent-core"))
+
+    def test_template_migrations_and_upgrade_script_parity_after_render(self) -> None:
+        for template in self.TEMPLATE_NAMES:
+            template_core = ROOT / "templates" / template
+            self.assertTrue((template_core / ".automation" / "migrations.toml").exists())
+            self.assertEqual(
+                (ROOT / "components" / "agent-core" / ".automation" / "migrations.toml").read_bytes(),
+                (template_core / ".automation" / "migrations.toml").read_bytes(),
+            )
+            self.assertEqual(
+                SCRIPT.read_bytes(),
+                (template_core / ".automation" / "bin" / "automation_upgrade.py").read_bytes(),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -385,6 +385,23 @@ mod project 'just/project/mod.just'
             self.assertEqual("delete", self._plan_action(plan, ".automation/one")["action"])
             self.assertEqual("delete", self._plan_action(plan, ".automation/two")["action"])
 
+    def test_later_precondition_accepts_path_planned_for_earlier_deletion(self) -> None:
+        first = self._migration_manifest(1, 2, remove_paths=(".automation/old",)).split("\n\n", 1)[1]
+        second = self._migration_manifest(
+            2,
+            3,
+            require_absent_paths=(".automation/old",),
+        ).split("\n\n", 1)[1]
+        manifest = "schema_version = 1\n\n" + first + "\n" + second
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=1)
+            self._write_file(repo / ".automation/old", "old\n")
+            self._core_root_source(root, version=3, migrations=manifest)
+            plan = upgrade.build_plan(repo, root)
+            self.assertTrue(plan["canApply"], plan["blockers"])
+            self.assertEqual("delete", self._plan_action(plan, ".automation/old")["action"])
+
     def test_build_plan_rejects_downgrade(self) -> None:
         self._require_migration_api()
         with tempfile.TemporaryDirectory() as directory:
@@ -407,6 +424,26 @@ mod project 'just/project/mod.just'
                 result = upgrade.apply(repo, root)
             self.assertIn(".automation/stale.py", result["changedPaths"])
             self.assertFalse((repo / ".automation/stale.py").exists())
+
+    def test_migration_catches_up_residue_after_version_already_advanced(self) -> None:
+        manifest = self._migration_manifest(remove_paths=(".automation/legacy.py",))
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self._destination_repo(root / "repo", version=3)
+            self._write_file(repo / ".automation/legacy.py", "legacy\n")
+            self._write_file(repo / "opencode.json", "before\n")
+            source = self._core_root_source(root, version=3, migrations=manifest)
+            self._write_file(source / "opencode.json", "after\n")
+
+            plan = upgrade.build_plan(repo, root)
+            self.assertTrue(plan["canApply"], plan["blockers"])
+            self.assertEqual("delete", self._plan_action(plan, ".automation/legacy.py")["action"])
+
+            with mock.patch.object(upgrade, "require_maintenance"):
+                upgrade.apply(repo, root)
+            self.assertFalse((repo / ".automation/legacy.py").exists())
+            self.assertEqual("3\n", (repo / ".automation/VERSION").read_text())
+            self.assertEqual("after\n", (repo / "opencode.json").read_text())
 
     def test_apply_symlink_removed_without_deleting_target(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- add a strict versioned `migrations.toml` schema while keeping Agent Core VERSION 2
- plan exact managed-file and symlink deletions plus require-absent migration preconditions
- reject traversal, globs, protected paths, unsafe topology, directories, and symlink escapes before mutation
- apply deletes before materialization and update `.automation/VERSION` only after all other actions succeed
- render the bridge updater and empty manifest into all five generated templates

## Bridge compatibility
- no Agent Core-managed runtime path is removed in this change
- the empty v2 manifest produces no delete actions
- the prior v2 updater can create `.automation/migrations.toml` and replace `automation_upgrade.py` using its existing create/replace behavior
- fallback, recovery, Spark/model allocation, and Agent Core VERSION remain unchanged

## Verification
- `python3 -m unittest discover -s tests -v` (172 tests)
- `just template::check`
- `just template::distribution-verify`
- `nix flake check --no-update-lock-file`
- `nix flake check --all-systems --no-build --no-update-lock-file`
- `git diff --check`
- pinned OpenCodePolicy contract passes at `e4ff446514c303fe275ba9eb3a4ab498caea7ac0`

## Follow-up
A separate Agent Core v3 migration can add the 2 -> 3 manifest entry, remove obsolete fallback/recovery paths, update model assignments, and advance the OpenCodePolicy pin.