### PR TITLE
fix: make Python lockfile bootstrap deterministic

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -45,6 +45,10 @@ jobs:
           cd "$target"
           nix flake init -t "path:$GITHUB_WORKSPACE#${{ matrix.template }}"
           nix develop --command just project::bootstrap smoke-project
+          if [ "${{ matrix.template }}" = agent-python ]; then
+            test -f flake.lock
+            test -f uv.lock
+          fi
           if grep -R --fixed-strings '@@PROJECT_NAME@@' . \
             --exclude-dir=.git \
             --exclude=project_bootstrap.py; then
@@ -56,6 +60,7 @@ jobs:
           git config user.email "template-ci@example.invalid"
           git add .
           git commit -m initial
+          test -z "$(git status --porcelain)"
           git update-ref refs/remotes/origin/main HEAD
           git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
       - name: Bootstrap idempotency
@@ -65,35 +70,86 @@ jobs:
           target="$RUNNER_TEMP/${{ matrix.template }}"
           cd "$target"
           before="$(git status --porcelain)"
-          nix develop --command just project::bootstrap smoke-project
+          if [ "${{ matrix.template }}" = agent-python ]; then
+            before_locks="$(sha256sum flake.lock uv.lock)"
+          fi
+          nix develop --no-update-lock-file --command just project::bootstrap smoke-project
           after="$(git status --porcelain)"
           test "$before" = "$after"
+          if [ "${{ matrix.template }}" = agent-python ]; then
+            after_locks="$(sha256sum flake.lock uv.lock)"
+            test "$before_locks" = "$after_locks"
+          fi
+      - name: Record Python lockfile state
+        if: matrix.template == 'agent-python'
+        shell: bash
+        run: |
+          set -euo pipefail
+          target="$RUNNER_TEMP/${{ matrix.template }}"
+          cd "$target"
+          sha256sum flake.lock uv.lock > "$RUNNER_TEMP/python-lockfiles.before"
+          git status --porcelain > "$RUNNER_TEMP/python-status.before"
       - name: Agent initialization smoke
         shell: bash
         run: |
           set -euo pipefail
           target="$RUNNER_TEMP/${{ matrix.template }}"
           cd "$target"
-          nix develop --command just agent::preflight
-          nix develop --command just agent::doctor
-          nix develop --command just agent::context
+          nix develop --no-update-lock-file --command just agent::preflight
+          nix develop --no-update-lock-file --command just agent::doctor
+          nix develop --no-update-lock-file --command just agent::context
       - name: Project Adapter smoke
         shell: bash
         run: |
           set -euo pipefail
           target="$RUNNER_TEMP/${{ matrix.template }}"
           cd "$target"
-          nix develop --command just project::doctor
-          nix develop --command just project::check
+          nix develop --no-update-lock-file --command just project::doctor
+          nix develop --no-update-lock-file --command just project::check
           if [ "${{ matrix.template }}" = agent-cpp-cmake ]; then
-            nix develop --command env CXX=c++ just project::doctor
-            if nix develop --command env CXX=definitely-not-a-cxx-compiler just project::doctor; then
+            nix develop --no-update-lock-file --command env CXX=c++ just project::doctor
+            if nix develop --no-update-lock-file --command env CXX=definitely-not-a-cxx-compiler just project::doctor; then
               echo 'doctor unexpectedly accepted missing CXX' >&2
               exit 1
             fi
-            nix develop --command env -u CXX just project::doctor
-            nix develop --command env CXX= just project::doctor
+            nix develop --no-update-lock-file --command env -u CXX just project::doctor
+            nix develop --no-update-lock-file --command env CXX= just project::doctor
           fi
+      - name: Verify Python lockfile state
+        if: matrix.template == 'agent-python'
+        shell: bash
+        run: |
+          set -euo pipefail
+          target="$RUNNER_TEMP/${{ matrix.template }}"
+          cd "$target"
+          sha256sum --check "$RUNNER_TEMP/python-lockfiles.before"
+          git status --porcelain > "$RUNNER_TEMP/python-status.after"
+          cmp "$RUNNER_TEMP/python-status.before" "$RUNNER_TEMP/python-status.after"
+          test -z "$(git status --porcelain)"
+      - name: Python verification rejects missing or stale lockfile
+        if: matrix.template == 'agent-python'
+        shell: bash
+        run: |
+          set -euo pipefail
+          target="$RUNNER_TEMP/${{ matrix.template }}"
+          cd "$target"
+          rm uv.lock
+          if nix develop --no-update-lock-file --command just project::check; then
+            echo 'project::check unexpectedly accepted a missing uv.lock' >&2
+            exit 1
+          fi
+          test ! -e uv.lock
+          git checkout -- uv.lock
+          before_uv="$(sha256sum uv.lock)"
+          python3 -c 'from pathlib import Path; p = Path("pyproject.toml"); p.write_text(p.read_text().replace("dependencies = []", "dependencies = [\"idna==3.10\"]"))'
+          if nix develop --no-update-lock-file --command just project::check; then
+            echo 'project::check unexpectedly accepted a stale uv.lock' >&2
+            exit 1
+          fi
+          after_uv="$(sha256sum uv.lock)"
+          test "$before_uv" = "$after_uv"
+          git checkout -- pyproject.toml
+          test -z "$(git status --porcelain)"
       - name: Python inherited worktree environment smoke
         if: matrix.template == 'agent-python'
         shell: bash
@@ -101,7 +157,7 @@ jobs:
           set -euo pipefail
           target="$RUNNER_TEMP/${{ matrix.template }}"
           cd "$target"
-          nix develop --command bash -c '
+          nix develop --no-update-lock-file --command bash -c '
             set -euo pipefail
             export VIRTUAL_ENV=/tmp/main-worktree/.venv
             export UV_PROJECT_ENVIRONMENT=/tmp/main-worktree/.venv

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -44,10 +44,14 @@ jobs:
           mkdir -p "$target"
           cd "$target"
           nix flake init -t "path:$GITHUB_WORKSPACE#${{ matrix.template }}"
-          nix develop --command just project::bootstrap smoke-project
           if [ "${{ matrix.template }}" = agent-python ]; then
+            test ! -e flake.lock
+            test ! -e uv.lock
+            nix develop --no-write-lock-file --command just project::bootstrap smoke-project
             test -f flake.lock
             test -f uv.lock
+          else
+            nix develop --command just project::bootstrap smoke-project
           fi
           if grep -R --fixed-strings '@@PROJECT_NAME@@' . \
             --exclude-dir=.git \
@@ -72,8 +76,10 @@ jobs:
           before="$(git status --porcelain)"
           if [ "${{ matrix.template }}" = agent-python ]; then
             before_locks="$(sha256sum flake.lock uv.lock)"
+            nix develop --no-write-lock-file --command just project::bootstrap smoke-project
+          else
+            nix develop --no-update-lock-file --command just project::bootstrap smoke-project
           fi
-          nix develop --no-update-lock-file --command just project::bootstrap smoke-project
           after="$(git status --porcelain)"
           test "$before" = "$after"
           if [ "${{ matrix.template }}" = agent-python ]; then

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The optional explicit project name can be supplied when the directory name is no
 nix develop --command just project::bootstrap my-project
 ```
 
-`project::bootstrap` is the explicit state-changing setup step. It resolves generated project-name placeholders and is idempotent. It does not commit, push, merge, or change GitHub repository settings. After bootstrap, initialize Git as needed and use `/init` or the corresponding Just checks for normal read-only session validation.
+`project::bootstrap` is the explicit state-changing setup step. It resolves generated project-name placeholders and is idempotent. In the Python template it then creates missing repository-owned `flake.lock` and `uv.lock` files without refreshing existing lockfiles. It does not commit, push, merge, or change GitHub repository settings. Include bootstrap output in the initial commit, then use `nix develop --no-update-lock-file --command ...` and the corresponding Just checks for normal read-only validation; Python verification uses `uv run --locked` and does not repair missing or stale dependency identity.
 
 ## Repository policy
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,26 @@ rust   -> agent-rust
 
 Every Agent-ready repository contains the shared Agent Core plus exactly one Project Adapter. Adapter-less repositories are not supported; unknown projects use `base` as the minimum contract.
 
-After instantiating a generated language/toolchain template, run the one-time project bootstrap before the first validation or development session:
+After instantiating a generated non-Python language/toolchain template, run the one-time project bootstrap before the first validation or development session:
 
 ```sh
 nix develop --command just project::bootstrap
 ```
 
-The optional explicit project name can be supplied when the directory name is not the desired project name:
+For the Python template, prevent the outer Nix invocation from writing `flake.lock`; the Python Adapter bootstrap owns explicit materialization of missing `flake.lock` and `uv.lock` files:
+
+```sh
+nix develop --no-write-lock-file --command just project::bootstrap
+```
+
+The optional explicit project name can be supplied when the directory name is not the desired project name. Preserve the same Python-specific flag when using it:
 
 ```sh
 nix develop --command just project::bootstrap my-project
+nix develop --no-write-lock-file --command just project::bootstrap my-project
 ```
 
-`project::bootstrap` is the explicit state-changing setup step. It resolves generated project-name placeholders and is idempotent. In the Python template it then creates missing repository-owned `flake.lock` and `uv.lock` files without refreshing existing lockfiles. It does not commit, push, merge, or change GitHub repository settings. Include bootstrap output in the initial commit, then use `nix develop --no-update-lock-file --command ...` and the corresponding Just checks for normal read-only validation; Python verification uses `uv run --locked` and does not repair missing or stale dependency identity.
+`project::bootstrap` is the explicit state-changing setup step. It resolves generated project-name placeholders and is idempotent. Python uses `--no-write-lock-file` so outer `nix develop` may resolve inputs but cannot take ownership of lockfile mutation; the Adapter then creates missing repository-owned `flake.lock` and `uv.lock` files without refreshing existing lockfiles. It does not commit, push, merge, or change GitHub repository settings. Include bootstrap output in the initial commit, then use `nix develop --no-update-lock-file --command ...` and the corresponding Just checks for normal read-only validation; Python verification uses `uv run --locked` and does not repair missing or stale dependency identity.
 
 ## Repository policy
 

--- a/components/adapters/python/.automation/INIT.fragment.md
+++ b/components/adapters/python/.automation/INIT.fragment.md
@@ -1,7 +1,10 @@
 ## Python Project Adapter initialization
 
 - `just project::environment` reports the worktree-local Python environment boundary without mutating project files.
+- `flake.lock` and `uv.lock` are repository-owned dependency identity. `just project::bootstrap [name]` resolves the project-name placeholder first, then creates only missing lockfiles; existing lockfiles are preserved byte-for-byte.
+- `.venv`, `.direnv`, and Python caches are ignored local artifacts; lockfiles are not caches and are not ignored.
 - `just project::doctor` requires `uv`, `ruff`, `mypy`, and `pytest` to be available through that boundary.
+- Verification recipes use `uv run --locked`, so missing or stale `uv.lock` blocks verification instead of updating dependency identity.
 - The managed virtual environment is always the current worktree's `.venv`; inherited `VIRTUAL_ENV`, `UV_PROJECT_ENVIRONMENT`, or `PATH` entries for another `.venv/bin` are not trusted.
 - `PIP_REQUIRE_VIRTUALENV=1` is enforced by Project Adapter execution rather than inherited ambient shell state.
-- Dependency synchronization is explicit through `just project::python::sync`; `/init` remains read-only and does not run it.
+- Dependency synchronization is explicit through `just project::python::sync`; it may update `uv.lock` when project metadata requires it. `/init` remains read-only and does not create or update either lockfile.

--- a/components/adapters/python/.pre-commit-config.yaml
+++ b/components/adapters/python/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ repos:
     hooks:
       - id: ruff-check
         name: Ruff Linter
-        entry: uv run ruff check --force-exclude
+        entry: uv run --locked ruff check --force-exclude
         language: system
         types_or: [python, pyi]
         require_serial: true
       - id: ruff-format
         name: Ruff Formatter
-        entry: uv run ruff format --force-exclude --check
+        entry: uv run --locked ruff format --force-exclude --check
         language: system
         types_or: [python, pyi]
         require_serial: true

--- a/components/adapters/python/just/project/lockfiles.py
+++ b/components/adapters/python/just/project/lockfiles.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from environment import sanitized_environment
+
+
+def ensure_lockfile(
+    repo: Path,
+    lockfile: str,
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> int:
+    path = repo / lockfile
+    if path.exists():
+        if path.is_file():
+            return 0
+        print(f"lockfile path is not a file: {lockfile}", file=sys.stderr)
+        return 1
+
+    if env is None:
+        result = subprocess.run(command, cwd=repo)
+    else:
+        result = subprocess.run(command, cwd=repo, env=env)
+    if result.returncode != 0:
+        return result.returncode
+    if not path.is_file():
+        print(f"lockfile generation did not create {lockfile}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def ensure(repo: Path) -> int:
+    result = ensure_lockfile(repo, "flake.lock", ["nix", "flake", "lock"])
+    if result != 0:
+        return result
+    return ensure_lockfile(
+        repo,
+        "uv.lock",
+        ["uv", "lock"],
+        env=sanitized_environment(repo),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Materialize missing Python project lockfiles")
+    parser.add_argument("command", choices=["ensure"])
+    args = parser.parse_args()
+    if args.command == "ensure":
+        return ensure(Path.cwd().resolve())
+    raise AssertionError("unreachable")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/components/adapters/python/just/project/mod.just
+++ b/components/adapters/python/just/project/mod.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 bootstrap_script := root / ".automation/bin/project_bootstrap.py"
 environment_script := root / "just/project/environment.py"
+lockfiles_script := root / "just/project/lockfiles.py"
 
 mod python 'python.just'
 mod? repository 'repository.just'
@@ -8,6 +9,7 @@ mod? repository 'repository.just'
 [working-directory: root]
 bootstrap name='':
     python3 {{quote(bootstrap_script)}} {{quote(name)}}
+    python3 {{quote(lockfiles_script)}} ensure
 
 [working-directory: root]
 environment:
@@ -23,16 +25,16 @@ doctor:
 
 [working-directory: root]
 format-check:
-    python3 {{quote(environment_script)}} exec uv run ruff format --check src tests
+    python3 {{quote(environment_script)}} exec uv run --locked ruff format --check src tests
 
 [working-directory: root]
 lint:
-    python3 {{quote(environment_script)}} exec uv run ruff check src tests
-    python3 {{quote(environment_script)}} exec uv run mypy src tests
+    python3 {{quote(environment_script)}} exec uv run --locked ruff check src tests
+    python3 {{quote(environment_script)}} exec uv run --locked mypy src tests
 
 [working-directory: root]
 test:
-    python3 {{quote(environment_script)}} exec uv run pytest -v
+    python3 {{quote(environment_script)}} exec uv run --locked pytest -v
 
 [working-directory: root]
 build:

--- a/components/adapters/python/just/project/python.just
+++ b/components/adapters/python/just/project/python.just
@@ -7,9 +7,9 @@ sync:
 
 [working-directory: root]
 format:
-    python3 {{quote(environment_script)}} exec uv run ruff format src tests
-    python3 {{quote(environment_script)}} exec uv run ruff check --fix src tests
+    python3 {{quote(environment_script)}} exec uv run --locked ruff format src tests
+    python3 {{quote(environment_script)}} exec uv run --locked ruff check --fix src tests
 
 [working-directory: root]
 typecheck:
-    python3 {{quote(environment_script)}} exec uv run mypy src tests
+    python3 {{quote(environment_script)}} exec uv run --locked mypy src tests

--- a/docs/existing-repository-adoption.md
+++ b/docs/existing-repository-adoption.md
@@ -21,11 +21,11 @@ nix develop --command just template::adapter-migrate-plan /path/to/repository cp
 For a Python repository, adoption deliberately leaves dependency resolution outside the generic adoption engine. Existing `flake.lock` and `uv.lock` files are preserved byte-for-byte. After `template::adopt-apply`, run the explicit bootstrap boundary, review any newly generated lockfiles, verify without lockfile updates, and include the accepted bootstrap output in the adoption pull request:
 
 ```sh
-nix develop --command just project::bootstrap
+nix develop --no-write-lock-file --command just project::bootstrap
 nix develop --no-update-lock-file --command just project::check
 ```
 
-Python `project::bootstrap` resolves the project name before creating only missing lockfiles. `project::check` uses `uv run --locked`; `/init` and verification do not create or update lockfiles. `just project::python::sync` remains the explicit dependency synchronization operation and may update `uv.lock` when project metadata requires it.
+The Python bootstrap entry uses `--no-write-lock-file` so outer Nix resolution cannot update an existing `flake.lock` or materialize a missing one before the Adapter runs. Python `project::bootstrap` resolves the project name before creating only missing lockfiles. Post-bootstrap verification instead uses `--no-update-lock-file`; `project::check` uses `uv run --locked`, and `/init` and verification do not create or update lockfiles. `just project::python::sync` remains the explicit dependency synchronization operation and may update `uv.lock` when project metadata requires it.
 
 After applying Agent Core on an existing bootstrap/adoption branch, `just agent::preflight` can verify tools, required files, VERSION, and Adapter readiness without requiring fabricated Task State. This is not full initialization: `just agent::doctor`, `just agent::context`, and `/init` retain strict branch/Task identity requirements and may intentionally block until the repository is on its default branch or in a registered Task worktree.
 

--- a/docs/existing-repository-adoption.md
+++ b/docs/existing-repository-adoption.md
@@ -18,6 +18,15 @@ nix develop --command just template::adapter-migrate-plan /path/to/repository cp
 
 `adopt-apply` performs no commit, push, or merge. It refuses to run when the target working tree is dirty or when the plan contains unresolved collisions.
 
+For a Python repository, adoption deliberately leaves dependency resolution outside the generic adoption engine. Existing `flake.lock` and `uv.lock` files are preserved byte-for-byte. After `template::adopt-apply`, run the explicit bootstrap boundary, review any newly generated lockfiles, verify without lockfile updates, and include the accepted bootstrap output in the adoption pull request:
+
+```sh
+nix develop --command just project::bootstrap
+nix develop --no-update-lock-file --command just project::check
+```
+
+Python `project::bootstrap` resolves the project name before creating only missing lockfiles. `project::check` uses `uv run --locked`; `/init` and verification do not create or update lockfiles. `just project::python::sync` remains the explicit dependency synchronization operation and may update `uv.lock` when project metadata requires it.
+
 After applying Agent Core on an existing bootstrap/adoption branch, `just agent::preflight` can verify tools, required files, VERSION, and Adapter readiness without requiring fabricated Task State. This is not full initialization: `just agent::doctor`, `just agent::context`, and `/init` retain strict branch/Task identity requirements and may intentionally block until the repository is on its default branch or in a registered Task worktree.
 
 ## Adapter selection

--- a/templates/agent-python/.automation/INIT.fragment.md
+++ b/templates/agent-python/.automation/INIT.fragment.md
@@ -1,7 +1,10 @@
 ## Python Project Adapter initialization
 
 - `just project::environment` reports the worktree-local Python environment boundary without mutating project files.
+- `flake.lock` and `uv.lock` are repository-owned dependency identity. `just project::bootstrap [name]` resolves the project-name placeholder first, then creates only missing lockfiles; existing lockfiles are preserved byte-for-byte.
+- `.venv`, `.direnv`, and Python caches are ignored local artifacts; lockfiles are not caches and are not ignored.
 - `just project::doctor` requires `uv`, `ruff`, `mypy`, and `pytest` to be available through that boundary.
+- Verification recipes use `uv run --locked`, so missing or stale `uv.lock` blocks verification instead of updating dependency identity.
 - The managed virtual environment is always the current worktree's `.venv`; inherited `VIRTUAL_ENV`, `UV_PROJECT_ENVIRONMENT`, or `PATH` entries for another `.venv/bin` are not trusted.
 - `PIP_REQUIRE_VIRTUALENV=1` is enforced by Project Adapter execution rather than inherited ambient shell state.
-- Dependency synchronization is explicit through `just project::python::sync`; `/init` remains read-only and does not run it.
+- Dependency synchronization is explicit through `just project::python::sync`; it may update `uv.lock` when project metadata requires it. `/init` remains read-only and does not create or update either lockfile.

--- a/templates/agent-python/.pre-commit-config.yaml
+++ b/templates/agent-python/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ repos:
     hooks:
       - id: ruff-check
         name: Ruff Linter
-        entry: uv run ruff check --force-exclude
+        entry: uv run --locked ruff check --force-exclude
         language: system
         types_or: [python, pyi]
         require_serial: true
       - id: ruff-format
         name: Ruff Formatter
-        entry: uv run ruff format --force-exclude --check
+        entry: uv run --locked ruff format --force-exclude --check
         language: system
         types_or: [python, pyi]
         require_serial: true

--- a/templates/agent-python/just/project/lockfiles.py
+++ b/templates/agent-python/just/project/lockfiles.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from environment import sanitized_environment
+
+
+def ensure_lockfile(
+    repo: Path,
+    lockfile: str,
+    command: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> int:
+    path = repo / lockfile
+    if path.exists():
+        if path.is_file():
+            return 0
+        print(f"lockfile path is not a file: {lockfile}", file=sys.stderr)
+        return 1
+
+    if env is None:
+        result = subprocess.run(command, cwd=repo)
+    else:
+        result = subprocess.run(command, cwd=repo, env=env)
+    if result.returncode != 0:
+        return result.returncode
+    if not path.is_file():
+        print(f"lockfile generation did not create {lockfile}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def ensure(repo: Path) -> int:
+    result = ensure_lockfile(repo, "flake.lock", ["nix", "flake", "lock"])
+    if result != 0:
+        return result
+    return ensure_lockfile(
+        repo,
+        "uv.lock",
+        ["uv", "lock"],
+        env=sanitized_environment(repo),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Materialize missing Python project lockfiles")
+    parser.add_argument("command", choices=["ensure"])
+    args = parser.parse_args()
+    if args.command == "ensure":
+        return ensure(Path.cwd().resolve())
+    raise AssertionError("unreachable")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-python/just/project/mod.just
+++ b/templates/agent-python/just/project/mod.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 bootstrap_script := root / ".automation/bin/project_bootstrap.py"
 environment_script := root / "just/project/environment.py"
+lockfiles_script := root / "just/project/lockfiles.py"
 
 mod python 'python.just'
 mod? repository 'repository.just'
@@ -8,6 +9,7 @@ mod? repository 'repository.just'
 [working-directory: root]
 bootstrap name='':
     python3 {{quote(bootstrap_script)}} {{quote(name)}}
+    python3 {{quote(lockfiles_script)}} ensure
 
 [working-directory: root]
 environment:
@@ -23,16 +25,16 @@ doctor:
 
 [working-directory: root]
 format-check:
-    python3 {{quote(environment_script)}} exec uv run ruff format --check src tests
+    python3 {{quote(environment_script)}} exec uv run --locked ruff format --check src tests
 
 [working-directory: root]
 lint:
-    python3 {{quote(environment_script)}} exec uv run ruff check src tests
-    python3 {{quote(environment_script)}} exec uv run mypy src tests
+    python3 {{quote(environment_script)}} exec uv run --locked ruff check src tests
+    python3 {{quote(environment_script)}} exec uv run --locked mypy src tests
 
 [working-directory: root]
 test:
-    python3 {{quote(environment_script)}} exec uv run pytest -v
+    python3 {{quote(environment_script)}} exec uv run --locked pytest -v
 
 [working-directory: root]
 build:

--- a/templates/agent-python/just/project/python.just
+++ b/templates/agent-python/just/project/python.just
@@ -7,9 +7,9 @@ sync:
 
 [working-directory: root]
 format:
-    python3 {{quote(environment_script)}} exec uv run ruff format src tests
-    python3 {{quote(environment_script)}} exec uv run ruff check --fix src tests
+    python3 {{quote(environment_script)}} exec uv run --locked ruff format src tests
+    python3 {{quote(environment_script)}} exec uv run --locked ruff check --fix src tests
 
 [working-directory: root]
 typecheck:
-    python3 {{quote(environment_script)}} exec uv run mypy src tests
+    python3 {{quote(environment_script)}} exec uv run --locked mypy src tests

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -17,6 +17,15 @@ class CiContractTest(unittest.TestCase):
         self.assertIn("just agent::context", workflow)
         self.assertIn("just project::doctor", workflow)
         self.assertIn("just project::check", workflow)
+        self.assertIn("test -f flake.lock", workflow)
+        self.assertIn("test -f uv.lock", workflow)
+        self.assertIn("sha256sum flake.lock uv.lock", workflow)
+        self.assertIn("sha256sum --check", workflow)
+        self.assertIn("--no-update-lock-file --command just project::check", workflow)
+        self.assertIn('test -z "$(git status --porcelain)"', workflow)
+        self.assertIn("project::check unexpectedly accepted a missing uv.lock", workflow)
+        self.assertIn("project::check unexpectedly accepted a stale uv.lock", workflow)
+        self.assertIn("test ! -e uv.lock", workflow)
 
     def test_ci_has_read_only_repository_permission(self) -> None:
         workflow = (ROOT / ".github" / "workflows" / "template-ci.yml").read_text(encoding="utf-8")

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -26,6 +26,13 @@ class CiContractTest(unittest.TestCase):
         self.assertIn("project::check unexpectedly accepted a missing uv.lock", workflow)
         self.assertIn("project::check unexpectedly accepted a stale uv.lock", workflow)
         self.assertIn("test ! -e uv.lock", workflow)
+        self.assertIn("test ! -e flake.lock", workflow)
+        self.assertGreaterEqual(
+            workflow.count(
+                "nix develop --no-write-lock-file --command just project::bootstrap smoke-project"
+            ),
+            2,
+        )
 
     def test_ci_has_read_only_repository_permission(self) -> None:
         workflow = (ROOT / ".github" / "workflows" / "template-ci.yml").read_text(encoding="utf-8")

--- a/tests/test_language_adapters.py
+++ b/tests/test_language_adapters.py
@@ -28,6 +28,20 @@ class LanguageAdapterTest(unittest.TestCase):
             self.assertIn(tool, project)
         self.assertIn("src tests", project)
         self.assertIn("SKIPPED", project)
+        self.assertIn("lockfiles.py", project)
+        self.assertLess(project.index("project_bootstrap.py"), project.index("lockfiles.py"))
+        self.assertEqual(project.count("uv run --locked"), 4)
+        self.assertNotIn("exec uv run ruff", project)
+        self.assertNotIn("exec uv run mypy", project)
+        self.assertNotIn("exec uv run pytest", project)
+
+        python = (adapter / "just" / "project" / "python.just").read_text(encoding="utf-8")
+        self.assertEqual(python.count("uv run --locked"), 3)
+        self.assertIn("exec uv sync", python)
+
+        pre_commit = (adapter / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+        self.assertEqual(pre_commit.count("uv run --locked"), 2)
+        self.assertNotIn("entry: uv run ruff", pre_commit)
 
         flake = (adapter / "flake.nix").read_text(encoding="utf-8")
         for tool in ("uv", "just", "git", "gh", "jq", "ruff", "mypy"):

--- a/tests/test_project_bootstrap.py
+++ b/tests/test_project_bootstrap.py
@@ -61,9 +61,27 @@ class ProjectBootstrapTest(unittest.TestCase):
     def test_ci_uses_public_bootstrap_path(self) -> None:
         workflow = (ROOT / ".github" / "workflows" / "template-ci.yml").read_text(encoding="utf-8")
         self.assertIn("just project::bootstrap smoke-project", workflow)
+        self.assertIn(
+            "nix develop --no-write-lock-file --command just project::bootstrap smoke-project",
+            workflow,
+        )
         self.assertNotIn("prepare_smoke_template.py", workflow)
         self.assertIn("unresolved project-name placeholder remains after bootstrap", workflow)
         self.assertIn("--exclude=project_bootstrap.py", workflow)
+
+    def test_python_documented_bootstrap_prevents_outer_nix_lock_writes(self) -> None:
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+        adoption = (ROOT / "docs" / "existing-repository-adoption.md").read_text(
+            encoding="utf-8"
+        )
+        python_bootstrap = (
+            "nix develop --no-write-lock-file --command just project::bootstrap"
+        )
+        self.assertGreaterEqual(readme.count(python_bootstrap), 2)
+        self.assertIn(python_bootstrap, adoption)
+        self.assertIn(
+            "nix develop --no-update-lock-file --command just project::check", adoption
+        )
 
     def test_python_bootstrap_resolves_name_before_ensuring_lockfiles(self) -> None:
         project = (

--- a/tests/test_project_bootstrap.py
+++ b/tests/test_project_bootstrap.py
@@ -65,6 +65,13 @@ class ProjectBootstrapTest(unittest.TestCase):
         self.assertIn("unresolved project-name placeholder remains after bootstrap", workflow)
         self.assertIn("--exclude=project_bootstrap.py", workflow)
 
+    def test_python_bootstrap_resolves_name_before_ensuring_lockfiles(self) -> None:
+        project = (
+            ROOT / "components" / "adapters" / "python" / "just" / "project" / "mod.just"
+        ).read_text(encoding="utf-8")
+        bootstrap_recipe = project.split("bootstrap name='':", 1)[1].split("\n\n", 1)[0]
+        self.assertLess(bootstrap_recipe.index("bootstrap_script"), bootstrap_recipe.index("lockfiles_script"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_python_lockfiles.py
+++ b/tests/test_python_lockfiles.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+PROJECT = ROOT / "components" / "adapters" / "python" / "just" / "project"
+
+
+def load_lockfiles_module():
+    environment_spec = importlib.util.spec_from_file_location("lockfiles_environment", PROJECT / "environment.py")
+    assert environment_spec and environment_spec.loader
+    environment = importlib.util.module_from_spec(environment_spec)
+    environment_spec.loader.exec_module(environment)
+
+    lockfiles_spec = importlib.util.spec_from_file_location("python_lockfiles", PROJECT / "lockfiles.py")
+    assert lockfiles_spec and lockfiles_spec.loader
+    lockfiles = importlib.util.module_from_spec(lockfiles_spec)
+    with mock.patch.dict(sys.modules, {"environment": environment}):
+        lockfiles_spec.loader.exec_module(lockfiles)
+    return lockfiles
+
+
+lockfiles = load_lockfiles_module()
+
+
+class PythonLockfilesTest(unittest.TestCase):
+    def test_missing_both_runs_nix_then_uv_and_creates_both(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+
+            def run(command, *, cwd, env=None):
+                self.assertEqual(cwd, repo)
+                if command == ["nix", "flake", "lock"]:
+                    (repo / "flake.lock").write_bytes(b"flake")
+                elif command == ["uv", "lock"]:
+                    (repo / "uv.lock").write_bytes(b"uv")
+                else:
+                    self.fail(f"unexpected command: {command}")
+                return SimpleNamespace(returncode=0)
+
+            with mock.patch.object(lockfiles.subprocess, "run", side_effect=run) as run_mock:
+                self.assertEqual(lockfiles.ensure(repo), 0)
+
+            self.assertEqual(run_mock.call_args_list[0], mock.call(["nix", "flake", "lock"], cwd=repo))
+            self.assertEqual(run_mock.call_args_list[1].args[0], ["uv", "lock"])
+            self.assertEqual((repo / "flake.lock").read_bytes(), b"flake")
+            self.assertEqual((repo / "uv.lock").read_bytes(), b"uv")
+
+    def test_uv_receives_sanitized_environment(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            (repo / "flake.lock").write_bytes(b"flake")
+            (repo / "uv.lock").write_bytes(b"uv")
+            with mock.patch.dict(os.environ, {"VIRTUAL_ENV": "/old/.venv", "UV_PROJECT_ENVIRONMENT": "/old"}):
+                with mock.patch.object(lockfiles.subprocess, "run", return_value=SimpleNamespace(returncode=0)) as run_mock:
+                    self.assertEqual(lockfiles.ensure(repo), 0)
+
+            self.assertEqual(run_mock.call_count, 0)
+
+            (repo / "uv.lock").unlink()
+            with mock.patch.dict(os.environ, {"VIRTUAL_ENV": "/old/.venv", "UV_PROJECT_ENVIRONMENT": "/old"}):
+                def run(command, *, cwd, env):
+                    (cwd / "uv.lock").write_bytes(b"uv")
+                    return SimpleNamespace(returncode=0)
+
+                with mock.patch.object(lockfiles.subprocess, "run", side_effect=run) as run_mock:
+                    self.assertEqual(lockfiles.ensure(repo), 0)
+
+            env = run_mock.call_args.kwargs["env"]
+            self.assertNotIn("VIRTUAL_ENV", env)
+            self.assertEqual(env["UV_PROJECT_ENVIRONMENT"], str(repo / ".venv"))
+            self.assertEqual(env["PIP_REQUIRE_VIRTUALENV"], "1")
+
+    def test_existing_both_arbitrary_bytes_are_preserved_without_subprocess(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            flake_bytes = b"\x00flake\xff"
+            uv_bytes = b"\x00uv\xfe"
+            (repo / "flake.lock").write_bytes(flake_bytes)
+            (repo / "uv.lock").write_bytes(uv_bytes)
+            with mock.patch.object(lockfiles.subprocess, "run") as run_mock:
+                self.assertEqual(lockfiles.ensure(repo), 0)
+            self.assertEqual(run_mock.call_count, 0)
+            self.assertEqual((repo / "flake.lock").read_bytes(), flake_bytes)
+            self.assertEqual((repo / "uv.lock").read_bytes(), uv_bytes)
+
+    def test_existing_flake_missing_uv_runs_only_uv(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            (repo / "flake.lock").write_bytes(b"flake")
+
+            def run(command, *, cwd, env):
+                self.assertEqual(command, ["uv", "lock"])
+                (cwd / "uv.lock").write_bytes(b"uv")
+                return SimpleNamespace(returncode=0)
+
+            with mock.patch.object(lockfiles.subprocess, "run", side_effect=run) as run_mock:
+                self.assertEqual(lockfiles.ensure(repo), 0)
+            self.assertEqual(run_mock.call_count, 1)
+
+    def test_missing_flake_existing_uv_runs_only_nix(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            (repo / "uv.lock").write_bytes(b"uv")
+            def run(command, *, cwd):
+                (cwd / "flake.lock").write_bytes(b"flake")
+                return SimpleNamespace(returncode=0)
+
+            with mock.patch.object(lockfiles.subprocess, "run", side_effect=run) as run_mock:
+                self.assertEqual(lockfiles.ensure(repo), 0)
+            run_mock.assert_called_once_with(["nix", "flake", "lock"], cwd=repo)
+
+    def test_nix_failure_returns_nonzero_and_skips_uv(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            with mock.patch.object(lockfiles.subprocess, "run", return_value=SimpleNamespace(returncode=7)) as run_mock:
+                self.assertEqual(lockfiles.ensure(repo), 7)
+            run_mock.assert_called_once_with(["nix", "flake", "lock"], cwd=repo)
+            self.assertFalse((repo / "uv.lock").exists())
+
+    def test_uv_failure_returns_nonzero_without_fake_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            (repo / "flake.lock").write_bytes(b"flake")
+            with mock.patch.object(lockfiles.subprocess, "run", return_value=SimpleNamespace(returncode=9)) as run_mock:
+                self.assertEqual(lockfiles.ensure(repo), 9)
+            run_mock.assert_called_once()
+            self.assertFalse((repo / "uv.lock").exists())
+
+    def test_success_without_expected_file_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            with mock.patch.object(lockfiles.subprocess, "run", return_value=SimpleNamespace(returncode=0)):
+                self.assertEqual(lockfiles.ensure_lockfile(repo, "flake.lock", ["nix", "flake", "lock"]), 1)
+
+    def test_second_ensure_is_idempotent_and_preserves_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            repo = Path(temporary)
+            contents = {"flake.lock": b"flake\x00\xff", "uv.lock": b"uv\x01\xfe"}
+
+            def run(command, *, cwd, env=None):
+                name = "flake.lock" if command[0] == "nix" else "uv.lock"
+                (cwd / name).write_bytes(contents[name])
+                return SimpleNamespace(returncode=0)
+
+            with mock.patch.object(lockfiles.subprocess, "run", side_effect=run) as run_mock:
+                self.assertEqual(lockfiles.ensure(repo), 0)
+                first = {name: (repo / name).read_bytes() for name in contents}
+                run_mock.reset_mock()
+                self.assertEqual(lockfiles.ensure(repo), 0)
+                second = {name: (repo / name).read_bytes() for name in contents}
+
+            self.assertEqual(second, first)
+            run_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_worktree_environment.py
+++ b/tests/test_worktree_environment.py
@@ -46,7 +46,7 @@ class WorktreeEnvironmentTest(unittest.TestCase):
             SCRIPT.read_bytes(),
             (ROOT / "templates" / "agent-python" / "just" / "project" / "environment.py").read_bytes(),
         )
-        for relative in ("mod.just", "python.just"):
+        for relative in ("mod.just", "python.just", "lockfiles.py"):
             self.assertEqual(
                 (ROOT / "components" / "adapters" / "python" / "just" / "project" / relative).read_bytes(),
                 (ROOT / "templates" / "agent-python" / "just" / "project" / relative).read_bytes(),


### PR DESCRIPTION
## 概要

Python Agent templateで`flake.lock`と`uv.lock`をrepository-owned dependency identityとして扱い、生成をPython `project::bootstrap`へ限定しました。bootstrap shell entryとverification shell entryを分離し、既存lockfileを外側のNix invocationからも保護します。

## Lockfile ownership

- `flake.lock` / `uv.lock`はversion control対象です。
- template sourceへ静的lockfileは追加しません。
- 既存lockfileはbyte-for-byte preserveし、missing fileだけを生成します。

## Bootstrap boundary

- Pythonの公開bootstrap commandは`nix develop --no-write-lock-file --command just project::bootstrap`です。
- outer `nix develop`はinputsをresolveできますが、`flake.lock`を生成・更新しません。
- generic Agent Core bootstrapがproject nameを解決した後、Python Adapter-owned `lockfiles.py`がmissing `flake.lock`を`nix flake lock`、missing `uv.lock`を`uv lock`で明示的に生成します。
- 既存lockfileがある場合、helperは対応する生成commandを呼びません。

## Verification boundary

- post-bootstrap Nix verificationは`--no-update-lock-file`を使用します。
- format/lint/typecheck/test/pre-commit hookは`uv run --locked`を使用します。
- missing/stale `uv.lock`は修復せずverificationを失敗させます。
- `project::python::sync`は明示的なmutation boundaryとして`uv sync`のままです。

## Existing repository adoption

`template::adopt-apply`にはdependency resolutionを追加していません。Python adoption後は`--no-write-lock-file`付きbootstrap、lockfile review、`--no-update-lock-file`付きverification、adoption PR commitの順で実行します。これによりdevShellへ入るだけで既存`flake.lock`が更新されることを防ぎます。

## Clean-status evidence

Generated `agent-python` smokeでbootstrap前に両lockfileが存在しないことを確認し、`--no-write-lock-file` entryからAdapter helperが両方を生成することを確認しました。initial commit後の2回目bootstrapでも両hashとGit statusは不変で、`project::check`後もcleanです。

- `flake.lock`: `3bc43c37eecd91aa1075fcfd18631b336c216bf84f9e0dc6cbb4d48451de221c`
- `uv.lock`: `5873e200f47da922c810d39284688c9c395c9716ad2b97e753f21e44bec732c9`

## Tests

- Python unittest: 204 PASS
- generated template render/check: PASS
- all-systems Nix evaluation: PASS
- OpenCodePolicy strict audit: `DIFF=0 MISSING=0`
- template distribution verification: PASS
- generated `agent-python` no-write bootstrap/check smoke: PASS
- Template CIでbootstrap materialization、idempotency、hash不変、clean status、missing/stale lock rejectionを検証します。

## Non-goals

- Agent Core VERSION変更/migration
- generic bootstrapへのPython-specific behavior追加
- 他Adapterのlockfile lifecycle再設計
- `/init`、Task lifecycle、OpenCode permission、OpenCodePolicy変更

Closes #72