### PR TITLE
Fix Depth-2 leaf initialization and status contracts

### DIFF
--- a/components/agent-core/.automation/INIT.md
+++ b/components/agent-core/.automation/INIT.md
@@ -1,6 +1,6 @@
 # Agent Initialization Contract
 
-This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands.
+This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands. It does not require a Depth-2 leaf to start a new initialization sequence: the parent Task Orchestrator supplies the completed worktree initialization and Task Contract validation handoff.
 
 ## Read-only boundary
 
@@ -41,6 +41,10 @@ The repository-local `plan` agent is read-only and has `bash: deny`. It must sti
 A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
 
 This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
+## Depth-2 leaf sessions
+
+Depth-2 leaves do not start `initialize` or the full initialization workflow. They must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. They execute only already-allowed operations necessary for the bounded Work Unit. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them, but are not startup initialization. The parent Task Orchestrator remains responsible for durable initialization evidence and Task Contract validation.
 
 ## Stop conditions
 

--- a/components/agent-core/.opencode/agents/explore.md
+++ b/components/agent-core/.opencode/agents/explore.md
@@ -32,6 +32,8 @@ permission:
 
 Explore code, configuration, history, and symbol relationships needed by the assigned Work Unit. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/components/agent-core/.opencode/agents/general.md
+++ b/components/agent-core/.opencode/agents/general.md
@@ -47,6 +47,8 @@ permission:
 
 Implement only the assigned Work Unit inside its exclusive edit scope. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/components/agent-core/.opencode/agents/investigator.md
+++ b/components/agent-core/.opencode/agents/investigator.md
@@ -39,6 +39,8 @@ permission:
 
 Investigate failures using falsifiable hypotheses, reproduction evidence, and repository history/configuration. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/components/agent-core/.opencode/agents/reviewer.md
+++ b/components/agent-core/.opencode/agents/reviewer.md
@@ -16,6 +16,8 @@ permission:
 
 Review the assigned change for concrete correctness, regression, maintainability, and contract violations. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/components/agent-core/.opencode/agents/scout.md
+++ b/components/agent-core/.opencode/agents/scout.md
@@ -16,6 +16,8 @@ permission:
 
 Research only the external question assigned by the parent agent. Prefer official documentation, upstream repositories, standards, and primary sources. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/components/agent-core/.opencode/agents/security-reviewer.md
+++ b/components/agent-core/.opencode/agents/security-reviewer.md
@@ -32,6 +32,8 @@ permission:
 
 Review the assigned change for concrete security boundaries, trust assumptions, credential exposure, privilege changes, command injection, path traversal, unsafe defaults, and bypass paths. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/components/agent-core/.opencode/agents/task-orchestrator.md
+++ b/components/agent-core/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,12 @@ Before planning, editing, delegation, or project commands, load the `initialize`
 Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
 
 Depth-2 leaf Work Units are non-interactive:
-- accept and process only leaf status returns of `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION`; treat any other leaf status as invalid evidence and set Task BLOCKED.
+- accept exactly one canonical leaf status field, using one of these exact lines:
+  - `status: COMPLETED` -> `completed`
+  - `status: BLOCKED` -> `blocked`
+  - `status: NEEDS_APPROVAL` -> `needs-approval`
+  - `status: NEEDS_DECISION` -> `needs-decision`
+- `status: BLOCKED` is valid evidence. Only an unknown, multiple, or missing status field is invalid evidence; treat those cases as invalid and set Task BLOCKED.
 - do not allow leaf agents to propose direct permission requests or permission bypasses.
 
 On `NEEDS_APPROVAL` / `NEEDS_DECISION`, this orchestrator is the approval and decision boundary:

--- a/components/agent-core/.opencode/agents/verifier.md
+++ b/components/agent-core/.opencode/agents/verifier.md
@@ -27,6 +27,8 @@ permission:
 
 Run the project-standard verification entry points relevant to the assigned Work Unit. Prefer `just project::*` APIs. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/components/agent-core/.opencode/skills/initialize/SKILL.md
+++ b/components/agent-core/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,7 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session. It is not a leaf-session startup prerequisite: a Depth-2 leaf receives the parent Task Orchestrator's completed worktree initialization and Task Contract validation and must not start this skill or the full workflow.
 
 Full initialization for execution-capable primary agents and Task Orchestrators:
 
@@ -27,3 +27,7 @@ Planning-only initialization for the repository-local `plan` agent:
 5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
 
 Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.
+
+## Depth-2 leaf applicability
+
+The parent Task Orchestrator already completed Task worktree initialization and Task Contract validation before delegating a leaf Work Unit. A leaf executes only already-allowed operations necessary for its bounded objective. It must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as session startup prerequisites. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them; that use is not initialization.

--- a/components/agent-core/AGENTS.md
+++ b/components/agent-core/AGENTS.md
@@ -5,6 +5,7 @@ This repository is designed for hierarchical agent-driven development.
 ## Durable invariants
 
 - Before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session, read `.automation/INIT.md` and complete the `initialize` skill. Initialization is read-only and failures block work.
+- Depth-2 leaves inherit the parent Task Orchestrator's completed Task worktree initialization and Task Contract validation. They must not start `initialize` or the full workflow, and must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as startup prerequisites; already-allowed `project::*` commands remain usable when the bounded objective/check requires them.
 - Use the repository-local Just API for Task lifecycle, publication, and integration operations.
 - Do not bypass guarded Just recipes with raw state-changing Git or GitHub commands.
 - Ordinary implementation Tasks must not modify Automation Core files: `opencode.json`, `AGENTS.md`, `Justfile`, `.opencode/**`, `.automation/**`, or `.github/workflows/**`.
@@ -14,7 +15,7 @@ This repository is designed for hierarchical agent-driven development.
 - Leaf agents must not create subagents.
 - Main Orchestrator owns Task scheduling and final integration. Task Orchestrators own implementation and publication preparation for exactly one Task.
 - Task Orchestrators must not merge pull requests.
-- Depth-2 leaf agents are non-interactive; they may only report `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION` and never perform their own permission requests.
+- Depth-2 leaf agents are non-interactive; they must start their final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field and never perform their own permission requests.
 - Task Orchestrator is the approval and decision boundary for any delegated escalation (`NEEDS_APPROVAL`/`NEEDS_DECISION`) and must re-evaluate scope, authority, least privilege, safety, alternatives, and current evidence before deciding.
 - A leaf denial is not automatically promoted to Ask. After independent re-evaluation, the Task Orchestrator may originate a new Depth-1 request only when that operation is already Ask/allow under its own configured authority; the leaf profile remains unchanged.
 - A user-rejected Depth-1 permission decision is final for that exact operation within the Task. It must not be retried, rephrased, re-delegated, or replaced by an equivalent operation; use recorded permission evidence and a safe alternative or BLOCKED result.

--- a/just/runtime.just
+++ b/just/runtime.just
@@ -36,8 +36,22 @@ smoke-escalation-reject issue='issue-41':
     bash {{quote(debug_runner)}} {{quote(issue)}} leaf-escalation-reject
 
 [working-directory: root]
+smoke-leaf-completed issue='issue-41':
+    @echo "Depth-2 completed leaf smoke: run /task-run SMOKE-LEAF-COMPLETED in the TUI"
+    bash {{quote(debug_runner)}} {{quote(issue)}} leaf-completed
+
+[working-directory: root]
+smoke-leaf-blocked issue='issue-41':
+    @echo "Depth-2 blocked leaf smoke: run /task-run SMOKE-LEAF-BLOCKED in the TUI"
+    bash {{quote(debug_runner)}} {{quote(issue)}} leaf-blocked
+
+[working-directory: root]
 validate-escalation issue='issue-41':
     python3 {{quote(runner)}} validate-escalation --issue {{quote(issue)}}
+
+[working-directory: root]
+validate-leaf-contract issue='issue-41':
+    python3 {{quote(runner)}} validate-leaf-contract --issue {{quote(issue)}}
 
 [working-directory: root]
 direct-leaf issue='issue-41':

--- a/templates/agent-base/.automation/INIT.md
+++ b/templates/agent-base/.automation/INIT.md
@@ -1,6 +1,6 @@
 # Agent Initialization Contract
 
-This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands.
+This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands. It does not require a Depth-2 leaf to start a new initialization sequence: the parent Task Orchestrator supplies the completed worktree initialization and Task Contract validation handoff.
 
 ## Read-only boundary
 
@@ -41,6 +41,10 @@ The repository-local `plan` agent is read-only and has `bash: deny`. It must sti
 A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
 
 This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
+## Depth-2 leaf sessions
+
+Depth-2 leaves do not start `initialize` or the full initialization workflow. They must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. They execute only already-allowed operations necessary for the bounded Work Unit. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them, but are not startup initialization. The parent Task Orchestrator remains responsible for durable initialization evidence and Task Contract validation.
 
 ## Stop conditions
 

--- a/templates/agent-base/.opencode/agents/explore.md
+++ b/templates/agent-base/.opencode/agents/explore.md
@@ -32,6 +32,8 @@ permission:
 
 Explore code, configuration, history, and symbol relationships needed by the assigned Work Unit. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-base/.opencode/agents/general.md
+++ b/templates/agent-base/.opencode/agents/general.md
@@ -47,6 +47,8 @@ permission:
 
 Implement only the assigned Work Unit inside its exclusive edit scope. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-base/.opencode/agents/investigator.md
+++ b/templates/agent-base/.opencode/agents/investigator.md
@@ -39,6 +39,8 @@ permission:
 
 Investigate failures using falsifiable hypotheses, reproduction evidence, and repository history/configuration. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-base/.opencode/agents/reviewer.md
+++ b/templates/agent-base/.opencode/agents/reviewer.md
@@ -16,6 +16,8 @@ permission:
 
 Review the assigned change for concrete correctness, regression, maintainability, and contract violations. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-base/.opencode/agents/scout.md
+++ b/templates/agent-base/.opencode/agents/scout.md
@@ -16,6 +16,8 @@ permission:
 
 Research only the external question assigned by the parent agent. Prefer official documentation, upstream repositories, standards, and primary sources. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-base/.opencode/agents/security-reviewer.md
+++ b/templates/agent-base/.opencode/agents/security-reviewer.md
@@ -32,6 +32,8 @@ permission:
 
 Review the assigned change for concrete security boundaries, trust assumptions, credential exposure, privilege changes, command injection, path traversal, unsafe defaults, and bypass paths. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-base/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-base/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,12 @@ Before planning, editing, delegation, or project commands, load the `initialize`
 Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
 
 Depth-2 leaf Work Units are non-interactive:
-- accept and process only leaf status returns of `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION`; treat any other leaf status as invalid evidence and set Task BLOCKED.
+- accept exactly one canonical leaf status field, using one of these exact lines:
+  - `status: COMPLETED` -> `completed`
+  - `status: BLOCKED` -> `blocked`
+  - `status: NEEDS_APPROVAL` -> `needs-approval`
+  - `status: NEEDS_DECISION` -> `needs-decision`
+- `status: BLOCKED` is valid evidence. Only an unknown, multiple, or missing status field is invalid evidence; treat those cases as invalid and set Task BLOCKED.
 - do not allow leaf agents to propose direct permission requests or permission bypasses.
 
 On `NEEDS_APPROVAL` / `NEEDS_DECISION`, this orchestrator is the approval and decision boundary:

--- a/templates/agent-base/.opencode/agents/verifier.md
+++ b/templates/agent-base/.opencode/agents/verifier.md
@@ -27,6 +27,8 @@ permission:
 
 Run the project-standard verification entry points relevant to the assigned Work Unit. Prefer `just project::*` APIs. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-base/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-base/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,7 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session. It is not a leaf-session startup prerequisite: a Depth-2 leaf receives the parent Task Orchestrator's completed worktree initialization and Task Contract validation and must not start this skill or the full workflow.
 
 Full initialization for execution-capable primary agents and Task Orchestrators:
 
@@ -27,3 +27,7 @@ Planning-only initialization for the repository-local `plan` agent:
 5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
 
 Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.
+
+## Depth-2 leaf applicability
+
+The parent Task Orchestrator already completed Task worktree initialization and Task Contract validation before delegating a leaf Work Unit. A leaf executes only already-allowed operations necessary for its bounded objective. It must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as session startup prerequisites. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them; that use is not initialization.

--- a/templates/agent-base/AGENTS.md
+++ b/templates/agent-base/AGENTS.md
@@ -5,6 +5,7 @@ This repository is designed for hierarchical agent-driven development.
 ## Durable invariants
 
 - Before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session, read `.automation/INIT.md` and complete the `initialize` skill. Initialization is read-only and failures block work.
+- Depth-2 leaves inherit the parent Task Orchestrator's completed Task worktree initialization and Task Contract validation. They must not start `initialize` or the full workflow, and must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as startup prerequisites; already-allowed `project::*` commands remain usable when the bounded objective/check requires them.
 - Use the repository-local Just API for Task lifecycle, publication, and integration operations.
 - Do not bypass guarded Just recipes with raw state-changing Git or GitHub commands.
 - Ordinary implementation Tasks must not modify Automation Core files: `opencode.json`, `AGENTS.md`, `Justfile`, `.opencode/**`, `.automation/**`, or `.github/workflows/**`.
@@ -14,7 +15,7 @@ This repository is designed for hierarchical agent-driven development.
 - Leaf agents must not create subagents.
 - Main Orchestrator owns Task scheduling and final integration. Task Orchestrators own implementation and publication preparation for exactly one Task.
 - Task Orchestrators must not merge pull requests.
-- Depth-2 leaf agents are non-interactive; they may only report `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION` and never perform their own permission requests.
+- Depth-2 leaf agents are non-interactive; they must start their final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field and never perform their own permission requests.
 - Task Orchestrator is the approval and decision boundary for any delegated escalation (`NEEDS_APPROVAL`/`NEEDS_DECISION`) and must re-evaluate scope, authority, least privilege, safety, alternatives, and current evidence before deciding.
 - A leaf denial is not automatically promoted to Ask. After independent re-evaluation, the Task Orchestrator may originate a new Depth-1 request only when that operation is already Ask/allow under its own configured authority; the leaf profile remains unchanged.
 - A user-rejected Depth-1 permission decision is final for that exact operation within the Task. It must not be retried, rephrased, re-delegated, or replaced by an equivalent operation; use recorded permission evidence and a safe alternative or BLOCKED result.

--- a/templates/agent-cpp-cmake/.automation/INIT.md
+++ b/templates/agent-cpp-cmake/.automation/INIT.md
@@ -1,6 +1,6 @@
 # Agent Initialization Contract
 
-This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands.
+This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands. It does not require a Depth-2 leaf to start a new initialization sequence: the parent Task Orchestrator supplies the completed worktree initialization and Task Contract validation handoff.
 
 ## Read-only boundary
 
@@ -41,6 +41,10 @@ The repository-local `plan` agent is read-only and has `bash: deny`. It must sti
 A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
 
 This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
+## Depth-2 leaf sessions
+
+Depth-2 leaves do not start `initialize` or the full initialization workflow. They must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. They execute only already-allowed operations necessary for the bounded Work Unit. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them, but are not startup initialization. The parent Task Orchestrator remains responsible for durable initialization evidence and Task Contract validation.
 
 ## Stop conditions
 

--- a/templates/agent-cpp-cmake/.opencode/agents/explore.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/explore.md
@@ -32,6 +32,8 @@ permission:
 
 Explore code, configuration, history, and symbol relationships needed by the assigned Work Unit. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-cpp-cmake/.opencode/agents/general.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/general.md
@@ -47,6 +47,8 @@ permission:
 
 Implement only the assigned Work Unit inside its exclusive edit scope. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-cpp-cmake/.opencode/agents/investigator.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/investigator.md
@@ -39,6 +39,8 @@ permission:
 
 Investigate failures using falsifiable hypotheses, reproduction evidence, and repository history/configuration. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-cpp-cmake/.opencode/agents/reviewer.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/reviewer.md
@@ -16,6 +16,8 @@ permission:
 
 Review the assigned change for concrete correctness, regression, maintainability, and contract violations. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-cpp-cmake/.opencode/agents/scout.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/scout.md
@@ -16,6 +16,8 @@ permission:
 
 Research only the external question assigned by the parent agent. Prefer official documentation, upstream repositories, standards, and primary sources. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-cpp-cmake/.opencode/agents/security-reviewer.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/security-reviewer.md
@@ -32,6 +32,8 @@ permission:
 
 Review the assigned change for concrete security boundaries, trust assumptions, credential exposure, privilege changes, command injection, path traversal, unsafe defaults, and bypass paths. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-cpp-cmake/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,12 @@ Before planning, editing, delegation, or project commands, load the `initialize`
 Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
 
 Depth-2 leaf Work Units are non-interactive:
-- accept and process only leaf status returns of `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION`; treat any other leaf status as invalid evidence and set Task BLOCKED.
+- accept exactly one canonical leaf status field, using one of these exact lines:
+  - `status: COMPLETED` -> `completed`
+  - `status: BLOCKED` -> `blocked`
+  - `status: NEEDS_APPROVAL` -> `needs-approval`
+  - `status: NEEDS_DECISION` -> `needs-decision`
+- `status: BLOCKED` is valid evidence. Only an unknown, multiple, or missing status field is invalid evidence; treat those cases as invalid and set Task BLOCKED.
 - do not allow leaf agents to propose direct permission requests or permission bypasses.
 
 On `NEEDS_APPROVAL` / `NEEDS_DECISION`, this orchestrator is the approval and decision boundary:

--- a/templates/agent-cpp-cmake/.opencode/agents/verifier.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/verifier.md
@@ -27,6 +27,8 @@ permission:
 
 Run the project-standard verification entry points relevant to the assigned Work Unit. Prefer `just project::*` APIs. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-cpp-cmake/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-cpp-cmake/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,7 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session. It is not a leaf-session startup prerequisite: a Depth-2 leaf receives the parent Task Orchestrator's completed worktree initialization and Task Contract validation and must not start this skill or the full workflow.
 
 Full initialization for execution-capable primary agents and Task Orchestrators:
 
@@ -27,3 +27,7 @@ Planning-only initialization for the repository-local `plan` agent:
 5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
 
 Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.
+
+## Depth-2 leaf applicability
+
+The parent Task Orchestrator already completed Task worktree initialization and Task Contract validation before delegating a leaf Work Unit. A leaf executes only already-allowed operations necessary for its bounded objective. It must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as session startup prerequisites. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them; that use is not initialization.

--- a/templates/agent-cpp-cmake/AGENTS.md
+++ b/templates/agent-cpp-cmake/AGENTS.md
@@ -5,6 +5,7 @@ This repository is designed for hierarchical agent-driven development.
 ## Durable invariants
 
 - Before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session, read `.automation/INIT.md` and complete the `initialize` skill. Initialization is read-only and failures block work.
+- Depth-2 leaves inherit the parent Task Orchestrator's completed Task worktree initialization and Task Contract validation. They must not start `initialize` or the full workflow, and must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as startup prerequisites; already-allowed `project::*` commands remain usable when the bounded objective/check requires them.
 - Use the repository-local Just API for Task lifecycle, publication, and integration operations.
 - Do not bypass guarded Just recipes with raw state-changing Git or GitHub commands.
 - Ordinary implementation Tasks must not modify Automation Core files: `opencode.json`, `AGENTS.md`, `Justfile`, `.opencode/**`, `.automation/**`, or `.github/workflows/**`.
@@ -14,7 +15,7 @@ This repository is designed for hierarchical agent-driven development.
 - Leaf agents must not create subagents.
 - Main Orchestrator owns Task scheduling and final integration. Task Orchestrators own implementation and publication preparation for exactly one Task.
 - Task Orchestrators must not merge pull requests.
-- Depth-2 leaf agents are non-interactive; they may only report `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION` and never perform their own permission requests.
+- Depth-2 leaf agents are non-interactive; they must start their final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field and never perform their own permission requests.
 - Task Orchestrator is the approval and decision boundary for any delegated escalation (`NEEDS_APPROVAL`/`NEEDS_DECISION`) and must re-evaluate scope, authority, least privilege, safety, alternatives, and current evidence before deciding.
 - A leaf denial is not automatically promoted to Ask. After independent re-evaluation, the Task Orchestrator may originate a new Depth-1 request only when that operation is already Ask/allow under its own configured authority; the leaf profile remains unchanged.
 - A user-rejected Depth-1 permission decision is final for that exact operation within the Task. It must not be retried, rephrased, re-delegated, or replaced by an equivalent operation; use recorded permission evidence and a safe alternative or BLOCKED result.

--- a/templates/agent-nix/.automation/INIT.md
+++ b/templates/agent-nix/.automation/INIT.md
@@ -1,6 +1,6 @@
 # Agent Initialization Contract
 
-This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands.
+This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands. It does not require a Depth-2 leaf to start a new initialization sequence: the parent Task Orchestrator supplies the completed worktree initialization and Task Contract validation handoff.
 
 ## Read-only boundary
 
@@ -41,6 +41,10 @@ The repository-local `plan` agent is read-only and has `bash: deny`. It must sti
 A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
 
 This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
+## Depth-2 leaf sessions
+
+Depth-2 leaves do not start `initialize` or the full initialization workflow. They must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. They execute only already-allowed operations necessary for the bounded Work Unit. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them, but are not startup initialization. The parent Task Orchestrator remains responsible for durable initialization evidence and Task Contract validation.
 
 ## Stop conditions
 

--- a/templates/agent-nix/.opencode/agents/explore.md
+++ b/templates/agent-nix/.opencode/agents/explore.md
@@ -32,6 +32,8 @@ permission:
 
 Explore code, configuration, history, and symbol relationships needed by the assigned Work Unit. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-nix/.opencode/agents/general.md
+++ b/templates/agent-nix/.opencode/agents/general.md
@@ -47,6 +47,8 @@ permission:
 
 Implement only the assigned Work Unit inside its exclusive edit scope. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-nix/.opencode/agents/investigator.md
+++ b/templates/agent-nix/.opencode/agents/investigator.md
@@ -39,6 +39,8 @@ permission:
 
 Investigate failures using falsifiable hypotheses, reproduction evidence, and repository history/configuration. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-nix/.opencode/agents/reviewer.md
+++ b/templates/agent-nix/.opencode/agents/reviewer.md
@@ -16,6 +16,8 @@ permission:
 
 Review the assigned change for concrete correctness, regression, maintainability, and contract violations. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-nix/.opencode/agents/scout.md
+++ b/templates/agent-nix/.opencode/agents/scout.md
@@ -16,6 +16,8 @@ permission:
 
 Research only the external question assigned by the parent agent. Prefer official documentation, upstream repositories, standards, and primary sources. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-nix/.opencode/agents/security-reviewer.md
+++ b/templates/agent-nix/.opencode/agents/security-reviewer.md
@@ -32,6 +32,8 @@ permission:
 
 Review the assigned change for concrete security boundaries, trust assumptions, credential exposure, privilege changes, command injection, path traversal, unsafe defaults, and bypass paths. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-nix/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-nix/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,12 @@ Before planning, editing, delegation, or project commands, load the `initialize`
 Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
 
 Depth-2 leaf Work Units are non-interactive:
-- accept and process only leaf status returns of `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION`; treat any other leaf status as invalid evidence and set Task BLOCKED.
+- accept exactly one canonical leaf status field, using one of these exact lines:
+  - `status: COMPLETED` -> `completed`
+  - `status: BLOCKED` -> `blocked`
+  - `status: NEEDS_APPROVAL` -> `needs-approval`
+  - `status: NEEDS_DECISION` -> `needs-decision`
+- `status: BLOCKED` is valid evidence. Only an unknown, multiple, or missing status field is invalid evidence; treat those cases as invalid and set Task BLOCKED.
 - do not allow leaf agents to propose direct permission requests or permission bypasses.
 
 On `NEEDS_APPROVAL` / `NEEDS_DECISION`, this orchestrator is the approval and decision boundary:

--- a/templates/agent-nix/.opencode/agents/verifier.md
+++ b/templates/agent-nix/.opencode/agents/verifier.md
@@ -27,6 +27,8 @@ permission:
 
 Run the project-standard verification entry points relevant to the assigned Work Unit. Prefer `just project::*` APIs. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-nix/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-nix/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,7 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session. It is not a leaf-session startup prerequisite: a Depth-2 leaf receives the parent Task Orchestrator's completed worktree initialization and Task Contract validation and must not start this skill or the full workflow.
 
 Full initialization for execution-capable primary agents and Task Orchestrators:
 
@@ -27,3 +27,7 @@ Planning-only initialization for the repository-local `plan` agent:
 5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
 
 Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.
+
+## Depth-2 leaf applicability
+
+The parent Task Orchestrator already completed Task worktree initialization and Task Contract validation before delegating a leaf Work Unit. A leaf executes only already-allowed operations necessary for its bounded objective. It must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as session startup prerequisites. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them; that use is not initialization.

--- a/templates/agent-nix/AGENTS.md
+++ b/templates/agent-nix/AGENTS.md
@@ -5,6 +5,7 @@ This repository is designed for hierarchical agent-driven development.
 ## Durable invariants
 
 - Before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session, read `.automation/INIT.md` and complete the `initialize` skill. Initialization is read-only and failures block work.
+- Depth-2 leaves inherit the parent Task Orchestrator's completed Task worktree initialization and Task Contract validation. They must not start `initialize` or the full workflow, and must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as startup prerequisites; already-allowed `project::*` commands remain usable when the bounded objective/check requires them.
 - Use the repository-local Just API for Task lifecycle, publication, and integration operations.
 - Do not bypass guarded Just recipes with raw state-changing Git or GitHub commands.
 - Ordinary implementation Tasks must not modify Automation Core files: `opencode.json`, `AGENTS.md`, `Justfile`, `.opencode/**`, `.automation/**`, or `.github/workflows/**`.
@@ -14,7 +15,7 @@ This repository is designed for hierarchical agent-driven development.
 - Leaf agents must not create subagents.
 - Main Orchestrator owns Task scheduling and final integration. Task Orchestrators own implementation and publication preparation for exactly one Task.
 - Task Orchestrators must not merge pull requests.
-- Depth-2 leaf agents are non-interactive; they may only report `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION` and never perform their own permission requests.
+- Depth-2 leaf agents are non-interactive; they must start their final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field and never perform their own permission requests.
 - Task Orchestrator is the approval and decision boundary for any delegated escalation (`NEEDS_APPROVAL`/`NEEDS_DECISION`) and must re-evaluate scope, authority, least privilege, safety, alternatives, and current evidence before deciding.
 - A leaf denial is not automatically promoted to Ask. After independent re-evaluation, the Task Orchestrator may originate a new Depth-1 request only when that operation is already Ask/allow under its own configured authority; the leaf profile remains unchanged.
 - A user-rejected Depth-1 permission decision is final for that exact operation within the Task. It must not be retried, rephrased, re-delegated, or replaced by an equivalent operation; use recorded permission evidence and a safe alternative or BLOCKED result.

--- a/templates/agent-python/.automation/INIT.md
+++ b/templates/agent-python/.automation/INIT.md
@@ -1,6 +1,6 @@
 # Agent Initialization Contract
 
-This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands.
+This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands. It does not require a Depth-2 leaf to start a new initialization sequence: the parent Task Orchestrator supplies the completed worktree initialization and Task Contract validation handoff.
 
 ## Read-only boundary
 
@@ -41,6 +41,10 @@ The repository-local `plan` agent is read-only and has `bash: deny`. It must sti
 A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
 
 This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
+## Depth-2 leaf sessions
+
+Depth-2 leaves do not start `initialize` or the full initialization workflow. They must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. They execute only already-allowed operations necessary for the bounded Work Unit. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them, but are not startup initialization. The parent Task Orchestrator remains responsible for durable initialization evidence and Task Contract validation.
 
 ## Stop conditions
 

--- a/templates/agent-python/.opencode/agents/explore.md
+++ b/templates/agent-python/.opencode/agents/explore.md
@@ -32,6 +32,8 @@ permission:
 
 Explore code, configuration, history, and symbol relationships needed by the assigned Work Unit. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-python/.opencode/agents/general.md
+++ b/templates/agent-python/.opencode/agents/general.md
@@ -47,6 +47,8 @@ permission:
 
 Implement only the assigned Work Unit inside its exclusive edit scope. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-python/.opencode/agents/investigator.md
+++ b/templates/agent-python/.opencode/agents/investigator.md
@@ -39,6 +39,8 @@ permission:
 
 Investigate failures using falsifiable hypotheses, reproduction evidence, and repository history/configuration. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-python/.opencode/agents/reviewer.md
+++ b/templates/agent-python/.opencode/agents/reviewer.md
@@ -16,6 +16,8 @@ permission:
 
 Review the assigned change for concrete correctness, regression, maintainability, and contract violations. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-python/.opencode/agents/scout.md
+++ b/templates/agent-python/.opencode/agents/scout.md
@@ -16,6 +16,8 @@ permission:
 
 Research only the external question assigned by the parent agent. Prefer official documentation, upstream repositories, standards, and primary sources. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-python/.opencode/agents/security-reviewer.md
+++ b/templates/agent-python/.opencode/agents/security-reviewer.md
@@ -32,6 +32,8 @@ permission:
 
 Review the assigned change for concrete security boundaries, trust assumptions, credential exposure, privilege changes, command injection, path traversal, unsafe defaults, and bypass paths. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-python/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-python/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,12 @@ Before planning, editing, delegation, or project commands, load the `initialize`
 Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
 
 Depth-2 leaf Work Units are non-interactive:
-- accept and process only leaf status returns of `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION`; treat any other leaf status as invalid evidence and set Task BLOCKED.
+- accept exactly one canonical leaf status field, using one of these exact lines:
+  - `status: COMPLETED` -> `completed`
+  - `status: BLOCKED` -> `blocked`
+  - `status: NEEDS_APPROVAL` -> `needs-approval`
+  - `status: NEEDS_DECISION` -> `needs-decision`
+- `status: BLOCKED` is valid evidence. Only an unknown, multiple, or missing status field is invalid evidence; treat those cases as invalid and set Task BLOCKED.
 - do not allow leaf agents to propose direct permission requests or permission bypasses.
 
 On `NEEDS_APPROVAL` / `NEEDS_DECISION`, this orchestrator is the approval and decision boundary:

--- a/templates/agent-python/.opencode/agents/verifier.md
+++ b/templates/agent-python/.opencode/agents/verifier.md
@@ -27,6 +27,8 @@ permission:
 
 Run the project-standard verification entry points relevant to the assigned Work Unit. Prefer `just project::*` APIs. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-python/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-python/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,7 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session. It is not a leaf-session startup prerequisite: a Depth-2 leaf receives the parent Task Orchestrator's completed worktree initialization and Task Contract validation and must not start this skill or the full workflow.
 
 Full initialization for execution-capable primary agents and Task Orchestrators:
 
@@ -27,3 +27,7 @@ Planning-only initialization for the repository-local `plan` agent:
 5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
 
 Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.
+
+## Depth-2 leaf applicability
+
+The parent Task Orchestrator already completed Task worktree initialization and Task Contract validation before delegating a leaf Work Unit. A leaf executes only already-allowed operations necessary for its bounded objective. It must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as session startup prerequisites. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them; that use is not initialization.

--- a/templates/agent-python/AGENTS.md
+++ b/templates/agent-python/AGENTS.md
@@ -5,6 +5,7 @@ This repository is designed for hierarchical agent-driven development.
 ## Durable invariants
 
 - Before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session, read `.automation/INIT.md` and complete the `initialize` skill. Initialization is read-only and failures block work.
+- Depth-2 leaves inherit the parent Task Orchestrator's completed Task worktree initialization and Task Contract validation. They must not start `initialize` or the full workflow, and must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as startup prerequisites; already-allowed `project::*` commands remain usable when the bounded objective/check requires them.
 - Use the repository-local Just API for Task lifecycle, publication, and integration operations.
 - Do not bypass guarded Just recipes with raw state-changing Git or GitHub commands.
 - Ordinary implementation Tasks must not modify Automation Core files: `opencode.json`, `AGENTS.md`, `Justfile`, `.opencode/**`, `.automation/**`, or `.github/workflows/**`.
@@ -14,7 +15,7 @@ This repository is designed for hierarchical agent-driven development.
 - Leaf agents must not create subagents.
 - Main Orchestrator owns Task scheduling and final integration. Task Orchestrators own implementation and publication preparation for exactly one Task.
 - Task Orchestrators must not merge pull requests.
-- Depth-2 leaf agents are non-interactive; they may only report `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION` and never perform their own permission requests.
+- Depth-2 leaf agents are non-interactive; they must start their final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field and never perform their own permission requests.
 - Task Orchestrator is the approval and decision boundary for any delegated escalation (`NEEDS_APPROVAL`/`NEEDS_DECISION`) and must re-evaluate scope, authority, least privilege, safety, alternatives, and current evidence before deciding.
 - A leaf denial is not automatically promoted to Ask. After independent re-evaluation, the Task Orchestrator may originate a new Depth-1 request only when that operation is already Ask/allow under its own configured authority; the leaf profile remains unchanged.
 - A user-rejected Depth-1 permission decision is final for that exact operation within the Task. It must not be retried, rephrased, re-delegated, or replaced by an equivalent operation; use recorded permission evidence and a safe alternative or BLOCKED result.

--- a/templates/agent-rust/.automation/INIT.md
+++ b/templates/agent-rust/.automation/INIT.md
@@ -1,6 +1,6 @@
 # Agent Initialization Contract
 
-This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands.
+This file defines the mandatory read-only initialization sequence for every primary agent session and every Task Orchestrator before planning, editing, delegation, or project commands. It does not require a Depth-2 leaf to start a new initialization sequence: the parent Task Orchestrator supplies the completed worktree initialization and Task Contract validation handoff.
 
 ## Read-only boundary
 
@@ -41,6 +41,10 @@ The repository-local `plan` agent is read-only and has `bash: deny`. It must sti
 A planning-only session reports `PLANNING_INITIALIZATION_HANDOFF` with explicit `execution_prerequisites` and `verification_handoff` entries for every unexecuted doctor, context, project, build, test, or verification check. It must not report `INITIALIZED`, PASS, or successful verification for checks it did not execute.
 
 This exception applies only to the repository-local `plan` agent. Execution-capable primary agents and Task Orchestrators must complete the mandatory sequence above before editing, implementation delegation, or project commands.
+
+## Depth-2 leaf sessions
+
+Depth-2 leaves do not start `initialize` or the full initialization workflow. They must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. They execute only already-allowed operations necessary for the bounded Work Unit. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them, but are not startup initialization. The parent Task Orchestrator remains responsible for durable initialization evidence and Task Contract validation.
 
 ## Stop conditions
 

--- a/templates/agent-rust/.opencode/agents/explore.md
+++ b/templates/agent-rust/.opencode/agents/explore.md
@@ -32,6 +32,8 @@ permission:
 
 Explore code, configuration, history, and symbol relationships needed by the assigned Work Unit. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-rust/.opencode/agents/general.md
+++ b/templates/agent-rust/.opencode/agents/general.md
@@ -47,6 +47,8 @@ permission:
 
 Implement only the assigned Work Unit inside its exclusive edit scope. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-rust/.opencode/agents/investigator.md
+++ b/templates/agent-rust/.opencode/agents/investigator.md
@@ -39,6 +39,8 @@ permission:
 
 Investigate failures using falsifiable hypotheses, reproduction evidence, and repository history/configuration. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-rust/.opencode/agents/reviewer.md
+++ b/templates/agent-rust/.opencode/agents/reviewer.md
@@ -16,6 +16,8 @@ permission:
 
 Review the assigned change for concrete correctness, regression, maintainability, and contract violations. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-rust/.opencode/agents/scout.md
+++ b/templates/agent-rust/.opencode/agents/scout.md
@@ -16,6 +16,8 @@ permission:
 
 Research only the external question assigned by the parent agent. Prefer official documentation, upstream repositories, standards, and primary sources. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-rust/.opencode/agents/security-reviewer.md
+++ b/templates/agent-rust/.opencode/agents/security-reviewer.md
@@ -32,6 +32,8 @@ permission:
 
 Review the assigned change for concrete security boundaries, trust assumptions, credential exposure, privilege changes, command injection, path traversal, unsafe defaults, and bypass paths. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-rust/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-rust/.opencode/agents/task-orchestrator.md
@@ -34,7 +34,12 @@ Before planning, editing, delegation, or project commands, load the `initialize`
 Own exactly one Task in its assigned worktree. Focus on high-leverage coordination: establish and maintain the Task Contract, decompose and delegate Work Units, integrate evidence, inspect actual diffs and results, update Task State through guarded Agent APIs, verify the integrated Task, commit through the guarded Just API, and prepare the Task pull request.
 
 Depth-2 leaf Work Units are non-interactive:
-- accept and process only leaf status returns of `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION`; treat any other leaf status as invalid evidence and set Task BLOCKED.
+- accept exactly one canonical leaf status field, using one of these exact lines:
+  - `status: COMPLETED` -> `completed`
+  - `status: BLOCKED` -> `blocked`
+  - `status: NEEDS_APPROVAL` -> `needs-approval`
+  - `status: NEEDS_DECISION` -> `needs-decision`
+- `status: BLOCKED` is valid evidence. Only an unknown, multiple, or missing status field is invalid evidence; treat those cases as invalid and set Task BLOCKED.
 - do not allow leaf agents to propose direct permission requests or permission bypasses.
 
 On `NEEDS_APPROVAL` / `NEEDS_DECISION`, this orchestrator is the approval and decision boundary:

--- a/templates/agent-rust/.opencode/agents/verifier.md
+++ b/templates/agent-rust/.opencode/agents/verifier.md
@@ -27,6 +27,8 @@ permission:
 
 Run the project-standard verification entry points relevant to the assigned Work Unit. Prefer `just project::*` APIs. This is a non-interactive Depth-2 leaf.
 
+The parent Task Orchestrator already initialized the Task worktree and validated the Task Contract. Do not start the `initialize` skill or the full initialization workflow in this leaf session. Do not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as leaf-session startup prerequisites. Execute only already-allowed operations necessary for the bounded Work Unit; an already-allowed `project::*` command, including `just project::doctor`, remains usable when the objective or check requires it, but is not startup initialization.
+
 Depth-2 leaf return contract:
 - Start the final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field.
 - Do not attempt denied operations, ask the user, call `question`, delegate, broaden permissions, or claim any unexecuted command as executed/passed.

--- a/templates/agent-rust/.opencode/skills/initialize/SKILL.md
+++ b/templates/agent-rust/.opencode/skills/initialize/SKILL.md
@@ -5,7 +5,7 @@ description: Run mandatory read-only repository and Task initialization checks b
 
 # Initialize
 
-Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session.
+Use this skill before editing, implementation delegation, or project commands in a new primary-agent or Task-Orchestrator session. It is not a leaf-session startup prerequisite: a Depth-2 leaf receives the parent Task Orchestrator's completed worktree initialization and Task Contract validation and must not start this skill or the full workflow.
 
 Full initialization for execution-capable primary agents and Task Orchestrators:
 
@@ -27,3 +27,7 @@ Planning-only initialization for the repository-local `plan` agent:
 5. Report unexecuted doctor, context, project, build, test, or verification checks as `UNEXECUTED`; never report them as PASS.
 
 Initialization is read-only. Do not edit `AGENTS.md`, Task State, Automation Core, project files, Git refs, worktrees, or installed packages. Do not perform bootstrap or repair actions. Planning-only handoff does not weaken the full initialization contract for execution-capable workflows.
+
+## Depth-2 leaf applicability
+
+The parent Task Orchestrator already completed Task worktree initialization and Task Contract validation before delegating a leaf Work Unit. A leaf executes only already-allowed operations necessary for its bounded objective. It must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as session startup prerequisites. Already-allowed `project::*` commands, including `just project::doctor`, remain usable when the objective or check requires them; that use is not initialization.

--- a/templates/agent-rust/AGENTS.md
+++ b/templates/agent-rust/AGENTS.md
@@ -5,6 +5,7 @@ This repository is designed for hierarchical agent-driven development.
 ## Durable invariants
 
 - Before planning, editing, delegation, or project commands in a new primary-agent or Task-Orchestrator session, read `.automation/INIT.md` and complete the `initialize` skill. Initialization is read-only and failures block work.
+- Depth-2 leaves inherit the parent Task Orchestrator's completed Task worktree initialization and Task Contract validation. They must not start `initialize` or the full workflow, and must not run `just agent::doctor`, `just agent::context`, or mandatory `just project::doctor` as startup prerequisites; already-allowed `project::*` commands remain usable when the bounded objective/check requires them.
 - Use the repository-local Just API for Task lifecycle, publication, and integration operations.
 - Do not bypass guarded Just recipes with raw state-changing Git or GitHub commands.
 - Ordinary implementation Tasks must not modify Automation Core files: `opencode.json`, `AGENTS.md`, `Justfile`, `.opencode/**`, `.automation/**`, or `.github/workflows/**`.
@@ -14,7 +15,7 @@ This repository is designed for hierarchical agent-driven development.
 - Leaf agents must not create subagents.
 - Main Orchestrator owns Task scheduling and final integration. Task Orchestrators own implementation and publication preparation for exactly one Task.
 - Task Orchestrators must not merge pull requests.
-- Depth-2 leaf agents are non-interactive; they may only report `COMPLETED`, `BLOCKED`, `NEEDS_APPROVAL`, or `NEEDS_DECISION` and never perform their own permission requests.
+- Depth-2 leaf agents are non-interactive; they must start their final response with exactly one `status: COMPLETED`, `status: BLOCKED`, `status: NEEDS_APPROVAL`, or `status: NEEDS_DECISION` field and never perform their own permission requests.
 - Task Orchestrator is the approval and decision boundary for any delegated escalation (`NEEDS_APPROVAL`/`NEEDS_DECISION`) and must re-evaluate scope, authority, least privilege, safety, alternatives, and current evidence before deciding.
 - A leaf denial is not automatically promoted to Ask. After independent re-evaluation, the Task Orchestrator may originate a new Depth-1 request only when that operation is already Ask/allow under its own configured authority; the leaf profile remains unchanged.
 - A user-rejected Depth-1 permission decision is final for that exact operation within the Task. It must not be retried, rephrased, re-delegated, or replaced by an equivalent operation; use recorded permission evidence and a safe alternative or BLOCKED result.

--- a/tests/runtime/runtime_smoke.py
+++ b/tests/runtime/runtime_smoke.py
@@ -22,6 +22,42 @@ LEAF_ESCALATION_REJECT_COMMAND = "printf 'leaf-escalation-user-rejected\\n'"
 
 TASK_DEFINITIONS = (
     (
+        "SMOKE-LEAF-COMPLETED",
+        "depth2-leaf-completed",
+        "Prove that a bounded Depth-2 general leaf can complete an allowed read-only Work Unit after parent initialization.",
+        [
+            "After parent initialization, delegate exactly one bounded Work Unit to `general` (or `explore`).",
+            "Pass this exact objective: run `git status --short` exactly once, perform no other operation, and return the result.",
+            "The leaf must not invoke `agent::doctor`, `agent::context`, or `project::doctor`.",
+            "The leaf returns exactly `status: COMPLETED`; the parent accepts and records completed.",
+        ],
+        [
+            "Parent initialization may contain doctor/context/project::doctor events; they are outside the leaf-session inspection window.",
+            "The leaf session contains no denied initialization attempt or denied initialization event.",
+            "The leaf response has exactly one valid status field: `status: COMPLETED`.",
+            "Task State and work-units evidence record the Work Unit as completed.",
+        ],
+        ["Run from Main TUI with `/task-run SMOKE-LEAF-COMPLETED` under `just runtime::smoke-leaf-completed`."],
+    ),
+    (
+        "SMOKE-LEAF-BLOCKED",
+        "depth2-leaf-blocked",
+        "Prove that an intentionally impossible bounded Work Unit is reported as a valid blocked result rather than a false success.",
+        [
+            "After parent initialization, delegate exactly one bounded Work Unit to `explore`.",
+            "Pass this exact objective: report the contents of the guaranteed-absent tracked file `.runtime-smoke-intentionally-missing`; do not broaden the objective or substitute another path.",
+            "The leaf may establish that the required file is absent, but must not attempt any denied operation.",
+            "The leaf returns exactly `status: BLOCKED`; the parent treats it as valid and records the Work Unit as blocked.",
+        ],
+        [
+            "Parent initialization events are not attributed to the leaf.",
+            "The leaf response has exactly one valid status field: `status: BLOCKED`.",
+            "Task State and work-units evidence record the Work Unit as blocked.",
+            "No unexecuted runtime observation is classified as PASS.",
+        ],
+        ["Run from Main TUI with `/task-run SMOKE-LEAF-BLOCKED` under `just runtime::smoke-leaf-blocked`."],
+    ),
+    (
         "SMOKE-CONTROL",
         "ask-free-control",
         "Diagnose whether a nested Depth-2 leaf can complete without any Ask permission event.",
@@ -372,6 +408,8 @@ def report_template(issue: str, metadata: dict) -> str:
 - `runtime::doctor`: PASS
 - fixture bootstrap: PASS
 - Main initialization: PASS
+- SMOKE-LEAF-COMPLETED contract: READY
+- SMOKE-LEAF-BLOCKED contract: READY
 - SMOKE-CONTROL contract: READY
 - SMOKE-ASK contract: READY
 - SMOKE-ESCALATION contract: READY
@@ -388,6 +426,22 @@ def report_template(issue: str, metadata: dict) -> str:
 - provider response observed: PASS / FAIL / INCOMPLETE
 - read-only tool completed: PASS / FAIL / INCOMPLETE
 - child returned to parent: PASS / FAIL / INCOMPLETE
+- result: PASS / FAIL / INCOMPLETE
+
+## Depth-2 leaf Work Unit contracts
+
+- completed-case Log:
+- blocked-case Log:
+- Task Orchestrator session ID:
+- completed leaf session ID:
+- blocked leaf session ID:
+- parent initialization doctor/context/project::doctor events excluded from leaf inspection: PASS / FAIL / INCOMPLETE
+- completed leaf exact `status: COMPLETED`: PASS / FAIL / INCOMPLETE
+- parent accepted and recorded completed Work Unit: PASS / FAIL / INCOMPLETE
+- blocked leaf exact `status: BLOCKED`: PASS / FAIL / INCOMPLETE
+- parent recorded blocked Work Unit: PASS / FAIL / INCOMPLETE
+- denied initialization attempt/event in either leaf session: PASS / FAIL / INCOMPLETE
+- `runtime::validate-leaf-contract`: PASS / FAIL / INCOMPLETE
 - result: PASS / FAIL / INCOMPLETE
 
 ## Direct leaf control
@@ -924,6 +978,159 @@ def validate_escalation(issue: str) -> dict:
     }
 
 
+VALID_LEAF_STATUSES = {"COMPLETED", "BLOCKED", "NEEDS_APPROVAL", "NEEDS_DECISION"}
+
+
+def _canonical_leaf_status(text: str, leaf_id: str) -> str:
+    """Return an exact, first-line canonical status from a leaf final response."""
+    lines = text.splitlines()
+    matches = re.findall(r"(?m)^status: ([A-Z_]+)$", text)
+    if not lines or len(matches) != 1 or lines[0] != f"status: {matches[0]}" or matches[0] not in VALID_LEAF_STATUSES:
+        raise RuntimeSmokeError(
+            f"leaf {leaf_id} must emit exactly one valid first-line status field; observed {matches!r}"
+        )
+    return matches[0]
+
+
+def _leaf_session_from_log(path: Path) -> tuple[str, str]:
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    parent_matches = [
+        (index, match.group(1))
+        for index, line in enumerate(lines)
+        if "agent=task-orchestrator" in line
+        for match in [re.search(r"message=created id=(\S+)", line)]
+        if match is not None
+    ]
+    if len(parent_matches) != 1:
+        raise RuntimeSmokeError(f"expected one Task Orchestrator session in {path}, observed {len(parent_matches)}")
+    parent_index, parent_id = parent_matches[0]
+    leaf_matches = [
+        (index, match.group(1))
+        for index, line in enumerate(lines)
+        if f"parentID={parent_id}" in line and ("agent=general" in line or "agent=explore" in line)
+        for match in [re.search(r"message=created id=(\S+)", line)]
+        if match is not None
+    ]
+    if len(leaf_matches) != 1:
+        raise RuntimeSmokeError(f"expected one Depth-2 leaf session in {path}, observed {len(leaf_matches)}")
+    leaf_index, leaf_id = leaf_matches[0]
+    exits = [index for index, line in enumerate(lines) if f'message="exiting loop" session.id={leaf_id}' in line]
+    if len(exits) != 1 or not (parent_index < leaf_index < exits[0]):
+        raise RuntimeSmokeError(f"leaf {leaf_id} does not have one ordered completion event in {path}")
+    return parent_id, leaf_id
+
+
+def _session_export(repo: Path, session_id: str) -> tuple[list[str], list[tuple[str, str]]]:
+    try:
+        exported = json.loads(run_capture(["opencode", "export", "--sanitize", session_id], cwd=repo))
+    except (json.JSONDecodeError, AttributeError) as exc:
+        raise RuntimeSmokeError(f"invalid sanitized export for session {session_id}") from exc
+    messages = exported.get("messages", []) if isinstance(exported, dict) else []
+    assistant_texts: list[str] = []
+    tools: list[tuple[str, str]] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        info = message.get("info", {})
+        parts = message.get("parts", [])
+        if isinstance(info, dict) and info.get("role") == "assistant":
+            text = "\n".join(
+                part.get("text", "")
+                for part in parts
+                if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str)
+            ).strip()
+            if text:
+                assistant_texts.append(text)
+        for part in parts:
+            if not isinstance(part, dict) or part.get("type") != "tool":
+                continue
+            command = part.get("state", {}).get("input", {}).get("command")
+            if isinstance(command, str):
+                status = part.get("state", {}).get("status", "")
+                tools.append((command, status if isinstance(status, str) else ""))
+    return assistant_texts, tools
+
+
+def _leaf_export(repo: Path, leaf_id: str) -> tuple[str, list[str]]:
+    assistant_texts, tools = _session_export(repo, leaf_id)
+    if not assistant_texts:
+        raise RuntimeSmokeError(f"sanitized export has no assistant response for leaf {leaf_id}")
+    return assistant_texts[-1], [command for command, _status in tools]
+
+
+def _require_parent_initialization(repo: Path, parent_id: str) -> None:
+    _responses, tools = _session_export(repo, parent_id)
+    for command in ("just agent::doctor", "just agent::context", "just project::doctor"):
+        matches = [status for candidate, status in tools if candidate == command]
+        if matches != ["completed"]:
+            raise RuntimeSmokeError(
+                f"Task Orchestrator {parent_id} did not complete initialization command {command}: {matches!r}"
+            )
+
+
+def _reject_leaf_initialization_commands(commands: list[str], leaf_id: str) -> None:
+    forbidden = ("agent::doctor", "agent::context", "project::doctor")
+    if any(command in candidate for candidate in commands for command in forbidden):
+        raise RuntimeSmokeError(f"leaf {leaf_id} attempted initialization inspection")
+
+
+def validate_leaf_contract(issue: str) -> dict:
+    """Validate completed/blocked contracts using leaf exports, never parent init output."""
+    base = workspace(issue)
+    repo = smoke_repo(issue)
+    case_logs: dict[str, Path] = {}
+    for expected, mode in (("completed", "leaf-completed"), ("blocked", "leaf-blocked")):
+        matches = sorted((base / "logs").glob(f"opencode-{mode}-[0-9]*.log"))
+        if not matches:
+            raise RuntimeSmokeError(f"missing {mode} DEBUG log")
+        case_logs[expected] = matches[-1]
+
+    parent_ids: dict[str, str] = {}
+    results: dict[str, str] = {}
+    for expected, log in case_logs.items():
+        parent_id, leaf_id = _leaf_session_from_log(log)
+        _require_parent_initialization(repo, parent_id)
+        response, commands = _leaf_export(repo, leaf_id)
+        status_value = _canonical_leaf_status(response, leaf_id)
+        if status_value.lower() != expected:
+            raise RuntimeSmokeError(f"leaf {leaf_id} returned {status_value}, expected {expected.upper()}")
+        _reject_leaf_initialization_commands(commands, leaf_id)
+        if expected == "completed" and commands != ["git status --short"]:
+            raise RuntimeSmokeError(f"completed leaf operations are not exactly git status --short: {commands!r}")
+        parent_ids[expected] = parent_id
+        results[expected] = status_value
+
+    state_paths = {
+        "completed": base / "smoke-repo" / ".worktrees" / "SMOKE-LEAF-COMPLETED-depth2-leaf-completed" / ".task-state" / "task.md",
+        "blocked": base / "smoke-repo" / ".worktrees" / "SMOKE-LEAF-BLOCKED-depth2-leaf-blocked" / ".task-state" / "task.md",
+    }
+    for expected, path in state_paths.items():
+        if not path.is_file():
+            raise RuntimeSmokeError(f"missing {expected} Task State: {path}")
+        text = path.read_text(encoding="utf-8")
+        if f"state={expected}" not in text and f'"state": "{expected}"' not in text:
+            raise RuntimeSmokeError(f"Task State does not record {expected}: {path}")
+        work_units = path.parent / "work-units.json"
+        if not work_units.is_file():
+            raise RuntimeSmokeError(f"missing machine-readable Work Unit evidence: {work_units}")
+        try:
+            units = json.loads(work_units.read_text(encoding="utf-8"))
+            states = [unit.get("state") for unit in units.get("units", {}).values()]
+        except (OSError, json.JSONDecodeError, AttributeError):
+            raise RuntimeSmokeError(f"invalid machine-readable Work Unit evidence: {work_units}")
+        if states != [expected]:
+            raise RuntimeSmokeError(f"Work Unit state evidence is not exactly {expected}: {work_units}")
+
+    return {
+        "status": "PASS",
+        "issue": issue,
+        "logs": {key: str(value) for key, value in case_logs.items()},
+        "parentSessions": parent_ids,
+        "leafStatuses": results,
+        "taskStates": {key: str(value) for key, value in state_paths.items()},
+    }
+
+
 def snapshot_sessions(issue: str, label: str) -> dict:
     label = validate_name(label, "snapshot label")
     repo = smoke_repo(issue)
@@ -976,6 +1183,9 @@ def parser() -> argparse.ArgumentParser:
     command = sub.add_parser("validate-escalation")
     command.add_argument("--issue", default="issue-41")
 
+    command = sub.add_parser("validate-leaf-contract")
+    command.add_argument("--issue", default="issue-41")
+
     command = sub.add_parser("snapshot-sessions")
     command.add_argument("--issue", default="issue-41")
     command.add_argument("--label", required=True)
@@ -1000,6 +1210,8 @@ def main() -> int:
             value = status(args.issue)
         elif args.command == "validate-escalation":
             value = validate_escalation(args.issue)
+        elif args.command == "validate-leaf-contract":
+            value = validate_leaf_contract(args.issue)
         elif args.command == "snapshot-sessions":
             value = snapshot_sessions(args.issue, args.label)
         elif args.command == "export-session":

--- a/tests/runtime/runtime_smoke.py
+++ b/tests/runtime/runtime_smoke.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -1020,51 +1021,151 @@ def _leaf_session_from_log(path: Path) -> tuple[str, str]:
     return parent_id, leaf_id
 
 
-def _session_export(repo: Path, session_id: str) -> tuple[list[str], list[tuple[str, str]]]:
+def _latest_complete_leaf_log(paths: list[Path], mode: str) -> tuple[Path, str, str]:
+    for path in reversed(paths):
+        try:
+            parent_id, leaf_id = _leaf_session_from_log(path)
+        except RuntimeSmokeError:
+            continue
+        return path, parent_id, leaf_id
+    raise RuntimeSmokeError(
+        f"no complete {mode} leaf session found across {len(paths)} DEBUG log(s)"
+    )
+
+
+def _opencode_version(repo: Path) -> str:
     try:
-        exported = json.loads(run_capture(["opencode", "export", "--sanitize", session_id], cwd=repo))
-    except (json.JSONDecodeError, AttributeError) as exc:
-        raise RuntimeSmokeError(f"invalid sanitized export for session {session_id}") from exc
+        result = subprocess.run(
+            ["opencode", "--version"],
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"unavailable ({type(exc).__name__})"
+    value = result.stdout.strip().splitlines()
+    if result.returncode != 0 or not value:
+        return f"unavailable (exit {result.returncode})"
+    return value[0][:120]
+
+
+def _bounded_stderr(value: str, limit: int = 300) -> str:
+    summary = " ".join(value.split())
+    if not summary:
+        return "<empty>"
+    return summary[:limit] + ("..." if len(summary) > limit else "")
+
+
+def _transient_session_export(repo: Path, session_id: str) -> object:
+    """Load one unsanitized export transiently without persisting transcript data."""
+    command = ["opencode", "export", session_id]
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as export_file:
+        try:
+            result = subprocess.run(
+                command,
+                cwd=repo,
+                text=True,
+                stdout=export_file,
+                stderr=subprocess.PIPE,
+                timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise RuntimeSmokeError(
+                f"transient export failed for session {session_id}; "
+                f"opencode_version={_opencode_version(repo)}; error={type(exc).__name__}"
+            ) from exc
+        if result.returncode != 0:
+            raise RuntimeSmokeError(
+                f"transient export failed for session {session_id}; "
+                f"opencode_version={_opencode_version(repo)}; exit_code={result.returncode}; "
+                f"stderr={_bounded_stderr(result.stderr)}"
+            )
+        export_file.seek(0)
+        try:
+            return json.load(export_file)
+        except json.JSONDecodeError as exc:
+            raise RuntimeSmokeError(
+                f"transient export JSON invalid for session {session_id}; "
+                f"opencode_version={_opencode_version(repo)}; exit_code={result.returncode}; "
+                f"stderr={_bounded_stderr(result.stderr)}; "
+                f"json_error=line {exc.lineno} column {exc.colno} position {exc.pos}"
+            ) from exc
+
+
+def _derive_session_evidence(
+    exported: object, session_id: str, *, require_final_status: bool
+) -> dict[str, object]:
+    """Reduce a transient transcript to non-sensitive contract evidence."""
+    if not isinstance(exported, dict) or not isinstance(exported.get("messages"), list):
+        raise RuntimeSmokeError(f"invalid export structure for session {session_id}")
     messages = exported.get("messages", []) if isinstance(exported, dict) else []
-    assistant_texts: list[str] = []
-    tools: list[tuple[str, str]] = []
+    final_assistant_text: str | None = None
+    tool_commands: list[str | None] = []
+    tool_statuses: list[str | None] = []
     for message in messages:
         if not isinstance(message, dict):
-            continue
+            raise RuntimeSmokeError(f"invalid message structure for session {session_id}")
         info = message.get("info", {})
         parts = message.get("parts", [])
+        if not isinstance(parts, list):
+            raise RuntimeSmokeError(f"invalid parts structure for session {session_id}")
         if isinstance(info, dict) and info.get("role") == "assistant":
-            text = "\n".join(
+            final_assistant_text = "\n".join(
                 part.get("text", "")
                 for part in parts
                 if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str)
             ).strip()
-            if text:
-                assistant_texts.append(text)
         for part in parts:
-            if not isinstance(part, dict) or part.get("type") != "tool":
+            if not isinstance(part, dict):
+                raise RuntimeSmokeError(f"invalid part structure for session {session_id}")
+            if part.get("type") != "tool" or part.get("tool") != "bash":
                 continue
-            command = part.get("state", {}).get("input", {}).get("command")
-            if isinstance(command, str):
-                status = part.get("state", {}).get("status", "")
-                tools.append((command, status if isinstance(status, str) else ""))
-    return assistant_texts, tools
+            state = part.get("state")
+            state = state if isinstance(state, dict) else {}
+            tool_input = state.get("input")
+            tool_input = tool_input if isinstance(tool_input, dict) else {}
+            command = tool_input.get("command")
+            status = state.get("status")
+            tool_commands.append(command if isinstance(command, str) else None)
+            tool_statuses.append(status if isinstance(status, str) else None)
+    final_status = None
+    if require_final_status:
+        if final_assistant_text is None:
+            raise RuntimeSmokeError(f"export has no assistant final response for leaf {session_id}")
+        final_status = _canonical_leaf_status(final_assistant_text, session_id)
+    return {
+        "session_id": session_id,
+        "assistant_final_status": final_status,
+        "tool_commands": tool_commands,
+        "tool_statuses": tool_statuses,
+    }
 
 
-def _leaf_export(repo: Path, leaf_id: str) -> tuple[str, list[str]]:
-    assistant_texts, tools = _session_export(repo, leaf_id)
-    if not assistant_texts:
-        raise RuntimeSmokeError(f"sanitized export has no assistant response for leaf {leaf_id}")
-    return assistant_texts[-1], [command for command, _status in tools]
+def _session_export(
+    repo: Path, session_id: str, *, require_final_status: bool = False
+) -> dict[str, object]:
+    exported = _transient_session_export(repo, session_id)
+    return _derive_session_evidence(
+        exported, session_id, require_final_status=require_final_status
+    )
 
 
-def _require_parent_initialization(repo: Path, parent_id: str) -> None:
-    _responses, tools = _session_export(repo, parent_id)
+def _require_parent_initialization(evidence: dict[str, object], parent_id: str) -> None:
+    commands = evidence.get("tool_commands")
+    statuses = evidence.get("tool_statuses")
+    if not isinstance(commands, list) or not isinstance(statuses, list) or len(commands) != len(statuses):
+        raise RuntimeSmokeError(f"invalid derived tool evidence for Task Orchestrator {parent_id}")
+    completed_steps = [
+        step.strip()
+        for command, status in zip(commands, statuses)
+        if isinstance(command, str) and status == "completed"
+        for step in command.split(" && ")
+    ]
     for command in ("just agent::doctor", "just agent::context", "just project::doctor"):
-        matches = [status for candidate, status in tools if candidate == command]
-        if matches != ["completed"]:
+        if completed_steps.count(command) != 1:
             raise RuntimeSmokeError(
-                f"Task Orchestrator {parent_id} did not complete initialization command {command}: {matches!r}"
+                f"Task Orchestrator {parent_id} did not complete initialization command {command} exactly once"
             )
 
 
@@ -1074,29 +1175,49 @@ def _reject_leaf_initialization_commands(commands: list[str], leaf_id: str) -> N
         raise RuntimeSmokeError(f"leaf {leaf_id} attempted initialization inspection")
 
 
+def _require_leaf_tool_evidence(
+    evidence: dict[str, object], expected: str, leaf_id: str
+) -> None:
+    commands = evidence.get("tool_commands")
+    statuses = evidence.get("tool_statuses")
+    if not isinstance(commands, list) or not isinstance(statuses, list) or len(commands) != len(statuses):
+        raise RuntimeSmokeError(f"invalid derived tool evidence for leaf {leaf_id}")
+    if any(not isinstance(command, str) for command in commands):
+        raise RuntimeSmokeError(f"leaf {leaf_id} has missing or redacted Bash command evidence")
+    if any(not isinstance(status, str) for status in statuses):
+        raise RuntimeSmokeError(f"leaf {leaf_id} has missing Bash status evidence")
+    _reject_leaf_initialization_commands(commands, leaf_id)
+    if expected == "completed" and (
+        commands != ["git status --short"] or statuses != ["completed"]
+    ):
+        raise RuntimeSmokeError(f"completed leaf {leaf_id} operation evidence is invalid")
+    if expected == "blocked" and (commands or statuses):
+        raise RuntimeSmokeError(f"blocked leaf {leaf_id} attempted a Bash operation")
+
+
 def validate_leaf_contract(issue: str) -> dict:
     """Validate completed/blocked contracts using leaf exports, never parent init output."""
     base = workspace(issue)
     repo = smoke_repo(issue)
-    case_logs: dict[str, Path] = {}
+    cases: dict[str, tuple[Path, str, str]] = {}
     for expected, mode in (("completed", "leaf-completed"), ("blocked", "leaf-blocked")):
         matches = sorted((base / "logs").glob(f"opencode-{mode}-[0-9]*.log"))
         if not matches:
             raise RuntimeSmokeError(f"missing {mode} DEBUG log")
-        case_logs[expected] = matches[-1]
+        cases[expected] = _latest_complete_leaf_log(matches, mode)
 
     parent_ids: dict[str, str] = {}
     results: dict[str, str] = {}
-    for expected, log in case_logs.items():
-        parent_id, leaf_id = _leaf_session_from_log(log)
-        _require_parent_initialization(repo, parent_id)
-        response, commands = _leaf_export(repo, leaf_id)
-        status_value = _canonical_leaf_status(response, leaf_id)
+    for expected, (_log, parent_id, leaf_id) in cases.items():
+        parent_evidence = _session_export(repo, parent_id)
+        _require_parent_initialization(parent_evidence, parent_id)
+        leaf_evidence = _session_export(repo, leaf_id, require_final_status=True)
+        status_value = leaf_evidence.get("assistant_final_status")
+        if not isinstance(status_value, str):
+            raise RuntimeSmokeError(f"missing derived final status for leaf {leaf_id}")
         if status_value.lower() != expected:
             raise RuntimeSmokeError(f"leaf {leaf_id} returned {status_value}, expected {expected.upper()}")
-        _reject_leaf_initialization_commands(commands, leaf_id)
-        if expected == "completed" and commands != ["git status --short"]:
-            raise RuntimeSmokeError(f"completed leaf operations are not exactly git status --short: {commands!r}")
+        _require_leaf_tool_evidence(leaf_evidence, expected, leaf_id)
         parent_ids[expected] = parent_id
         results[expected] = status_value
 
@@ -1124,7 +1245,7 @@ def validate_leaf_contract(issue: str) -> dict:
     return {
         "status": "PASS",
         "issue": issue,
-        "logs": {key: str(value) for key, value in case_logs.items()},
+        "logs": {key: str(value[0]) for key, value in cases.items()},
         "parentSessions": parent_ids,
         "leafStatuses": results,
         "taskStates": {key: str(value) for key, value in state_paths.items()},

--- a/tests/test_opencode_contract.py
+++ b/tests/test_opencode_contract.py
@@ -34,6 +34,19 @@ TASK_ORCHESTRATOR_LEAVES = (
     "scout",
 )
 LEAF_STATUS_SET = {"COMPLETED", "BLOCKED", "NEEDS_APPROVAL", "NEEDS_DECISION"}
+LEAF_STATUS_FIELDS = tuple(f"status: {status}" for status in (
+    "COMPLETED",
+    "BLOCKED",
+    "NEEDS_APPROVAL",
+    "NEEDS_DECISION",
+))
+LEAF_CONTRACT_TEMPLATES = (
+    "agent-base",
+    "agent-python",
+    "agent-rust",
+    "agent-nix",
+    "agent-cpp-cmake",
+)
 READ_ONLY_GIT_COMMANDS = {
     "git status",
     "git status *",
@@ -178,6 +191,10 @@ def status_report_lines(text: str) -> set[str]:
     return set(re.findall(r"\b(?:COMPLETED|BLOCKED|NEEDS_APPROVAL|NEEDS_DECISION)\b", text))
 
 
+def exact_status_fields(text: str) -> list[str]:
+    return re.findall(r"`(status: (?:COMPLETED|BLOCKED|NEEDS_APPROVAL|NEEDS_DECISION))`", text)
+
+
 def assert_prompt_contract_for_leaf_statuses(test_case: unittest.TestCase, body: str, name: str) -> None:
     test_case.assertEqual(status_report_lines(body), LEAF_STATUS_SET, name)
     lower = body.lower()
@@ -199,6 +216,61 @@ def assert_prompt_contract_for_leaf_statuses(test_case: unittest.TestCase, body:
     ):
         test_case.assertIn(field, lower, name)
     test_case.assertIn("ambiguity, options with tradeoffs, and recommendation", lower, name)
+
+
+def assert_leaf_startup_contract(test_case: unittest.TestCase, body: str, name: str) -> None:
+    lower = body.lower()
+    test_case.assertIn("initialize", lower, name)
+    test_case.assertRegex(lower, r"(?:no|not|without|do not|don't)[^\n.]{0,80}initialize", name)
+    test_case.assertIn(
+        "parent task orchestrator already initialized the task worktree and validated the task contract",
+        lower,
+        name,
+    )
+    test_case.assertIn("bounded", lower, name)
+    test_case.assertIn("objective", lower, name)
+    test_case.assertIn("project::", lower, name)
+    test_case.assertIn("as leaf-session startup prerequisites", lower, name)
+    for command in ("just agent::doctor", "just agent::context", "just project::doctor"):
+        test_case.assertIn(command, lower, name)
+    test_case.assertIn(
+        "do not run `just agent::doctor`, `just agent::context`, or mandatory "
+        "`just project::doctor` as leaf-session startup prerequisites",
+        lower,
+        name,
+    )
+
+
+def assert_orchestrator_status_contract(test_case: unittest.TestCase, body: str) -> None:
+    lower = body.lower()
+    for field in LEAF_STATUS_FIELDS:
+        test_case.assertIn(field.lower(), lower)
+    test_case.assertEqual(set(exact_status_fields(body)), set(LEAF_STATUS_FIELDS))
+    for phrase in (
+        "unknown, multiple, or missing status field",
+        "invalid evidence",
+    ):
+        test_case.assertIn(phrase, lower)
+    invalid_lines = [line for line in lower.splitlines() if "invalid evidence" in line]
+    test_case.assertTrue(
+        any(
+            "only" in line
+            and all(term in line for term in ("unknown", "multiple", "missing"))
+            for line in invalid_lines
+        ),
+        "invalid evidence must be limited to unknown, multiple, or missing status fields",
+    )
+    for source, target in (
+        ("COMPLETED", "completed"),
+        ("BLOCKED", "blocked"),
+        ("NEEDS_APPROVAL", "needs-approval"),
+        ("NEEDS_DECISION", "needs-decision"),
+    ):
+        test_case.assertRegex(
+            lower,
+            rf"status:\s*{source.lower()}[^\n]*(?:->|→|maps? to|means|becomes)[^\n]*{re.escape(target)}",
+            source,
+        )
 
 
 def frontmatter(path: Path) -> str:
@@ -515,6 +587,62 @@ global permissive plan
                         r"integrate::status|project::commit|project::publish|project::release)",
                         leaf,
                     )
+
+    def test_leaf_permissions_are_exact_and_exclude_startup_commands(self) -> None:
+        """Leaf profiles are the complete allowlist, not a reduced init profile."""
+        for leaf in TASK_ORCHESTRATOR_LEAVES:
+            permission = permission_for(leaf)
+            bash = permission.get("bash", {})
+            self.assertIsInstance(bash, dict, leaf)
+            self.assertEqual(
+                {command for command, action in bash.items() if action == "allow"},
+                LEAF_ALLOWED_BASH[leaf],
+                leaf,
+            )
+            self.assertNotIn("just agent::doctor", bash, leaf)
+            self.assertNotIn("just agent::context", bash, leaf)
+            if "just project::doctor" in LEAF_ALLOWED_BASH[leaf]:
+                self.assertEqual(bash.get("just project::doctor"), "allow", leaf)
+
+    def test_leaf_prompts_require_parent_initialized_contract_and_bounded_objective(self) -> None:
+        for leaf in TASK_ORCHESTRATOR_LEAVES:
+            assert_leaf_startup_contract(self, body_text(leaf), leaf)
+
+    def test_leaf_status_fields_use_one_canonical_exact_format(self) -> None:
+        pattern = re.compile(r"(?m)^\s*-?\s*Start .* exactly one `status: (\w+)`")
+        for leaf in TASK_ORCHESTRATOR_LEAVES:
+            body = body_text(leaf)
+            self.assertTrue(pattern.search(body), leaf)
+            self.assertEqual(
+                {f"status: {status}" for status in status_report_lines(body)},
+                set(LEAF_STATUS_FIELDS),
+                leaf,
+            )
+            self.assertEqual(exact_status_fields(body), list(LEAF_STATUS_FIELDS), leaf)
+
+    def test_task_orchestrator_has_exact_leaf_status_mapping(self) -> None:
+        assert_orchestrator_status_contract(self, body_text("task-orchestrator"))
+
+    def test_generated_templates_share_leaf_source_contract(self) -> None:
+        for template in LEAF_CONTRACT_TEMPLATES:
+            agents = ROOT / "templates" / template / ".opencode" / "agents"
+            for leaf in TASK_ORCHESTRATOR_LEAVES:
+                source = (AGENTS / f"{leaf}.md").read_text(encoding="utf-8")
+                generated = (agents / f"{leaf}.md").read_text(encoding="utf-8")
+                self.assertEqual(generated, source, f"{template}: {leaf}")
+                assert_leaf_startup_contract(self, generated, f"{template}: {leaf}")
+                self.assertEqual(status_report_lines(generated), LEAF_STATUS_SET, f"{template}: {leaf} statuses")
+                self.assertEqual(exact_status_fields(generated), list(LEAF_STATUS_FIELDS), f"{template}: {leaf} status format")
+                for field in LEAF_STATUS_FIELDS:
+                    self.assertIn(field, generated, f"{template}: {leaf}: {field}")
+
+            source_orchestrator = (AGENTS / "task-orchestrator.md").read_text(encoding="utf-8")
+            generated_orchestrator = (agents / "task-orchestrator.md").read_text(encoding="utf-8")
+            self.assertEqual(generated_orchestrator, source_orchestrator, f"{template}: task-orchestrator")
+            assert_orchestrator_status_contract(self, generated_orchestrator)
+            for field in LEAF_STATUS_FIELDS:
+                self.assertIn(field, generated_orchestrator, f"{template}: task-orchestrator: {field}")
+            self.assertEqual(set(exact_status_fields(generated_orchestrator)), set(LEAF_STATUS_FIELDS), f"{template}: task-orchestrator status format")
     def test_leaf_prompts_expose_completion_status_contract(self) -> None:
         for leaf in LEAF_PRIMARY_AGENTS:
             assert_prompt_contract_for_leaf_statuses(self, body_text(leaf), leaf)

--- a/tests/test_runtime_smoke_harness.py
+++ b/tests/test_runtime_smoke_harness.py
@@ -339,49 +339,40 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
                 ]) + "\n", encoding="utf-8"
             )
             original_workspace = runtime.workspace
-            original_run_capture = runtime.run_capture
+            original_session_export = runtime._session_export
             runtime.workspace = lambda _issue: base
-            exports = {
+            evidence = {
                 "to-completed": {
-                    "messages": [{
-                        "info": {"role": "assistant"},
-                        "parts": [
-                            {"type": "tool", "state": {"status": "completed", "input": {"command": command}}}
-                            for command in ("just agent::doctor", "just agent::context", "just project::doctor")
-                        ],
-                    }],
+                    "session_id": "to-completed",
+                    "assistant_final_status": None,
+                    "tool_commands": ["just agent::doctor", "just agent::context", "just project::doctor"],
+                    "tool_statuses": ["completed", "completed", "completed"],
                 },
                 "to-blocked": {
-                    "messages": [{
-                        "info": {"role": "assistant"},
-                        "parts": [
-                            {"type": "tool", "state": {"status": "completed", "input": {"command": command}}}
-                            for command in ("just agent::doctor", "just agent::context", "just project::doctor")
-                        ],
-                    }],
+                    "session_id": "to-blocked",
+                    "assistant_final_status": None,
+                    "tool_commands": ["just agent::doctor", "just agent::context", "just project::doctor"],
+                    "tool_statuses": ["completed", "completed", "completed"],
                 },
                 "done": {
-                    "messages": [{
-                        "info": {"role": "assistant"},
-                        "parts": [
-                            {"type": "tool", "state": {"status": "completed", "input": {"command": "git status --short"}}},
-                            {"type": "text", "text": "status: COMPLETED\n\nGit status is clean."},
-                        ],
-                    }],
+                    "session_id": "done",
+                    "assistant_final_status": "COMPLETED",
+                    "tool_commands": ["git status --short"],
+                    "tool_statuses": ["completed"],
                 },
                 "blocked": {
-                    "messages": [{
-                        "info": {"role": "assistant"},
-                        "parts": [{"type": "text", "text": "status: BLOCKED\n\nRequired file is absent."}],
-                    }],
+                    "session_id": "blocked",
+                    "assistant_final_status": "BLOCKED",
+                    "tool_commands": [],
+                    "tool_statuses": [],
                 },
             }
-            runtime.run_capture = lambda command, *, cwd: json.dumps(exports[command[-1]])
+            runtime._session_export = lambda _repo, session_id, **_kwargs: evidence[session_id]
             try:
                 result = runtime.validate_leaf_contract("test")
             finally:
                 runtime.workspace = original_workspace
-                runtime.run_capture = original_run_capture
+                runtime._session_export = original_session_export
             self.assertEqual("PASS", result["status"])
             self.assertEqual(
                 {"completed": "COMPLETED", "blocked": "BLOCKED"},
@@ -403,42 +394,171 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
                 with self.assertRaisesRegex(runtime.RuntimeSmokeError, "exactly one valid first-line status"):
                     runtime._canonical_leaf_status(response, "leaf")
 
-    def test_leaf_export_exposes_denied_initialization_attempts(self) -> None:
-        original_run_capture = runtime.run_capture
-        runtime.run_capture = lambda _command, *, cwd: json.dumps({
+    def test_sanitized_redacted_tool_input_cannot_satisfy_command_assertions(self) -> None:
+        sanitized = {
             "messages": [{
                 "info": {"role": "assistant"},
                 "parts": [
-                    {"type": "tool", "state": {"input": {"command": "just agent::doctor"}}},
+                    {
+                        "type": "tool",
+                        "tool": "bash",
+                        "state": {
+                            "status": "completed",
+                            "input": {"redacted": "tool-input"},
+                        },
+                    },
                     {"type": "text", "text": "status: BLOCKED\n\nInitialization was denied."},
                 ],
             }],
-        })
+        }
+        evidence = runtime._derive_session_evidence(
+            sanitized, "leaf", require_final_status=True
+        )
+        self.assertEqual([None], evidence["tool_commands"])
+        self.assertNotEqual(["git status --short"], evidence["tool_commands"])
+        with self.assertRaisesRegex(runtime.RuntimeSmokeError, "did not complete initialization"):
+            runtime._require_parent_initialization(evidence, "leaf")
+        with self.assertRaisesRegex(runtime.RuntimeSmokeError, "missing or redacted"):
+            runtime._require_leaf_tool_evidence(evidence, "completed", "leaf")
+
+    def test_unsanitized_export_is_reduced_to_minimal_derived_evidence(self) -> None:
+        unsanitized = {
+            "messages": [
+                {
+                    "info": {"role": "user"},
+                    "parts": [{"type": "text", "text": "full private prompt"}],
+                },
+                {
+                    "info": {"role": "assistant"},
+                    "parts": [
+                        {
+                            "type": "tool",
+                            "tool": "bash",
+                            "state": {
+                                "status": "completed",
+                                "input": {"command": "git status --short"},
+                                "output": "full private tool output",
+                            },
+                        },
+                        {
+                            "type": "text",
+                            "text": "status: COMPLETED\n\nfull private assistant explanation",
+                        },
+                    ],
+                },
+            ]
+        }
+        original_run = runtime.subprocess.run
+
+        def fake_run(_command, **kwargs):
+            json.dump(unsanitized, kwargs["stdout"])
+            kwargs["stdout"].flush()
+            return subprocess.CompletedProcess(_command, 0, stderr="")
+
+        runtime.subprocess.run = fake_run
         try:
-            response, commands = runtime._leaf_export(Path("."), "leaf")
+            evidence = runtime._session_export(
+                Path("."), "leaf", require_final_status=True
+            )
         finally:
-            runtime.run_capture = original_run_capture
-        self.assertEqual("BLOCKED", runtime._canonical_leaf_status(response, "leaf"))
-        self.assertEqual(["just agent::doctor"], commands)
-        with self.assertRaisesRegex(runtime.RuntimeSmokeError, "attempted initialization"):
-            runtime._reject_leaf_initialization_commands(commands, "leaf")
+            runtime.subprocess.run = original_run
+        self.assertEqual(
+            {
+                "session_id": "leaf",
+                "assistant_final_status": "COMPLETED",
+                "tool_commands": ["git status --short"],
+                "tool_statuses": ["completed"],
+            },
+            evidence,
+        )
+        rendered = json.dumps(evidence)
+        self.assertNotIn("private", rendered)
+        self.assertNotIn("output", rendered)
+        self.assertNotIn("messages", rendered)
+
+    def test_leaf_tool_evidence_rejects_blocked_bash_and_hides_command(self) -> None:
+        evidence = {
+            "session_id": "leaf",
+            "assistant_final_status": "BLOCKED",
+            "tool_commands": ["secret-command-value"],
+            "tool_statuses": ["completed"],
+        }
+        with self.assertRaisesRegex(
+            runtime.RuntimeSmokeError, "blocked leaf leaf attempted a Bash operation"
+        ) as raised:
+            runtime._require_leaf_tool_evidence(evidence, "blocked", "leaf")
+        self.assertNotIn("secret-command-value", str(raised.exception))
+
+    def test_trailing_empty_assistant_message_cannot_reuse_earlier_status(self) -> None:
+        exported = {
+            "messages": [
+                {
+                    "info": {"role": "assistant"},
+                    "parts": [{"type": "text", "text": "status: COMPLETED"}],
+                },
+                {"info": {"role": "assistant"}, "parts": []},
+            ]
+        }
+        with self.assertRaisesRegex(
+            runtime.RuntimeSmokeError, "exactly one valid first-line status"
+        ):
+            runtime._derive_session_evidence(
+                exported, "leaf", require_final_status=True
+            )
+
+    def test_latest_complete_leaf_log_skips_newer_incomplete_attempt(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            complete = root / "opencode-leaf-blocked-20260101.log"
+            incomplete = root / "opencode-leaf-blocked-20260102.log"
+            complete.write_text(
+                "message=created id=parent parentID=main agent=task-orchestrator\n"
+                "message=created id=leaf parentID=parent agent=explore\n"
+                'message="exiting loop" session.id=leaf\n',
+                encoding="utf-8",
+            )
+            incomplete.write_text(
+                "message=created id=new-parent parentID=main agent=task-orchestrator\n",
+                encoding="utf-8",
+            )
+            selected = runtime._latest_complete_leaf_log(
+                [complete, incomplete], "leaf-blocked"
+            )
+        self.assertEqual((complete, "parent", "leaf"), selected)
+
+    def test_transient_export_invalid_json_and_status_prefix_fail_closed(self) -> None:
+        original_run = runtime.subprocess.run
+        original_version = runtime._opencode_version
+        runtime._opencode_version = lambda _repo: "1.18.test"
+
+        def fake_run(_command, **kwargs):
+            kwargs["stdout"].write('Exporting session...\n{"messages": []}')
+            kwargs["stdout"].flush()
+            return subprocess.CompletedProcess(_command, 0, stderr="bounded stderr")
+
+        runtime.subprocess.run = fake_run
+        try:
+            with self.assertRaisesRegex(
+                runtime.RuntimeSmokeError,
+                r"opencode_version=1\.18\.test; exit_code=0; stderr=bounded stderr; "
+                r"json_error=line 1 column 1 position 0",
+            ) as raised:
+                runtime._transient_session_export(Path("."), "leaf")
+        finally:
+            runtime.subprocess.run = original_run
+            runtime._opencode_version = original_version
+        self.assertNotIn("Exporting session", str(raised.exception))
+        self.assertNotIn("messages", str(raised.exception))
 
     def test_parent_initialization_does_not_treat_unexecuted_checks_as_pass(self) -> None:
-        original_run_capture = runtime.run_capture
-        runtime.run_capture = lambda _command, *, cwd: json.dumps({
-            "messages": [{
-                "info": {"role": "assistant"},
-                "parts": [
-                    {"type": "tool", "state": {"status": "completed", "input": {"command": "just agent::doctor"}}},
-                    {"type": "tool", "state": {"status": "pending", "input": {"command": "just agent::context"}}},
-                ],
-            }],
-        })
-        try:
-            with self.assertRaisesRegex(runtime.RuntimeSmokeError, "did not complete initialization"):
-                runtime._require_parent_initialization(Path("."), "parent")
-        finally:
-            runtime.run_capture = original_run_capture
+        evidence = {
+            "session_id": "parent",
+            "assistant_final_status": None,
+            "tool_commands": ["just agent::doctor", "just agent::context"],
+            "tool_statuses": ["completed", "pending"],
+        }
+        with self.assertRaisesRegex(runtime.RuntimeSmokeError, "did not complete initialization"):
+            runtime._require_parent_initialization(evidence, "parent")
 
     def test_runtime_fixture_installs_explicit_native_ask_canary_profile(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_runtime_smoke_harness.py
+++ b/tests/test_runtime_smoke_harness.py
@@ -30,6 +30,9 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
             "smoke-escalation issue='issue-41'",
             "smoke-escalation-reject issue='issue-41'",
             "validate-escalation issue='issue-41'",
+            "smoke-leaf-completed issue='issue-41'",
+            "smoke-leaf-blocked issue='issue-41'",
+            "validate-leaf-contract issue='issue-41'",
             "direct-leaf issue='issue-41'",
             "export-session session issue='issue-41'",
         ):
@@ -48,12 +51,30 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
         self.assertEqual(
             tasks,
             {
+                ("SMOKE-LEAF-COMPLETED", "depth2-leaf-completed"),
+                ("SMOKE-LEAF-BLOCKED", "depth2-leaf-blocked"),
                 ("SMOKE-CONTROL", "ask-free-control"),
                 ("SMOKE-ASK", "depth2-ask"),
                 ("SMOKE-ESCALATION", "leaf-escalation"),
                 ("SMOKE-ESCALATION-PERMISSION", "leaf-escalation-permission"),
             },
         )
+
+        completed = next(
+            definition for definition in runtime.TASK_DEFINITIONS
+            if definition[0] == "SMOKE-LEAF-COMPLETED"
+        )
+        completed_text = " ".join(completed[3] + completed[4])
+        self.assertIn("git status --short", completed_text)
+        self.assertIn("status: COMPLETED", completed_text)
+        self.assertIn("agent::doctor", completed_text)
+        self.assertIn("project::doctor", completed_text)
+
+        blocked = next(
+            definition for definition in runtime.TASK_DEFINITIONS
+            if definition[0] == "SMOKE-LEAF-BLOCKED"
+        )
+        self.assertIn("status: BLOCKED", " ".join(blocked[3] + blocked[4]))
 
         smoke_ask = next(
             definition
@@ -284,6 +305,140 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
             finally:
                 runtime.workspace = original_workspace
                 runtime.run_capture = original_run_capture
+
+    def test_validate_leaf_contract_scopes_initialization_checks_to_leaf_sessions(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary) / "issue"
+            logs = base / "logs"
+            logs.mkdir(parents=True)
+            for task, slug, state, extra in (
+                ("SMOKE-LEAF-COMPLETED", "depth2-leaf-completed", "completed", "parent accepted"),
+                ("SMOKE-LEAF-BLOCKED", "depth2-leaf-blocked", "blocked", ""),
+            ):
+                path = base / "smoke-repo" / ".worktrees" / f"{task}-{slug}" / ".task-state" / "task.md"
+                path.parent.mkdir(parents=True)
+                path.write_text(f"Work Unit state={state}\n{extra}\n", encoding="utf-8")
+                (path.parent / "work-units.json").write_text(
+                    json.dumps({"units": {"WU-1": {"state": state}}}) + "\n",
+                    encoding="utf-8",
+                )
+            (logs / "opencode-leaf-completed-20260101.log").write_text(
+                "\n".join([
+                    "message=created id=main agent=main",
+                    "message=created id=to-completed parentID=main agent=task-orchestrator",
+                    "initialization just agent::doctor just agent::context just project::doctor",
+                    "message=created id=done parentID=to-completed title=completed agent=general",
+                    'message="exiting loop" session.id=done',
+                ]) + "\n", encoding="utf-8"
+            )
+            (logs / "opencode-leaf-blocked-20260101.log").write_text(
+                "\n".join([
+                    "message=created id=to-blocked parentID=main agent=task-orchestrator",
+                    "message=created id=blocked parentID=to-blocked title=blocked agent=explore",
+                    'message="exiting loop" session.id=blocked',
+                ]) + "\n", encoding="utf-8"
+            )
+            original_workspace = runtime.workspace
+            original_run_capture = runtime.run_capture
+            runtime.workspace = lambda _issue: base
+            exports = {
+                "to-completed": {
+                    "messages": [{
+                        "info": {"role": "assistant"},
+                        "parts": [
+                            {"type": "tool", "state": {"status": "completed", "input": {"command": command}}}
+                            for command in ("just agent::doctor", "just agent::context", "just project::doctor")
+                        ],
+                    }],
+                },
+                "to-blocked": {
+                    "messages": [{
+                        "info": {"role": "assistant"},
+                        "parts": [
+                            {"type": "tool", "state": {"status": "completed", "input": {"command": command}}}
+                            for command in ("just agent::doctor", "just agent::context", "just project::doctor")
+                        ],
+                    }],
+                },
+                "done": {
+                    "messages": [{
+                        "info": {"role": "assistant"},
+                        "parts": [
+                            {"type": "tool", "state": {"status": "completed", "input": {"command": "git status --short"}}},
+                            {"type": "text", "text": "status: COMPLETED\n\nGit status is clean."},
+                        ],
+                    }],
+                },
+                "blocked": {
+                    "messages": [{
+                        "info": {"role": "assistant"},
+                        "parts": [{"type": "text", "text": "status: BLOCKED\n\nRequired file is absent."}],
+                    }],
+                },
+            }
+            runtime.run_capture = lambda command, *, cwd: json.dumps(exports[command[-1]])
+            try:
+                result = runtime.validate_leaf_contract("test")
+            finally:
+                runtime.workspace = original_workspace
+                runtime.run_capture = original_run_capture
+            self.assertEqual("PASS", result["status"])
+            self.assertEqual(
+                {"completed": "COMPLETED", "blocked": "BLOCKED"},
+                result["leafStatuses"],
+            )
+
+    def test_canonical_leaf_status_rejects_unknown_multiple_and_missing_fields(self) -> None:
+        self.assertEqual(
+            "BLOCKED",
+            runtime._canonical_leaf_status("status: BLOCKED\n\nEvidence.", "leaf"),
+        )
+        for response in (
+            "status: PASS",
+            "Evidence before status.\nstatus: BLOCKED",
+            "status: BLOCKED\nstatus: COMPLETED",
+            "BLOCKED",
+        ):
+            with self.subTest(response=response):
+                with self.assertRaisesRegex(runtime.RuntimeSmokeError, "exactly one valid first-line status"):
+                    runtime._canonical_leaf_status(response, "leaf")
+
+    def test_leaf_export_exposes_denied_initialization_attempts(self) -> None:
+        original_run_capture = runtime.run_capture
+        runtime.run_capture = lambda _command, *, cwd: json.dumps({
+            "messages": [{
+                "info": {"role": "assistant"},
+                "parts": [
+                    {"type": "tool", "state": {"input": {"command": "just agent::doctor"}}},
+                    {"type": "text", "text": "status: BLOCKED\n\nInitialization was denied."},
+                ],
+            }],
+        })
+        try:
+            response, commands = runtime._leaf_export(Path("."), "leaf")
+        finally:
+            runtime.run_capture = original_run_capture
+        self.assertEqual("BLOCKED", runtime._canonical_leaf_status(response, "leaf"))
+        self.assertEqual(["just agent::doctor"], commands)
+        with self.assertRaisesRegex(runtime.RuntimeSmokeError, "attempted initialization"):
+            runtime._reject_leaf_initialization_commands(commands, "leaf")
+
+    def test_parent_initialization_does_not_treat_unexecuted_checks_as_pass(self) -> None:
+        original_run_capture = runtime.run_capture
+        runtime.run_capture = lambda _command, *, cwd: json.dumps({
+            "messages": [{
+                "info": {"role": "assistant"},
+                "parts": [
+                    {"type": "tool", "state": {"status": "completed", "input": {"command": "just agent::doctor"}}},
+                    {"type": "tool", "state": {"status": "pending", "input": {"command": "just agent::context"}}},
+                ],
+            }],
+        })
+        try:
+            with self.assertRaisesRegex(runtime.RuntimeSmokeError, "did not complete initialization"):
+                runtime._require_parent_initialization(Path("."), "parent")
+        finally:
+            runtime.run_capture = original_run_capture
 
     def test_runtime_fixture_installs_explicit_native_ask_canary_profile(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -622,12 +777,15 @@ class RuntimeSmokeHarnessTest(unittest.TestCase):
         report = runtime.report_template("issue-41", metadata)
         self.assertIn("Ask-free nested control", report)
         self.assertIn("Direct leaf control", report)
+        self.assertIn("Depth-2 leaf Work Unit contracts", report)
         self.assertIn("Depth-2 native Ask compatibility canary", report)
         self.assertIn("Leaf → Depth-1 escalation release gate", report)
         self.assertIn("release blocker: NO", report)
         self.assertIn("#51 release gate (Leaf -> Depth-1 escalation)", report)
         self.assertIn("#7 release status", report)
         self.assertIn("SMOKE-ESCALATION contract: READY", report)
+        self.assertIn("SMOKE-LEAF-COMPLETED contract: READY", report)
+        self.assertIn("SMOKE-LEAF-BLOCKED contract: READY", report)
         self.assertIn("SMOKE-ESCALATION-PERMISSION contract: READY", report)
         self.assertIn("Ask origin is Task Orchestrator session", report)
         self.assertIn("`runtime::validate-escalation`", report)


### PR DESCRIPTION
## Summary
- make Task-Orchestrator leaves inherit parent initialization instead of rerunning startup checks
- align leaf and Task Orchestrator wire status handling on exact `status: <ENUM>` fields
- add static/generated parity coverage and completed/blocked runtime smoke contracts
- validate commands from transient unsanitized exports while retaining only bounded derived evidence

## Verification
- `nix develop --command python3 -m unittest discover -s tests -v` (218 tests)
- `nix develop --command just template::check`
- `nix develop --command just template::distribution-verify`
- `git diff --check`
- `nix develop --command just runtime::doctor`
- `nix develop --command just runtime::validate-leaf-contract issue-75` — PASS using the existing fixture/sessions
  - completed leaf final status: `COMPLETED`; Work Unit state: `completed`
  - blocked leaf final status: `BLOCKED`; Work Unit state: `blocked`
  - parent initialization commands and leaf Bash command/status evidence validated from transient exports

Unsanitized transcripts are processed only through an automatically removed temporary file. They are not saved to tracked files or evidence directories and are not printed; only session IDs, canonical final status, Bash command names, and tool statuses are retained transiently as derived evidence.

Closes #75