### PR TITLE
feat: add Agent Core runtime preflight

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -74,6 +74,7 @@ jobs:
           set -euo pipefail
           target="$RUNNER_TEMP/${{ matrix.template }}"
           cd "$target"
+          nix develop --command just agent::preflight
           nix develop --command just agent::doctor
           nix develop --command just agent::context
       - name: Project Adapter smoke

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ nix flake init ...
 
 `/init` is read-only. It validates Agent Core version, Adapter identity, branch/worktree/Task State, tools, project doctor, HEAD, and Git status. It never bootstraps, repairs, installs packages, changes Task State, rewrites `AGENTS.md`, or mutates GitHub repository settings.
 
-For bootstrap, adoption, or upgrade diagnostics that need only runtime readiness, run `just agent::preflight` from the root of a generated or trusted installed Agent Core. It checks required tools/files, Agent Core version, and Adapter readability without resolving or relaxing branch/Task identity. Preflight is read-only, but it executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content. `preflight = PASS` does not mean the checkout is a valid Agent session: `/init`, `agent::doctor`, and `agent::context` remain strict and may intentionally block a non-default branch without registered Task State.
+For bootstrap, adoption, or upgrade diagnostics that need only runtime readiness, run `just agent::preflight` from the root of an installed Agent Core. It checks required tools/files, Agent Core version, and a non-empty Adapter marker without resolving or relaxing branch/Task identity. Preflight is read-only, but `preflight = PASS` does not mean the checkout is a valid Agent session: `/init`, `agent::doctor`, and `agent::context` remain strict and may intentionally block a non-default branch without registered Task State.
 
 Existing-repository adoption and Agent Core upgrade are separate mutating workflows from generated-project bootstrap.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ nix flake init ...
 
 `/init` is read-only. It validates Agent Core version, Adapter identity, branch/worktree/Task State, tools, project doctor, HEAD, and Git status. It never bootstraps, repairs, installs packages, changes Task State, rewrites `AGENTS.md`, or mutates GitHub repository settings.
 
+For bootstrap, adoption, or upgrade diagnostics that need only runtime readiness, run `just agent::preflight` from the root of a generated or trusted installed Agent Core. It checks required tools/files, Agent Core version, and Adapter readability without resolving or relaxing branch/Task identity. Preflight is read-only, but it executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content. `preflight = PASS` does not mean the checkout is a valid Agent session: `/init`, `agent::doctor`, and `agent::context` remain strict and may intentionally block a non-default branch without registered Task State.
+
 Existing-repository adoption and Agent Core upgrade are separate mutating workflows from generated-project bootstrap.
 
 ## Existing repositories

--- a/components/agent-core/.automation/INIT.md
+++ b/components/agent-core/.automation/INIT.md
@@ -18,7 +18,7 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 
 ## Runtime preflight
 
-`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of an installed Agent Core. It validates required runtime tools, required Agent Core files, the supported Agent Core version, and a non-empty Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity.
 
 A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
 

--- a/components/agent-core/.automation/INIT.md
+++ b/components/agent-core/.automation/INIT.md
@@ -16,6 +16,12 @@ Initialization validates and reports state. It must not:
 
 Repository bootstrap and Automation Core upgrade are separate state-changing workflows.
 
+## Runtime preflight
+
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+
+A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
+
 ## Mandatory sequence
 
 1. Read `AGENTS.md` and this file.

--- a/components/agent-core/.automation/bin/init_context.py
+++ b/components/agent-core/.automation/bin/init_context.py
@@ -10,6 +10,17 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
+ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+REQUIRED_TOOLS = ("git", "gh", "just", "python3")
+REQUIRED_FILES = (
+    "AGENTS.md",
+    ".automation/INIT.md",
+    ".automation/VERSION",
+    ".automation/ADAPTER",
+    ".automation/policy.toml",
+    "just/project/mod.just",
+    "opencode.json",
+)
 TASK_ID_RE = re.compile(r"(?m)^- Task ID: (.+)$")
 BRANCH_RE = re.compile(r"(?m)^- Branch: (.+)$")
 WORKTREE_RE = re.compile(r"(?m)^- Worktree: (.+)$")
@@ -75,9 +86,17 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
+    if path.is_symlink():
+        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    return path.read_text(encoding="utf-8").strip()
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
+    if not value:
+        raise InitError(f"empty {label}: {path}")
+    return value
 
 
 def task_state(root: Path) -> dict | None:
@@ -128,6 +147,33 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
+def preflight(root: Path) -> dict:
+    missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        raise InitError("missing required tools: " + ", ".join(missing))
+    for relative in REQUIRED_FILES:
+        path = root / relative
+        if path.is_symlink():
+            raise InitError(f"required repository file must not be a symlink: {relative}")
+        if not path.is_file():
+            raise InitError(f"missing required repository file: {relative}")
+    version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
+    if version != SUPPORTED_AGENT_CORE_VERSION:
+        raise InitError(
+            f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
+        )
+    adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
+    if ADAPTER_RE.fullmatch(adapter) is None:
+        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    return {
+        "status": "PASS",
+        "readOnly": True,
+        "repositoryRoot": str(root),
+        "agentCoreVersion": version,
+        "adapter": adapter,
+    }
+
+
 def context(root: Path) -> dict:
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
@@ -154,35 +200,27 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    missing = [tool for tool in ("git", "gh", "just", "python3") if shutil.which(tool) is None]
-    if missing:
-        raise InitError("missing required tools: " + ", ".join(missing))
-    for relative in (
-        "AGENTS.md",
-        ".automation/INIT.md",
-        ".automation/VERSION",
-        ".automation/ADAPTER",
-        ".automation/policy.toml",
-        "just/project/mod.just",
-        "opencode.json",
-    ):
-        if not (root / relative).is_file():
-            raise InitError(f"missing required repository file: {relative}")
+    preflight(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 
 
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description="Read-only Agent initialization checks")
-    result.add_argument("command", choices=("doctor", "context"))
+    result.add_argument("command", choices=("preflight", "doctor", "context"))
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
     try:
-        root = repo_root()
-        result = doctor(root) if args.command == "doctor" else context(root)
+        commands = {
+            "preflight": preflight,
+            "doctor": doctor,
+            "context": context,
+        }
+        root = Path.cwd().resolve() if args.command == "preflight" else repo_root()
+        result = commands[args.command](root)
         print(json.dumps(result, sort_keys=True))
     except InitError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/components/agent-core/.automation/bin/init_context.py
+++ b/components/agent-core/.automation/bin/init_context.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
-ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 REQUIRED_TOOLS = ("git", "gh", "just", "python3")
 REQUIRED_FILES = (
     "AGENTS.md",
@@ -86,17 +85,9 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
-    if path.is_symlink():
-        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    try:
-        value = path.read_text(encoding="utf-8").strip()
-    except OSError as exc:
-        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
-    if not value:
-        raise InitError(f"empty {label}: {path}")
-    return value
+    return path.read_text(encoding="utf-8").strip()
 
 
 def task_state(root: Path) -> dict | None:
@@ -147,24 +138,25 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
-def preflight(root: Path) -> dict:
+def check_runtime_prerequisites(root: Path) -> None:
     missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
     if missing:
         raise InitError("missing required tools: " + ", ".join(missing))
     for relative in REQUIRED_FILES:
-        path = root / relative
-        if path.is_symlink():
-            raise InitError(f"required repository file must not be a symlink: {relative}")
-        if not path.is_file():
+        if not (root / relative).is_file():
             raise InitError(f"missing required repository file: {relative}")
+
+
+def preflight(root: Path) -> dict:
+    check_runtime_prerequisites(root)
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
         raise InitError(
             f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
         )
     adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
-    if ADAPTER_RE.fullmatch(adapter) is None:
-        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    if not adapter:
+        raise InitError(f"empty Project Adapter marker: {root / '.automation' / 'ADAPTER'}")
     return {
         "status": "PASS",
         "readOnly": True,
@@ -200,7 +192,7 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    preflight(root)
+    check_runtime_prerequisites(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 

--- a/components/agent-core/.automation/just/agent.just
+++ b/components/agent-core/.automation/just/agent.just
@@ -4,6 +4,10 @@ lifecycle := root / ".automation/bin/task_lifecycle.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
+preflight:
+    python3 {{quote(init)}} preflight
+
+[working-directory: root]
 doctor:
     python3 {{quote(init)}} doctor
 

--- a/components/agent-core/.opencode/agents/build.md
+++ b/components/agent-core/.opencode/agents/build.md
@@ -13,6 +13,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/components/agent-core/.opencode/agents/task-orchestrator.md
+++ b/components/agent-core/.opencode/agents/task-orchestrator.md
@@ -15,6 +15,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/components/agent-core/opencode.json
+++ b/components/agent-core/opencode.json
@@ -60,6 +60,7 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
+      "just agent::preflight": "allow",
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -159,6 +159,7 @@ Internal helper recipes should remain private and should not be treated as publi
 Every Agent-ready repository should expose the following logical operations:
 
 ```text
+just agent::preflight
 just agent::doctor
 just agent::context
 just agent::task-start <TASK-ID> <slug>
@@ -174,8 +175,9 @@ just agent::cleanup <TASK-ID>
 
 Semantics:
 
-- `doctor`: validate Agent Core prerequisites without repairing them.
-- `context`: resolve repository/worktree/branch/Task/adapter context in machine-readable form.
+- `preflight`: validate runtime tools, required files, Agent Core version, and Adapter readiness without branch/Task identity; read-only and suitable for bootstrap/adoption/upgrade diagnostics.
+- `doctor`: validate full repository/session readiness, including strict context and branch/Task identity, without repairing it.
+- `context`: resolve repository/worktree/branch/Task/adapter context in machine-readable form with strict identity validation.
 - `task-start`: create a dedicated branch/worktree and initialize Task State.
 - `status`: report current Task state and Git relationship.
 - `verify`: execute the stable project verification contract and record evidence.
@@ -266,6 +268,8 @@ plan
 Because `plan` has `bash: deny`, it cannot complete the executable initialization sequence. Instead it performs planning-only initialization by reading `AGENTS.md`, `.automation/INIT.md`, `.automation/INIT.fragment.md`, and optional Task State, then returns `PLANNING_INITIALIZATION_HANDOFF` semantics: explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or policy check. Unexecuted checks remain `UNEXECUTED`; they are never reported as PASS.
 
 This planning-only branch does not weaken full initialization. `build`, `task-orchestrator`, and other execution-capable workflows still must run `just agent::doctor`, `just agent::context`, and `just project::doctor` before editing, implementation delegation, or project commands.
+
+`agent::preflight` is not a substitute for that initialization sequence. A bootstrap or adoption branch may use it to prove runtime readiness without fabricating Task State, while doctor/context and `/init` continue to reject an unregistered non-default branch.
 
 ### 9.1 Allowed delegation graph
 

--- a/docs/existing-repository-adoption.md
+++ b/docs/existing-repository-adoption.md
@@ -18,6 +18,8 @@ nix develop --command just template::adapter-migrate-plan /path/to/repository cp
 
 `adopt-apply` performs no commit, push, or merge. It refuses to run when the target working tree is dirty or when the plan contains unresolved collisions.
 
+After applying Agent Core on an existing bootstrap/adoption branch, `just agent::preflight` can verify tools, required files, VERSION, and Adapter readiness without requiring fabricated Task State. This is not full initialization: `just agent::doctor`, `just agent::context`, and `/init` retain strict branch/Task identity requirements and may intentionally block until the repository is on its default branch or in a registered Task worktree.
+
 ## Adapter selection
 
 Explicit `--adapter <id>` always wins when the Adapter exists.

--- a/templates/agent-base/.automation/INIT.md
+++ b/templates/agent-base/.automation/INIT.md
@@ -18,7 +18,7 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 
 ## Runtime preflight
 
-`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of an installed Agent Core. It validates required runtime tools, required Agent Core files, the supported Agent Core version, and a non-empty Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity.
 
 A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
 

--- a/templates/agent-base/.automation/INIT.md
+++ b/templates/agent-base/.automation/INIT.md
@@ -16,6 +16,12 @@ Initialization validates and reports state. It must not:
 
 Repository bootstrap and Automation Core upgrade are separate state-changing workflows.
 
+## Runtime preflight
+
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+
+A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
+
 ## Mandatory sequence
 
 1. Read `AGENTS.md` and this file.

--- a/templates/agent-base/.automation/bin/init_context.py
+++ b/templates/agent-base/.automation/bin/init_context.py
@@ -10,6 +10,17 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
+ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+REQUIRED_TOOLS = ("git", "gh", "just", "python3")
+REQUIRED_FILES = (
+    "AGENTS.md",
+    ".automation/INIT.md",
+    ".automation/VERSION",
+    ".automation/ADAPTER",
+    ".automation/policy.toml",
+    "just/project/mod.just",
+    "opencode.json",
+)
 TASK_ID_RE = re.compile(r"(?m)^- Task ID: (.+)$")
 BRANCH_RE = re.compile(r"(?m)^- Branch: (.+)$")
 WORKTREE_RE = re.compile(r"(?m)^- Worktree: (.+)$")
@@ -75,9 +86,17 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
+    if path.is_symlink():
+        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    return path.read_text(encoding="utf-8").strip()
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
+    if not value:
+        raise InitError(f"empty {label}: {path}")
+    return value
 
 
 def task_state(root: Path) -> dict | None:
@@ -128,6 +147,33 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
+def preflight(root: Path) -> dict:
+    missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        raise InitError("missing required tools: " + ", ".join(missing))
+    for relative in REQUIRED_FILES:
+        path = root / relative
+        if path.is_symlink():
+            raise InitError(f"required repository file must not be a symlink: {relative}")
+        if not path.is_file():
+            raise InitError(f"missing required repository file: {relative}")
+    version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
+    if version != SUPPORTED_AGENT_CORE_VERSION:
+        raise InitError(
+            f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
+        )
+    adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
+    if ADAPTER_RE.fullmatch(adapter) is None:
+        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    return {
+        "status": "PASS",
+        "readOnly": True,
+        "repositoryRoot": str(root),
+        "agentCoreVersion": version,
+        "adapter": adapter,
+    }
+
+
 def context(root: Path) -> dict:
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
@@ -154,35 +200,27 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    missing = [tool for tool in ("git", "gh", "just", "python3") if shutil.which(tool) is None]
-    if missing:
-        raise InitError("missing required tools: " + ", ".join(missing))
-    for relative in (
-        "AGENTS.md",
-        ".automation/INIT.md",
-        ".automation/VERSION",
-        ".automation/ADAPTER",
-        ".automation/policy.toml",
-        "just/project/mod.just",
-        "opencode.json",
-    ):
-        if not (root / relative).is_file():
-            raise InitError(f"missing required repository file: {relative}")
+    preflight(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 
 
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description="Read-only Agent initialization checks")
-    result.add_argument("command", choices=("doctor", "context"))
+    result.add_argument("command", choices=("preflight", "doctor", "context"))
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
     try:
-        root = repo_root()
-        result = doctor(root) if args.command == "doctor" else context(root)
+        commands = {
+            "preflight": preflight,
+            "doctor": doctor,
+            "context": context,
+        }
+        root = Path.cwd().resolve() if args.command == "preflight" else repo_root()
+        result = commands[args.command](root)
         print(json.dumps(result, sort_keys=True))
     except InitError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/templates/agent-base/.automation/bin/init_context.py
+++ b/templates/agent-base/.automation/bin/init_context.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
-ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 REQUIRED_TOOLS = ("git", "gh", "just", "python3")
 REQUIRED_FILES = (
     "AGENTS.md",
@@ -86,17 +85,9 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
-    if path.is_symlink():
-        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    try:
-        value = path.read_text(encoding="utf-8").strip()
-    except OSError as exc:
-        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
-    if not value:
-        raise InitError(f"empty {label}: {path}")
-    return value
+    return path.read_text(encoding="utf-8").strip()
 
 
 def task_state(root: Path) -> dict | None:
@@ -147,24 +138,25 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
-def preflight(root: Path) -> dict:
+def check_runtime_prerequisites(root: Path) -> None:
     missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
     if missing:
         raise InitError("missing required tools: " + ", ".join(missing))
     for relative in REQUIRED_FILES:
-        path = root / relative
-        if path.is_symlink():
-            raise InitError(f"required repository file must not be a symlink: {relative}")
-        if not path.is_file():
+        if not (root / relative).is_file():
             raise InitError(f"missing required repository file: {relative}")
+
+
+def preflight(root: Path) -> dict:
+    check_runtime_prerequisites(root)
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
         raise InitError(
             f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
         )
     adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
-    if ADAPTER_RE.fullmatch(adapter) is None:
-        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    if not adapter:
+        raise InitError(f"empty Project Adapter marker: {root / '.automation' / 'ADAPTER'}")
     return {
         "status": "PASS",
         "readOnly": True,
@@ -200,7 +192,7 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    preflight(root)
+    check_runtime_prerequisites(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 

--- a/templates/agent-base/.automation/just/agent.just
+++ b/templates/agent-base/.automation/just/agent.just
@@ -4,6 +4,10 @@ lifecycle := root / ".automation/bin/task_lifecycle.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
+preflight:
+    python3 {{quote(init)}} preflight
+
+[working-directory: root]
 doctor:
     python3 {{quote(init)}} doctor
 

--- a/templates/agent-base/.opencode/agents/build.md
+++ b/templates/agent-base/.opencode/agents/build.md
@@ -13,6 +13,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-base/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-base/.opencode/agents/task-orchestrator.md
@@ -15,6 +15,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-base/opencode.json
+++ b/templates/agent-base/opencode.json
@@ -60,6 +60,7 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
+      "just agent::preflight": "allow",
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",

--- a/templates/agent-cpp-cmake/.automation/INIT.md
+++ b/templates/agent-cpp-cmake/.automation/INIT.md
@@ -18,7 +18,7 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 
 ## Runtime preflight
 
-`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of an installed Agent Core. It validates required runtime tools, required Agent Core files, the supported Agent Core version, and a non-empty Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity.
 
 A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
 

--- a/templates/agent-cpp-cmake/.automation/INIT.md
+++ b/templates/agent-cpp-cmake/.automation/INIT.md
@@ -16,6 +16,12 @@ Initialization validates and reports state. It must not:
 
 Repository bootstrap and Automation Core upgrade are separate state-changing workflows.
 
+## Runtime preflight
+
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+
+A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
+
 ## Mandatory sequence
 
 1. Read `AGENTS.md` and this file.

--- a/templates/agent-cpp-cmake/.automation/bin/init_context.py
+++ b/templates/agent-cpp-cmake/.automation/bin/init_context.py
@@ -10,6 +10,17 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
+ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+REQUIRED_TOOLS = ("git", "gh", "just", "python3")
+REQUIRED_FILES = (
+    "AGENTS.md",
+    ".automation/INIT.md",
+    ".automation/VERSION",
+    ".automation/ADAPTER",
+    ".automation/policy.toml",
+    "just/project/mod.just",
+    "opencode.json",
+)
 TASK_ID_RE = re.compile(r"(?m)^- Task ID: (.+)$")
 BRANCH_RE = re.compile(r"(?m)^- Branch: (.+)$")
 WORKTREE_RE = re.compile(r"(?m)^- Worktree: (.+)$")
@@ -75,9 +86,17 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
+    if path.is_symlink():
+        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    return path.read_text(encoding="utf-8").strip()
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
+    if not value:
+        raise InitError(f"empty {label}: {path}")
+    return value
 
 
 def task_state(root: Path) -> dict | None:
@@ -128,6 +147,33 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
+def preflight(root: Path) -> dict:
+    missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        raise InitError("missing required tools: " + ", ".join(missing))
+    for relative in REQUIRED_FILES:
+        path = root / relative
+        if path.is_symlink():
+            raise InitError(f"required repository file must not be a symlink: {relative}")
+        if not path.is_file():
+            raise InitError(f"missing required repository file: {relative}")
+    version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
+    if version != SUPPORTED_AGENT_CORE_VERSION:
+        raise InitError(
+            f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
+        )
+    adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
+    if ADAPTER_RE.fullmatch(adapter) is None:
+        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    return {
+        "status": "PASS",
+        "readOnly": True,
+        "repositoryRoot": str(root),
+        "agentCoreVersion": version,
+        "adapter": adapter,
+    }
+
+
 def context(root: Path) -> dict:
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
@@ -154,35 +200,27 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    missing = [tool for tool in ("git", "gh", "just", "python3") if shutil.which(tool) is None]
-    if missing:
-        raise InitError("missing required tools: " + ", ".join(missing))
-    for relative in (
-        "AGENTS.md",
-        ".automation/INIT.md",
-        ".automation/VERSION",
-        ".automation/ADAPTER",
-        ".automation/policy.toml",
-        "just/project/mod.just",
-        "opencode.json",
-    ):
-        if not (root / relative).is_file():
-            raise InitError(f"missing required repository file: {relative}")
+    preflight(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 
 
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description="Read-only Agent initialization checks")
-    result.add_argument("command", choices=("doctor", "context"))
+    result.add_argument("command", choices=("preflight", "doctor", "context"))
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
     try:
-        root = repo_root()
-        result = doctor(root) if args.command == "doctor" else context(root)
+        commands = {
+            "preflight": preflight,
+            "doctor": doctor,
+            "context": context,
+        }
+        root = Path.cwd().resolve() if args.command == "preflight" else repo_root()
+        result = commands[args.command](root)
         print(json.dumps(result, sort_keys=True))
     except InitError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/templates/agent-cpp-cmake/.automation/bin/init_context.py
+++ b/templates/agent-cpp-cmake/.automation/bin/init_context.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
-ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 REQUIRED_TOOLS = ("git", "gh", "just", "python3")
 REQUIRED_FILES = (
     "AGENTS.md",
@@ -86,17 +85,9 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
-    if path.is_symlink():
-        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    try:
-        value = path.read_text(encoding="utf-8").strip()
-    except OSError as exc:
-        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
-    if not value:
-        raise InitError(f"empty {label}: {path}")
-    return value
+    return path.read_text(encoding="utf-8").strip()
 
 
 def task_state(root: Path) -> dict | None:
@@ -147,24 +138,25 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
-def preflight(root: Path) -> dict:
+def check_runtime_prerequisites(root: Path) -> None:
     missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
     if missing:
         raise InitError("missing required tools: " + ", ".join(missing))
     for relative in REQUIRED_FILES:
-        path = root / relative
-        if path.is_symlink():
-            raise InitError(f"required repository file must not be a symlink: {relative}")
-        if not path.is_file():
+        if not (root / relative).is_file():
             raise InitError(f"missing required repository file: {relative}")
+
+
+def preflight(root: Path) -> dict:
+    check_runtime_prerequisites(root)
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
         raise InitError(
             f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
         )
     adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
-    if ADAPTER_RE.fullmatch(adapter) is None:
-        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    if not adapter:
+        raise InitError(f"empty Project Adapter marker: {root / '.automation' / 'ADAPTER'}")
     return {
         "status": "PASS",
         "readOnly": True,
@@ -200,7 +192,7 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    preflight(root)
+    check_runtime_prerequisites(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 

--- a/templates/agent-cpp-cmake/.automation/just/agent.just
+++ b/templates/agent-cpp-cmake/.automation/just/agent.just
@@ -4,6 +4,10 @@ lifecycle := root / ".automation/bin/task_lifecycle.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
+preflight:
+    python3 {{quote(init)}} preflight
+
+[working-directory: root]
 doctor:
     python3 {{quote(init)}} doctor
 

--- a/templates/agent-cpp-cmake/.opencode/agents/build.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/build.md
@@ -13,6 +13,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-cpp-cmake/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/task-orchestrator.md
@@ -15,6 +15,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-cpp-cmake/opencode.json
+++ b/templates/agent-cpp-cmake/opencode.json
@@ -60,6 +60,7 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
+      "just agent::preflight": "allow",
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",

--- a/templates/agent-nix/.automation/INIT.md
+++ b/templates/agent-nix/.automation/INIT.md
@@ -18,7 +18,7 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 
 ## Runtime preflight
 
-`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of an installed Agent Core. It validates required runtime tools, required Agent Core files, the supported Agent Core version, and a non-empty Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity.
 
 A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
 

--- a/templates/agent-nix/.automation/INIT.md
+++ b/templates/agent-nix/.automation/INIT.md
@@ -16,6 +16,12 @@ Initialization validates and reports state. It must not:
 
 Repository bootstrap and Automation Core upgrade are separate state-changing workflows.
 
+## Runtime preflight
+
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+
+A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
+
 ## Mandatory sequence
 
 1. Read `AGENTS.md` and this file.

--- a/templates/agent-nix/.automation/bin/init_context.py
+++ b/templates/agent-nix/.automation/bin/init_context.py
@@ -10,6 +10,17 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
+ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+REQUIRED_TOOLS = ("git", "gh", "just", "python3")
+REQUIRED_FILES = (
+    "AGENTS.md",
+    ".automation/INIT.md",
+    ".automation/VERSION",
+    ".automation/ADAPTER",
+    ".automation/policy.toml",
+    "just/project/mod.just",
+    "opencode.json",
+)
 TASK_ID_RE = re.compile(r"(?m)^- Task ID: (.+)$")
 BRANCH_RE = re.compile(r"(?m)^- Branch: (.+)$")
 WORKTREE_RE = re.compile(r"(?m)^- Worktree: (.+)$")
@@ -75,9 +86,17 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
+    if path.is_symlink():
+        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    return path.read_text(encoding="utf-8").strip()
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
+    if not value:
+        raise InitError(f"empty {label}: {path}")
+    return value
 
 
 def task_state(root: Path) -> dict | None:
@@ -128,6 +147,33 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
+def preflight(root: Path) -> dict:
+    missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        raise InitError("missing required tools: " + ", ".join(missing))
+    for relative in REQUIRED_FILES:
+        path = root / relative
+        if path.is_symlink():
+            raise InitError(f"required repository file must not be a symlink: {relative}")
+        if not path.is_file():
+            raise InitError(f"missing required repository file: {relative}")
+    version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
+    if version != SUPPORTED_AGENT_CORE_VERSION:
+        raise InitError(
+            f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
+        )
+    adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
+    if ADAPTER_RE.fullmatch(adapter) is None:
+        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    return {
+        "status": "PASS",
+        "readOnly": True,
+        "repositoryRoot": str(root),
+        "agentCoreVersion": version,
+        "adapter": adapter,
+    }
+
+
 def context(root: Path) -> dict:
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
@@ -154,35 +200,27 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    missing = [tool for tool in ("git", "gh", "just", "python3") if shutil.which(tool) is None]
-    if missing:
-        raise InitError("missing required tools: " + ", ".join(missing))
-    for relative in (
-        "AGENTS.md",
-        ".automation/INIT.md",
-        ".automation/VERSION",
-        ".automation/ADAPTER",
-        ".automation/policy.toml",
-        "just/project/mod.just",
-        "opencode.json",
-    ):
-        if not (root / relative).is_file():
-            raise InitError(f"missing required repository file: {relative}")
+    preflight(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 
 
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description="Read-only Agent initialization checks")
-    result.add_argument("command", choices=("doctor", "context"))
+    result.add_argument("command", choices=("preflight", "doctor", "context"))
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
     try:
-        root = repo_root()
-        result = doctor(root) if args.command == "doctor" else context(root)
+        commands = {
+            "preflight": preflight,
+            "doctor": doctor,
+            "context": context,
+        }
+        root = Path.cwd().resolve() if args.command == "preflight" else repo_root()
+        result = commands[args.command](root)
         print(json.dumps(result, sort_keys=True))
     except InitError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/templates/agent-nix/.automation/bin/init_context.py
+++ b/templates/agent-nix/.automation/bin/init_context.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
-ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 REQUIRED_TOOLS = ("git", "gh", "just", "python3")
 REQUIRED_FILES = (
     "AGENTS.md",
@@ -86,17 +85,9 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
-    if path.is_symlink():
-        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    try:
-        value = path.read_text(encoding="utf-8").strip()
-    except OSError as exc:
-        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
-    if not value:
-        raise InitError(f"empty {label}: {path}")
-    return value
+    return path.read_text(encoding="utf-8").strip()
 
 
 def task_state(root: Path) -> dict | None:
@@ -147,24 +138,25 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
-def preflight(root: Path) -> dict:
+def check_runtime_prerequisites(root: Path) -> None:
     missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
     if missing:
         raise InitError("missing required tools: " + ", ".join(missing))
     for relative in REQUIRED_FILES:
-        path = root / relative
-        if path.is_symlink():
-            raise InitError(f"required repository file must not be a symlink: {relative}")
-        if not path.is_file():
+        if not (root / relative).is_file():
             raise InitError(f"missing required repository file: {relative}")
+
+
+def preflight(root: Path) -> dict:
+    check_runtime_prerequisites(root)
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
         raise InitError(
             f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
         )
     adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
-    if ADAPTER_RE.fullmatch(adapter) is None:
-        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    if not adapter:
+        raise InitError(f"empty Project Adapter marker: {root / '.automation' / 'ADAPTER'}")
     return {
         "status": "PASS",
         "readOnly": True,
@@ -200,7 +192,7 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    preflight(root)
+    check_runtime_prerequisites(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 

--- a/templates/agent-nix/.automation/just/agent.just
+++ b/templates/agent-nix/.automation/just/agent.just
@@ -4,6 +4,10 @@ lifecycle := root / ".automation/bin/task_lifecycle.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
+preflight:
+    python3 {{quote(init)}} preflight
+
+[working-directory: root]
 doctor:
     python3 {{quote(init)}} doctor
 

--- a/templates/agent-nix/.opencode/agents/build.md
+++ b/templates/agent-nix/.opencode/agents/build.md
@@ -13,6 +13,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-nix/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-nix/.opencode/agents/task-orchestrator.md
@@ -15,6 +15,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-nix/opencode.json
+++ b/templates/agent-nix/opencode.json
@@ -60,6 +60,7 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
+      "just agent::preflight": "allow",
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",

--- a/templates/agent-python/.automation/INIT.md
+++ b/templates/agent-python/.automation/INIT.md
@@ -18,7 +18,7 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 
 ## Runtime preflight
 
-`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of an installed Agent Core. It validates required runtime tools, required Agent Core files, the supported Agent Core version, and a non-empty Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity.
 
 A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
 

--- a/templates/agent-python/.automation/INIT.md
+++ b/templates/agent-python/.automation/INIT.md
@@ -16,6 +16,12 @@ Initialization validates and reports state. It must not:
 
 Repository bootstrap and Automation Core upgrade are separate state-changing workflows.
 
+## Runtime preflight
+
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+
+A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
+
 ## Mandatory sequence
 
 1. Read `AGENTS.md` and this file.

--- a/templates/agent-python/.automation/bin/init_context.py
+++ b/templates/agent-python/.automation/bin/init_context.py
@@ -10,6 +10,17 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
+ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+REQUIRED_TOOLS = ("git", "gh", "just", "python3")
+REQUIRED_FILES = (
+    "AGENTS.md",
+    ".automation/INIT.md",
+    ".automation/VERSION",
+    ".automation/ADAPTER",
+    ".automation/policy.toml",
+    "just/project/mod.just",
+    "opencode.json",
+)
 TASK_ID_RE = re.compile(r"(?m)^- Task ID: (.+)$")
 BRANCH_RE = re.compile(r"(?m)^- Branch: (.+)$")
 WORKTREE_RE = re.compile(r"(?m)^- Worktree: (.+)$")
@@ -75,9 +86,17 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
+    if path.is_symlink():
+        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    return path.read_text(encoding="utf-8").strip()
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
+    if not value:
+        raise InitError(f"empty {label}: {path}")
+    return value
 
 
 def task_state(root: Path) -> dict | None:
@@ -128,6 +147,33 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
+def preflight(root: Path) -> dict:
+    missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        raise InitError("missing required tools: " + ", ".join(missing))
+    for relative in REQUIRED_FILES:
+        path = root / relative
+        if path.is_symlink():
+            raise InitError(f"required repository file must not be a symlink: {relative}")
+        if not path.is_file():
+            raise InitError(f"missing required repository file: {relative}")
+    version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
+    if version != SUPPORTED_AGENT_CORE_VERSION:
+        raise InitError(
+            f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
+        )
+    adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
+    if ADAPTER_RE.fullmatch(adapter) is None:
+        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    return {
+        "status": "PASS",
+        "readOnly": True,
+        "repositoryRoot": str(root),
+        "agentCoreVersion": version,
+        "adapter": adapter,
+    }
+
+
 def context(root: Path) -> dict:
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
@@ -154,35 +200,27 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    missing = [tool for tool in ("git", "gh", "just", "python3") if shutil.which(tool) is None]
-    if missing:
-        raise InitError("missing required tools: " + ", ".join(missing))
-    for relative in (
-        "AGENTS.md",
-        ".automation/INIT.md",
-        ".automation/VERSION",
-        ".automation/ADAPTER",
-        ".automation/policy.toml",
-        "just/project/mod.just",
-        "opencode.json",
-    ):
-        if not (root / relative).is_file():
-            raise InitError(f"missing required repository file: {relative}")
+    preflight(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 
 
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description="Read-only Agent initialization checks")
-    result.add_argument("command", choices=("doctor", "context"))
+    result.add_argument("command", choices=("preflight", "doctor", "context"))
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
     try:
-        root = repo_root()
-        result = doctor(root) if args.command == "doctor" else context(root)
+        commands = {
+            "preflight": preflight,
+            "doctor": doctor,
+            "context": context,
+        }
+        root = Path.cwd().resolve() if args.command == "preflight" else repo_root()
+        result = commands[args.command](root)
         print(json.dumps(result, sort_keys=True))
     except InitError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/templates/agent-python/.automation/bin/init_context.py
+++ b/templates/agent-python/.automation/bin/init_context.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
-ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 REQUIRED_TOOLS = ("git", "gh", "just", "python3")
 REQUIRED_FILES = (
     "AGENTS.md",
@@ -86,17 +85,9 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
-    if path.is_symlink():
-        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    try:
-        value = path.read_text(encoding="utf-8").strip()
-    except OSError as exc:
-        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
-    if not value:
-        raise InitError(f"empty {label}: {path}")
-    return value
+    return path.read_text(encoding="utf-8").strip()
 
 
 def task_state(root: Path) -> dict | None:
@@ -147,24 +138,25 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
-def preflight(root: Path) -> dict:
+def check_runtime_prerequisites(root: Path) -> None:
     missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
     if missing:
         raise InitError("missing required tools: " + ", ".join(missing))
     for relative in REQUIRED_FILES:
-        path = root / relative
-        if path.is_symlink():
-            raise InitError(f"required repository file must not be a symlink: {relative}")
-        if not path.is_file():
+        if not (root / relative).is_file():
             raise InitError(f"missing required repository file: {relative}")
+
+
+def preflight(root: Path) -> dict:
+    check_runtime_prerequisites(root)
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
         raise InitError(
             f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
         )
     adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
-    if ADAPTER_RE.fullmatch(adapter) is None:
-        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    if not adapter:
+        raise InitError(f"empty Project Adapter marker: {root / '.automation' / 'ADAPTER'}")
     return {
         "status": "PASS",
         "readOnly": True,
@@ -200,7 +192,7 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    preflight(root)
+    check_runtime_prerequisites(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 

--- a/templates/agent-python/.automation/just/agent.just
+++ b/templates/agent-python/.automation/just/agent.just
@@ -4,6 +4,10 @@ lifecycle := root / ".automation/bin/task_lifecycle.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
+preflight:
+    python3 {{quote(init)}} preflight
+
+[working-directory: root]
 doctor:
     python3 {{quote(init)}} doctor
 

--- a/templates/agent-python/.opencode/agents/build.md
+++ b/templates/agent-python/.opencode/agents/build.md
@@ -13,6 +13,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-python/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-python/.opencode/agents/task-orchestrator.md
@@ -15,6 +15,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-python/opencode.json
+++ b/templates/agent-python/opencode.json
@@ -60,6 +60,7 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
+      "just agent::preflight": "allow",
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",

--- a/templates/agent-rust/.automation/INIT.md
+++ b/templates/agent-rust/.automation/INIT.md
@@ -18,7 +18,7 @@ Repository bootstrap and Automation Core upgrade are separate state-changing wor
 
 ## Runtime preflight
 
-`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of an installed Agent Core. It validates required runtime tools, required Agent Core files, the supported Agent Core version, and a non-empty Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity.
 
 A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
 

--- a/templates/agent-rust/.automation/INIT.md
+++ b/templates/agent-rust/.automation/INIT.md
@@ -16,6 +16,12 @@ Initialization validates and reports state. It must not:
 
 Repository bootstrap and Automation Core upgrade are separate state-changing workflows.
 
+## Runtime preflight
+
+`just agent::preflight` is a narrower read-only readiness check for bootstrap, adoption, and upgrade verification from the root of a generated or trusted installed Agent Core. It validates required runtime tools, regular (non-symlink) Agent Core files, the supported Agent Core version, and the bounded Adapter marker without requiring a Git repository, resolving the default branch, or validating branch/worktree/Task identity. It executes the installed Agent Core runtime and is not an integrity validator for untrusted checkout content.
+
+A successful preflight does not establish a valid Agent session and does not replace `/init`, `agent::doctor`, or `agent::context`. A non-default bootstrap branch without Task State may pass preflight while strict doctor/context initialization remains blocked; this separation is intentional and is not an identity-check bypass.
+
 ## Mandatory sequence
 
 1. Read `AGENTS.md` and this file.

--- a/templates/agent-rust/.automation/bin/init_context.py
+++ b/templates/agent-rust/.automation/bin/init_context.py
@@ -10,6 +10,17 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
+ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+REQUIRED_TOOLS = ("git", "gh", "just", "python3")
+REQUIRED_FILES = (
+    "AGENTS.md",
+    ".automation/INIT.md",
+    ".automation/VERSION",
+    ".automation/ADAPTER",
+    ".automation/policy.toml",
+    "just/project/mod.just",
+    "opencode.json",
+)
 TASK_ID_RE = re.compile(r"(?m)^- Task ID: (.+)$")
 BRANCH_RE = re.compile(r"(?m)^- Branch: (.+)$")
 WORKTREE_RE = re.compile(r"(?m)^- Worktree: (.+)$")
@@ -75,9 +86,17 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
+    if path.is_symlink():
+        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    return path.read_text(encoding="utf-8").strip()
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
+    if not value:
+        raise InitError(f"empty {label}: {path}")
+    return value
 
 
 def task_state(root: Path) -> dict | None:
@@ -128,6 +147,33 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
+def preflight(root: Path) -> dict:
+    missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        raise InitError("missing required tools: " + ", ".join(missing))
+    for relative in REQUIRED_FILES:
+        path = root / relative
+        if path.is_symlink():
+            raise InitError(f"required repository file must not be a symlink: {relative}")
+        if not path.is_file():
+            raise InitError(f"missing required repository file: {relative}")
+    version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
+    if version != SUPPORTED_AGENT_CORE_VERSION:
+        raise InitError(
+            f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
+        )
+    adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
+    if ADAPTER_RE.fullmatch(adapter) is None:
+        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    return {
+        "status": "PASS",
+        "readOnly": True,
+        "repositoryRoot": str(root),
+        "agentCoreVersion": version,
+        "adapter": adapter,
+    }
+
+
 def context(root: Path) -> dict:
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
@@ -154,35 +200,27 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    missing = [tool for tool in ("git", "gh", "just", "python3") if shutil.which(tool) is None]
-    if missing:
-        raise InitError("missing required tools: " + ", ".join(missing))
-    for relative in (
-        "AGENTS.md",
-        ".automation/INIT.md",
-        ".automation/VERSION",
-        ".automation/ADAPTER",
-        ".automation/policy.toml",
-        "just/project/mod.just",
-        "opencode.json",
-    ):
-        if not (root / relative).is_file():
-            raise InitError(f"missing required repository file: {relative}")
+    preflight(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 
 
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description="Read-only Agent initialization checks")
-    result.add_argument("command", choices=("doctor", "context"))
+    result.add_argument("command", choices=("preflight", "doctor", "context"))
     return result
 
 
 def main() -> int:
     args = parser().parse_args()
     try:
-        root = repo_root()
-        result = doctor(root) if args.command == "doctor" else context(root)
+        commands = {
+            "preflight": preflight,
+            "doctor": doctor,
+            "context": context,
+        }
+        root = Path.cwd().resolve() if args.command == "preflight" else repo_root()
+        result = commands[args.command](root)
         print(json.dumps(result, sort_keys=True))
     except InitError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/templates/agent-rust/.automation/bin/init_context.py
+++ b/templates/agent-rust/.automation/bin/init_context.py
@@ -10,7 +10,6 @@ import sys
 from pathlib import Path
 
 SUPPORTED_AGENT_CORE_VERSION = "3"
-ADAPTER_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 REQUIRED_TOOLS = ("git", "gh", "just", "python3")
 REQUIRED_FILES = (
     "AGENTS.md",
@@ -86,17 +85,9 @@ def common_git_dir(root: Path) -> Path:
 
 
 def read_required(path: Path, label: str) -> str:
-    if path.is_symlink():
-        raise InitError(f"{label} must not be a symlink: {path}")
     if not path.is_file():
         raise InitError(f"missing {label}: {path}")
-    try:
-        value = path.read_text(encoding="utf-8").strip()
-    except OSError as exc:
-        raise InitError(f"cannot read {label}: {path}: {exc}") from exc
-    if not value:
-        raise InitError(f"empty {label}: {path}")
-    return value
+    return path.read_text(encoding="utf-8").strip()
 
 
 def task_state(root: Path) -> dict | None:
@@ -147,24 +138,25 @@ def validate_identity(root: Path, branch: str, base: str, state: dict | None) ->
     return task_id
 
 
-def preflight(root: Path) -> dict:
+def check_runtime_prerequisites(root: Path) -> None:
     missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
     if missing:
         raise InitError("missing required tools: " + ", ".join(missing))
     for relative in REQUIRED_FILES:
-        path = root / relative
-        if path.is_symlink():
-            raise InitError(f"required repository file must not be a symlink: {relative}")
-        if not path.is_file():
+        if not (root / relative).is_file():
             raise InitError(f"missing required repository file: {relative}")
+
+
+def preflight(root: Path) -> dict:
+    check_runtime_prerequisites(root)
     version = read_required(root / ".automation" / "VERSION", "Agent Core VERSION")
     if version != SUPPORTED_AGENT_CORE_VERSION:
         raise InitError(
             f"unsupported Agent Core version: repository={version}, runtime={SUPPORTED_AGENT_CORE_VERSION}"
         )
     adapter = read_required(root / ".automation" / "ADAPTER", "Project Adapter marker")
-    if ADAPTER_RE.fullmatch(adapter) is None:
-        raise InitError(f"invalid Project Adapter marker: {adapter!r}")
+    if not adapter:
+        raise InitError(f"empty Project Adapter marker: {root / '.automation' / 'ADAPTER'}")
     return {
         "status": "PASS",
         "readOnly": True,
@@ -200,7 +192,7 @@ def context(root: Path) -> dict:
 
 
 def doctor(root: Path) -> dict:
-    preflight(root)
+    check_runtime_prerequisites(root)
     data = context(root)
     return {"status": "PASS", "readOnly": True, **data}
 

--- a/templates/agent-rust/.automation/just/agent.just
+++ b/templates/agent-rust/.automation/just/agent.just
@@ -4,6 +4,10 @@ lifecycle := root / ".automation/bin/task_lifecycle.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
+preflight:
+    python3 {{quote(init)}} preflight
+
+[working-directory: root]
 doctor:
     python3 {{quote(init)}} doctor
 

--- a/templates/agent-rust/.opencode/agents/build.md
+++ b/templates/agent-rust/.opencode/agents/build.md
@@ -13,6 +13,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-rust/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-rust/.opencode/agents/task-orchestrator.md
@@ -15,6 +15,7 @@ permission:
     security-reviewer: allow
     scout: allow
   bash:
+    "just agent::preflight": allow
     "just agent::doctor": allow
     "just agent::context": allow
     "just project::doctor": allow

--- a/templates/agent-rust/opencode.json
+++ b/templates/agent-rust/opencode.json
@@ -60,6 +60,7 @@
       "gh run view *": "allow",
       "gh run list *": "allow",
       "gh repo view *": "allow",
+      "just agent::preflight": "allow",
       "just project::doctor": "allow",
       "just project::eval": "allow",
       "just project::format-check": "allow",

--- a/tests/runtime/runtime_smoke.py
+++ b/tests/runtime/runtime_smoke.py
@@ -537,7 +537,13 @@ def prepare(issue: str, template: str) -> dict:
         log=prepare_log,
     )
 
-    for recipe in ("agent::doctor", "agent::context", "project::doctor", "project::check"):
+    for recipe in (
+        "agent::preflight",
+        "agent::doctor",
+        "agent::context",
+        "project::doctor",
+        "project::check",
+    ):
         run_logged(
             ["nix", "develop", "--command", "just", recipe],
             cwd=repo,

--- a/tests/test_init_contract.py
+++ b/tests/test_init_contract.py
@@ -306,6 +306,7 @@ class InitContractTest(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("preflight:\n    python3 {{quote(init)}} preflight", recipes)
 
+    @unittest.skipUnless(shutil.which("just"), "just is required for runtime preflight smoke")
     def test_preflight_cli_does_not_require_git_repository_identity(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -319,6 +320,7 @@ class InitContractTest(unittest.TestCase):
             self.assertIn('"status": "PASS"', result.stdout)
             self.assertFalse((root / ".git").exists())
 
+    @unittest.skipUnless(shutil.which("just"), "just is required for runtime preflight smoke")
     def test_real_repository_identity_modes_preserve_strictness(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory) / "repository"

--- a/tests/test_init_contract.py
+++ b/tests/test_init_contract.py
@@ -251,10 +251,15 @@ class InitContractTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.create_runtime(root, adapter="")
-            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), self.assertRaisesRegex(
-                init.InitError, "empty Project Adapter marker"
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), mock.patch.object(
+                init, "current_branch", return_value="main"
+            ), mock.patch.object(init, "default_branch", return_value="main"), mock.patch.object(
+                init, "git", side_effect=self.context_git
             ):
-                init.preflight(root)
+                with self.assertRaisesRegex(init.InitError, "empty Project Adapter marker"):
+                    init.preflight(root)
+                self.assertEqual("", init.context(root)["adapter"])
+                self.assertEqual("PASS", init.doctor(root)["status"])
 
     def test_preflight_rejects_missing_adapter(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -265,26 +270,12 @@ class InitContractTest(unittest.TestCase):
             ):
                 init.preflight(root)
 
-    def test_preflight_rejects_invalid_adapter(self) -> None:
+    def test_preflight_does_not_impose_adapter_naming_grammar(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            self.create_runtime(root, adapter="../../secret")
-            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), self.assertRaisesRegex(
-                init.InitError, "invalid Project Adapter marker"
-            ):
-                init.preflight(root)
-
-    def test_preflight_rejects_symlinked_required_file(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            self.create_runtime(root)
-            adapter = root / ".automation" / "ADAPTER"
-            adapter.unlink()
-            adapter.symlink_to(root / "AGENTS.md")
-            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), self.assertRaisesRegex(
-                init.InitError, "must not be a symlink"
-            ):
-                init.preflight(root)
+            self.create_runtime(root, adapter="Legacy_Adapter.v1")
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"):
+                self.assertEqual("Legacy_Adapter.v1", init.preflight(root)["adapter"])
 
     def test_preflight_is_read_only(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_init_contract.py
+++ b/tests/test_init_contract.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -17,6 +19,65 @@ spec.loader.exec_module(init)
 
 
 class InitContractTest(unittest.TestCase):
+    def run_fixture(
+        self, root: Path, *command: str, check: bool = True
+    ) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            command,
+            cwd=root,
+            text=True,
+            capture_output=True,
+        )
+        if check and result.returncode != 0:
+            self.fail(
+                f"command failed ({' '.join(command)}):\n{result.stdout}\n{result.stderr}"
+            )
+        return result
+
+    def create_runtime(
+        self,
+        root: Path,
+        *,
+        version: str = "3",
+        adapter: str = "base",
+        omit: str | None = None,
+    ) -> None:
+        files = {
+            "AGENTS.md": "# Agent rules\n",
+            ".automation/INIT.md": "# Init\n",
+            ".automation/VERSION": version + "\n",
+            ".automation/ADAPTER": adapter + "\n",
+            ".automation/policy.toml": "version = 1\n",
+            "just/project/mod.just": "doctor:\n    @true\n",
+            "opencode.json": "{}\n",
+        }
+        for relative, content in files.items():
+            if relative == omit:
+                continue
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+
+    def context_git(self, root: Path, *args: str, check: bool = True) -> str:
+        del root, check
+        if args == ("rev-parse", "HEAD"):
+            return "1" * 40
+        if args == ("status", "--short"):
+            return ""
+        raise AssertionError(f"unexpected git call: {args}")
+
+    def task_state_text(self, root: Path) -> str:
+        sections = "\n".join(
+            f"## {section}\n\n- defined\n" for section in init.REQUIRED_TASK_SECTIONS
+        )
+        return (
+            "# TASK-1\n\n"
+            "- Task ID: TASK-1\n"
+            "- Branch: task/TASK-1-example\n"
+            f"- Worktree: {root}\n\n"
+            f"{sections}"
+        )
+
     def test_runtime_version_matches_agent_core_version(self) -> None:
         version = (
             ROOT / "components" / "agent-core" / ".automation" / "VERSION"
@@ -38,6 +99,27 @@ class InitContractTest(unittest.TestCase):
         with self.assertRaisesRegex(init.InitError, "branch/Task identity mismatch"):
             init.validate_identity(Path("."), "task/TASK-2-example", "main", state)
 
+    def test_task_state_worktree_mismatch_is_rejected(self) -> None:
+        state = {
+            "taskId": "TASK-1",
+            "branch": "task/TASK-1-example",
+            "worktree": "/different/worktree",
+        }
+        with self.assertRaisesRegex(init.InitError, "Task State worktree does not match"):
+            init.validate_identity(Path("."), "task/TASK-1-example", "main", state)
+
+    def test_task_state_must_be_ignored(self) -> None:
+        root = Path(".")
+        state = {
+            "taskId": "TASK-1",
+            "branch": "task/TASK-1-example",
+            "worktree": str(root.resolve()),
+        }
+        with mock.patch.object(init, "task_state_is_ignored", return_value=False), self.assertRaisesRegex(
+            init.InitError, ".task-state is not ignored"
+        ):
+            init.validate_identity(root, "task/TASK-1-example", "main", state)
+
     def test_version_mismatch_blocks_context(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -47,6 +129,244 @@ class InitContractTest(unittest.TestCase):
             (automation / "ADAPTER").write_text("base\n", encoding="utf-8")
             with self.assertRaisesRegex(init.InitError, "unsupported Agent Core version"):
                 init.context(root)
+
+    def test_bootstrap_branch_preflight_passes_while_context_and_doctor_block(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root)
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"):
+                self.assertEqual("PASS", init.preflight(root)["status"])
+                with mock.patch.object(init, "current_branch", return_value="bootstrap"), mock.patch.object(
+                    init, "default_branch", return_value="main"
+                ):
+                    for operation in (init.context, init.doctor):
+                        with self.subTest(operation=operation.__name__), self.assertRaisesRegex(
+                            init.InitError, "non-default branch requires Task State"
+                        ):
+                            operation(root)
+
+    def test_preflight_never_calls_identity_or_context_helpers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root)
+            forbidden = (
+                "default_branch",
+                "current_branch",
+                "task_state",
+                "validate_identity",
+                "context",
+            )
+            patches = [
+                mock.patch.object(init, name, side_effect=AssertionError(name))
+                for name in forbidden
+            ]
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"):
+                for patch in patches:
+                    patch.start()
+                try:
+                    self.assertEqual("PASS", init.preflight(root)["status"])
+                finally:
+                    for patch in reversed(patches):
+                        patch.stop()
+
+    def test_default_branch_preflight_doctor_and_context_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root)
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), mock.patch.object(
+                init, "current_branch", return_value="main"
+            ), mock.patch.object(init, "default_branch", return_value="main"), mock.patch.object(
+                init, "git", side_effect=self.context_git
+            ):
+                self.assertEqual("PASS", init.preflight(root)["status"])
+                self.assertIsNone(init.context(root)["taskId"])
+                self.assertEqual("PASS", init.doctor(root)["status"])
+
+    def test_registered_task_preflight_doctor_and_context_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root)
+            state = root / ".task-state" / "task.md"
+            state.parent.mkdir()
+            state.write_text(self.task_state_text(root), encoding="utf-8")
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), mock.patch.object(
+                init, "current_branch", return_value="task/TASK-1-example"
+            ), mock.patch.object(init, "default_branch", return_value="main"), mock.patch.object(
+                init, "task_state_is_ignored", return_value=True
+            ), mock.patch.object(init, "git", side_effect=self.context_git):
+                self.assertEqual("PASS", init.preflight(root)["status"])
+                self.assertEqual("TASK-1", init.context(root)["taskId"])
+                self.assertEqual("PASS", init.doctor(root)["status"])
+
+    def test_detached_head_remains_strict_for_context_and_doctor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root)
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), mock.patch.object(
+                init, "current_branch", side_effect=init.InitError("detached HEAD is not supported")
+            ):
+                self.assertEqual("PASS", init.preflight(root)["status"])
+                for operation in (init.context, init.doctor):
+                    with self.subTest(operation=operation.__name__), self.assertRaisesRegex(
+                        init.InitError, "detached HEAD is not supported"
+                    ):
+                        operation(root)
+
+    def test_preflight_rejects_missing_tool(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root)
+            with mock.patch.object(
+                init.shutil,
+                "which",
+                side_effect=lambda tool: None if tool == "gh" else f"/bin/{tool}",
+            ), self.assertRaisesRegex(init.InitError, "missing required tools: gh"):
+                init.preflight(root)
+
+    def test_preflight_rejects_missing_required_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root, omit="AGENTS.md")
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), self.assertRaisesRegex(
+                init.InitError, "missing required repository file: AGENTS.md"
+            ):
+                init.preflight(root)
+
+    def test_preflight_rejects_unsupported_version(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root, version="999")
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), self.assertRaisesRegex(
+                init.InitError, "unsupported Agent Core version"
+            ):
+                init.preflight(root)
+
+    def test_preflight_rejects_empty_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root, adapter="")
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), self.assertRaisesRegex(
+                init.InitError, "empty Project Adapter marker"
+            ):
+                init.preflight(root)
+
+    def test_preflight_rejects_missing_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root, omit=".automation/ADAPTER")
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), self.assertRaisesRegex(
+                init.InitError, "missing required repository file: .automation/ADAPTER"
+            ):
+                init.preflight(root)
+
+    def test_preflight_rejects_invalid_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root, adapter="../../secret")
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), self.assertRaisesRegex(
+                init.InitError, "invalid Project Adapter marker"
+            ):
+                init.preflight(root)
+
+    def test_preflight_rejects_symlinked_required_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root)
+            adapter = root / ".automation" / "ADAPTER"
+            adapter.unlink()
+            adapter.symlink_to(root / "AGENTS.md")
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"), self.assertRaisesRegex(
+                init.InitError, "must not be a symlink"
+            ):
+                init.preflight(root)
+
+    def test_preflight_is_read_only(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root)
+            before = {
+                path.relative_to(root): path.read_bytes()
+                for path in root.rglob("*")
+                if path.is_file()
+            }
+            with mock.patch.object(init.shutil, "which", return_value="/bin/tool"):
+                init.preflight(root)
+            after = {
+                path.relative_to(root): path.read_bytes()
+                for path in root.rglob("*")
+                if path.is_file()
+            }
+            self.assertEqual(before, after)
+            self.assertFalse((root / ".task-state").exists())
+
+    def test_preflight_cli_and_just_api_are_exposed(self) -> None:
+        self.assertEqual("preflight", init.parser().parse_args(["preflight"]).command)
+        recipes = (
+            ROOT / "components" / "agent-core" / ".automation" / "just" / "agent.just"
+        ).read_text(encoding="utf-8")
+        self.assertIn("preflight:\n    python3 {{quote(init)}} preflight", recipes)
+
+    def test_preflight_cli_does_not_require_git_repository_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.create_runtime(root)
+            result = self.run_fixture(
+                root,
+                sys.executable,
+                str(MODULE_PATH),
+                "preflight",
+            )
+            self.assertIn('"status": "PASS"', result.stdout)
+            self.assertFalse((root / ".git").exists())
+
+    def test_real_repository_identity_modes_preserve_strictness(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "repository"
+            shutil.copytree(ROOT / "templates" / "agent-base", root)
+            self.run_fixture(root, "git", "init", "-b", "main")
+            self.run_fixture(root, "git", "config", "user.name", "Preflight Test")
+            self.run_fixture(
+                root, "git", "config", "user.email", "preflight@example.invalid"
+            )
+            self.run_fixture(root, "git", "add", ".")
+            self.run_fixture(root, "git", "commit", "-m", "fixture")
+            self.run_fixture(root, "git", "update-ref", "refs/remotes/origin/main", "HEAD")
+            self.run_fixture(
+                root,
+                "git",
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/main",
+            )
+
+            for command in ("agent::preflight", "agent::doctor", "agent::context"):
+                self.run_fixture(root, "just", command)
+
+            self.run_fixture(root, "git", "switch", "-c", "bootstrap-adoption")
+            before = self.run_fixture(root, "git", "status", "--porcelain").stdout
+            self.run_fixture(root, "just", "agent::preflight")
+            after = self.run_fixture(root, "git", "status", "--porcelain").stdout
+            self.assertEqual(before, after)
+            for command in ("agent::doctor", "agent::context"):
+                result = self.run_fixture(root, "just", command, check=False)
+                self.assertEqual(2, result.returncode, command)
+                self.assertIn(
+                    "non-default branch requires Task State",
+                    result.stderr,
+                    command,
+                )
+
+            self.run_fixture(root, "git", "switch", "main")
+            self.run_fixture(
+                root,
+                "just",
+                "agent::task-start",
+                "SMOKE-PREFLIGHT",
+                "runtime-preflight",
+            )
+            task = root / ".worktrees" / "SMOKE-PREFLIGHT-runtime-preflight"
+            for command in ("agent::preflight", "agent::doctor", "agent::context"):
+                self.run_fixture(task, "just", command)
 
     def test_init_runtime_contains_no_repository_mutation_commands(self) -> None:
         text = MODULE_PATH.read_text(encoding="utf-8")

--- a/tests/test_init_contract.py
+++ b/tests/test_init_contract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import shutil
 import subprocess
 import sys
@@ -20,13 +21,18 @@ spec.loader.exec_module(init)
 
 class InitContractTest(unittest.TestCase):
     def run_fixture(
-        self, root: Path, *command: str, check: bool = True
+        self,
+        root: Path,
+        *command: str,
+        check: bool = True,
+        env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         result = subprocess.run(
             command,
             cwd=root,
             text=True,
             capture_output=True,
+            env=env,
         )
         if check and result.returncode != 0:
             self.fail(
@@ -306,16 +312,23 @@ class InitContractTest(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("preflight:\n    python3 {{quote(init)}} preflight", recipes)
 
-    @unittest.skipUnless(shutil.which("just"), "just is required for runtime preflight smoke")
     def test_preflight_cli_does_not_require_git_repository_identity(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             self.create_runtime(root)
+            tools = root / ".test-tools"
+            tools.mkdir()
+            just = tools / "just"
+            just.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            just.chmod(0o755)
+            env = os.environ.copy()
+            env["PATH"] = f"{tools}:{env['PATH']}"
             result = self.run_fixture(
                 root,
                 sys.executable,
                 str(MODULE_PATH),
                 "preflight",
+                env=env,
             )
             self.assertIn('"status": "PASS"', result.stdout)
             self.assertFalse((root / ".git").exists())

--- a/tests/test_opencode_contract.py
+++ b/tests/test_opencode_contract.py
@@ -238,6 +238,17 @@ class OpenCodeContractTest(unittest.TestCase):
         self.assertEqual(bash["just agent::push *"], "ask")
         self.assertEqual(bash["just integrate::merge *"], "ask")
 
+    def test_runtime_preflight_is_narrowly_allowlisted(self) -> None:
+        self.assertEqual(
+            "allow", self.config["permission"]["bash"]["just agent::preflight"]
+        )
+        for agent in ("build", "task-orchestrator"):
+            self.assertEqual(
+                "allow",
+                permission_for(agent)["bash"].get("just agent::preflight"),
+                agent,
+            )
+
     def test_automation_core_is_not_editable(self) -> None:
         edit = self.config["permission"]["edit"]
         for path in (


### PR DESCRIPTION
## 概要
- Agent Core v3へread-onlyな`agent::preflight` APIを追加
- runtime/tools/files/VERSION/Adapter readinessとstrict branch/Task identityを分離
- Agent Core VERSIONは3のまま維持

## Contract
- `agent::preflight`: `git`、`gh`、`just`、`python3`、required Agent Core files、VERSION 3、non-empty Adapter markerを検証
- Git repository/default branch/Task Stateを要求せず、branch/worktree identity validationを実行しない
- installed Agent Coreを変更しないread-only診断API

## Strict identity preservation
- `agent::doctor`はpreflight追加前と同じtool/file prerequisite semanticsの後に既存strict `context(root)`を実行
- `read_required()`の既存file/read/strip semanticsを維持
- empty Adapter拒否はpreflight内だけに限定し、新しいAdapter naming grammarは導入しない
- `agent::context`のdetached HEAD、default branch、Task State、branch/worktree identity、ignore検証は維持
- `/init`のmandatory doctor/context/project doctor sequenceは変更なし
- skip/bypass/bootstrap mode flagは追加していない

## Bootstrap scenario
実generated `agent-base` fixtureで実行:
- pre-Git checkout: preflight PASS
- non-default bootstrap branch without Task State: preflight PASS
- 同branch: doctor/contextは`non-default branch requires Task State`でBLOCKED
- normal default branch: preflight/doctor/context PASS
- registered Task worktree: preflight/doctor/context PASS
- preflight前後のGit status不変

## Generated templates
normal rendererで以下を再生成:
- agent-base
- agent-python
- agent-rust
- agent-nix
- agent-cpp-cmake

全templateへruntime、Just recipe、allowlist、INIT documentationを反映。通常Template CI smokeでも`agent::preflight`を実行。

## Verification
- Python contracts: 193 PASS
- generated template check: PASS
- `nix flake check --all-systems --no-build --no-update-lock-file`: PASS
- explicit OpenCodePolicy check build: PASS
- policy validate: PASS
- strict agent-core audit: `PASS=24 INTENTIONAL_DIFFERENCE=2 DIFF=0 MISSING=0`
- `just template::check`: PASS
- `just template::distribution-verify`: PASS
- `git diff --check`: PASS

## Non-goals
- `context()`/`doctor()`/`/init`の既存semantics変更なし
- symlink integrity hardening、Adapter schema導入なし
- model allocation、fallback policy、migration、Task lifecycle変更なし
- OpenCodePolicy、`flake.lock`、Project Adapter変更なし
- merge/Ready化なし

Closes #62