### PR TITLE
Allow guarded Automation Maintenance publication

### DIFF
--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Python contract tests
         run: python3 -m unittest discover -s tests -v
       - name: Generated template drift

--- a/README.md
+++ b/README.md
@@ -234,6 +234,24 @@ just agent::push <task>
 just agent::pr-create <task>
 ```
 
+The normal flow creates the receipt before verification. A self-hosted pre-receipt
+upgrade may instead leave the exact upgraded diff without a receipt. After normal
+verification and immediately before `automation::commit`, recover it with:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+```
+
+The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
+pins the clean source revision, reconstructs expected output by materializing the
+tracked `HEAD` Agent Core baseline and applying canonical upgrade semantics in
+isolation, then requires exact pending paths, content, modes, and Task
+identity/`HEAD` before issuing the existing receipt and protected authority. Any
+product, Adapter, repository, secret-pattern, or `.task-state` path, or tampering,
+fails closed. Continue with the existing commit/push/Draft-PR flow; ordinary
+`agent::commit` rejection and the receipt/authority design remain unchanged.
+This is the PR #79 review fix only; it does not change Issue #77.
+
 `automation::commit` is the only commit path for this upgrade. It fails closed unless the schema-1 JSON receipt contains Task `task_id`, `branch`, `worktree`, source/source revision, current/upstream versions, sorted unique `changed_paths`, `authority_head`, and matching `path_fingerprints`. Receipt identity must match the current Task/worktree and `authority_head` must equal current `HEAD`; every fingerprint and the complete pending path set must still match. A protected record under the shared Git directory binds the active receipt to the preceding successful upgrade, so an ambient variable or fabricated Task State receipt is not commit authority. Receipt paths must be Agent Core-managed only: mixed Adapter, repository, product, secret-pattern, or `.task-state` paths are rejected. The command scrubs ambient Git repository/index overrides, stages into a private Task State index, checks the exact staged blobs and modes, creates the commit from that verified tree without hooks, and atomically advances only the expected Task branch HEAD.
 
 After a successful commit, the active receipt is consumed as `.task-state/automation-maintenance.consumed.json`. A later successful upgrade with changes replaces the active receipt and removes the prior consumed receipt; a no-change invocation returns `NO_CHANGES` and preserves existing receipt lifecycle evidence. There is no raw Git/GitHub bypass, and merge is excluded: the Main Orchestrator performs the separately gated integration/merge workflow.

--- a/README.md
+++ b/README.md
@@ -214,14 +214,29 @@ This reports current/upstream versions and the ownership boundaries without muta
 
 ## Agent Core upgrade
 
-Use a dedicated Task worktree. The upgrade command is an Ask operation and additionally requires an explicit maintenance marker:
+Use a dedicated, registered, non-default **Automation Maintenance Task** worktree. The complete canonical publication workflow is:
 
 ```sh
-export AUTOMATION_MAINTENANCE=1
-just automation::upgrade /path/to/Templates
+AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
 ```
 
-It refuses the default branch and repositories without Task State. It materializes only Agent Core-owned paths and preserves Adapter-owned `.automation/ADAPTER`, `.automation/INIT.fragment.md`, `.automation/adoption.toml`, `just/project/**`, local modules, and repository CI.
+The source must be a trusted local Templates checkout. The command refuses the default branch, an unregistered Task, missing Task State, or a non-ignored/tracked Task State path. The ambient `AUTOMATION_MAINTENANCE=1` variable grants upgrade opt-in only; it does not grant commit authority, and ordinary `just agent::commit <task>` still rejects Automation Core changes.
+
+It materializes only Agent Core-owned paths and preserves Adapter-owned `.automation/ADAPTER`, `.automation/INIT.fragment.md`, `.automation/adoption.toml`, `just/project/**`, local modules, and repository CI. On success it creates or replaces the ignored `.task-state/automation-maintenance.json` receipt; it does not commit, push, or merge. Inspect the diff and run:
+
+```sh
+git diff --check
+just agent::doctor
+just project::check
+# repository CI/smoke suite
+just automation::commit <task> [message]
+just agent::push <task>
+just agent::pr-create <task>
+```
+
+`automation::commit` is the only commit path for this upgrade. It fails closed unless the schema-1 JSON receipt contains Task `task_id`, `branch`, `worktree`, source/source revision, current/upstream versions, sorted unique `changed_paths`, `authority_head`, and matching `path_fingerprints`. Receipt identity must match the current Task/worktree and `authority_head` must equal current `HEAD`; every fingerprint and the complete pending path set must still match. A protected record under the shared Git directory binds the active receipt to the preceding successful upgrade, so an ambient variable or fabricated Task State receipt is not commit authority. Receipt paths must be Agent Core-managed only: mixed Adapter, repository, product, secret-pattern, or `.task-state` paths are rejected. The command scrubs ambient Git repository/index overrides, stages into a private Task State index, checks the exact staged blobs and modes, creates the commit from that verified tree without hooks, and atomically advances only the expected Task branch HEAD.
+
+After a successful commit, the active receipt is consumed as `.task-state/automation-maintenance.consumed.json`. A later successful upgrade with changes replaces the active receipt and removes the prior consumed receipt; a no-change invocation returns `NO_CHANGES` and preserves existing receipt lifecycle evidence. There is no raw Git/GitHub bypass, and merge is excluded: the Main Orchestrator performs the separately gated integration/merge workflow.
 
 The upgrade system supports versioned removal migrations. Removals name explicit, exact Agent Core-managed paths; repository-owned and protected paths cannot be removed. Migration preconditions are checked before any mutation, and `.automation/VERSION` advances only after all deletion, creation, replacement, and merge actions succeed.
 

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -11,3 +11,48 @@ The current implementation provides guarded Task-local commit/push/PR operations
 integration head-SHA checkpoints, disposable Task State templates, and common
 safety policy. Repository-local OpenCode agents and permissions are added by the
 separate OpenCode configuration work.
+
+## Automation Maintenance workflow
+
+An Agent Core upgrade is permitted only from a dedicated registered, non-default
+Automation Maintenance Task. From that Task worktree, use a trusted local
+Templates checkout as the source:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
+```
+
+The environment variable is an upgrade opt-in only. It does not authorize a
+commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
+Upgrade does not commit, push, or merge and writes the ignored receipt
+`.task-state/automation-maintenance.json`.
+
+Before publication, execute `git diff --check`, `just agent::doctor`,
+`just project::check`, and the repository CI/smoke suite. Then publish only with:
+
+```sh
+just automation::commit <task> [message]
+just agent::push <task>
+just agent::pr-create <task>
+```
+
+The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
+`worktree`), source/source revision, current/upstream versions, sorted unique
+`changed_paths`, `authority_head`, and exact per-path content/state
+`path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
+stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
+or does not exactly equal all pending paths. A protected shared-Git-directory
+record binds it to the preceding successful upgrade; a fabricated Task State
+receipt is not authority. Ambient Git repository/index overrides are scrubbed.
+The exact paths are staged and rechecked in a private Task State index, then the
+commit is created from that verified tree without hooks and the expected Task
+branch HEAD is advanced atomically. Only Agent Core-managed paths are
+accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
+scopes are rejected. After a successful commit it is consumed at
+`.task-state/automation-maintenance.consumed.json`; a subsequent successful
+upgrade with changes replaces the active receipt and removes the previous consumed
+receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
+receipt lifecycle evidence.
+
+Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
+this workflow and remains the separately gated Main Orchestrator operation.

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -36,6 +36,25 @@ just agent::push <task>
 just agent::pr-create <task>
 ```
 
+The normal upgrade flow creates its receipt before verification. If a self-hosted
+pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
+normal verification and, before `automation::commit`, run the canonical recovery
+bridge:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+```
+
+The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
+pins the clean source revision, materializes the tracked `HEAD` Agent Core
+baseline, applies canonical upgrade semantics in isolation, and requires exact
+pending paths/content/modes plus Task identity and `HEAD` before issuing the
+existing receipt and protected authority. Product, Adapter, repository,
+secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
+with the existing `automation::commit` flow; ordinary `agent::commit` rejection
+and the receipt/authority design remain unchanged. This is the PR #79 review fix
+only; there are no Issue #77 changes.
+
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tomllib
@@ -15,6 +18,192 @@ from pathlib import Path, PurePosixPath
 
 class UpgradeError(RuntimeError):
     pass
+
+
+RECEIPT_NAME = "automation-maintenance.json"
+CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+RECEIPT_FIELDS = {
+    "schema_version",
+    "status",
+    "task_id",
+    "branch",
+    "worktree",
+    "source",
+    "source_revision",
+    "current_version",
+    "upstream_version",
+    "changed_paths",
+    "authority_head",
+    "authority_nonce",
+    "path_fingerprints",
+}
+_GIT_EXECUTABLE: Path | None = None
+
+
+def git_head(repo: Path) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def source_revision(source: Path) -> str | None:
+    value = git_head(source)
+    return value or None
+
+
+def receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / RECEIPT_NAME
+
+
+def consumed_receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+
+
+def common_git_dir(repo: Path) -> Path:
+    value = Path(run(["git", "rev-parse", "--git-common-dir"], cwd=repo).stdout.strip())
+    return value.resolve() if value.is_absolute() else (repo / value).resolve()
+
+
+def authority_path(repo: Path) -> Path:
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+
+
+def canonical_json(value: dict) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def receipt_digest(receipt: dict) -> str:
+    return hashlib.sha256(canonical_json(receipt)).hexdigest()
+
+
+def write_authority(repo: Path, receipt: dict) -> None:
+    atomic_json_write(
+        authority_path(repo),
+        {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        },
+    )
+
+
+def validate_authority(repo: Path, receipt: dict) -> None:
+    path = authority_path(repo)
+    try:
+        authority = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+    expected = {
+        "schema_version": 1,
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+    }
+    if authority != expected:
+        raise UpgradeError("automation receipt does not match successful-upgrade authority")
+
+
+def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
+    for path in paths:
+        relative = path.relative_to(repo).as_posix()
+        tracked = run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=repo,
+            check=False,
+        ).returncode == 0
+        if tracked:
+            raise UpgradeError(f"required Task State path is tracked: {relative}")
+        ignored = run(["git", "check-ignore", "-q", relative], cwd=repo, check=False).returncode == 0
+        if not ignored:
+            raise UpgradeError(f"required Task State path is not ignored: {relative}")
+
+
+def atomic_json_write(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
+    path = repo / Path(*raw_path.split("/"))
+    try:
+        state = path.lstat()
+    except FileNotFoundError:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    mode = stat.S_IMODE(state.st_mode)
+    if path.is_file() and not path.is_symlink():
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        return {"state": "file", "mode": mode, "content_sha256": digest}
+    if path.is_symlink():
+        digest = hashlib.sha256(os.readlink(path).encode("utf-8", "surrogateescape")).hexdigest()
+        return {"state": "symlink", "mode": mode, "content_sha256": digest}
+    if path.is_dir():
+        return {"state": "directory", "mode": mode, "content_sha256": None}
+    return {"state": "special", "mode": mode, "content_sha256": None}
+
+
+def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
+    if not TASK_ID_RE.fullmatch(task):
+        raise UpgradeError(f"invalid Task ID: {task!r}")
+    state_path = repo / ".task-state" / "task.md"
+    if not state_path.is_file():
+        raise UpgradeError("operation requires a Task worktree with Task State")
+    text = state_path.read_text(encoding="utf-8")
+    values: dict[str, str] = {}
+    for label in ("Task ID", "Branch", "Worktree"):
+        matches = re.findall(rf"(?m)^- {re.escape(label)}: (.+)$", text)
+        if len(matches) != 1 or not matches[0].strip():
+            raise UpgradeError(f"Task State must contain exactly one {label} identity field")
+        values[label] = matches[0].strip()
+    if values["Task ID"] != task:
+        raise UpgradeError("Task State identity does not match requested Task")
+    branch = values["Branch"]
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        raise UpgradeError(f"Task State branch is not the Task branch for {task}")
+    worktree = Path(values["Worktree"]).resolve()
+    if worktree != repo.resolve():
+        raise UpgradeError("Task State worktree does not match the current worktree")
+    return task, branch, worktree
+
+
+def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]]:
+    output = run(["git", "worktree", "list", "--porcelain"], cwd=repo).stdout
+    records: dict[Path, tuple[str | None, str | None]] = {}
+    current: dict[str, str] = {}
+    for line in output.splitlines() + [""]:
+        if not line:
+            if current.get("worktree"):
+                branch = current.get("branch", "").removeprefix("refs/heads/") or None
+                records[Path(current["worktree"]).resolve()] = (branch, current.get("HEAD"))
+            current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    return records
+
+
+def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
+    _, branch, worktree = parse_task_identity(repo, task)
+    registered = registered_worktrees(repo)
+    actual = registered.get(worktree)
+    if actual is None or actual[0] != branch:
+        raise UpgradeError("current Task worktree is not registered with the expected branch")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if not default:
+        raise UpgradeError("cannot resolve default branch")
+    if branch == default:
+        raise UpgradeError("operation refused on the default branch")
+    return task, branch, worktree
 
 
 @dataclass(frozen=True)
@@ -32,8 +221,58 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
-def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and key != "EMAIL"
+    }
+    if overrides:
+        environment.update(overrides)
+    return environment
+
+
+def git_executable() -> Path:
+    global _GIT_EXECUTABLE
+    if _GIT_EXECUTABLE is not None:
+        return _GIT_EXECUTABLE
+    candidate = shutil.which("git")
+    if not candidate:
+        raise UpgradeError("trusted Git executable is unavailable")
+    executable = Path(candidate).resolve()
+    try:
+        metadata = executable.stat()
+    except OSError as exc:
+        raise UpgradeError("trusted Git executable is unavailable") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+    ):
+        raise UpgradeError(f"Git executable is not root-owned and immutable: {executable}")
+    _GIT_EXECUTABLE = executable
+    return executable
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    env_overrides: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    is_git = bool(command and command[0] == "git")
+    environment = git_environment(env_overrides) if is_git else None
+    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    result = subprocess.run(
+        executable_command,
+        cwd=cwd,
+        text=True,
+        input=input_text,
+        capture_output=True,
+        env=environment,
+    )
     if check and result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         raise UpgradeError(f"{' '.join(command)}: {detail}")
@@ -41,8 +280,12 @@ def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.Comp
 
 
 def root() -> Path:
-    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
-    return Path(result.stdout.strip()).resolve()
+    installed_root = Path(__file__).resolve().parents[2]
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=installed_root)
+    discovered = Path(result.stdout.strip()).resolve()
+    if discovered != installed_root:
+        raise UpgradeError("installed Agent Core path does not match the Git worktree root")
+    return installed_root
 
 
 def version(repo: Path) -> str:
@@ -424,31 +667,45 @@ def build_plan(repo: Path, source: Path) -> dict:
     }
 
 
-def require_maintenance(repo: Path) -> None:
+def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    default = run(
-        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
-        cwd=repo,
-        check=False,
-    ).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    state = repo / ".task-state" / "task.md"
+    task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
+    if not task_match:
+        raise UpgradeError("upgrade requires a registered non-default Task branch")
+    task_id = task_match.group(1).strip()
+    identity = require_registered_task(repo, task_id)
+    require_ignored_untracked(
+        repo,
+        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+    )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+    return identity
 
 
 def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+    task_id, branch, worktree = require_maintenance(repo)
     plan = build_plan(repo, source)
     if plan["blockers"]:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    if not actionable:
+        return {
+            "status": "NO_CHANGES",
+            "repositoryRoot": str(repo),
+            "sourceCore": str(source_core),
+            "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+            "changedPaths": [],
+            "commitCreated": False,
+            "pushPerformed": False,
+            "mergePerformed": False,
+            "requiredNextChecks": [],
+        }
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
     preflight_blockers: list[str] = []
     for item in actionable:
@@ -516,7 +773,7 @@ def apply(repo: Path, source: Path) -> dict:
         else:
             raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
-    return {
+    result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
         "sourceCore": str(source_core),
@@ -532,6 +789,246 @@ def apply(repo: Path, source: Path) -> dict:
             "repository CI/smoke tests",
         ],
     }
+    changed_paths = sorted(set(changed))
+    result["changedPaths"] = changed_paths
+    receipt = {
+        "schema_version": 1,
+        "status": "active",
+        "task_id": task_id,
+        "branch": branch,
+        "worktree": str(worktree),
+        "source": str(source.resolve()),
+        "source_revision": source_revision(source),
+        "current_version": plan["currentVersion"],
+        "upstream_version": plan["upstreamVersion"],
+        "changed_paths": changed_paths,
+        "authority_head": git_head(repo),
+        "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return result
+
+
+def pending_paths(repo: Path) -> list[str]:
+    paths: set[str] = set()
+    for args in (
+        ("diff", "--no-ext-diff", "--name-only"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only"),
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
+        output = run(["git", *args], cwd=repo).stdout
+        paths.update(output.splitlines())
+    return sorted(paths)
+
+
+def validate_receipt_path(raw: object) -> str:
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise UpgradeError("receipt contains an unsafe path")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts) or pure.as_posix() != raw:
+        raise UpgradeError(f"receipt contains an unnormalized path: {raw!r}")
+    return raw
+
+
+def receipt_paths(repo: Path, receipt: dict) -> list[str]:
+    raw = receipt.get("changed_paths")
+    if not isinstance(raw, list) or not raw:
+        raise UpgradeError("automation receipt has no changed paths")
+    paths = [validate_receipt_path(item) for item in raw]
+    if paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise UpgradeError("automation receipt paths must be sorted and unique")
+    secret_file = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(secret_file.read_text(encoding="utf-8")) if secret_file.is_file() else {}
+    secrets = policy.get("paths", {}).get("secret_patterns", [])
+    for path in paths:
+        relative = Path(*path.split("/"))
+        if path == ".task-state" or path.startswith(".task-state/") or not managed(relative):
+            raise UpgradeError(f"receipt path is not Agent Core managed: {path}")
+        if any(token.lower() in path.lower() for token in secrets):
+            raise UpgradeError(f"receipt path matches a configured secret pattern: {path}")
+    return paths
+
+
+def validate_receipt_schema(receipt: object) -> dict:
+    if not isinstance(receipt, dict) or set(receipt) != RECEIPT_FIELDS:
+        raise UpgradeError("automation upgrade receipt has an invalid schema")
+    if receipt.get("schema_version") != 1 or receipt.get("status") != "active":
+        raise UpgradeError("unsupported automation upgrade receipt")
+    required_strings = (
+        "task_id",
+        "branch",
+        "worktree",
+        "source",
+        "current_version",
+        "upstream_version",
+        "authority_head",
+        "authority_nonce",
+    )
+    if any(not isinstance(receipt.get(field), str) or not receipt[field] for field in required_strings):
+        raise UpgradeError("automation upgrade receipt has invalid provenance fields")
+    revision = receipt.get("source_revision")
+    if revision is not None and (not isinstance(revision, str) or not revision):
+        raise UpgradeError("automation upgrade receipt has an invalid source revision")
+    if not Path(receipt["source"]).is_absolute():
+        raise UpgradeError("automation upgrade receipt source must be absolute")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", receipt["authority_head"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority HEAD")
+    if not re.fullmatch(r"[0-9a-f]{64}", receipt["authority_nonce"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority nonce")
+    return receipt
+
+
+def staged_fingerprint(
+    repo: Path,
+    path: str,
+    *,
+    env_overrides: dict[str, str],
+) -> dict[str, object]:
+    entry = run(
+        ["git", "ls-files", "--stage", "--", path],
+        cwd=repo,
+        env_overrides=env_overrides,
+    ).stdout.strip()
+    if not entry:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    fields = entry.split(maxsplit=3)
+    if len(fields) != 4 or fields[2] != "0":
+        raise UpgradeError(f"staged path has an unsupported index entry: {path}")
+    mode = fields[0]
+    result = subprocess.run(
+        [str(git_executable()), "show", f":{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(env_overrides),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read staged content for {path}")
+    if mode not in {"100644", "100755"}:
+        raise UpgradeError(f"staged path has an unsupported mode: {path}")
+    return {
+        "state": "file",
+        "mode": 0o755 if mode == "100755" else 0o644,
+        "content_sha256": hashlib.sha256(result.stdout).hexdigest(),
+    }
+
+
+def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
+    if not isinstance(fingerprint, dict):
+        raise UpgradeError("automation receipt contains an invalid path fingerprint")
+    state = fingerprint.get("state")
+    if state == "absent":
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    if state != "file" or not isinstance(fingerprint.get("mode"), int):
+        raise UpgradeError("automation receipt authorizes an unsupported path state")
+    digest = fingerprint.get("content_sha256")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise UpgradeError("automation receipt contains an invalid content fingerprint")
+    return {
+        "state": "file",
+        "mode": 0o755 if fingerprint["mode"] & 0o111 else 0o644,
+        "content_sha256": digest,
+    }
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+    _, branch, worktree = require_registered_task(repo, task)
+    active = receipt_path(repo)
+    private_index = repo / ".task-state" / "automation-maintenance.index"
+    require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
+    if not active.is_file():
+        raise UpgradeError("no active successful automation upgrade receipt")
+    try:
+        receipt = json.loads(active.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt = validate_receipt_schema(receipt)
+    if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    if receipt.get("authority_head") != git_head(repo):
+        raise UpgradeError("automation receipt authority HEAD is stale")
+    paths = receipt_paths(repo, receipt)
+    fingerprints = receipt.get("path_fingerprints")
+    if not isinstance(fingerprints, dict) or set(fingerprints) != set(paths):
+        raise UpgradeError("automation receipt fingerprints do not match its paths")
+    if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+        raise UpgradeError("automation receipt path content/state fingerprint changed")
+    if pending_paths(repo) != paths:
+        raise UpgradeError("pending paths do not exactly match the automation receipt")
+    validate_authority(repo, receipt)
+
+    consumed = consumed_receipt_path(repo)
+    os.replace(active, consumed)
+    consumed_receipt = dict(receipt)
+    consumed_receipt["status"] = "consumed"
+    consumed_receipt["commit_sha"] = None
+    atomic_json_write(consumed, consumed_receipt)
+    authority = authority_path(repo)
+    authority.unlink(missing_ok=True)
+    private_index.unlink(missing_ok=True)
+    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    committed = False
+    commit_sha = ""
+    try:
+        run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
+        run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
+        run(
+            ["git", "diff", "--no-ext-diff", "--cached", "--check"],
+            cwd=repo,
+            env_overrides=index_environment,
+        )
+        staged = sorted(
+            run(
+                ["git", "diff", "--no-ext-diff", "--cached", "--name-only"],
+                cwd=repo,
+                env_overrides=index_environment,
+            ).stdout.splitlines()
+        )
+        if staged != paths:
+            raise UpgradeError("staged paths do not exactly match the automation receipt")
+        if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+            raise UpgradeError("automation receipt path changed while staging")
+        for path in paths:
+            if staged_fingerprint(
+                repo,
+                path,
+                env_overrides=index_environment,
+            ) != normalized_git_fingerprint(fingerprints[path]):
+                raise UpgradeError(f"staged content does not match the automation receipt: {path}")
+        commit_message = message.strip() or f"task: {task}"
+        if task not in commit_message:
+            commit_message = f"{commit_message}\n\nTask: {task}"
+        tree = run(
+            ["git", "write-tree"],
+            cwd=repo,
+            env_overrides=index_environment,
+        ).stdout.strip()
+        expected_head = receipt["authority_head"]
+        commit_sha = run(
+            ["git", "commit-tree", tree, "-p", expected_head],
+            cwd=repo,
+            input_text=commit_message + "\n",
+        ).stdout.strip()
+        run(
+            ["git", "update-ref", f"refs/heads/{branch}", commit_sha, expected_head],
+            cwd=repo,
+        )
+        committed = True
+        consumed_receipt["commit_sha"] = commit_sha
+        atomic_json_write(consumed, consumed_receipt)
+        run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
+    except UpgradeError:
+        if not committed and not active.exists():
+            atomic_json_write(active, receipt)
+            write_authority(repo, receipt)
+            consumed.unlink(missing_ok=True)
+        raise
+    finally:
+        private_index.unlink(missing_ok=True)
+    return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 
 def parser() -> argparse.ArgumentParser:
@@ -542,6 +1039,9 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    commit_parser = sub.add_parser("commit")
+    commit_parser.add_argument("task")
+    commit_parser.add_argument("message", nargs="?", default="")
     return p
 
 
@@ -555,6 +1055,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "commit":
+            result = commit(repo, args.task, args.message)
         else:  # pragma: no cover
             raise UpgradeError(f"unsupported command: {args.command}")
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tomllib
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
@@ -196,7 +197,18 @@ def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
     _, branch, worktree = parse_task_identity(repo, task)
     registered = registered_worktrees(repo)
     actual = registered.get(worktree)
-    if actual is None or actual[0] != branch:
+    current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    head = git_head(repo)
+    branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo, check=False).stdout.strip()
+    if (
+        actual is None
+        or current_branch != branch
+        or actual[0] != branch
+        or not head
+        or not branch_oid
+        or actual[1] != head
+        or branch_oid != head
+    ):
         raise UpgradeError("current Task worktree is not registered with the expected branch")
     default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
     if not default:
@@ -322,6 +334,36 @@ def resolve_source(path: Path | None) -> Path:
     if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
         raise UpgradeError(f"not a Templates source checkout: {source}")
     return source
+
+
+def git_bytes(command: list[str], *, cwd: Path) -> bytes:
+    if not command or command[0] != "git":
+        raise UpgradeError("byte helper only accepts Git commands")
+    result = subprocess.run(
+        [str(git_executable()), *command[1:]],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result.stdout
+
+
+def resolve_pinned_source(path: Path) -> tuple[Path, str]:
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    status = git_bytes(
+        ["git", "status", "--porcelain=v1", "-z", "--", "components/agent-core"], cwd=source
+    )
+    if status:
+        raise UpgradeError("source components/agent-core must be clean")
+    return source, head
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -621,6 +663,124 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
     return Action(rel, "replace", "Agent Core-owned path")
 
 
+def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
+    result = subprocess.run(
+        [str(git_executable()), "show", f"{revision}:{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read Git object {path}")
+    return result.stdout
+
+
+def materialize_tree(
+    repo: Path, revision: str, destination: Path, prefix: str = "", *, surface_only: bool = False
+) -> None:
+    entries = git_bytes(["git", "ls-tree", "-r", "-z", revision, "--", prefix or "."], cwd=repo).split(b"\0")
+    destination.mkdir(parents=True, exist_ok=True)
+    prefix_bytes = (prefix.rstrip("/") + "/").encode() if prefix else b""
+    for entry in entries:
+        if not entry:
+            continue
+        header, raw_path = entry.split(b"\t", 1)
+        fields = header.split()
+        if prefix_bytes and not raw_path.startswith(prefix_bytes):
+            raise UpgradeError("Git returned an unexpected snapshot path")
+        relative_raw = raw_path[len(prefix_bytes):] if prefix_bytes else raw_path
+        try:
+            relative_text = relative_raw.decode("utf-8")
+            relative = PurePosixPath(relative_text)
+        except UnicodeDecodeError as exc:
+            raise UpgradeError("snapshot contains a non-UTF-8 path") from exc
+        if surface_only and not (
+            relative_text in {"AGENTS.md", "Justfile", "opencode.json"}
+            or relative_text.startswith(".automation/")
+            or relative_text.startswith(".opencode/")
+        ):
+            continue
+        if len(fields) != 3 or fields[0] not in {b"100644", b"100755"} or fields[1] != b"blob":
+            raise UpgradeError("Agent Core snapshot contains a symlink, submodule, or special Git entry")
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or relative.as_posix() != relative_text
+        ):
+            raise UpgradeError("snapshot contains an unsafe or unnormalized path")
+        target = destination.joinpath(*relative.parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(git_object_bytes(repo, revision, raw_path.decode("utf-8")))
+        target.chmod(0o755 if fields[0] == b"100755" else 0o644)
+
+
+def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        if item["action"] == "delete":
+            target = tree / relative
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                blockers.append(f"{item['path']}: delete has symlink ancestor {ancestor.as_posix()}")
+                continue
+            if path_present(target) and not (target.is_symlink() or target.is_file()):
+                blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(tree, relative, planned_deletes)
+            if blocker:
+                blockers.append(f"{item['path']}: {blocker}")
+    if blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(blockers))
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered = sorted(
+        [item for item in actionable if item["path"] != ".automation/VERSION"],
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + [item for item in actionable if item["path"] == ".automation/VERSION"]
+    changed: list[str] = []
+    for item in ordered:
+        relative = Path(item["path"])
+        target = tree / relative
+        source = source_core / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if target.is_symlink() or target.is_file():
+                target.unlink()
+            elif path_present(target):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+        else:
+            blocker = write_topology_blocker(tree, relative, set())
+            if blocker:
+                raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {blocker}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
+            if item["action"] in {"create", "replace"}:
+                shutil.copy2(source, target)
+            elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+                merged, detail = replace_agent_rules(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            elif item["action"] == "merge" and item["path"] == "Justfile":
+                merged, detail = merge_just_router(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            else:
+                raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
+    return sorted(set(changed))
+
+
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
@@ -706,73 +866,7 @@ def apply(repo: Path, source: Path) -> dict:
             "mergePerformed": False,
             "requiredNextChecks": [],
         }
-    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
-    preflight_blockers: list[str] = []
-    for item in actionable:
-        relative = Path(item["path"])
-        destination = repo / relative
-        if item["action"] == "delete":
-            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
-                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
-        else:
-            blocker = write_topology_blocker(repo, relative, planned_deletes)
-            if blocker:
-                preflight_blockers.append(f"{item['path']}: {blocker}")
-    if preflight_blockers:
-        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
-
-    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
-    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
-    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
-    ordered_actions = sorted(
-        ordinary_actions,
-        key=lambda item: (phases.get(item["action"], 99), item["path"]),
-    ) + version_actions
-    for item in ordered_actions:
-        relative = Path(item["path"])
-        source_path = source_core / relative
-        destination = repo / relative
-        if item["action"] == "delete":
-            ancestor = symlink_ancestor(repo, relative)
-            if ancestor is not None:
-                raise UpgradeError(
-                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
-                )
-            if destination.is_symlink() or destination.is_file():
-                destination.unlink()
-            elif path_present(destination):
-                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
-            changed.append(item["path"])
-            continue
-        topology_blocker = write_topology_blocker(repo, relative, set())
-        if topology_blocker:
-            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        if item["action"] in {"create", "replace"}:
-            if destination.is_symlink():
-                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
-            shutil.copy2(source_path, destination)
-        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
-            if destination.is_symlink():
-                raise UpgradeError("AGENTS.md became a symlink after planning")
-            merged, detail = replace_agent_rules(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        elif item["action"] == "merge" and item["path"] == "Justfile":
-            if destination.is_symlink():
-                raise UpgradeError("Justfile became a symlink after planning")
-            merged, detail = merge_just_router(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        else:
-            raise UpgradeError(f"unsupported upgrade action: {item}")
-        changed.append(item["path"])
+    changed = apply_plan_to_tree(repo, source_core, plan)
     result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -815,13 +909,117 @@ def apply(repo: Path, source: Path) -> dict:
 def pending_paths(repo: Path) -> list[str]:
     paths: set[str] = set()
     for args in (
-        ("diff", "--no-ext-diff", "--name-only"),
-        ("diff", "--no-ext-diff", "--cached", "--name-only"),
-        ("ls-files", "--others", "--exclude-standard"),
+        ("diff", "--no-ext-diff", "--name-only", "-z"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only", "-z"),
+        ("ls-files", "--others", "--exclude-standard", "-z"),
     ):
-        output = run(["git", *args], cwd=repo).stdout
-        paths.update(output.splitlines())
+        output = git_bytes(["git", *args], cwd=repo)
+        for raw in output.split(b"\0"):
+            if not raw:
+                continue
+            try:
+                paths.add(raw.decode("utf-8"))
+            except UnicodeDecodeError as exc:
+                raise UpgradeError("Git reported a non-UTF-8 pending path") from exc
     return sorted(paths)
+
+
+def bootstrap_fingerprint(tree: Path, raw_path: str) -> dict[str, object]:
+    return file_fingerprint(tree, raw_path)
+
+
+def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
+    path = validate_receipt_path(raw_path)
+    relative = Path(*path.split("/"))
+    policy_path = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(policy_path.read_text(encoding="utf-8")) if policy_path.is_file() else {}
+    secret_patterns = policy.get("paths", {}).get("secret_patterns", [])
+    if path == ".task-state" or path.startswith(".task-state/"):
+        raise UpgradeError(f"pending path is Task State: {path}")
+    if any(token.lower() in path.lower() for token in secret_patterns):
+        raise UpgradeError(f"pending path matches a configured secret pattern: {path}")
+    if path.startswith("just/project/") or path == "just/local.just":
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path.startswith(".github/"):
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path == ".automation/ADAPTER" or path == ".automation/INIT.fragment.md" or path == ".automation/adoption.toml":
+        raise UpgradeError(f"pending path is Adapter-owned: {path}")
+    if not managed(relative):
+        raise UpgradeError(f"pending path is outside Agent Core: {path}")
+
+
+def bootstrap_receipt(repo: Path, source: Path) -> dict:
+    task_id, branch, worktree = require_maintenance(repo)
+    authority_head = git_head(repo)
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
+    if receipt_path(repo).exists() or authority_path(repo).exists():
+        raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    pending = pending_paths(repo)
+    if not pending:
+        raise UpgradeError("bootstrap requires non-empty pending paths")
+    for path in pending:
+        reject_bootstrap_path(repo, path)
+    source, source_head = resolve_pinned_source(source)
+    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+        baseline = Path(temporary) / "baseline"
+        source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
+        materialize_tree(repo, authority_head, baseline, surface_only=True)
+        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        before = {
+            p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
+            for p in baseline.rglob("*") if p.is_file()
+        }
+        plan = build_plan(baseline, source_snapshot.parent.parent)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [
+            migration for migration in load_migrations(source_snapshot)
+            if migration.to_version <= version_number(source_snapshot)
+        ]
+        _, migration_blockers, _ = migration_actions(repo, selected)
+        if migration_blockers:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(migration_blockers))
+        apply_plan_to_tree(baseline, source_snapshot, plan)
+        returned = set(item["path"] for item in plan["actions"] if item["action"] != "noop")
+        expected = sorted(
+            path for path in returned
+            if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+            != bootstrap_fingerprint(baseline, path)
+        )
+        if expected != pending:
+            raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
+        if not expected:
+            return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+    pinned_source, current_source_head = resolve_pinned_source(source)
+    if pinned_source != source or current_source_head != source_head:
+        raise UpgradeError("source changed during receipt reconstruction")
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed during receipt reconstruction")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed during receipt reconstruction")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content does not match the reconstructed upgrade")
+    receipt = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": str(source.resolve()), "source_revision": source_head,
+        "current_version": plan["currentVersion"], "upstream_version": plan["upstreamVersion"],
+        "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": current_fingerprints,
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1039,6 +1237,8 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    bootstrap = sub.add_parser("bootstrap-receipt")
+    bootstrap.add_argument("--source", type=Path, required=True)
     commit_parser = sub.add_parser("commit")
     commit_parser.add_argument("task")
     commit_parser.add_argument("message", nargs="?", default="")
@@ -1055,6 +1255,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "bootstrap-receipt":
+            result = bootstrap_receipt(repo, resolve_source(args.source))
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/components/agent-core/.automation/just/automation.just
+++ b/components/agent-core/.automation/just/automation.just
@@ -1,11 +1,18 @@
 root := justfile_directory() / ".." / ".."
 script := root / ".automation" / "bin" / "automation_upgrade.py"
 
+[working-directory: root]
 version:
-    python3 '{{script}}' version
+    python3 {{quote(script)}} version
 
+[working-directory: root]
 check-update source:
-    python3 '{{script}}' check-update --source '{{source}}'
+    python3 {{quote(script)}} check-update --source {{quote(source)}}
 
+[working-directory: root]
 upgrade source:
-    python3 '{{script}}' upgrade --source '{{source}}'
+    python3 {{quote(script)}} upgrade --source {{quote(source)}}
+
+[working-directory: root]
+commit task message="":
+    python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/components/agent-core/.automation/just/automation.just
+++ b/components/agent-core/.automation/just/automation.just
@@ -14,5 +14,9 @@ upgrade source:
     python3 {{quote(script)}} upgrade --source {{quote(source)}}
 
 [working-directory: root]
+bootstrap-receipt source:
+    python3 {{quote(script)}} bootstrap-receipt --source {{quote(source)}}
+
+[working-directory: root]
 commit task message="":
     python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/components/agent-core/opencode.json
+++ b/components/agent-core/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::bootstrap-receipt *": "ask",
       "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",

--- a/components/agent-core/opencode.json
+++ b/components/agent-core/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -618,6 +618,32 @@ AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates check
 
 The ambient variable is only an upgrade opt-in. It cannot authorize a commit; ordinary `just agent::commit <task>` continues to reject Automation Core paths. Upgrade preserves Adapter, repository, product, and CI-owned paths, and performs no commit, push, or merge.
 
+The canonical publication flows are:
+
+1. **Normal upgrade:** run `automation::upgrade` from the dedicated Automation
+   Maintenance Task, inspect the resulting diff, perform normal verification,
+   then use `automation::commit`, `agent::push`, and `agent::pr-create`.
+2. **Pre-receipt consumer recovery:** a self-hosted upgrade may leave the exact
+   upgraded diff without a receipt. After normal verification and before
+   `automation::commit`, run:
+
+   ```sh
+   AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+   ```
+
+   This bridge does not trust `NO_CHANGES`, the current diff, or the environment.
+   It pins the clean source revision, materializes the tracked `HEAD` Agent Core
+   baseline, and applies canonical upgrade semantics in isolation to reconstruct
+   expected output. It then requires exact pending paths, content, and modes,
+   plus matching Task identity and `HEAD`, before issuing the existing receipt
+   and protected authority. Product, Adapter, repository, secret-pattern, or
+   `.task-state` paths and any tampering fail closed.
+
+The bridge only repairs missing pre-receipt evidence; the existing receipt and
+authority design remains in force, and ordinary `agent::commit` continues to
+reject Automation Core changes. This is the PR #79 review fix only; no Issue #77
+behavior or scope changes.
+
 Successful upgrade writes or replaces the ignored `.task-state/automation-maintenance.json` receipt. Its schema-1 content records Task identity (`task_id`, `branch`, `worktree`), source and source revision, current/upstream versions, sorted unique `changed_paths`, the authority `HEAD`, and per-path content/state fingerprints. A protected record in the shared Git directory binds that receipt to the successful upgrade. `automation::commit <task> [message]` fails closed unless both records match the current Task/worktree identity and `HEAD`, fingerprints, and complete pending path set. Receipt paths must be Agent Core-managed; any mixed Adapter, repository, product, configured-secret, or `.task-state` scope is rejected. Ambient Git repository/index overrides are scrubbed; exact blobs and modes are staged and rechecked in a private index, committed as that verified tree without hooks, and published only by an atomic expected-HEAD Task branch update. The receipt is moved to `.task-state/automation-maintenance.consumed.json` after successful commit; the next successful upgrade with changes replaces the active receipt and removes the prior consumed receipt. A no-change invocation returns `NO_CHANGES` and preserves existing lifecycle evidence.
 
 The required sequence is `git diff --check`, `just agent::doctor`, `just project::check`, and the repository CI/smoke suite, followed by `just automation::commit <task> [message]`, existing `just agent::push <task>`, and `just agent::pr-create <task>` (Draft PR). Raw Git/GitHub bypass is not permitted. Merge is excluded from this workflow and remains a separately gated Main Orchestrator operation.

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -608,6 +608,20 @@ The publication API validates at least:
 
 Push is restricted to the Task branch with an explicit refspec. Force push is never part of the ordinary Task API.
 
+### 17.1 Automation Maintenance publication
+
+Agent Core upgrades are a separate, dedicated publication workflow, not ordinary Task work. The Task must be registered, non-default, and have ignored disposable Task State. From that Task worktree, use:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
+```
+
+The ambient variable is only an upgrade opt-in. It cannot authorize a commit; ordinary `just agent::commit <task>` continues to reject Automation Core paths. Upgrade preserves Adapter, repository, product, and CI-owned paths, and performs no commit, push, or merge.
+
+Successful upgrade writes or replaces the ignored `.task-state/automation-maintenance.json` receipt. Its schema-1 content records Task identity (`task_id`, `branch`, `worktree`), source and source revision, current/upstream versions, sorted unique `changed_paths`, the authority `HEAD`, and per-path content/state fingerprints. A protected record in the shared Git directory binds that receipt to the successful upgrade. `automation::commit <task> [message]` fails closed unless both records match the current Task/worktree identity and `HEAD`, fingerprints, and complete pending path set. Receipt paths must be Agent Core-managed; any mixed Adapter, repository, product, configured-secret, or `.task-state` scope is rejected. Ambient Git repository/index overrides are scrubbed; exact blobs and modes are staged and rechecked in a private index, committed as that verified tree without hooks, and published only by an atomic expected-HEAD Task branch update. The receipt is moved to `.task-state/automation-maintenance.consumed.json` after successful commit; the next successful upgrade with changes replaces the active receipt and removes the prior consumed receipt. A no-change invocation returns `NO_CHANGES` and preserves existing lifecycle evidence.
+
+The required sequence is `git diff --check`, `just agent::doctor`, `just project::check`, and the repository CI/smoke suite, followed by `just automation::commit <task> [message]`, existing `just agent::push <task>`, and `just agent::pr-create <task>` (Draft PR). Raw Git/GitHub bypass is not permitted. Merge is excluded from this workflow and remains a separately gated Main Orchestrator operation.
+
 ## 18. Integration boundary
 
 Only the Main Orchestrator uses `integrate::*`.

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -11,3 +11,48 @@ The current implementation provides guarded Task-local commit/push/PR operations
 integration head-SHA checkpoints, disposable Task State templates, and common
 safety policy. Repository-local OpenCode agents and permissions are added by the
 separate OpenCode configuration work.
+
+## Automation Maintenance workflow
+
+An Agent Core upgrade is permitted only from a dedicated registered, non-default
+Automation Maintenance Task. From that Task worktree, use a trusted local
+Templates checkout as the source:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
+```
+
+The environment variable is an upgrade opt-in only. It does not authorize a
+commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
+Upgrade does not commit, push, or merge and writes the ignored receipt
+`.task-state/automation-maintenance.json`.
+
+Before publication, execute `git diff --check`, `just agent::doctor`,
+`just project::check`, and the repository CI/smoke suite. Then publish only with:
+
+```sh
+just automation::commit <task> [message]
+just agent::push <task>
+just agent::pr-create <task>
+```
+
+The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
+`worktree`), source/source revision, current/upstream versions, sorted unique
+`changed_paths`, `authority_head`, and exact per-path content/state
+`path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
+stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
+or does not exactly equal all pending paths. A protected shared-Git-directory
+record binds it to the preceding successful upgrade; a fabricated Task State
+receipt is not authority. Ambient Git repository/index overrides are scrubbed.
+The exact paths are staged and rechecked in a private Task State index, then the
+commit is created from that verified tree without hooks and the expected Task
+branch HEAD is advanced atomically. Only Agent Core-managed paths are
+accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
+scopes are rejected. After a successful commit it is consumed at
+`.task-state/automation-maintenance.consumed.json`; a subsequent successful
+upgrade with changes replaces the active receipt and removes the previous consumed
+receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
+receipt lifecycle evidence.
+
+Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
+this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -36,6 +36,25 @@ just agent::push <task>
 just agent::pr-create <task>
 ```
 
+The normal upgrade flow creates its receipt before verification. If a self-hosted
+pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
+normal verification and, before `automation::commit`, run the canonical recovery
+bridge:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+```
+
+The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
+pins the clean source revision, materializes the tracked `HEAD` Agent Core
+baseline, applies canonical upgrade semantics in isolation, and requires exact
+pending paths/content/modes plus Task identity and `HEAD` before issuing the
+existing receipt and protected authority. Product, Adapter, repository,
+secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
+with the existing `automation::commit` flow; ordinary `agent::commit` rejection
+and the receipt/authority design remain unchanged. This is the PR #79 review fix
+only; there are no Issue #77 changes.
+
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tomllib
@@ -15,6 +18,192 @@ from pathlib import Path, PurePosixPath
 
 class UpgradeError(RuntimeError):
     pass
+
+
+RECEIPT_NAME = "automation-maintenance.json"
+CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+RECEIPT_FIELDS = {
+    "schema_version",
+    "status",
+    "task_id",
+    "branch",
+    "worktree",
+    "source",
+    "source_revision",
+    "current_version",
+    "upstream_version",
+    "changed_paths",
+    "authority_head",
+    "authority_nonce",
+    "path_fingerprints",
+}
+_GIT_EXECUTABLE: Path | None = None
+
+
+def git_head(repo: Path) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def source_revision(source: Path) -> str | None:
+    value = git_head(source)
+    return value or None
+
+
+def receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / RECEIPT_NAME
+
+
+def consumed_receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+
+
+def common_git_dir(repo: Path) -> Path:
+    value = Path(run(["git", "rev-parse", "--git-common-dir"], cwd=repo).stdout.strip())
+    return value.resolve() if value.is_absolute() else (repo / value).resolve()
+
+
+def authority_path(repo: Path) -> Path:
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+
+
+def canonical_json(value: dict) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def receipt_digest(receipt: dict) -> str:
+    return hashlib.sha256(canonical_json(receipt)).hexdigest()
+
+
+def write_authority(repo: Path, receipt: dict) -> None:
+    atomic_json_write(
+        authority_path(repo),
+        {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        },
+    )
+
+
+def validate_authority(repo: Path, receipt: dict) -> None:
+    path = authority_path(repo)
+    try:
+        authority = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+    expected = {
+        "schema_version": 1,
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+    }
+    if authority != expected:
+        raise UpgradeError("automation receipt does not match successful-upgrade authority")
+
+
+def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
+    for path in paths:
+        relative = path.relative_to(repo).as_posix()
+        tracked = run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=repo,
+            check=False,
+        ).returncode == 0
+        if tracked:
+            raise UpgradeError(f"required Task State path is tracked: {relative}")
+        ignored = run(["git", "check-ignore", "-q", relative], cwd=repo, check=False).returncode == 0
+        if not ignored:
+            raise UpgradeError(f"required Task State path is not ignored: {relative}")
+
+
+def atomic_json_write(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
+    path = repo / Path(*raw_path.split("/"))
+    try:
+        state = path.lstat()
+    except FileNotFoundError:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    mode = stat.S_IMODE(state.st_mode)
+    if path.is_file() and not path.is_symlink():
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        return {"state": "file", "mode": mode, "content_sha256": digest}
+    if path.is_symlink():
+        digest = hashlib.sha256(os.readlink(path).encode("utf-8", "surrogateescape")).hexdigest()
+        return {"state": "symlink", "mode": mode, "content_sha256": digest}
+    if path.is_dir():
+        return {"state": "directory", "mode": mode, "content_sha256": None}
+    return {"state": "special", "mode": mode, "content_sha256": None}
+
+
+def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
+    if not TASK_ID_RE.fullmatch(task):
+        raise UpgradeError(f"invalid Task ID: {task!r}")
+    state_path = repo / ".task-state" / "task.md"
+    if not state_path.is_file():
+        raise UpgradeError("operation requires a Task worktree with Task State")
+    text = state_path.read_text(encoding="utf-8")
+    values: dict[str, str] = {}
+    for label in ("Task ID", "Branch", "Worktree"):
+        matches = re.findall(rf"(?m)^- {re.escape(label)}: (.+)$", text)
+        if len(matches) != 1 or not matches[0].strip():
+            raise UpgradeError(f"Task State must contain exactly one {label} identity field")
+        values[label] = matches[0].strip()
+    if values["Task ID"] != task:
+        raise UpgradeError("Task State identity does not match requested Task")
+    branch = values["Branch"]
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        raise UpgradeError(f"Task State branch is not the Task branch for {task}")
+    worktree = Path(values["Worktree"]).resolve()
+    if worktree != repo.resolve():
+        raise UpgradeError("Task State worktree does not match the current worktree")
+    return task, branch, worktree
+
+
+def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]]:
+    output = run(["git", "worktree", "list", "--porcelain"], cwd=repo).stdout
+    records: dict[Path, tuple[str | None, str | None]] = {}
+    current: dict[str, str] = {}
+    for line in output.splitlines() + [""]:
+        if not line:
+            if current.get("worktree"):
+                branch = current.get("branch", "").removeprefix("refs/heads/") or None
+                records[Path(current["worktree"]).resolve()] = (branch, current.get("HEAD"))
+            current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    return records
+
+
+def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
+    _, branch, worktree = parse_task_identity(repo, task)
+    registered = registered_worktrees(repo)
+    actual = registered.get(worktree)
+    if actual is None or actual[0] != branch:
+        raise UpgradeError("current Task worktree is not registered with the expected branch")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if not default:
+        raise UpgradeError("cannot resolve default branch")
+    if branch == default:
+        raise UpgradeError("operation refused on the default branch")
+    return task, branch, worktree
 
 
 @dataclass(frozen=True)
@@ -32,8 +221,58 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
-def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and key != "EMAIL"
+    }
+    if overrides:
+        environment.update(overrides)
+    return environment
+
+
+def git_executable() -> Path:
+    global _GIT_EXECUTABLE
+    if _GIT_EXECUTABLE is not None:
+        return _GIT_EXECUTABLE
+    candidate = shutil.which("git")
+    if not candidate:
+        raise UpgradeError("trusted Git executable is unavailable")
+    executable = Path(candidate).resolve()
+    try:
+        metadata = executable.stat()
+    except OSError as exc:
+        raise UpgradeError("trusted Git executable is unavailable") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+    ):
+        raise UpgradeError(f"Git executable is not root-owned and immutable: {executable}")
+    _GIT_EXECUTABLE = executable
+    return executable
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    env_overrides: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    is_git = bool(command and command[0] == "git")
+    environment = git_environment(env_overrides) if is_git else None
+    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    result = subprocess.run(
+        executable_command,
+        cwd=cwd,
+        text=True,
+        input=input_text,
+        capture_output=True,
+        env=environment,
+    )
     if check and result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         raise UpgradeError(f"{' '.join(command)}: {detail}")
@@ -41,8 +280,12 @@ def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.Comp
 
 
 def root() -> Path:
-    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
-    return Path(result.stdout.strip()).resolve()
+    installed_root = Path(__file__).resolve().parents[2]
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=installed_root)
+    discovered = Path(result.stdout.strip()).resolve()
+    if discovered != installed_root:
+        raise UpgradeError("installed Agent Core path does not match the Git worktree root")
+    return installed_root
 
 
 def version(repo: Path) -> str:
@@ -424,31 +667,45 @@ def build_plan(repo: Path, source: Path) -> dict:
     }
 
 
-def require_maintenance(repo: Path) -> None:
+def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    default = run(
-        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
-        cwd=repo,
-        check=False,
-    ).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    state = repo / ".task-state" / "task.md"
+    task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
+    if not task_match:
+        raise UpgradeError("upgrade requires a registered non-default Task branch")
+    task_id = task_match.group(1).strip()
+    identity = require_registered_task(repo, task_id)
+    require_ignored_untracked(
+        repo,
+        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+    )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+    return identity
 
 
 def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+    task_id, branch, worktree = require_maintenance(repo)
     plan = build_plan(repo, source)
     if plan["blockers"]:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    if not actionable:
+        return {
+            "status": "NO_CHANGES",
+            "repositoryRoot": str(repo),
+            "sourceCore": str(source_core),
+            "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+            "changedPaths": [],
+            "commitCreated": False,
+            "pushPerformed": False,
+            "mergePerformed": False,
+            "requiredNextChecks": [],
+        }
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
     preflight_blockers: list[str] = []
     for item in actionable:
@@ -516,7 +773,7 @@ def apply(repo: Path, source: Path) -> dict:
         else:
             raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
-    return {
+    result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
         "sourceCore": str(source_core),
@@ -532,6 +789,246 @@ def apply(repo: Path, source: Path) -> dict:
             "repository CI/smoke tests",
         ],
     }
+    changed_paths = sorted(set(changed))
+    result["changedPaths"] = changed_paths
+    receipt = {
+        "schema_version": 1,
+        "status": "active",
+        "task_id": task_id,
+        "branch": branch,
+        "worktree": str(worktree),
+        "source": str(source.resolve()),
+        "source_revision": source_revision(source),
+        "current_version": plan["currentVersion"],
+        "upstream_version": plan["upstreamVersion"],
+        "changed_paths": changed_paths,
+        "authority_head": git_head(repo),
+        "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return result
+
+
+def pending_paths(repo: Path) -> list[str]:
+    paths: set[str] = set()
+    for args in (
+        ("diff", "--no-ext-diff", "--name-only"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only"),
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
+        output = run(["git", *args], cwd=repo).stdout
+        paths.update(output.splitlines())
+    return sorted(paths)
+
+
+def validate_receipt_path(raw: object) -> str:
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise UpgradeError("receipt contains an unsafe path")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts) or pure.as_posix() != raw:
+        raise UpgradeError(f"receipt contains an unnormalized path: {raw!r}")
+    return raw
+
+
+def receipt_paths(repo: Path, receipt: dict) -> list[str]:
+    raw = receipt.get("changed_paths")
+    if not isinstance(raw, list) or not raw:
+        raise UpgradeError("automation receipt has no changed paths")
+    paths = [validate_receipt_path(item) for item in raw]
+    if paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise UpgradeError("automation receipt paths must be sorted and unique")
+    secret_file = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(secret_file.read_text(encoding="utf-8")) if secret_file.is_file() else {}
+    secrets = policy.get("paths", {}).get("secret_patterns", [])
+    for path in paths:
+        relative = Path(*path.split("/"))
+        if path == ".task-state" or path.startswith(".task-state/") or not managed(relative):
+            raise UpgradeError(f"receipt path is not Agent Core managed: {path}")
+        if any(token.lower() in path.lower() for token in secrets):
+            raise UpgradeError(f"receipt path matches a configured secret pattern: {path}")
+    return paths
+
+
+def validate_receipt_schema(receipt: object) -> dict:
+    if not isinstance(receipt, dict) or set(receipt) != RECEIPT_FIELDS:
+        raise UpgradeError("automation upgrade receipt has an invalid schema")
+    if receipt.get("schema_version") != 1 or receipt.get("status") != "active":
+        raise UpgradeError("unsupported automation upgrade receipt")
+    required_strings = (
+        "task_id",
+        "branch",
+        "worktree",
+        "source",
+        "current_version",
+        "upstream_version",
+        "authority_head",
+        "authority_nonce",
+    )
+    if any(not isinstance(receipt.get(field), str) or not receipt[field] for field in required_strings):
+        raise UpgradeError("automation upgrade receipt has invalid provenance fields")
+    revision = receipt.get("source_revision")
+    if revision is not None and (not isinstance(revision, str) or not revision):
+        raise UpgradeError("automation upgrade receipt has an invalid source revision")
+    if not Path(receipt["source"]).is_absolute():
+        raise UpgradeError("automation upgrade receipt source must be absolute")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", receipt["authority_head"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority HEAD")
+    if not re.fullmatch(r"[0-9a-f]{64}", receipt["authority_nonce"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority nonce")
+    return receipt
+
+
+def staged_fingerprint(
+    repo: Path,
+    path: str,
+    *,
+    env_overrides: dict[str, str],
+) -> dict[str, object]:
+    entry = run(
+        ["git", "ls-files", "--stage", "--", path],
+        cwd=repo,
+        env_overrides=env_overrides,
+    ).stdout.strip()
+    if not entry:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    fields = entry.split(maxsplit=3)
+    if len(fields) != 4 or fields[2] != "0":
+        raise UpgradeError(f"staged path has an unsupported index entry: {path}")
+    mode = fields[0]
+    result = subprocess.run(
+        [str(git_executable()), "show", f":{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(env_overrides),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read staged content for {path}")
+    if mode not in {"100644", "100755"}:
+        raise UpgradeError(f"staged path has an unsupported mode: {path}")
+    return {
+        "state": "file",
+        "mode": 0o755 if mode == "100755" else 0o644,
+        "content_sha256": hashlib.sha256(result.stdout).hexdigest(),
+    }
+
+
+def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
+    if not isinstance(fingerprint, dict):
+        raise UpgradeError("automation receipt contains an invalid path fingerprint")
+    state = fingerprint.get("state")
+    if state == "absent":
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    if state != "file" or not isinstance(fingerprint.get("mode"), int):
+        raise UpgradeError("automation receipt authorizes an unsupported path state")
+    digest = fingerprint.get("content_sha256")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise UpgradeError("automation receipt contains an invalid content fingerprint")
+    return {
+        "state": "file",
+        "mode": 0o755 if fingerprint["mode"] & 0o111 else 0o644,
+        "content_sha256": digest,
+    }
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+    _, branch, worktree = require_registered_task(repo, task)
+    active = receipt_path(repo)
+    private_index = repo / ".task-state" / "automation-maintenance.index"
+    require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
+    if not active.is_file():
+        raise UpgradeError("no active successful automation upgrade receipt")
+    try:
+        receipt = json.loads(active.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt = validate_receipt_schema(receipt)
+    if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    if receipt.get("authority_head") != git_head(repo):
+        raise UpgradeError("automation receipt authority HEAD is stale")
+    paths = receipt_paths(repo, receipt)
+    fingerprints = receipt.get("path_fingerprints")
+    if not isinstance(fingerprints, dict) or set(fingerprints) != set(paths):
+        raise UpgradeError("automation receipt fingerprints do not match its paths")
+    if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+        raise UpgradeError("automation receipt path content/state fingerprint changed")
+    if pending_paths(repo) != paths:
+        raise UpgradeError("pending paths do not exactly match the automation receipt")
+    validate_authority(repo, receipt)
+
+    consumed = consumed_receipt_path(repo)
+    os.replace(active, consumed)
+    consumed_receipt = dict(receipt)
+    consumed_receipt["status"] = "consumed"
+    consumed_receipt["commit_sha"] = None
+    atomic_json_write(consumed, consumed_receipt)
+    authority = authority_path(repo)
+    authority.unlink(missing_ok=True)
+    private_index.unlink(missing_ok=True)
+    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    committed = False
+    commit_sha = ""
+    try:
+        run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
+        run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
+        run(
+            ["git", "diff", "--no-ext-diff", "--cached", "--check"],
+            cwd=repo,
+            env_overrides=index_environment,
+        )
+        staged = sorted(
+            run(
+                ["git", "diff", "--no-ext-diff", "--cached", "--name-only"],
+                cwd=repo,
+                env_overrides=index_environment,
+            ).stdout.splitlines()
+        )
+        if staged != paths:
+            raise UpgradeError("staged paths do not exactly match the automation receipt")
+        if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+            raise UpgradeError("automation receipt path changed while staging")
+        for path in paths:
+            if staged_fingerprint(
+                repo,
+                path,
+                env_overrides=index_environment,
+            ) != normalized_git_fingerprint(fingerprints[path]):
+                raise UpgradeError(f"staged content does not match the automation receipt: {path}")
+        commit_message = message.strip() or f"task: {task}"
+        if task not in commit_message:
+            commit_message = f"{commit_message}\n\nTask: {task}"
+        tree = run(
+            ["git", "write-tree"],
+            cwd=repo,
+            env_overrides=index_environment,
+        ).stdout.strip()
+        expected_head = receipt["authority_head"]
+        commit_sha = run(
+            ["git", "commit-tree", tree, "-p", expected_head],
+            cwd=repo,
+            input_text=commit_message + "\n",
+        ).stdout.strip()
+        run(
+            ["git", "update-ref", f"refs/heads/{branch}", commit_sha, expected_head],
+            cwd=repo,
+        )
+        committed = True
+        consumed_receipt["commit_sha"] = commit_sha
+        atomic_json_write(consumed, consumed_receipt)
+        run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
+    except UpgradeError:
+        if not committed and not active.exists():
+            atomic_json_write(active, receipt)
+            write_authority(repo, receipt)
+            consumed.unlink(missing_ok=True)
+        raise
+    finally:
+        private_index.unlink(missing_ok=True)
+    return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 
 def parser() -> argparse.ArgumentParser:
@@ -542,6 +1039,9 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    commit_parser = sub.add_parser("commit")
+    commit_parser.add_argument("task")
+    commit_parser.add_argument("message", nargs="?", default="")
     return p
 
 
@@ -555,6 +1055,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "commit":
+            result = commit(repo, args.task, args.message)
         else:  # pragma: no cover
             raise UpgradeError(f"unsupported command: {args.command}")
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tomllib
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
@@ -196,7 +197,18 @@ def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
     _, branch, worktree = parse_task_identity(repo, task)
     registered = registered_worktrees(repo)
     actual = registered.get(worktree)
-    if actual is None or actual[0] != branch:
+    current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    head = git_head(repo)
+    branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo, check=False).stdout.strip()
+    if (
+        actual is None
+        or current_branch != branch
+        or actual[0] != branch
+        or not head
+        or not branch_oid
+        or actual[1] != head
+        or branch_oid != head
+    ):
         raise UpgradeError("current Task worktree is not registered with the expected branch")
     default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
     if not default:
@@ -322,6 +334,36 @@ def resolve_source(path: Path | None) -> Path:
     if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
         raise UpgradeError(f"not a Templates source checkout: {source}")
     return source
+
+
+def git_bytes(command: list[str], *, cwd: Path) -> bytes:
+    if not command or command[0] != "git":
+        raise UpgradeError("byte helper only accepts Git commands")
+    result = subprocess.run(
+        [str(git_executable()), *command[1:]],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result.stdout
+
+
+def resolve_pinned_source(path: Path) -> tuple[Path, str]:
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    status = git_bytes(
+        ["git", "status", "--porcelain=v1", "-z", "--", "components/agent-core"], cwd=source
+    )
+    if status:
+        raise UpgradeError("source components/agent-core must be clean")
+    return source, head
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -621,6 +663,124 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
     return Action(rel, "replace", "Agent Core-owned path")
 
 
+def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
+    result = subprocess.run(
+        [str(git_executable()), "show", f"{revision}:{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read Git object {path}")
+    return result.stdout
+
+
+def materialize_tree(
+    repo: Path, revision: str, destination: Path, prefix: str = "", *, surface_only: bool = False
+) -> None:
+    entries = git_bytes(["git", "ls-tree", "-r", "-z", revision, "--", prefix or "."], cwd=repo).split(b"\0")
+    destination.mkdir(parents=True, exist_ok=True)
+    prefix_bytes = (prefix.rstrip("/") + "/").encode() if prefix else b""
+    for entry in entries:
+        if not entry:
+            continue
+        header, raw_path = entry.split(b"\t", 1)
+        fields = header.split()
+        if prefix_bytes and not raw_path.startswith(prefix_bytes):
+            raise UpgradeError("Git returned an unexpected snapshot path")
+        relative_raw = raw_path[len(prefix_bytes):] if prefix_bytes else raw_path
+        try:
+            relative_text = relative_raw.decode("utf-8")
+            relative = PurePosixPath(relative_text)
+        except UnicodeDecodeError as exc:
+            raise UpgradeError("snapshot contains a non-UTF-8 path") from exc
+        if surface_only and not (
+            relative_text in {"AGENTS.md", "Justfile", "opencode.json"}
+            or relative_text.startswith(".automation/")
+            or relative_text.startswith(".opencode/")
+        ):
+            continue
+        if len(fields) != 3 or fields[0] not in {b"100644", b"100755"} or fields[1] != b"blob":
+            raise UpgradeError("Agent Core snapshot contains a symlink, submodule, or special Git entry")
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or relative.as_posix() != relative_text
+        ):
+            raise UpgradeError("snapshot contains an unsafe or unnormalized path")
+        target = destination.joinpath(*relative.parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(git_object_bytes(repo, revision, raw_path.decode("utf-8")))
+        target.chmod(0o755 if fields[0] == b"100755" else 0o644)
+
+
+def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        if item["action"] == "delete":
+            target = tree / relative
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                blockers.append(f"{item['path']}: delete has symlink ancestor {ancestor.as_posix()}")
+                continue
+            if path_present(target) and not (target.is_symlink() or target.is_file()):
+                blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(tree, relative, planned_deletes)
+            if blocker:
+                blockers.append(f"{item['path']}: {blocker}")
+    if blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(blockers))
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered = sorted(
+        [item for item in actionable if item["path"] != ".automation/VERSION"],
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + [item for item in actionable if item["path"] == ".automation/VERSION"]
+    changed: list[str] = []
+    for item in ordered:
+        relative = Path(item["path"])
+        target = tree / relative
+        source = source_core / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if target.is_symlink() or target.is_file():
+                target.unlink()
+            elif path_present(target):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+        else:
+            blocker = write_topology_blocker(tree, relative, set())
+            if blocker:
+                raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {blocker}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
+            if item["action"] in {"create", "replace"}:
+                shutil.copy2(source, target)
+            elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+                merged, detail = replace_agent_rules(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            elif item["action"] == "merge" and item["path"] == "Justfile":
+                merged, detail = merge_just_router(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            else:
+                raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
+    return sorted(set(changed))
+
+
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
@@ -706,73 +866,7 @@ def apply(repo: Path, source: Path) -> dict:
             "mergePerformed": False,
             "requiredNextChecks": [],
         }
-    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
-    preflight_blockers: list[str] = []
-    for item in actionable:
-        relative = Path(item["path"])
-        destination = repo / relative
-        if item["action"] == "delete":
-            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
-                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
-        else:
-            blocker = write_topology_blocker(repo, relative, planned_deletes)
-            if blocker:
-                preflight_blockers.append(f"{item['path']}: {blocker}")
-    if preflight_blockers:
-        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
-
-    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
-    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
-    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
-    ordered_actions = sorted(
-        ordinary_actions,
-        key=lambda item: (phases.get(item["action"], 99), item["path"]),
-    ) + version_actions
-    for item in ordered_actions:
-        relative = Path(item["path"])
-        source_path = source_core / relative
-        destination = repo / relative
-        if item["action"] == "delete":
-            ancestor = symlink_ancestor(repo, relative)
-            if ancestor is not None:
-                raise UpgradeError(
-                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
-                )
-            if destination.is_symlink() or destination.is_file():
-                destination.unlink()
-            elif path_present(destination):
-                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
-            changed.append(item["path"])
-            continue
-        topology_blocker = write_topology_blocker(repo, relative, set())
-        if topology_blocker:
-            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        if item["action"] in {"create", "replace"}:
-            if destination.is_symlink():
-                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
-            shutil.copy2(source_path, destination)
-        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
-            if destination.is_symlink():
-                raise UpgradeError("AGENTS.md became a symlink after planning")
-            merged, detail = replace_agent_rules(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        elif item["action"] == "merge" and item["path"] == "Justfile":
-            if destination.is_symlink():
-                raise UpgradeError("Justfile became a symlink after planning")
-            merged, detail = merge_just_router(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        else:
-            raise UpgradeError(f"unsupported upgrade action: {item}")
-        changed.append(item["path"])
+    changed = apply_plan_to_tree(repo, source_core, plan)
     result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -815,13 +909,117 @@ def apply(repo: Path, source: Path) -> dict:
 def pending_paths(repo: Path) -> list[str]:
     paths: set[str] = set()
     for args in (
-        ("diff", "--no-ext-diff", "--name-only"),
-        ("diff", "--no-ext-diff", "--cached", "--name-only"),
-        ("ls-files", "--others", "--exclude-standard"),
+        ("diff", "--no-ext-diff", "--name-only", "-z"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only", "-z"),
+        ("ls-files", "--others", "--exclude-standard", "-z"),
     ):
-        output = run(["git", *args], cwd=repo).stdout
-        paths.update(output.splitlines())
+        output = git_bytes(["git", *args], cwd=repo)
+        for raw in output.split(b"\0"):
+            if not raw:
+                continue
+            try:
+                paths.add(raw.decode("utf-8"))
+            except UnicodeDecodeError as exc:
+                raise UpgradeError("Git reported a non-UTF-8 pending path") from exc
     return sorted(paths)
+
+
+def bootstrap_fingerprint(tree: Path, raw_path: str) -> dict[str, object]:
+    return file_fingerprint(tree, raw_path)
+
+
+def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
+    path = validate_receipt_path(raw_path)
+    relative = Path(*path.split("/"))
+    policy_path = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(policy_path.read_text(encoding="utf-8")) if policy_path.is_file() else {}
+    secret_patterns = policy.get("paths", {}).get("secret_patterns", [])
+    if path == ".task-state" or path.startswith(".task-state/"):
+        raise UpgradeError(f"pending path is Task State: {path}")
+    if any(token.lower() in path.lower() for token in secret_patterns):
+        raise UpgradeError(f"pending path matches a configured secret pattern: {path}")
+    if path.startswith("just/project/") or path == "just/local.just":
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path.startswith(".github/"):
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path == ".automation/ADAPTER" or path == ".automation/INIT.fragment.md" or path == ".automation/adoption.toml":
+        raise UpgradeError(f"pending path is Adapter-owned: {path}")
+    if not managed(relative):
+        raise UpgradeError(f"pending path is outside Agent Core: {path}")
+
+
+def bootstrap_receipt(repo: Path, source: Path) -> dict:
+    task_id, branch, worktree = require_maintenance(repo)
+    authority_head = git_head(repo)
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
+    if receipt_path(repo).exists() or authority_path(repo).exists():
+        raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    pending = pending_paths(repo)
+    if not pending:
+        raise UpgradeError("bootstrap requires non-empty pending paths")
+    for path in pending:
+        reject_bootstrap_path(repo, path)
+    source, source_head = resolve_pinned_source(source)
+    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+        baseline = Path(temporary) / "baseline"
+        source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
+        materialize_tree(repo, authority_head, baseline, surface_only=True)
+        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        before = {
+            p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
+            for p in baseline.rglob("*") if p.is_file()
+        }
+        plan = build_plan(baseline, source_snapshot.parent.parent)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [
+            migration for migration in load_migrations(source_snapshot)
+            if migration.to_version <= version_number(source_snapshot)
+        ]
+        _, migration_blockers, _ = migration_actions(repo, selected)
+        if migration_blockers:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(migration_blockers))
+        apply_plan_to_tree(baseline, source_snapshot, plan)
+        returned = set(item["path"] for item in plan["actions"] if item["action"] != "noop")
+        expected = sorted(
+            path for path in returned
+            if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+            != bootstrap_fingerprint(baseline, path)
+        )
+        if expected != pending:
+            raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
+        if not expected:
+            return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+    pinned_source, current_source_head = resolve_pinned_source(source)
+    if pinned_source != source or current_source_head != source_head:
+        raise UpgradeError("source changed during receipt reconstruction")
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed during receipt reconstruction")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed during receipt reconstruction")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content does not match the reconstructed upgrade")
+    receipt = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": str(source.resolve()), "source_revision": source_head,
+        "current_version": plan["currentVersion"], "upstream_version": plan["upstreamVersion"],
+        "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": current_fingerprints,
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1039,6 +1237,8 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    bootstrap = sub.add_parser("bootstrap-receipt")
+    bootstrap.add_argument("--source", type=Path, required=True)
     commit_parser = sub.add_parser("commit")
     commit_parser.add_argument("task")
     commit_parser.add_argument("message", nargs="?", default="")
@@ -1055,6 +1255,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "bootstrap-receipt":
+            result = bootstrap_receipt(repo, resolve_source(args.source))
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/templates/agent-base/.automation/just/automation.just
+++ b/templates/agent-base/.automation/just/automation.just
@@ -1,11 +1,18 @@
 root := justfile_directory() / ".." / ".."
 script := root / ".automation" / "bin" / "automation_upgrade.py"
 
+[working-directory: root]
 version:
-    python3 '{{script}}' version
+    python3 {{quote(script)}} version
 
+[working-directory: root]
 check-update source:
-    python3 '{{script}}' check-update --source '{{source}}'
+    python3 {{quote(script)}} check-update --source {{quote(source)}}
 
+[working-directory: root]
 upgrade source:
-    python3 '{{script}}' upgrade --source '{{source}}'
+    python3 {{quote(script)}} upgrade --source {{quote(source)}}
+
+[working-directory: root]
+commit task message="":
+    python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-base/.automation/just/automation.just
+++ b/templates/agent-base/.automation/just/automation.just
@@ -14,5 +14,9 @@ upgrade source:
     python3 {{quote(script)}} upgrade --source {{quote(source)}}
 
 [working-directory: root]
+bootstrap-receipt source:
+    python3 {{quote(script)}} bootstrap-receipt --source {{quote(source)}}
+
+[working-directory: root]
 commit task message="":
     python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-base/opencode.json
+++ b/templates/agent-base/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::bootstrap-receipt *": "ask",
       "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",

--- a/templates/agent-base/opencode.json
+++ b/templates/agent-base/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -11,3 +11,48 @@ The current implementation provides guarded Task-local commit/push/PR operations
 integration head-SHA checkpoints, disposable Task State templates, and common
 safety policy. Repository-local OpenCode agents and permissions are added by the
 separate OpenCode configuration work.
+
+## Automation Maintenance workflow
+
+An Agent Core upgrade is permitted only from a dedicated registered, non-default
+Automation Maintenance Task. From that Task worktree, use a trusted local
+Templates checkout as the source:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
+```
+
+The environment variable is an upgrade opt-in only. It does not authorize a
+commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
+Upgrade does not commit, push, or merge and writes the ignored receipt
+`.task-state/automation-maintenance.json`.
+
+Before publication, execute `git diff --check`, `just agent::doctor`,
+`just project::check`, and the repository CI/smoke suite. Then publish only with:
+
+```sh
+just automation::commit <task> [message]
+just agent::push <task>
+just agent::pr-create <task>
+```
+
+The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
+`worktree`), source/source revision, current/upstream versions, sorted unique
+`changed_paths`, `authority_head`, and exact per-path content/state
+`path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
+stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
+or does not exactly equal all pending paths. A protected shared-Git-directory
+record binds it to the preceding successful upgrade; a fabricated Task State
+receipt is not authority. Ambient Git repository/index overrides are scrubbed.
+The exact paths are staged and rechecked in a private Task State index, then the
+commit is created from that verified tree without hooks and the expected Task
+branch HEAD is advanced atomically. Only Agent Core-managed paths are
+accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
+scopes are rejected. After a successful commit it is consumed at
+`.task-state/automation-maintenance.consumed.json`; a subsequent successful
+upgrade with changes replaces the active receipt and removes the previous consumed
+receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
+receipt lifecycle evidence.
+
+Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
+this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -36,6 +36,25 @@ just agent::push <task>
 just agent::pr-create <task>
 ```
 
+The normal upgrade flow creates its receipt before verification. If a self-hosted
+pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
+normal verification and, before `automation::commit`, run the canonical recovery
+bridge:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+```
+
+The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
+pins the clean source revision, materializes the tracked `HEAD` Agent Core
+baseline, applies canonical upgrade semantics in isolation, and requires exact
+pending paths/content/modes plus Task identity and `HEAD` before issuing the
+existing receipt and protected authority. Product, Adapter, repository,
+secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
+with the existing `automation::commit` flow; ordinary `agent::commit` rejection
+and the receipt/authority design remain unchanged. This is the PR #79 review fix
+only; there are no Issue #77 changes.
+
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tomllib
@@ -15,6 +18,192 @@ from pathlib import Path, PurePosixPath
 
 class UpgradeError(RuntimeError):
     pass
+
+
+RECEIPT_NAME = "automation-maintenance.json"
+CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+RECEIPT_FIELDS = {
+    "schema_version",
+    "status",
+    "task_id",
+    "branch",
+    "worktree",
+    "source",
+    "source_revision",
+    "current_version",
+    "upstream_version",
+    "changed_paths",
+    "authority_head",
+    "authority_nonce",
+    "path_fingerprints",
+}
+_GIT_EXECUTABLE: Path | None = None
+
+
+def git_head(repo: Path) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def source_revision(source: Path) -> str | None:
+    value = git_head(source)
+    return value or None
+
+
+def receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / RECEIPT_NAME
+
+
+def consumed_receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+
+
+def common_git_dir(repo: Path) -> Path:
+    value = Path(run(["git", "rev-parse", "--git-common-dir"], cwd=repo).stdout.strip())
+    return value.resolve() if value.is_absolute() else (repo / value).resolve()
+
+
+def authority_path(repo: Path) -> Path:
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+
+
+def canonical_json(value: dict) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def receipt_digest(receipt: dict) -> str:
+    return hashlib.sha256(canonical_json(receipt)).hexdigest()
+
+
+def write_authority(repo: Path, receipt: dict) -> None:
+    atomic_json_write(
+        authority_path(repo),
+        {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        },
+    )
+
+
+def validate_authority(repo: Path, receipt: dict) -> None:
+    path = authority_path(repo)
+    try:
+        authority = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+    expected = {
+        "schema_version": 1,
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+    }
+    if authority != expected:
+        raise UpgradeError("automation receipt does not match successful-upgrade authority")
+
+
+def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
+    for path in paths:
+        relative = path.relative_to(repo).as_posix()
+        tracked = run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=repo,
+            check=False,
+        ).returncode == 0
+        if tracked:
+            raise UpgradeError(f"required Task State path is tracked: {relative}")
+        ignored = run(["git", "check-ignore", "-q", relative], cwd=repo, check=False).returncode == 0
+        if not ignored:
+            raise UpgradeError(f"required Task State path is not ignored: {relative}")
+
+
+def atomic_json_write(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
+    path = repo / Path(*raw_path.split("/"))
+    try:
+        state = path.lstat()
+    except FileNotFoundError:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    mode = stat.S_IMODE(state.st_mode)
+    if path.is_file() and not path.is_symlink():
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        return {"state": "file", "mode": mode, "content_sha256": digest}
+    if path.is_symlink():
+        digest = hashlib.sha256(os.readlink(path).encode("utf-8", "surrogateescape")).hexdigest()
+        return {"state": "symlink", "mode": mode, "content_sha256": digest}
+    if path.is_dir():
+        return {"state": "directory", "mode": mode, "content_sha256": None}
+    return {"state": "special", "mode": mode, "content_sha256": None}
+
+
+def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
+    if not TASK_ID_RE.fullmatch(task):
+        raise UpgradeError(f"invalid Task ID: {task!r}")
+    state_path = repo / ".task-state" / "task.md"
+    if not state_path.is_file():
+        raise UpgradeError("operation requires a Task worktree with Task State")
+    text = state_path.read_text(encoding="utf-8")
+    values: dict[str, str] = {}
+    for label in ("Task ID", "Branch", "Worktree"):
+        matches = re.findall(rf"(?m)^- {re.escape(label)}: (.+)$", text)
+        if len(matches) != 1 or not matches[0].strip():
+            raise UpgradeError(f"Task State must contain exactly one {label} identity field")
+        values[label] = matches[0].strip()
+    if values["Task ID"] != task:
+        raise UpgradeError("Task State identity does not match requested Task")
+    branch = values["Branch"]
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        raise UpgradeError(f"Task State branch is not the Task branch for {task}")
+    worktree = Path(values["Worktree"]).resolve()
+    if worktree != repo.resolve():
+        raise UpgradeError("Task State worktree does not match the current worktree")
+    return task, branch, worktree
+
+
+def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]]:
+    output = run(["git", "worktree", "list", "--porcelain"], cwd=repo).stdout
+    records: dict[Path, tuple[str | None, str | None]] = {}
+    current: dict[str, str] = {}
+    for line in output.splitlines() + [""]:
+        if not line:
+            if current.get("worktree"):
+                branch = current.get("branch", "").removeprefix("refs/heads/") or None
+                records[Path(current["worktree"]).resolve()] = (branch, current.get("HEAD"))
+            current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    return records
+
+
+def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
+    _, branch, worktree = parse_task_identity(repo, task)
+    registered = registered_worktrees(repo)
+    actual = registered.get(worktree)
+    if actual is None or actual[0] != branch:
+        raise UpgradeError("current Task worktree is not registered with the expected branch")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if not default:
+        raise UpgradeError("cannot resolve default branch")
+    if branch == default:
+        raise UpgradeError("operation refused on the default branch")
+    return task, branch, worktree
 
 
 @dataclass(frozen=True)
@@ -32,8 +221,58 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
-def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and key != "EMAIL"
+    }
+    if overrides:
+        environment.update(overrides)
+    return environment
+
+
+def git_executable() -> Path:
+    global _GIT_EXECUTABLE
+    if _GIT_EXECUTABLE is not None:
+        return _GIT_EXECUTABLE
+    candidate = shutil.which("git")
+    if not candidate:
+        raise UpgradeError("trusted Git executable is unavailable")
+    executable = Path(candidate).resolve()
+    try:
+        metadata = executable.stat()
+    except OSError as exc:
+        raise UpgradeError("trusted Git executable is unavailable") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+    ):
+        raise UpgradeError(f"Git executable is not root-owned and immutable: {executable}")
+    _GIT_EXECUTABLE = executable
+    return executable
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    env_overrides: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    is_git = bool(command and command[0] == "git")
+    environment = git_environment(env_overrides) if is_git else None
+    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    result = subprocess.run(
+        executable_command,
+        cwd=cwd,
+        text=True,
+        input=input_text,
+        capture_output=True,
+        env=environment,
+    )
     if check and result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         raise UpgradeError(f"{' '.join(command)}: {detail}")
@@ -41,8 +280,12 @@ def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.Comp
 
 
 def root() -> Path:
-    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
-    return Path(result.stdout.strip()).resolve()
+    installed_root = Path(__file__).resolve().parents[2]
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=installed_root)
+    discovered = Path(result.stdout.strip()).resolve()
+    if discovered != installed_root:
+        raise UpgradeError("installed Agent Core path does not match the Git worktree root")
+    return installed_root
 
 
 def version(repo: Path) -> str:
@@ -424,31 +667,45 @@ def build_plan(repo: Path, source: Path) -> dict:
     }
 
 
-def require_maintenance(repo: Path) -> None:
+def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    default = run(
-        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
-        cwd=repo,
-        check=False,
-    ).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    state = repo / ".task-state" / "task.md"
+    task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
+    if not task_match:
+        raise UpgradeError("upgrade requires a registered non-default Task branch")
+    task_id = task_match.group(1).strip()
+    identity = require_registered_task(repo, task_id)
+    require_ignored_untracked(
+        repo,
+        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+    )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+    return identity
 
 
 def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+    task_id, branch, worktree = require_maintenance(repo)
     plan = build_plan(repo, source)
     if plan["blockers"]:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    if not actionable:
+        return {
+            "status": "NO_CHANGES",
+            "repositoryRoot": str(repo),
+            "sourceCore": str(source_core),
+            "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+            "changedPaths": [],
+            "commitCreated": False,
+            "pushPerformed": False,
+            "mergePerformed": False,
+            "requiredNextChecks": [],
+        }
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
     preflight_blockers: list[str] = []
     for item in actionable:
@@ -516,7 +773,7 @@ def apply(repo: Path, source: Path) -> dict:
         else:
             raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
-    return {
+    result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
         "sourceCore": str(source_core),
@@ -532,6 +789,246 @@ def apply(repo: Path, source: Path) -> dict:
             "repository CI/smoke tests",
         ],
     }
+    changed_paths = sorted(set(changed))
+    result["changedPaths"] = changed_paths
+    receipt = {
+        "schema_version": 1,
+        "status": "active",
+        "task_id": task_id,
+        "branch": branch,
+        "worktree": str(worktree),
+        "source": str(source.resolve()),
+        "source_revision": source_revision(source),
+        "current_version": plan["currentVersion"],
+        "upstream_version": plan["upstreamVersion"],
+        "changed_paths": changed_paths,
+        "authority_head": git_head(repo),
+        "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return result
+
+
+def pending_paths(repo: Path) -> list[str]:
+    paths: set[str] = set()
+    for args in (
+        ("diff", "--no-ext-diff", "--name-only"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only"),
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
+        output = run(["git", *args], cwd=repo).stdout
+        paths.update(output.splitlines())
+    return sorted(paths)
+
+
+def validate_receipt_path(raw: object) -> str:
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise UpgradeError("receipt contains an unsafe path")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts) or pure.as_posix() != raw:
+        raise UpgradeError(f"receipt contains an unnormalized path: {raw!r}")
+    return raw
+
+
+def receipt_paths(repo: Path, receipt: dict) -> list[str]:
+    raw = receipt.get("changed_paths")
+    if not isinstance(raw, list) or not raw:
+        raise UpgradeError("automation receipt has no changed paths")
+    paths = [validate_receipt_path(item) for item in raw]
+    if paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise UpgradeError("automation receipt paths must be sorted and unique")
+    secret_file = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(secret_file.read_text(encoding="utf-8")) if secret_file.is_file() else {}
+    secrets = policy.get("paths", {}).get("secret_patterns", [])
+    for path in paths:
+        relative = Path(*path.split("/"))
+        if path == ".task-state" or path.startswith(".task-state/") or not managed(relative):
+            raise UpgradeError(f"receipt path is not Agent Core managed: {path}")
+        if any(token.lower() in path.lower() for token in secrets):
+            raise UpgradeError(f"receipt path matches a configured secret pattern: {path}")
+    return paths
+
+
+def validate_receipt_schema(receipt: object) -> dict:
+    if not isinstance(receipt, dict) or set(receipt) != RECEIPT_FIELDS:
+        raise UpgradeError("automation upgrade receipt has an invalid schema")
+    if receipt.get("schema_version") != 1 or receipt.get("status") != "active":
+        raise UpgradeError("unsupported automation upgrade receipt")
+    required_strings = (
+        "task_id",
+        "branch",
+        "worktree",
+        "source",
+        "current_version",
+        "upstream_version",
+        "authority_head",
+        "authority_nonce",
+    )
+    if any(not isinstance(receipt.get(field), str) or not receipt[field] for field in required_strings):
+        raise UpgradeError("automation upgrade receipt has invalid provenance fields")
+    revision = receipt.get("source_revision")
+    if revision is not None and (not isinstance(revision, str) or not revision):
+        raise UpgradeError("automation upgrade receipt has an invalid source revision")
+    if not Path(receipt["source"]).is_absolute():
+        raise UpgradeError("automation upgrade receipt source must be absolute")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", receipt["authority_head"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority HEAD")
+    if not re.fullmatch(r"[0-9a-f]{64}", receipt["authority_nonce"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority nonce")
+    return receipt
+
+
+def staged_fingerprint(
+    repo: Path,
+    path: str,
+    *,
+    env_overrides: dict[str, str],
+) -> dict[str, object]:
+    entry = run(
+        ["git", "ls-files", "--stage", "--", path],
+        cwd=repo,
+        env_overrides=env_overrides,
+    ).stdout.strip()
+    if not entry:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    fields = entry.split(maxsplit=3)
+    if len(fields) != 4 or fields[2] != "0":
+        raise UpgradeError(f"staged path has an unsupported index entry: {path}")
+    mode = fields[0]
+    result = subprocess.run(
+        [str(git_executable()), "show", f":{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(env_overrides),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read staged content for {path}")
+    if mode not in {"100644", "100755"}:
+        raise UpgradeError(f"staged path has an unsupported mode: {path}")
+    return {
+        "state": "file",
+        "mode": 0o755 if mode == "100755" else 0o644,
+        "content_sha256": hashlib.sha256(result.stdout).hexdigest(),
+    }
+
+
+def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
+    if not isinstance(fingerprint, dict):
+        raise UpgradeError("automation receipt contains an invalid path fingerprint")
+    state = fingerprint.get("state")
+    if state == "absent":
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    if state != "file" or not isinstance(fingerprint.get("mode"), int):
+        raise UpgradeError("automation receipt authorizes an unsupported path state")
+    digest = fingerprint.get("content_sha256")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise UpgradeError("automation receipt contains an invalid content fingerprint")
+    return {
+        "state": "file",
+        "mode": 0o755 if fingerprint["mode"] & 0o111 else 0o644,
+        "content_sha256": digest,
+    }
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+    _, branch, worktree = require_registered_task(repo, task)
+    active = receipt_path(repo)
+    private_index = repo / ".task-state" / "automation-maintenance.index"
+    require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
+    if not active.is_file():
+        raise UpgradeError("no active successful automation upgrade receipt")
+    try:
+        receipt = json.loads(active.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt = validate_receipt_schema(receipt)
+    if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    if receipt.get("authority_head") != git_head(repo):
+        raise UpgradeError("automation receipt authority HEAD is stale")
+    paths = receipt_paths(repo, receipt)
+    fingerprints = receipt.get("path_fingerprints")
+    if not isinstance(fingerprints, dict) or set(fingerprints) != set(paths):
+        raise UpgradeError("automation receipt fingerprints do not match its paths")
+    if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+        raise UpgradeError("automation receipt path content/state fingerprint changed")
+    if pending_paths(repo) != paths:
+        raise UpgradeError("pending paths do not exactly match the automation receipt")
+    validate_authority(repo, receipt)
+
+    consumed = consumed_receipt_path(repo)
+    os.replace(active, consumed)
+    consumed_receipt = dict(receipt)
+    consumed_receipt["status"] = "consumed"
+    consumed_receipt["commit_sha"] = None
+    atomic_json_write(consumed, consumed_receipt)
+    authority = authority_path(repo)
+    authority.unlink(missing_ok=True)
+    private_index.unlink(missing_ok=True)
+    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    committed = False
+    commit_sha = ""
+    try:
+        run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
+        run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
+        run(
+            ["git", "diff", "--no-ext-diff", "--cached", "--check"],
+            cwd=repo,
+            env_overrides=index_environment,
+        )
+        staged = sorted(
+            run(
+                ["git", "diff", "--no-ext-diff", "--cached", "--name-only"],
+                cwd=repo,
+                env_overrides=index_environment,
+            ).stdout.splitlines()
+        )
+        if staged != paths:
+            raise UpgradeError("staged paths do not exactly match the automation receipt")
+        if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+            raise UpgradeError("automation receipt path changed while staging")
+        for path in paths:
+            if staged_fingerprint(
+                repo,
+                path,
+                env_overrides=index_environment,
+            ) != normalized_git_fingerprint(fingerprints[path]):
+                raise UpgradeError(f"staged content does not match the automation receipt: {path}")
+        commit_message = message.strip() or f"task: {task}"
+        if task not in commit_message:
+            commit_message = f"{commit_message}\n\nTask: {task}"
+        tree = run(
+            ["git", "write-tree"],
+            cwd=repo,
+            env_overrides=index_environment,
+        ).stdout.strip()
+        expected_head = receipt["authority_head"]
+        commit_sha = run(
+            ["git", "commit-tree", tree, "-p", expected_head],
+            cwd=repo,
+            input_text=commit_message + "\n",
+        ).stdout.strip()
+        run(
+            ["git", "update-ref", f"refs/heads/{branch}", commit_sha, expected_head],
+            cwd=repo,
+        )
+        committed = True
+        consumed_receipt["commit_sha"] = commit_sha
+        atomic_json_write(consumed, consumed_receipt)
+        run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
+    except UpgradeError:
+        if not committed and not active.exists():
+            atomic_json_write(active, receipt)
+            write_authority(repo, receipt)
+            consumed.unlink(missing_ok=True)
+        raise
+    finally:
+        private_index.unlink(missing_ok=True)
+    return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 
 def parser() -> argparse.ArgumentParser:
@@ -542,6 +1039,9 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    commit_parser = sub.add_parser("commit")
+    commit_parser.add_argument("task")
+    commit_parser.add_argument("message", nargs="?", default="")
     return p
 
 
@@ -555,6 +1055,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "commit":
+            result = commit(repo, args.task, args.message)
         else:  # pragma: no cover
             raise UpgradeError(f"unsupported command: {args.command}")
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tomllib
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
@@ -196,7 +197,18 @@ def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
     _, branch, worktree = parse_task_identity(repo, task)
     registered = registered_worktrees(repo)
     actual = registered.get(worktree)
-    if actual is None or actual[0] != branch:
+    current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    head = git_head(repo)
+    branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo, check=False).stdout.strip()
+    if (
+        actual is None
+        or current_branch != branch
+        or actual[0] != branch
+        or not head
+        or not branch_oid
+        or actual[1] != head
+        or branch_oid != head
+    ):
         raise UpgradeError("current Task worktree is not registered with the expected branch")
     default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
     if not default:
@@ -322,6 +334,36 @@ def resolve_source(path: Path | None) -> Path:
     if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
         raise UpgradeError(f"not a Templates source checkout: {source}")
     return source
+
+
+def git_bytes(command: list[str], *, cwd: Path) -> bytes:
+    if not command or command[0] != "git":
+        raise UpgradeError("byte helper only accepts Git commands")
+    result = subprocess.run(
+        [str(git_executable()), *command[1:]],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result.stdout
+
+
+def resolve_pinned_source(path: Path) -> tuple[Path, str]:
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    status = git_bytes(
+        ["git", "status", "--porcelain=v1", "-z", "--", "components/agent-core"], cwd=source
+    )
+    if status:
+        raise UpgradeError("source components/agent-core must be clean")
+    return source, head
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -621,6 +663,124 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
     return Action(rel, "replace", "Agent Core-owned path")
 
 
+def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
+    result = subprocess.run(
+        [str(git_executable()), "show", f"{revision}:{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read Git object {path}")
+    return result.stdout
+
+
+def materialize_tree(
+    repo: Path, revision: str, destination: Path, prefix: str = "", *, surface_only: bool = False
+) -> None:
+    entries = git_bytes(["git", "ls-tree", "-r", "-z", revision, "--", prefix or "."], cwd=repo).split(b"\0")
+    destination.mkdir(parents=True, exist_ok=True)
+    prefix_bytes = (prefix.rstrip("/") + "/").encode() if prefix else b""
+    for entry in entries:
+        if not entry:
+            continue
+        header, raw_path = entry.split(b"\t", 1)
+        fields = header.split()
+        if prefix_bytes and not raw_path.startswith(prefix_bytes):
+            raise UpgradeError("Git returned an unexpected snapshot path")
+        relative_raw = raw_path[len(prefix_bytes):] if prefix_bytes else raw_path
+        try:
+            relative_text = relative_raw.decode("utf-8")
+            relative = PurePosixPath(relative_text)
+        except UnicodeDecodeError as exc:
+            raise UpgradeError("snapshot contains a non-UTF-8 path") from exc
+        if surface_only and not (
+            relative_text in {"AGENTS.md", "Justfile", "opencode.json"}
+            or relative_text.startswith(".automation/")
+            or relative_text.startswith(".opencode/")
+        ):
+            continue
+        if len(fields) != 3 or fields[0] not in {b"100644", b"100755"} or fields[1] != b"blob":
+            raise UpgradeError("Agent Core snapshot contains a symlink, submodule, or special Git entry")
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or relative.as_posix() != relative_text
+        ):
+            raise UpgradeError("snapshot contains an unsafe or unnormalized path")
+        target = destination.joinpath(*relative.parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(git_object_bytes(repo, revision, raw_path.decode("utf-8")))
+        target.chmod(0o755 if fields[0] == b"100755" else 0o644)
+
+
+def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        if item["action"] == "delete":
+            target = tree / relative
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                blockers.append(f"{item['path']}: delete has symlink ancestor {ancestor.as_posix()}")
+                continue
+            if path_present(target) and not (target.is_symlink() or target.is_file()):
+                blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(tree, relative, planned_deletes)
+            if blocker:
+                blockers.append(f"{item['path']}: {blocker}")
+    if blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(blockers))
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered = sorted(
+        [item for item in actionable if item["path"] != ".automation/VERSION"],
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + [item for item in actionable if item["path"] == ".automation/VERSION"]
+    changed: list[str] = []
+    for item in ordered:
+        relative = Path(item["path"])
+        target = tree / relative
+        source = source_core / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if target.is_symlink() or target.is_file():
+                target.unlink()
+            elif path_present(target):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+        else:
+            blocker = write_topology_blocker(tree, relative, set())
+            if blocker:
+                raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {blocker}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
+            if item["action"] in {"create", "replace"}:
+                shutil.copy2(source, target)
+            elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+                merged, detail = replace_agent_rules(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            elif item["action"] == "merge" and item["path"] == "Justfile":
+                merged, detail = merge_just_router(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            else:
+                raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
+    return sorted(set(changed))
+
+
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
@@ -706,73 +866,7 @@ def apply(repo: Path, source: Path) -> dict:
             "mergePerformed": False,
             "requiredNextChecks": [],
         }
-    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
-    preflight_blockers: list[str] = []
-    for item in actionable:
-        relative = Path(item["path"])
-        destination = repo / relative
-        if item["action"] == "delete":
-            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
-                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
-        else:
-            blocker = write_topology_blocker(repo, relative, planned_deletes)
-            if blocker:
-                preflight_blockers.append(f"{item['path']}: {blocker}")
-    if preflight_blockers:
-        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
-
-    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
-    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
-    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
-    ordered_actions = sorted(
-        ordinary_actions,
-        key=lambda item: (phases.get(item["action"], 99), item["path"]),
-    ) + version_actions
-    for item in ordered_actions:
-        relative = Path(item["path"])
-        source_path = source_core / relative
-        destination = repo / relative
-        if item["action"] == "delete":
-            ancestor = symlink_ancestor(repo, relative)
-            if ancestor is not None:
-                raise UpgradeError(
-                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
-                )
-            if destination.is_symlink() or destination.is_file():
-                destination.unlink()
-            elif path_present(destination):
-                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
-            changed.append(item["path"])
-            continue
-        topology_blocker = write_topology_blocker(repo, relative, set())
-        if topology_blocker:
-            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        if item["action"] in {"create", "replace"}:
-            if destination.is_symlink():
-                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
-            shutil.copy2(source_path, destination)
-        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
-            if destination.is_symlink():
-                raise UpgradeError("AGENTS.md became a symlink after planning")
-            merged, detail = replace_agent_rules(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        elif item["action"] == "merge" and item["path"] == "Justfile":
-            if destination.is_symlink():
-                raise UpgradeError("Justfile became a symlink after planning")
-            merged, detail = merge_just_router(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        else:
-            raise UpgradeError(f"unsupported upgrade action: {item}")
-        changed.append(item["path"])
+    changed = apply_plan_to_tree(repo, source_core, plan)
     result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -815,13 +909,117 @@ def apply(repo: Path, source: Path) -> dict:
 def pending_paths(repo: Path) -> list[str]:
     paths: set[str] = set()
     for args in (
-        ("diff", "--no-ext-diff", "--name-only"),
-        ("diff", "--no-ext-diff", "--cached", "--name-only"),
-        ("ls-files", "--others", "--exclude-standard"),
+        ("diff", "--no-ext-diff", "--name-only", "-z"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only", "-z"),
+        ("ls-files", "--others", "--exclude-standard", "-z"),
     ):
-        output = run(["git", *args], cwd=repo).stdout
-        paths.update(output.splitlines())
+        output = git_bytes(["git", *args], cwd=repo)
+        for raw in output.split(b"\0"):
+            if not raw:
+                continue
+            try:
+                paths.add(raw.decode("utf-8"))
+            except UnicodeDecodeError as exc:
+                raise UpgradeError("Git reported a non-UTF-8 pending path") from exc
     return sorted(paths)
+
+
+def bootstrap_fingerprint(tree: Path, raw_path: str) -> dict[str, object]:
+    return file_fingerprint(tree, raw_path)
+
+
+def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
+    path = validate_receipt_path(raw_path)
+    relative = Path(*path.split("/"))
+    policy_path = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(policy_path.read_text(encoding="utf-8")) if policy_path.is_file() else {}
+    secret_patterns = policy.get("paths", {}).get("secret_patterns", [])
+    if path == ".task-state" or path.startswith(".task-state/"):
+        raise UpgradeError(f"pending path is Task State: {path}")
+    if any(token.lower() in path.lower() for token in secret_patterns):
+        raise UpgradeError(f"pending path matches a configured secret pattern: {path}")
+    if path.startswith("just/project/") or path == "just/local.just":
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path.startswith(".github/"):
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path == ".automation/ADAPTER" or path == ".automation/INIT.fragment.md" or path == ".automation/adoption.toml":
+        raise UpgradeError(f"pending path is Adapter-owned: {path}")
+    if not managed(relative):
+        raise UpgradeError(f"pending path is outside Agent Core: {path}")
+
+
+def bootstrap_receipt(repo: Path, source: Path) -> dict:
+    task_id, branch, worktree = require_maintenance(repo)
+    authority_head = git_head(repo)
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
+    if receipt_path(repo).exists() or authority_path(repo).exists():
+        raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    pending = pending_paths(repo)
+    if not pending:
+        raise UpgradeError("bootstrap requires non-empty pending paths")
+    for path in pending:
+        reject_bootstrap_path(repo, path)
+    source, source_head = resolve_pinned_source(source)
+    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+        baseline = Path(temporary) / "baseline"
+        source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
+        materialize_tree(repo, authority_head, baseline, surface_only=True)
+        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        before = {
+            p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
+            for p in baseline.rglob("*") if p.is_file()
+        }
+        plan = build_plan(baseline, source_snapshot.parent.parent)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [
+            migration for migration in load_migrations(source_snapshot)
+            if migration.to_version <= version_number(source_snapshot)
+        ]
+        _, migration_blockers, _ = migration_actions(repo, selected)
+        if migration_blockers:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(migration_blockers))
+        apply_plan_to_tree(baseline, source_snapshot, plan)
+        returned = set(item["path"] for item in plan["actions"] if item["action"] != "noop")
+        expected = sorted(
+            path for path in returned
+            if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+            != bootstrap_fingerprint(baseline, path)
+        )
+        if expected != pending:
+            raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
+        if not expected:
+            return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+    pinned_source, current_source_head = resolve_pinned_source(source)
+    if pinned_source != source or current_source_head != source_head:
+        raise UpgradeError("source changed during receipt reconstruction")
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed during receipt reconstruction")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed during receipt reconstruction")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content does not match the reconstructed upgrade")
+    receipt = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": str(source.resolve()), "source_revision": source_head,
+        "current_version": plan["currentVersion"], "upstream_version": plan["upstreamVersion"],
+        "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": current_fingerprints,
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1039,6 +1237,8 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    bootstrap = sub.add_parser("bootstrap-receipt")
+    bootstrap.add_argument("--source", type=Path, required=True)
     commit_parser = sub.add_parser("commit")
     commit_parser.add_argument("task")
     commit_parser.add_argument("message", nargs="?", default="")
@@ -1055,6 +1255,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "bootstrap-receipt":
+            result = bootstrap_receipt(repo, resolve_source(args.source))
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/templates/agent-cpp-cmake/.automation/just/automation.just
+++ b/templates/agent-cpp-cmake/.automation/just/automation.just
@@ -1,11 +1,18 @@
 root := justfile_directory() / ".." / ".."
 script := root / ".automation" / "bin" / "automation_upgrade.py"
 
+[working-directory: root]
 version:
-    python3 '{{script}}' version
+    python3 {{quote(script)}} version
 
+[working-directory: root]
 check-update source:
-    python3 '{{script}}' check-update --source '{{source}}'
+    python3 {{quote(script)}} check-update --source {{quote(source)}}
 
+[working-directory: root]
 upgrade source:
-    python3 '{{script}}' upgrade --source '{{source}}'
+    python3 {{quote(script)}} upgrade --source {{quote(source)}}
+
+[working-directory: root]
+commit task message="":
+    python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-cpp-cmake/.automation/just/automation.just
+++ b/templates/agent-cpp-cmake/.automation/just/automation.just
@@ -14,5 +14,9 @@ upgrade source:
     python3 {{quote(script)}} upgrade --source {{quote(source)}}
 
 [working-directory: root]
+bootstrap-receipt source:
+    python3 {{quote(script)}} bootstrap-receipt --source {{quote(source)}}
+
+[working-directory: root]
 commit task message="":
     python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-cpp-cmake/opencode.json
+++ b/templates/agent-cpp-cmake/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::bootstrap-receipt *": "ask",
       "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",

--- a/templates/agent-cpp-cmake/opencode.json
+++ b/templates/agent-cpp-cmake/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -11,3 +11,48 @@ The current implementation provides guarded Task-local commit/push/PR operations
 integration head-SHA checkpoints, disposable Task State templates, and common
 safety policy. Repository-local OpenCode agents and permissions are added by the
 separate OpenCode configuration work.
+
+## Automation Maintenance workflow
+
+An Agent Core upgrade is permitted only from a dedicated registered, non-default
+Automation Maintenance Task. From that Task worktree, use a trusted local
+Templates checkout as the source:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
+```
+
+The environment variable is an upgrade opt-in only. It does not authorize a
+commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
+Upgrade does not commit, push, or merge and writes the ignored receipt
+`.task-state/automation-maintenance.json`.
+
+Before publication, execute `git diff --check`, `just agent::doctor`,
+`just project::check`, and the repository CI/smoke suite. Then publish only with:
+
+```sh
+just automation::commit <task> [message]
+just agent::push <task>
+just agent::pr-create <task>
+```
+
+The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
+`worktree`), source/source revision, current/upstream versions, sorted unique
+`changed_paths`, `authority_head`, and exact per-path content/state
+`path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
+stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
+or does not exactly equal all pending paths. A protected shared-Git-directory
+record binds it to the preceding successful upgrade; a fabricated Task State
+receipt is not authority. Ambient Git repository/index overrides are scrubbed.
+The exact paths are staged and rechecked in a private Task State index, then the
+commit is created from that verified tree without hooks and the expected Task
+branch HEAD is advanced atomically. Only Agent Core-managed paths are
+accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
+scopes are rejected. After a successful commit it is consumed at
+`.task-state/automation-maintenance.consumed.json`; a subsequent successful
+upgrade with changes replaces the active receipt and removes the previous consumed
+receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
+receipt lifecycle evidence.
+
+Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
+this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -36,6 +36,25 @@ just agent::push <task>
 just agent::pr-create <task>
 ```
 
+The normal upgrade flow creates its receipt before verification. If a self-hosted
+pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
+normal verification and, before `automation::commit`, run the canonical recovery
+bridge:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+```
+
+The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
+pins the clean source revision, materializes the tracked `HEAD` Agent Core
+baseline, applies canonical upgrade semantics in isolation, and requires exact
+pending paths/content/modes plus Task identity and `HEAD` before issuing the
+existing receipt and protected authority. Product, Adapter, repository,
+secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
+with the existing `automation::commit` flow; ordinary `agent::commit` rejection
+and the receipt/authority design remain unchanged. This is the PR #79 review fix
+only; there are no Issue #77 changes.
+
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tomllib
@@ -15,6 +18,192 @@ from pathlib import Path, PurePosixPath
 
 class UpgradeError(RuntimeError):
     pass
+
+
+RECEIPT_NAME = "automation-maintenance.json"
+CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+RECEIPT_FIELDS = {
+    "schema_version",
+    "status",
+    "task_id",
+    "branch",
+    "worktree",
+    "source",
+    "source_revision",
+    "current_version",
+    "upstream_version",
+    "changed_paths",
+    "authority_head",
+    "authority_nonce",
+    "path_fingerprints",
+}
+_GIT_EXECUTABLE: Path | None = None
+
+
+def git_head(repo: Path) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def source_revision(source: Path) -> str | None:
+    value = git_head(source)
+    return value or None
+
+
+def receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / RECEIPT_NAME
+
+
+def consumed_receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+
+
+def common_git_dir(repo: Path) -> Path:
+    value = Path(run(["git", "rev-parse", "--git-common-dir"], cwd=repo).stdout.strip())
+    return value.resolve() if value.is_absolute() else (repo / value).resolve()
+
+
+def authority_path(repo: Path) -> Path:
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+
+
+def canonical_json(value: dict) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def receipt_digest(receipt: dict) -> str:
+    return hashlib.sha256(canonical_json(receipt)).hexdigest()
+
+
+def write_authority(repo: Path, receipt: dict) -> None:
+    atomic_json_write(
+        authority_path(repo),
+        {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        },
+    )
+
+
+def validate_authority(repo: Path, receipt: dict) -> None:
+    path = authority_path(repo)
+    try:
+        authority = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+    expected = {
+        "schema_version": 1,
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+    }
+    if authority != expected:
+        raise UpgradeError("automation receipt does not match successful-upgrade authority")
+
+
+def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
+    for path in paths:
+        relative = path.relative_to(repo).as_posix()
+        tracked = run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=repo,
+            check=False,
+        ).returncode == 0
+        if tracked:
+            raise UpgradeError(f"required Task State path is tracked: {relative}")
+        ignored = run(["git", "check-ignore", "-q", relative], cwd=repo, check=False).returncode == 0
+        if not ignored:
+            raise UpgradeError(f"required Task State path is not ignored: {relative}")
+
+
+def atomic_json_write(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
+    path = repo / Path(*raw_path.split("/"))
+    try:
+        state = path.lstat()
+    except FileNotFoundError:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    mode = stat.S_IMODE(state.st_mode)
+    if path.is_file() and not path.is_symlink():
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        return {"state": "file", "mode": mode, "content_sha256": digest}
+    if path.is_symlink():
+        digest = hashlib.sha256(os.readlink(path).encode("utf-8", "surrogateescape")).hexdigest()
+        return {"state": "symlink", "mode": mode, "content_sha256": digest}
+    if path.is_dir():
+        return {"state": "directory", "mode": mode, "content_sha256": None}
+    return {"state": "special", "mode": mode, "content_sha256": None}
+
+
+def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
+    if not TASK_ID_RE.fullmatch(task):
+        raise UpgradeError(f"invalid Task ID: {task!r}")
+    state_path = repo / ".task-state" / "task.md"
+    if not state_path.is_file():
+        raise UpgradeError("operation requires a Task worktree with Task State")
+    text = state_path.read_text(encoding="utf-8")
+    values: dict[str, str] = {}
+    for label in ("Task ID", "Branch", "Worktree"):
+        matches = re.findall(rf"(?m)^- {re.escape(label)}: (.+)$", text)
+        if len(matches) != 1 or not matches[0].strip():
+            raise UpgradeError(f"Task State must contain exactly one {label} identity field")
+        values[label] = matches[0].strip()
+    if values["Task ID"] != task:
+        raise UpgradeError("Task State identity does not match requested Task")
+    branch = values["Branch"]
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        raise UpgradeError(f"Task State branch is not the Task branch for {task}")
+    worktree = Path(values["Worktree"]).resolve()
+    if worktree != repo.resolve():
+        raise UpgradeError("Task State worktree does not match the current worktree")
+    return task, branch, worktree
+
+
+def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]]:
+    output = run(["git", "worktree", "list", "--porcelain"], cwd=repo).stdout
+    records: dict[Path, tuple[str | None, str | None]] = {}
+    current: dict[str, str] = {}
+    for line in output.splitlines() + [""]:
+        if not line:
+            if current.get("worktree"):
+                branch = current.get("branch", "").removeprefix("refs/heads/") or None
+                records[Path(current["worktree"]).resolve()] = (branch, current.get("HEAD"))
+            current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    return records
+
+
+def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
+    _, branch, worktree = parse_task_identity(repo, task)
+    registered = registered_worktrees(repo)
+    actual = registered.get(worktree)
+    if actual is None or actual[0] != branch:
+        raise UpgradeError("current Task worktree is not registered with the expected branch")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if not default:
+        raise UpgradeError("cannot resolve default branch")
+    if branch == default:
+        raise UpgradeError("operation refused on the default branch")
+    return task, branch, worktree
 
 
 @dataclass(frozen=True)
@@ -32,8 +221,58 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
-def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and key != "EMAIL"
+    }
+    if overrides:
+        environment.update(overrides)
+    return environment
+
+
+def git_executable() -> Path:
+    global _GIT_EXECUTABLE
+    if _GIT_EXECUTABLE is not None:
+        return _GIT_EXECUTABLE
+    candidate = shutil.which("git")
+    if not candidate:
+        raise UpgradeError("trusted Git executable is unavailable")
+    executable = Path(candidate).resolve()
+    try:
+        metadata = executable.stat()
+    except OSError as exc:
+        raise UpgradeError("trusted Git executable is unavailable") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+    ):
+        raise UpgradeError(f"Git executable is not root-owned and immutable: {executable}")
+    _GIT_EXECUTABLE = executable
+    return executable
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    env_overrides: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    is_git = bool(command and command[0] == "git")
+    environment = git_environment(env_overrides) if is_git else None
+    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    result = subprocess.run(
+        executable_command,
+        cwd=cwd,
+        text=True,
+        input=input_text,
+        capture_output=True,
+        env=environment,
+    )
     if check and result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         raise UpgradeError(f"{' '.join(command)}: {detail}")
@@ -41,8 +280,12 @@ def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.Comp
 
 
 def root() -> Path:
-    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
-    return Path(result.stdout.strip()).resolve()
+    installed_root = Path(__file__).resolve().parents[2]
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=installed_root)
+    discovered = Path(result.stdout.strip()).resolve()
+    if discovered != installed_root:
+        raise UpgradeError("installed Agent Core path does not match the Git worktree root")
+    return installed_root
 
 
 def version(repo: Path) -> str:
@@ -424,31 +667,45 @@ def build_plan(repo: Path, source: Path) -> dict:
     }
 
 
-def require_maintenance(repo: Path) -> None:
+def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    default = run(
-        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
-        cwd=repo,
-        check=False,
-    ).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    state = repo / ".task-state" / "task.md"
+    task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
+    if not task_match:
+        raise UpgradeError("upgrade requires a registered non-default Task branch")
+    task_id = task_match.group(1).strip()
+    identity = require_registered_task(repo, task_id)
+    require_ignored_untracked(
+        repo,
+        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+    )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+    return identity
 
 
 def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+    task_id, branch, worktree = require_maintenance(repo)
     plan = build_plan(repo, source)
     if plan["blockers"]:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    if not actionable:
+        return {
+            "status": "NO_CHANGES",
+            "repositoryRoot": str(repo),
+            "sourceCore": str(source_core),
+            "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+            "changedPaths": [],
+            "commitCreated": False,
+            "pushPerformed": False,
+            "mergePerformed": False,
+            "requiredNextChecks": [],
+        }
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
     preflight_blockers: list[str] = []
     for item in actionable:
@@ -516,7 +773,7 @@ def apply(repo: Path, source: Path) -> dict:
         else:
             raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
-    return {
+    result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
         "sourceCore": str(source_core),
@@ -532,6 +789,246 @@ def apply(repo: Path, source: Path) -> dict:
             "repository CI/smoke tests",
         ],
     }
+    changed_paths = sorted(set(changed))
+    result["changedPaths"] = changed_paths
+    receipt = {
+        "schema_version": 1,
+        "status": "active",
+        "task_id": task_id,
+        "branch": branch,
+        "worktree": str(worktree),
+        "source": str(source.resolve()),
+        "source_revision": source_revision(source),
+        "current_version": plan["currentVersion"],
+        "upstream_version": plan["upstreamVersion"],
+        "changed_paths": changed_paths,
+        "authority_head": git_head(repo),
+        "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return result
+
+
+def pending_paths(repo: Path) -> list[str]:
+    paths: set[str] = set()
+    for args in (
+        ("diff", "--no-ext-diff", "--name-only"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only"),
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
+        output = run(["git", *args], cwd=repo).stdout
+        paths.update(output.splitlines())
+    return sorted(paths)
+
+
+def validate_receipt_path(raw: object) -> str:
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise UpgradeError("receipt contains an unsafe path")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts) or pure.as_posix() != raw:
+        raise UpgradeError(f"receipt contains an unnormalized path: {raw!r}")
+    return raw
+
+
+def receipt_paths(repo: Path, receipt: dict) -> list[str]:
+    raw = receipt.get("changed_paths")
+    if not isinstance(raw, list) or not raw:
+        raise UpgradeError("automation receipt has no changed paths")
+    paths = [validate_receipt_path(item) for item in raw]
+    if paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise UpgradeError("automation receipt paths must be sorted and unique")
+    secret_file = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(secret_file.read_text(encoding="utf-8")) if secret_file.is_file() else {}
+    secrets = policy.get("paths", {}).get("secret_patterns", [])
+    for path in paths:
+        relative = Path(*path.split("/"))
+        if path == ".task-state" or path.startswith(".task-state/") or not managed(relative):
+            raise UpgradeError(f"receipt path is not Agent Core managed: {path}")
+        if any(token.lower() in path.lower() for token in secrets):
+            raise UpgradeError(f"receipt path matches a configured secret pattern: {path}")
+    return paths
+
+
+def validate_receipt_schema(receipt: object) -> dict:
+    if not isinstance(receipt, dict) or set(receipt) != RECEIPT_FIELDS:
+        raise UpgradeError("automation upgrade receipt has an invalid schema")
+    if receipt.get("schema_version") != 1 or receipt.get("status") != "active":
+        raise UpgradeError("unsupported automation upgrade receipt")
+    required_strings = (
+        "task_id",
+        "branch",
+        "worktree",
+        "source",
+        "current_version",
+        "upstream_version",
+        "authority_head",
+        "authority_nonce",
+    )
+    if any(not isinstance(receipt.get(field), str) or not receipt[field] for field in required_strings):
+        raise UpgradeError("automation upgrade receipt has invalid provenance fields")
+    revision = receipt.get("source_revision")
+    if revision is not None and (not isinstance(revision, str) or not revision):
+        raise UpgradeError("automation upgrade receipt has an invalid source revision")
+    if not Path(receipt["source"]).is_absolute():
+        raise UpgradeError("automation upgrade receipt source must be absolute")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", receipt["authority_head"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority HEAD")
+    if not re.fullmatch(r"[0-9a-f]{64}", receipt["authority_nonce"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority nonce")
+    return receipt
+
+
+def staged_fingerprint(
+    repo: Path,
+    path: str,
+    *,
+    env_overrides: dict[str, str],
+) -> dict[str, object]:
+    entry = run(
+        ["git", "ls-files", "--stage", "--", path],
+        cwd=repo,
+        env_overrides=env_overrides,
+    ).stdout.strip()
+    if not entry:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    fields = entry.split(maxsplit=3)
+    if len(fields) != 4 or fields[2] != "0":
+        raise UpgradeError(f"staged path has an unsupported index entry: {path}")
+    mode = fields[0]
+    result = subprocess.run(
+        [str(git_executable()), "show", f":{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(env_overrides),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read staged content for {path}")
+    if mode not in {"100644", "100755"}:
+        raise UpgradeError(f"staged path has an unsupported mode: {path}")
+    return {
+        "state": "file",
+        "mode": 0o755 if mode == "100755" else 0o644,
+        "content_sha256": hashlib.sha256(result.stdout).hexdigest(),
+    }
+
+
+def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
+    if not isinstance(fingerprint, dict):
+        raise UpgradeError("automation receipt contains an invalid path fingerprint")
+    state = fingerprint.get("state")
+    if state == "absent":
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    if state != "file" or not isinstance(fingerprint.get("mode"), int):
+        raise UpgradeError("automation receipt authorizes an unsupported path state")
+    digest = fingerprint.get("content_sha256")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise UpgradeError("automation receipt contains an invalid content fingerprint")
+    return {
+        "state": "file",
+        "mode": 0o755 if fingerprint["mode"] & 0o111 else 0o644,
+        "content_sha256": digest,
+    }
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+    _, branch, worktree = require_registered_task(repo, task)
+    active = receipt_path(repo)
+    private_index = repo / ".task-state" / "automation-maintenance.index"
+    require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
+    if not active.is_file():
+        raise UpgradeError("no active successful automation upgrade receipt")
+    try:
+        receipt = json.loads(active.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt = validate_receipt_schema(receipt)
+    if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    if receipt.get("authority_head") != git_head(repo):
+        raise UpgradeError("automation receipt authority HEAD is stale")
+    paths = receipt_paths(repo, receipt)
+    fingerprints = receipt.get("path_fingerprints")
+    if not isinstance(fingerprints, dict) or set(fingerprints) != set(paths):
+        raise UpgradeError("automation receipt fingerprints do not match its paths")
+    if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+        raise UpgradeError("automation receipt path content/state fingerprint changed")
+    if pending_paths(repo) != paths:
+        raise UpgradeError("pending paths do not exactly match the automation receipt")
+    validate_authority(repo, receipt)
+
+    consumed = consumed_receipt_path(repo)
+    os.replace(active, consumed)
+    consumed_receipt = dict(receipt)
+    consumed_receipt["status"] = "consumed"
+    consumed_receipt["commit_sha"] = None
+    atomic_json_write(consumed, consumed_receipt)
+    authority = authority_path(repo)
+    authority.unlink(missing_ok=True)
+    private_index.unlink(missing_ok=True)
+    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    committed = False
+    commit_sha = ""
+    try:
+        run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
+        run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
+        run(
+            ["git", "diff", "--no-ext-diff", "--cached", "--check"],
+            cwd=repo,
+            env_overrides=index_environment,
+        )
+        staged = sorted(
+            run(
+                ["git", "diff", "--no-ext-diff", "--cached", "--name-only"],
+                cwd=repo,
+                env_overrides=index_environment,
+            ).stdout.splitlines()
+        )
+        if staged != paths:
+            raise UpgradeError("staged paths do not exactly match the automation receipt")
+        if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+            raise UpgradeError("automation receipt path changed while staging")
+        for path in paths:
+            if staged_fingerprint(
+                repo,
+                path,
+                env_overrides=index_environment,
+            ) != normalized_git_fingerprint(fingerprints[path]):
+                raise UpgradeError(f"staged content does not match the automation receipt: {path}")
+        commit_message = message.strip() or f"task: {task}"
+        if task not in commit_message:
+            commit_message = f"{commit_message}\n\nTask: {task}"
+        tree = run(
+            ["git", "write-tree"],
+            cwd=repo,
+            env_overrides=index_environment,
+        ).stdout.strip()
+        expected_head = receipt["authority_head"]
+        commit_sha = run(
+            ["git", "commit-tree", tree, "-p", expected_head],
+            cwd=repo,
+            input_text=commit_message + "\n",
+        ).stdout.strip()
+        run(
+            ["git", "update-ref", f"refs/heads/{branch}", commit_sha, expected_head],
+            cwd=repo,
+        )
+        committed = True
+        consumed_receipt["commit_sha"] = commit_sha
+        atomic_json_write(consumed, consumed_receipt)
+        run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
+    except UpgradeError:
+        if not committed and not active.exists():
+            atomic_json_write(active, receipt)
+            write_authority(repo, receipt)
+            consumed.unlink(missing_ok=True)
+        raise
+    finally:
+        private_index.unlink(missing_ok=True)
+    return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 
 def parser() -> argparse.ArgumentParser:
@@ -542,6 +1039,9 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    commit_parser = sub.add_parser("commit")
+    commit_parser.add_argument("task")
+    commit_parser.add_argument("message", nargs="?", default="")
     return p
 
 
@@ -555,6 +1055,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "commit":
+            result = commit(repo, args.task, args.message)
         else:  # pragma: no cover
             raise UpgradeError(f"unsupported command: {args.command}")
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tomllib
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
@@ -196,7 +197,18 @@ def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
     _, branch, worktree = parse_task_identity(repo, task)
     registered = registered_worktrees(repo)
     actual = registered.get(worktree)
-    if actual is None or actual[0] != branch:
+    current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    head = git_head(repo)
+    branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo, check=False).stdout.strip()
+    if (
+        actual is None
+        or current_branch != branch
+        or actual[0] != branch
+        or not head
+        or not branch_oid
+        or actual[1] != head
+        or branch_oid != head
+    ):
         raise UpgradeError("current Task worktree is not registered with the expected branch")
     default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
     if not default:
@@ -322,6 +334,36 @@ def resolve_source(path: Path | None) -> Path:
     if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
         raise UpgradeError(f"not a Templates source checkout: {source}")
     return source
+
+
+def git_bytes(command: list[str], *, cwd: Path) -> bytes:
+    if not command or command[0] != "git":
+        raise UpgradeError("byte helper only accepts Git commands")
+    result = subprocess.run(
+        [str(git_executable()), *command[1:]],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result.stdout
+
+
+def resolve_pinned_source(path: Path) -> tuple[Path, str]:
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    status = git_bytes(
+        ["git", "status", "--porcelain=v1", "-z", "--", "components/agent-core"], cwd=source
+    )
+    if status:
+        raise UpgradeError("source components/agent-core must be clean")
+    return source, head
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -621,6 +663,124 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
     return Action(rel, "replace", "Agent Core-owned path")
 
 
+def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
+    result = subprocess.run(
+        [str(git_executable()), "show", f"{revision}:{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read Git object {path}")
+    return result.stdout
+
+
+def materialize_tree(
+    repo: Path, revision: str, destination: Path, prefix: str = "", *, surface_only: bool = False
+) -> None:
+    entries = git_bytes(["git", "ls-tree", "-r", "-z", revision, "--", prefix or "."], cwd=repo).split(b"\0")
+    destination.mkdir(parents=True, exist_ok=True)
+    prefix_bytes = (prefix.rstrip("/") + "/").encode() if prefix else b""
+    for entry in entries:
+        if not entry:
+            continue
+        header, raw_path = entry.split(b"\t", 1)
+        fields = header.split()
+        if prefix_bytes and not raw_path.startswith(prefix_bytes):
+            raise UpgradeError("Git returned an unexpected snapshot path")
+        relative_raw = raw_path[len(prefix_bytes):] if prefix_bytes else raw_path
+        try:
+            relative_text = relative_raw.decode("utf-8")
+            relative = PurePosixPath(relative_text)
+        except UnicodeDecodeError as exc:
+            raise UpgradeError("snapshot contains a non-UTF-8 path") from exc
+        if surface_only and not (
+            relative_text in {"AGENTS.md", "Justfile", "opencode.json"}
+            or relative_text.startswith(".automation/")
+            or relative_text.startswith(".opencode/")
+        ):
+            continue
+        if len(fields) != 3 or fields[0] not in {b"100644", b"100755"} or fields[1] != b"blob":
+            raise UpgradeError("Agent Core snapshot contains a symlink, submodule, or special Git entry")
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or relative.as_posix() != relative_text
+        ):
+            raise UpgradeError("snapshot contains an unsafe or unnormalized path")
+        target = destination.joinpath(*relative.parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(git_object_bytes(repo, revision, raw_path.decode("utf-8")))
+        target.chmod(0o755 if fields[0] == b"100755" else 0o644)
+
+
+def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        if item["action"] == "delete":
+            target = tree / relative
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                blockers.append(f"{item['path']}: delete has symlink ancestor {ancestor.as_posix()}")
+                continue
+            if path_present(target) and not (target.is_symlink() or target.is_file()):
+                blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(tree, relative, planned_deletes)
+            if blocker:
+                blockers.append(f"{item['path']}: {blocker}")
+    if blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(blockers))
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered = sorted(
+        [item for item in actionable if item["path"] != ".automation/VERSION"],
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + [item for item in actionable if item["path"] == ".automation/VERSION"]
+    changed: list[str] = []
+    for item in ordered:
+        relative = Path(item["path"])
+        target = tree / relative
+        source = source_core / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if target.is_symlink() or target.is_file():
+                target.unlink()
+            elif path_present(target):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+        else:
+            blocker = write_topology_blocker(tree, relative, set())
+            if blocker:
+                raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {blocker}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
+            if item["action"] in {"create", "replace"}:
+                shutil.copy2(source, target)
+            elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+                merged, detail = replace_agent_rules(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            elif item["action"] == "merge" and item["path"] == "Justfile":
+                merged, detail = merge_just_router(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            else:
+                raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
+    return sorted(set(changed))
+
+
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
@@ -706,73 +866,7 @@ def apply(repo: Path, source: Path) -> dict:
             "mergePerformed": False,
             "requiredNextChecks": [],
         }
-    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
-    preflight_blockers: list[str] = []
-    for item in actionable:
-        relative = Path(item["path"])
-        destination = repo / relative
-        if item["action"] == "delete":
-            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
-                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
-        else:
-            blocker = write_topology_blocker(repo, relative, planned_deletes)
-            if blocker:
-                preflight_blockers.append(f"{item['path']}: {blocker}")
-    if preflight_blockers:
-        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
-
-    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
-    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
-    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
-    ordered_actions = sorted(
-        ordinary_actions,
-        key=lambda item: (phases.get(item["action"], 99), item["path"]),
-    ) + version_actions
-    for item in ordered_actions:
-        relative = Path(item["path"])
-        source_path = source_core / relative
-        destination = repo / relative
-        if item["action"] == "delete":
-            ancestor = symlink_ancestor(repo, relative)
-            if ancestor is not None:
-                raise UpgradeError(
-                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
-                )
-            if destination.is_symlink() or destination.is_file():
-                destination.unlink()
-            elif path_present(destination):
-                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
-            changed.append(item["path"])
-            continue
-        topology_blocker = write_topology_blocker(repo, relative, set())
-        if topology_blocker:
-            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        if item["action"] in {"create", "replace"}:
-            if destination.is_symlink():
-                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
-            shutil.copy2(source_path, destination)
-        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
-            if destination.is_symlink():
-                raise UpgradeError("AGENTS.md became a symlink after planning")
-            merged, detail = replace_agent_rules(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        elif item["action"] == "merge" and item["path"] == "Justfile":
-            if destination.is_symlink():
-                raise UpgradeError("Justfile became a symlink after planning")
-            merged, detail = merge_just_router(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        else:
-            raise UpgradeError(f"unsupported upgrade action: {item}")
-        changed.append(item["path"])
+    changed = apply_plan_to_tree(repo, source_core, plan)
     result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -815,13 +909,117 @@ def apply(repo: Path, source: Path) -> dict:
 def pending_paths(repo: Path) -> list[str]:
     paths: set[str] = set()
     for args in (
-        ("diff", "--no-ext-diff", "--name-only"),
-        ("diff", "--no-ext-diff", "--cached", "--name-only"),
-        ("ls-files", "--others", "--exclude-standard"),
+        ("diff", "--no-ext-diff", "--name-only", "-z"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only", "-z"),
+        ("ls-files", "--others", "--exclude-standard", "-z"),
     ):
-        output = run(["git", *args], cwd=repo).stdout
-        paths.update(output.splitlines())
+        output = git_bytes(["git", *args], cwd=repo)
+        for raw in output.split(b"\0"):
+            if not raw:
+                continue
+            try:
+                paths.add(raw.decode("utf-8"))
+            except UnicodeDecodeError as exc:
+                raise UpgradeError("Git reported a non-UTF-8 pending path") from exc
     return sorted(paths)
+
+
+def bootstrap_fingerprint(tree: Path, raw_path: str) -> dict[str, object]:
+    return file_fingerprint(tree, raw_path)
+
+
+def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
+    path = validate_receipt_path(raw_path)
+    relative = Path(*path.split("/"))
+    policy_path = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(policy_path.read_text(encoding="utf-8")) if policy_path.is_file() else {}
+    secret_patterns = policy.get("paths", {}).get("secret_patterns", [])
+    if path == ".task-state" or path.startswith(".task-state/"):
+        raise UpgradeError(f"pending path is Task State: {path}")
+    if any(token.lower() in path.lower() for token in secret_patterns):
+        raise UpgradeError(f"pending path matches a configured secret pattern: {path}")
+    if path.startswith("just/project/") or path == "just/local.just":
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path.startswith(".github/"):
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path == ".automation/ADAPTER" or path == ".automation/INIT.fragment.md" or path == ".automation/adoption.toml":
+        raise UpgradeError(f"pending path is Adapter-owned: {path}")
+    if not managed(relative):
+        raise UpgradeError(f"pending path is outside Agent Core: {path}")
+
+
+def bootstrap_receipt(repo: Path, source: Path) -> dict:
+    task_id, branch, worktree = require_maintenance(repo)
+    authority_head = git_head(repo)
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
+    if receipt_path(repo).exists() or authority_path(repo).exists():
+        raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    pending = pending_paths(repo)
+    if not pending:
+        raise UpgradeError("bootstrap requires non-empty pending paths")
+    for path in pending:
+        reject_bootstrap_path(repo, path)
+    source, source_head = resolve_pinned_source(source)
+    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+        baseline = Path(temporary) / "baseline"
+        source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
+        materialize_tree(repo, authority_head, baseline, surface_only=True)
+        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        before = {
+            p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
+            for p in baseline.rglob("*") if p.is_file()
+        }
+        plan = build_plan(baseline, source_snapshot.parent.parent)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [
+            migration for migration in load_migrations(source_snapshot)
+            if migration.to_version <= version_number(source_snapshot)
+        ]
+        _, migration_blockers, _ = migration_actions(repo, selected)
+        if migration_blockers:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(migration_blockers))
+        apply_plan_to_tree(baseline, source_snapshot, plan)
+        returned = set(item["path"] for item in plan["actions"] if item["action"] != "noop")
+        expected = sorted(
+            path for path in returned
+            if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+            != bootstrap_fingerprint(baseline, path)
+        )
+        if expected != pending:
+            raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
+        if not expected:
+            return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+    pinned_source, current_source_head = resolve_pinned_source(source)
+    if pinned_source != source or current_source_head != source_head:
+        raise UpgradeError("source changed during receipt reconstruction")
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed during receipt reconstruction")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed during receipt reconstruction")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content does not match the reconstructed upgrade")
+    receipt = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": str(source.resolve()), "source_revision": source_head,
+        "current_version": plan["currentVersion"], "upstream_version": plan["upstreamVersion"],
+        "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": current_fingerprints,
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1039,6 +1237,8 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    bootstrap = sub.add_parser("bootstrap-receipt")
+    bootstrap.add_argument("--source", type=Path, required=True)
     commit_parser = sub.add_parser("commit")
     commit_parser.add_argument("task")
     commit_parser.add_argument("message", nargs="?", default="")
@@ -1055,6 +1255,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "bootstrap-receipt":
+            result = bootstrap_receipt(repo, resolve_source(args.source))
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/templates/agent-nix/.automation/just/automation.just
+++ b/templates/agent-nix/.automation/just/automation.just
@@ -1,11 +1,18 @@
 root := justfile_directory() / ".." / ".."
 script := root / ".automation" / "bin" / "automation_upgrade.py"
 
+[working-directory: root]
 version:
-    python3 '{{script}}' version
+    python3 {{quote(script)}} version
 
+[working-directory: root]
 check-update source:
-    python3 '{{script}}' check-update --source '{{source}}'
+    python3 {{quote(script)}} check-update --source {{quote(source)}}
 
+[working-directory: root]
 upgrade source:
-    python3 '{{script}}' upgrade --source '{{source}}'
+    python3 {{quote(script)}} upgrade --source {{quote(source)}}
+
+[working-directory: root]
+commit task message="":
+    python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-nix/.automation/just/automation.just
+++ b/templates/agent-nix/.automation/just/automation.just
@@ -14,5 +14,9 @@ upgrade source:
     python3 {{quote(script)}} upgrade --source {{quote(source)}}
 
 [working-directory: root]
+bootstrap-receipt source:
+    python3 {{quote(script)}} bootstrap-receipt --source {{quote(source)}}
+
+[working-directory: root]
 commit task message="":
     python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-nix/opencode.json
+++ b/templates/agent-nix/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::bootstrap-receipt *": "ask",
       "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",

--- a/templates/agent-nix/opencode.json
+++ b/templates/agent-nix/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -11,3 +11,48 @@ The current implementation provides guarded Task-local commit/push/PR operations
 integration head-SHA checkpoints, disposable Task State templates, and common
 safety policy. Repository-local OpenCode agents and permissions are added by the
 separate OpenCode configuration work.
+
+## Automation Maintenance workflow
+
+An Agent Core upgrade is permitted only from a dedicated registered, non-default
+Automation Maintenance Task. From that Task worktree, use a trusted local
+Templates checkout as the source:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
+```
+
+The environment variable is an upgrade opt-in only. It does not authorize a
+commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
+Upgrade does not commit, push, or merge and writes the ignored receipt
+`.task-state/automation-maintenance.json`.
+
+Before publication, execute `git diff --check`, `just agent::doctor`,
+`just project::check`, and the repository CI/smoke suite. Then publish only with:
+
+```sh
+just automation::commit <task> [message]
+just agent::push <task>
+just agent::pr-create <task>
+```
+
+The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
+`worktree`), source/source revision, current/upstream versions, sorted unique
+`changed_paths`, `authority_head`, and exact per-path content/state
+`path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
+stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
+or does not exactly equal all pending paths. A protected shared-Git-directory
+record binds it to the preceding successful upgrade; a fabricated Task State
+receipt is not authority. Ambient Git repository/index overrides are scrubbed.
+The exact paths are staged and rechecked in a private Task State index, then the
+commit is created from that verified tree without hooks and the expected Task
+branch HEAD is advanced atomically. Only Agent Core-managed paths are
+accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
+scopes are rejected. After a successful commit it is consumed at
+`.task-state/automation-maintenance.consumed.json`; a subsequent successful
+upgrade with changes replaces the active receipt and removes the previous consumed
+receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
+receipt lifecycle evidence.
+
+Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
+this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -36,6 +36,25 @@ just agent::push <task>
 just agent::pr-create <task>
 ```
 
+The normal upgrade flow creates its receipt before verification. If a self-hosted
+pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
+normal verification and, before `automation::commit`, run the canonical recovery
+bridge:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+```
+
+The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
+pins the clean source revision, materializes the tracked `HEAD` Agent Core
+baseline, applies canonical upgrade semantics in isolation, and requires exact
+pending paths/content/modes plus Task identity and `HEAD` before issuing the
+existing receipt and protected authority. Product, Adapter, repository,
+secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
+with the existing `automation::commit` flow; ordinary `agent::commit` rejection
+and the receipt/authority design remain unchanged. This is the PR #79 review fix
+only; there are no Issue #77 changes.
+
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tomllib
@@ -15,6 +18,192 @@ from pathlib import Path, PurePosixPath
 
 class UpgradeError(RuntimeError):
     pass
+
+
+RECEIPT_NAME = "automation-maintenance.json"
+CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+RECEIPT_FIELDS = {
+    "schema_version",
+    "status",
+    "task_id",
+    "branch",
+    "worktree",
+    "source",
+    "source_revision",
+    "current_version",
+    "upstream_version",
+    "changed_paths",
+    "authority_head",
+    "authority_nonce",
+    "path_fingerprints",
+}
+_GIT_EXECUTABLE: Path | None = None
+
+
+def git_head(repo: Path) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def source_revision(source: Path) -> str | None:
+    value = git_head(source)
+    return value or None
+
+
+def receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / RECEIPT_NAME
+
+
+def consumed_receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+
+
+def common_git_dir(repo: Path) -> Path:
+    value = Path(run(["git", "rev-parse", "--git-common-dir"], cwd=repo).stdout.strip())
+    return value.resolve() if value.is_absolute() else (repo / value).resolve()
+
+
+def authority_path(repo: Path) -> Path:
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+
+
+def canonical_json(value: dict) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def receipt_digest(receipt: dict) -> str:
+    return hashlib.sha256(canonical_json(receipt)).hexdigest()
+
+
+def write_authority(repo: Path, receipt: dict) -> None:
+    atomic_json_write(
+        authority_path(repo),
+        {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        },
+    )
+
+
+def validate_authority(repo: Path, receipt: dict) -> None:
+    path = authority_path(repo)
+    try:
+        authority = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+    expected = {
+        "schema_version": 1,
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+    }
+    if authority != expected:
+        raise UpgradeError("automation receipt does not match successful-upgrade authority")
+
+
+def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
+    for path in paths:
+        relative = path.relative_to(repo).as_posix()
+        tracked = run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=repo,
+            check=False,
+        ).returncode == 0
+        if tracked:
+            raise UpgradeError(f"required Task State path is tracked: {relative}")
+        ignored = run(["git", "check-ignore", "-q", relative], cwd=repo, check=False).returncode == 0
+        if not ignored:
+            raise UpgradeError(f"required Task State path is not ignored: {relative}")
+
+
+def atomic_json_write(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
+    path = repo / Path(*raw_path.split("/"))
+    try:
+        state = path.lstat()
+    except FileNotFoundError:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    mode = stat.S_IMODE(state.st_mode)
+    if path.is_file() and not path.is_symlink():
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        return {"state": "file", "mode": mode, "content_sha256": digest}
+    if path.is_symlink():
+        digest = hashlib.sha256(os.readlink(path).encode("utf-8", "surrogateescape")).hexdigest()
+        return {"state": "symlink", "mode": mode, "content_sha256": digest}
+    if path.is_dir():
+        return {"state": "directory", "mode": mode, "content_sha256": None}
+    return {"state": "special", "mode": mode, "content_sha256": None}
+
+
+def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
+    if not TASK_ID_RE.fullmatch(task):
+        raise UpgradeError(f"invalid Task ID: {task!r}")
+    state_path = repo / ".task-state" / "task.md"
+    if not state_path.is_file():
+        raise UpgradeError("operation requires a Task worktree with Task State")
+    text = state_path.read_text(encoding="utf-8")
+    values: dict[str, str] = {}
+    for label in ("Task ID", "Branch", "Worktree"):
+        matches = re.findall(rf"(?m)^- {re.escape(label)}: (.+)$", text)
+        if len(matches) != 1 or not matches[0].strip():
+            raise UpgradeError(f"Task State must contain exactly one {label} identity field")
+        values[label] = matches[0].strip()
+    if values["Task ID"] != task:
+        raise UpgradeError("Task State identity does not match requested Task")
+    branch = values["Branch"]
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        raise UpgradeError(f"Task State branch is not the Task branch for {task}")
+    worktree = Path(values["Worktree"]).resolve()
+    if worktree != repo.resolve():
+        raise UpgradeError("Task State worktree does not match the current worktree")
+    return task, branch, worktree
+
+
+def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]]:
+    output = run(["git", "worktree", "list", "--porcelain"], cwd=repo).stdout
+    records: dict[Path, tuple[str | None, str | None]] = {}
+    current: dict[str, str] = {}
+    for line in output.splitlines() + [""]:
+        if not line:
+            if current.get("worktree"):
+                branch = current.get("branch", "").removeprefix("refs/heads/") or None
+                records[Path(current["worktree"]).resolve()] = (branch, current.get("HEAD"))
+            current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    return records
+
+
+def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
+    _, branch, worktree = parse_task_identity(repo, task)
+    registered = registered_worktrees(repo)
+    actual = registered.get(worktree)
+    if actual is None or actual[0] != branch:
+        raise UpgradeError("current Task worktree is not registered with the expected branch")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if not default:
+        raise UpgradeError("cannot resolve default branch")
+    if branch == default:
+        raise UpgradeError("operation refused on the default branch")
+    return task, branch, worktree
 
 
 @dataclass(frozen=True)
@@ -32,8 +221,58 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
-def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and key != "EMAIL"
+    }
+    if overrides:
+        environment.update(overrides)
+    return environment
+
+
+def git_executable() -> Path:
+    global _GIT_EXECUTABLE
+    if _GIT_EXECUTABLE is not None:
+        return _GIT_EXECUTABLE
+    candidate = shutil.which("git")
+    if not candidate:
+        raise UpgradeError("trusted Git executable is unavailable")
+    executable = Path(candidate).resolve()
+    try:
+        metadata = executable.stat()
+    except OSError as exc:
+        raise UpgradeError("trusted Git executable is unavailable") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+    ):
+        raise UpgradeError(f"Git executable is not root-owned and immutable: {executable}")
+    _GIT_EXECUTABLE = executable
+    return executable
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    env_overrides: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    is_git = bool(command and command[0] == "git")
+    environment = git_environment(env_overrides) if is_git else None
+    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    result = subprocess.run(
+        executable_command,
+        cwd=cwd,
+        text=True,
+        input=input_text,
+        capture_output=True,
+        env=environment,
+    )
     if check and result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         raise UpgradeError(f"{' '.join(command)}: {detail}")
@@ -41,8 +280,12 @@ def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.Comp
 
 
 def root() -> Path:
-    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
-    return Path(result.stdout.strip()).resolve()
+    installed_root = Path(__file__).resolve().parents[2]
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=installed_root)
+    discovered = Path(result.stdout.strip()).resolve()
+    if discovered != installed_root:
+        raise UpgradeError("installed Agent Core path does not match the Git worktree root")
+    return installed_root
 
 
 def version(repo: Path) -> str:
@@ -424,31 +667,45 @@ def build_plan(repo: Path, source: Path) -> dict:
     }
 
 
-def require_maintenance(repo: Path) -> None:
+def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    default = run(
-        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
-        cwd=repo,
-        check=False,
-    ).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    state = repo / ".task-state" / "task.md"
+    task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
+    if not task_match:
+        raise UpgradeError("upgrade requires a registered non-default Task branch")
+    task_id = task_match.group(1).strip()
+    identity = require_registered_task(repo, task_id)
+    require_ignored_untracked(
+        repo,
+        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+    )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+    return identity
 
 
 def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+    task_id, branch, worktree = require_maintenance(repo)
     plan = build_plan(repo, source)
     if plan["blockers"]:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    if not actionable:
+        return {
+            "status": "NO_CHANGES",
+            "repositoryRoot": str(repo),
+            "sourceCore": str(source_core),
+            "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+            "changedPaths": [],
+            "commitCreated": False,
+            "pushPerformed": False,
+            "mergePerformed": False,
+            "requiredNextChecks": [],
+        }
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
     preflight_blockers: list[str] = []
     for item in actionable:
@@ -516,7 +773,7 @@ def apply(repo: Path, source: Path) -> dict:
         else:
             raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
-    return {
+    result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
         "sourceCore": str(source_core),
@@ -532,6 +789,246 @@ def apply(repo: Path, source: Path) -> dict:
             "repository CI/smoke tests",
         ],
     }
+    changed_paths = sorted(set(changed))
+    result["changedPaths"] = changed_paths
+    receipt = {
+        "schema_version": 1,
+        "status": "active",
+        "task_id": task_id,
+        "branch": branch,
+        "worktree": str(worktree),
+        "source": str(source.resolve()),
+        "source_revision": source_revision(source),
+        "current_version": plan["currentVersion"],
+        "upstream_version": plan["upstreamVersion"],
+        "changed_paths": changed_paths,
+        "authority_head": git_head(repo),
+        "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return result
+
+
+def pending_paths(repo: Path) -> list[str]:
+    paths: set[str] = set()
+    for args in (
+        ("diff", "--no-ext-diff", "--name-only"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only"),
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
+        output = run(["git", *args], cwd=repo).stdout
+        paths.update(output.splitlines())
+    return sorted(paths)
+
+
+def validate_receipt_path(raw: object) -> str:
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise UpgradeError("receipt contains an unsafe path")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts) or pure.as_posix() != raw:
+        raise UpgradeError(f"receipt contains an unnormalized path: {raw!r}")
+    return raw
+
+
+def receipt_paths(repo: Path, receipt: dict) -> list[str]:
+    raw = receipt.get("changed_paths")
+    if not isinstance(raw, list) or not raw:
+        raise UpgradeError("automation receipt has no changed paths")
+    paths = [validate_receipt_path(item) for item in raw]
+    if paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise UpgradeError("automation receipt paths must be sorted and unique")
+    secret_file = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(secret_file.read_text(encoding="utf-8")) if secret_file.is_file() else {}
+    secrets = policy.get("paths", {}).get("secret_patterns", [])
+    for path in paths:
+        relative = Path(*path.split("/"))
+        if path == ".task-state" or path.startswith(".task-state/") or not managed(relative):
+            raise UpgradeError(f"receipt path is not Agent Core managed: {path}")
+        if any(token.lower() in path.lower() for token in secrets):
+            raise UpgradeError(f"receipt path matches a configured secret pattern: {path}")
+    return paths
+
+
+def validate_receipt_schema(receipt: object) -> dict:
+    if not isinstance(receipt, dict) or set(receipt) != RECEIPT_FIELDS:
+        raise UpgradeError("automation upgrade receipt has an invalid schema")
+    if receipt.get("schema_version") != 1 or receipt.get("status") != "active":
+        raise UpgradeError("unsupported automation upgrade receipt")
+    required_strings = (
+        "task_id",
+        "branch",
+        "worktree",
+        "source",
+        "current_version",
+        "upstream_version",
+        "authority_head",
+        "authority_nonce",
+    )
+    if any(not isinstance(receipt.get(field), str) or not receipt[field] for field in required_strings):
+        raise UpgradeError("automation upgrade receipt has invalid provenance fields")
+    revision = receipt.get("source_revision")
+    if revision is not None and (not isinstance(revision, str) or not revision):
+        raise UpgradeError("automation upgrade receipt has an invalid source revision")
+    if not Path(receipt["source"]).is_absolute():
+        raise UpgradeError("automation upgrade receipt source must be absolute")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", receipt["authority_head"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority HEAD")
+    if not re.fullmatch(r"[0-9a-f]{64}", receipt["authority_nonce"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority nonce")
+    return receipt
+
+
+def staged_fingerprint(
+    repo: Path,
+    path: str,
+    *,
+    env_overrides: dict[str, str],
+) -> dict[str, object]:
+    entry = run(
+        ["git", "ls-files", "--stage", "--", path],
+        cwd=repo,
+        env_overrides=env_overrides,
+    ).stdout.strip()
+    if not entry:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    fields = entry.split(maxsplit=3)
+    if len(fields) != 4 or fields[2] != "0":
+        raise UpgradeError(f"staged path has an unsupported index entry: {path}")
+    mode = fields[0]
+    result = subprocess.run(
+        [str(git_executable()), "show", f":{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(env_overrides),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read staged content for {path}")
+    if mode not in {"100644", "100755"}:
+        raise UpgradeError(f"staged path has an unsupported mode: {path}")
+    return {
+        "state": "file",
+        "mode": 0o755 if mode == "100755" else 0o644,
+        "content_sha256": hashlib.sha256(result.stdout).hexdigest(),
+    }
+
+
+def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
+    if not isinstance(fingerprint, dict):
+        raise UpgradeError("automation receipt contains an invalid path fingerprint")
+    state = fingerprint.get("state")
+    if state == "absent":
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    if state != "file" or not isinstance(fingerprint.get("mode"), int):
+        raise UpgradeError("automation receipt authorizes an unsupported path state")
+    digest = fingerprint.get("content_sha256")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise UpgradeError("automation receipt contains an invalid content fingerprint")
+    return {
+        "state": "file",
+        "mode": 0o755 if fingerprint["mode"] & 0o111 else 0o644,
+        "content_sha256": digest,
+    }
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+    _, branch, worktree = require_registered_task(repo, task)
+    active = receipt_path(repo)
+    private_index = repo / ".task-state" / "automation-maintenance.index"
+    require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
+    if not active.is_file():
+        raise UpgradeError("no active successful automation upgrade receipt")
+    try:
+        receipt = json.loads(active.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt = validate_receipt_schema(receipt)
+    if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    if receipt.get("authority_head") != git_head(repo):
+        raise UpgradeError("automation receipt authority HEAD is stale")
+    paths = receipt_paths(repo, receipt)
+    fingerprints = receipt.get("path_fingerprints")
+    if not isinstance(fingerprints, dict) or set(fingerprints) != set(paths):
+        raise UpgradeError("automation receipt fingerprints do not match its paths")
+    if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+        raise UpgradeError("automation receipt path content/state fingerprint changed")
+    if pending_paths(repo) != paths:
+        raise UpgradeError("pending paths do not exactly match the automation receipt")
+    validate_authority(repo, receipt)
+
+    consumed = consumed_receipt_path(repo)
+    os.replace(active, consumed)
+    consumed_receipt = dict(receipt)
+    consumed_receipt["status"] = "consumed"
+    consumed_receipt["commit_sha"] = None
+    atomic_json_write(consumed, consumed_receipt)
+    authority = authority_path(repo)
+    authority.unlink(missing_ok=True)
+    private_index.unlink(missing_ok=True)
+    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    committed = False
+    commit_sha = ""
+    try:
+        run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
+        run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
+        run(
+            ["git", "diff", "--no-ext-diff", "--cached", "--check"],
+            cwd=repo,
+            env_overrides=index_environment,
+        )
+        staged = sorted(
+            run(
+                ["git", "diff", "--no-ext-diff", "--cached", "--name-only"],
+                cwd=repo,
+                env_overrides=index_environment,
+            ).stdout.splitlines()
+        )
+        if staged != paths:
+            raise UpgradeError("staged paths do not exactly match the automation receipt")
+        if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+            raise UpgradeError("automation receipt path changed while staging")
+        for path in paths:
+            if staged_fingerprint(
+                repo,
+                path,
+                env_overrides=index_environment,
+            ) != normalized_git_fingerprint(fingerprints[path]):
+                raise UpgradeError(f"staged content does not match the automation receipt: {path}")
+        commit_message = message.strip() or f"task: {task}"
+        if task not in commit_message:
+            commit_message = f"{commit_message}\n\nTask: {task}"
+        tree = run(
+            ["git", "write-tree"],
+            cwd=repo,
+            env_overrides=index_environment,
+        ).stdout.strip()
+        expected_head = receipt["authority_head"]
+        commit_sha = run(
+            ["git", "commit-tree", tree, "-p", expected_head],
+            cwd=repo,
+            input_text=commit_message + "\n",
+        ).stdout.strip()
+        run(
+            ["git", "update-ref", f"refs/heads/{branch}", commit_sha, expected_head],
+            cwd=repo,
+        )
+        committed = True
+        consumed_receipt["commit_sha"] = commit_sha
+        atomic_json_write(consumed, consumed_receipt)
+        run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
+    except UpgradeError:
+        if not committed and not active.exists():
+            atomic_json_write(active, receipt)
+            write_authority(repo, receipt)
+            consumed.unlink(missing_ok=True)
+        raise
+    finally:
+        private_index.unlink(missing_ok=True)
+    return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 
 def parser() -> argparse.ArgumentParser:
@@ -542,6 +1039,9 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    commit_parser = sub.add_parser("commit")
+    commit_parser.add_argument("task")
+    commit_parser.add_argument("message", nargs="?", default="")
     return p
 
 
@@ -555,6 +1055,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "commit":
+            result = commit(repo, args.task, args.message)
         else:  # pragma: no cover
             raise UpgradeError(f"unsupported command: {args.command}")
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tomllib
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
@@ -196,7 +197,18 @@ def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
     _, branch, worktree = parse_task_identity(repo, task)
     registered = registered_worktrees(repo)
     actual = registered.get(worktree)
-    if actual is None or actual[0] != branch:
+    current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    head = git_head(repo)
+    branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo, check=False).stdout.strip()
+    if (
+        actual is None
+        or current_branch != branch
+        or actual[0] != branch
+        or not head
+        or not branch_oid
+        or actual[1] != head
+        or branch_oid != head
+    ):
         raise UpgradeError("current Task worktree is not registered with the expected branch")
     default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
     if not default:
@@ -322,6 +334,36 @@ def resolve_source(path: Path | None) -> Path:
     if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
         raise UpgradeError(f"not a Templates source checkout: {source}")
     return source
+
+
+def git_bytes(command: list[str], *, cwd: Path) -> bytes:
+    if not command or command[0] != "git":
+        raise UpgradeError("byte helper only accepts Git commands")
+    result = subprocess.run(
+        [str(git_executable()), *command[1:]],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result.stdout
+
+
+def resolve_pinned_source(path: Path) -> tuple[Path, str]:
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    status = git_bytes(
+        ["git", "status", "--porcelain=v1", "-z", "--", "components/agent-core"], cwd=source
+    )
+    if status:
+        raise UpgradeError("source components/agent-core must be clean")
+    return source, head
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -621,6 +663,124 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
     return Action(rel, "replace", "Agent Core-owned path")
 
 
+def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
+    result = subprocess.run(
+        [str(git_executable()), "show", f"{revision}:{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read Git object {path}")
+    return result.stdout
+
+
+def materialize_tree(
+    repo: Path, revision: str, destination: Path, prefix: str = "", *, surface_only: bool = False
+) -> None:
+    entries = git_bytes(["git", "ls-tree", "-r", "-z", revision, "--", prefix or "."], cwd=repo).split(b"\0")
+    destination.mkdir(parents=True, exist_ok=True)
+    prefix_bytes = (prefix.rstrip("/") + "/").encode() if prefix else b""
+    for entry in entries:
+        if not entry:
+            continue
+        header, raw_path = entry.split(b"\t", 1)
+        fields = header.split()
+        if prefix_bytes and not raw_path.startswith(prefix_bytes):
+            raise UpgradeError("Git returned an unexpected snapshot path")
+        relative_raw = raw_path[len(prefix_bytes):] if prefix_bytes else raw_path
+        try:
+            relative_text = relative_raw.decode("utf-8")
+            relative = PurePosixPath(relative_text)
+        except UnicodeDecodeError as exc:
+            raise UpgradeError("snapshot contains a non-UTF-8 path") from exc
+        if surface_only and not (
+            relative_text in {"AGENTS.md", "Justfile", "opencode.json"}
+            or relative_text.startswith(".automation/")
+            or relative_text.startswith(".opencode/")
+        ):
+            continue
+        if len(fields) != 3 or fields[0] not in {b"100644", b"100755"} or fields[1] != b"blob":
+            raise UpgradeError("Agent Core snapshot contains a symlink, submodule, or special Git entry")
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or relative.as_posix() != relative_text
+        ):
+            raise UpgradeError("snapshot contains an unsafe or unnormalized path")
+        target = destination.joinpath(*relative.parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(git_object_bytes(repo, revision, raw_path.decode("utf-8")))
+        target.chmod(0o755 if fields[0] == b"100755" else 0o644)
+
+
+def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        if item["action"] == "delete":
+            target = tree / relative
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                blockers.append(f"{item['path']}: delete has symlink ancestor {ancestor.as_posix()}")
+                continue
+            if path_present(target) and not (target.is_symlink() or target.is_file()):
+                blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(tree, relative, planned_deletes)
+            if blocker:
+                blockers.append(f"{item['path']}: {blocker}")
+    if blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(blockers))
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered = sorted(
+        [item for item in actionable if item["path"] != ".automation/VERSION"],
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + [item for item in actionable if item["path"] == ".automation/VERSION"]
+    changed: list[str] = []
+    for item in ordered:
+        relative = Path(item["path"])
+        target = tree / relative
+        source = source_core / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if target.is_symlink() or target.is_file():
+                target.unlink()
+            elif path_present(target):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+        else:
+            blocker = write_topology_blocker(tree, relative, set())
+            if blocker:
+                raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {blocker}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
+            if item["action"] in {"create", "replace"}:
+                shutil.copy2(source, target)
+            elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+                merged, detail = replace_agent_rules(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            elif item["action"] == "merge" and item["path"] == "Justfile":
+                merged, detail = merge_just_router(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            else:
+                raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
+    return sorted(set(changed))
+
+
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
@@ -706,73 +866,7 @@ def apply(repo: Path, source: Path) -> dict:
             "mergePerformed": False,
             "requiredNextChecks": [],
         }
-    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
-    preflight_blockers: list[str] = []
-    for item in actionable:
-        relative = Path(item["path"])
-        destination = repo / relative
-        if item["action"] == "delete":
-            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
-                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
-        else:
-            blocker = write_topology_blocker(repo, relative, planned_deletes)
-            if blocker:
-                preflight_blockers.append(f"{item['path']}: {blocker}")
-    if preflight_blockers:
-        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
-
-    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
-    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
-    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
-    ordered_actions = sorted(
-        ordinary_actions,
-        key=lambda item: (phases.get(item["action"], 99), item["path"]),
-    ) + version_actions
-    for item in ordered_actions:
-        relative = Path(item["path"])
-        source_path = source_core / relative
-        destination = repo / relative
-        if item["action"] == "delete":
-            ancestor = symlink_ancestor(repo, relative)
-            if ancestor is not None:
-                raise UpgradeError(
-                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
-                )
-            if destination.is_symlink() or destination.is_file():
-                destination.unlink()
-            elif path_present(destination):
-                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
-            changed.append(item["path"])
-            continue
-        topology_blocker = write_topology_blocker(repo, relative, set())
-        if topology_blocker:
-            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        if item["action"] in {"create", "replace"}:
-            if destination.is_symlink():
-                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
-            shutil.copy2(source_path, destination)
-        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
-            if destination.is_symlink():
-                raise UpgradeError("AGENTS.md became a symlink after planning")
-            merged, detail = replace_agent_rules(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        elif item["action"] == "merge" and item["path"] == "Justfile":
-            if destination.is_symlink():
-                raise UpgradeError("Justfile became a symlink after planning")
-            merged, detail = merge_just_router(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        else:
-            raise UpgradeError(f"unsupported upgrade action: {item}")
-        changed.append(item["path"])
+    changed = apply_plan_to_tree(repo, source_core, plan)
     result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -815,13 +909,117 @@ def apply(repo: Path, source: Path) -> dict:
 def pending_paths(repo: Path) -> list[str]:
     paths: set[str] = set()
     for args in (
-        ("diff", "--no-ext-diff", "--name-only"),
-        ("diff", "--no-ext-diff", "--cached", "--name-only"),
-        ("ls-files", "--others", "--exclude-standard"),
+        ("diff", "--no-ext-diff", "--name-only", "-z"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only", "-z"),
+        ("ls-files", "--others", "--exclude-standard", "-z"),
     ):
-        output = run(["git", *args], cwd=repo).stdout
-        paths.update(output.splitlines())
+        output = git_bytes(["git", *args], cwd=repo)
+        for raw in output.split(b"\0"):
+            if not raw:
+                continue
+            try:
+                paths.add(raw.decode("utf-8"))
+            except UnicodeDecodeError as exc:
+                raise UpgradeError("Git reported a non-UTF-8 pending path") from exc
     return sorted(paths)
+
+
+def bootstrap_fingerprint(tree: Path, raw_path: str) -> dict[str, object]:
+    return file_fingerprint(tree, raw_path)
+
+
+def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
+    path = validate_receipt_path(raw_path)
+    relative = Path(*path.split("/"))
+    policy_path = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(policy_path.read_text(encoding="utf-8")) if policy_path.is_file() else {}
+    secret_patterns = policy.get("paths", {}).get("secret_patterns", [])
+    if path == ".task-state" or path.startswith(".task-state/"):
+        raise UpgradeError(f"pending path is Task State: {path}")
+    if any(token.lower() in path.lower() for token in secret_patterns):
+        raise UpgradeError(f"pending path matches a configured secret pattern: {path}")
+    if path.startswith("just/project/") or path == "just/local.just":
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path.startswith(".github/"):
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path == ".automation/ADAPTER" or path == ".automation/INIT.fragment.md" or path == ".automation/adoption.toml":
+        raise UpgradeError(f"pending path is Adapter-owned: {path}")
+    if not managed(relative):
+        raise UpgradeError(f"pending path is outside Agent Core: {path}")
+
+
+def bootstrap_receipt(repo: Path, source: Path) -> dict:
+    task_id, branch, worktree = require_maintenance(repo)
+    authority_head = git_head(repo)
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
+    if receipt_path(repo).exists() or authority_path(repo).exists():
+        raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    pending = pending_paths(repo)
+    if not pending:
+        raise UpgradeError("bootstrap requires non-empty pending paths")
+    for path in pending:
+        reject_bootstrap_path(repo, path)
+    source, source_head = resolve_pinned_source(source)
+    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+        baseline = Path(temporary) / "baseline"
+        source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
+        materialize_tree(repo, authority_head, baseline, surface_only=True)
+        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        before = {
+            p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
+            for p in baseline.rglob("*") if p.is_file()
+        }
+        plan = build_plan(baseline, source_snapshot.parent.parent)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [
+            migration for migration in load_migrations(source_snapshot)
+            if migration.to_version <= version_number(source_snapshot)
+        ]
+        _, migration_blockers, _ = migration_actions(repo, selected)
+        if migration_blockers:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(migration_blockers))
+        apply_plan_to_tree(baseline, source_snapshot, plan)
+        returned = set(item["path"] for item in plan["actions"] if item["action"] != "noop")
+        expected = sorted(
+            path for path in returned
+            if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+            != bootstrap_fingerprint(baseline, path)
+        )
+        if expected != pending:
+            raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
+        if not expected:
+            return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+    pinned_source, current_source_head = resolve_pinned_source(source)
+    if pinned_source != source or current_source_head != source_head:
+        raise UpgradeError("source changed during receipt reconstruction")
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed during receipt reconstruction")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed during receipt reconstruction")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content does not match the reconstructed upgrade")
+    receipt = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": str(source.resolve()), "source_revision": source_head,
+        "current_version": plan["currentVersion"], "upstream_version": plan["upstreamVersion"],
+        "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": current_fingerprints,
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1039,6 +1237,8 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    bootstrap = sub.add_parser("bootstrap-receipt")
+    bootstrap.add_argument("--source", type=Path, required=True)
     commit_parser = sub.add_parser("commit")
     commit_parser.add_argument("task")
     commit_parser.add_argument("message", nargs="?", default="")
@@ -1055,6 +1255,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "bootstrap-receipt":
+            result = bootstrap_receipt(repo, resolve_source(args.source))
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/templates/agent-python/.automation/just/automation.just
+++ b/templates/agent-python/.automation/just/automation.just
@@ -1,11 +1,18 @@
 root := justfile_directory() / ".." / ".."
 script := root / ".automation" / "bin" / "automation_upgrade.py"
 
+[working-directory: root]
 version:
-    python3 '{{script}}' version
+    python3 {{quote(script)}} version
 
+[working-directory: root]
 check-update source:
-    python3 '{{script}}' check-update --source '{{source}}'
+    python3 {{quote(script)}} check-update --source {{quote(source)}}
 
+[working-directory: root]
 upgrade source:
-    python3 '{{script}}' upgrade --source '{{source}}'
+    python3 {{quote(script)}} upgrade --source {{quote(source)}}
+
+[working-directory: root]
+commit task message="":
+    python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-python/.automation/just/automation.just
+++ b/templates/agent-python/.automation/just/automation.just
@@ -14,5 +14,9 @@ upgrade source:
     python3 {{quote(script)}} upgrade --source {{quote(source)}}
 
 [working-directory: root]
+bootstrap-receipt source:
+    python3 {{quote(script)}} bootstrap-receipt --source {{quote(source)}}
+
+[working-directory: root]
 commit task message="":
     python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-python/opencode.json
+++ b/templates/agent-python/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::bootstrap-receipt *": "ask",
       "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",

--- a/templates/agent-python/opencode.json
+++ b/templates/agent-python/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -11,3 +11,48 @@ The current implementation provides guarded Task-local commit/push/PR operations
 integration head-SHA checkpoints, disposable Task State templates, and common
 safety policy. Repository-local OpenCode agents and permissions are added by the
 separate OpenCode configuration work.
+
+## Automation Maintenance workflow
+
+An Agent Core upgrade is permitted only from a dedicated registered, non-default
+Automation Maintenance Task. From that Task worktree, use a trusted local
+Templates checkout as the source:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
+```
+
+The environment variable is an upgrade opt-in only. It does not authorize a
+commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
+Upgrade does not commit, push, or merge and writes the ignored receipt
+`.task-state/automation-maintenance.json`.
+
+Before publication, execute `git diff --check`, `just agent::doctor`,
+`just project::check`, and the repository CI/smoke suite. Then publish only with:
+
+```sh
+just automation::commit <task> [message]
+just agent::push <task>
+just agent::pr-create <task>
+```
+
+The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
+`worktree`), source/source revision, current/upstream versions, sorted unique
+`changed_paths`, `authority_head`, and exact per-path content/state
+`path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
+stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
+or does not exactly equal all pending paths. A protected shared-Git-directory
+record binds it to the preceding successful upgrade; a fabricated Task State
+receipt is not authority. Ambient Git repository/index overrides are scrubbed.
+The exact paths are staged and rechecked in a private Task State index, then the
+commit is created from that verified tree without hooks and the expected Task
+branch HEAD is advanced atomically. Only Agent Core-managed paths are
+accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
+scopes are rejected. After a successful commit it is consumed at
+`.task-state/automation-maintenance.consumed.json`; a subsequent successful
+upgrade with changes replaces the active receipt and removes the previous consumed
+receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
+receipt lifecycle evidence.
+
+Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
+this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -36,6 +36,25 @@ just agent::push <task>
 just agent::pr-create <task>
 ```
 
+The normal upgrade flow creates its receipt before verification. If a self-hosted
+pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
+normal verification and, before `automation::commit`, run the canonical recovery
+bridge:
+
+```sh
+AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+```
+
+The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
+pins the clean source revision, materializes the tracked `HEAD` Agent Core
+baseline, applies canonical upgrade semantics in isolation, and requires exact
+pending paths/content/modes plus Task identity and `HEAD` before issuing the
+existing receipt and protected authority. Product, Adapter, repository,
+secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
+with the existing `automation::commit` flow; ordinary `agent::commit` rejection
+and the receipt/authority design remain unchanged. This is the PR #79 review fix
+only; there are no Issue #77 changes.
+
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import secrets
 import shutil
+import stat
 import subprocess
 import sys
 import tomllib
@@ -15,6 +18,192 @@ from pathlib import Path, PurePosixPath
 
 class UpgradeError(RuntimeError):
     pass
+
+
+RECEIPT_NAME = "automation-maintenance.json"
+CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+RECEIPT_FIELDS = {
+    "schema_version",
+    "status",
+    "task_id",
+    "branch",
+    "worktree",
+    "source",
+    "source_revision",
+    "current_version",
+    "upstream_version",
+    "changed_paths",
+    "authority_head",
+    "authority_nonce",
+    "path_fingerprints",
+}
+_GIT_EXECUTABLE: Path | None = None
+
+
+def git_head(repo: Path) -> str:
+    result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def source_revision(source: Path) -> str | None:
+    value = git_head(source)
+    return value or None
+
+
+def receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / RECEIPT_NAME
+
+
+def consumed_receipt_path(repo: Path) -> Path:
+    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+
+
+def common_git_dir(repo: Path) -> Path:
+    value = Path(run(["git", "rev-parse", "--git-common-dir"], cwd=repo).stdout.strip())
+    return value.resolve() if value.is_absolute() else (repo / value).resolve()
+
+
+def authority_path(repo: Path) -> Path:
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+
+
+def canonical_json(value: dict) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def receipt_digest(receipt: dict) -> str:
+    return hashlib.sha256(canonical_json(receipt)).hexdigest()
+
+
+def write_authority(repo: Path, receipt: dict) -> None:
+    atomic_json_write(
+        authority_path(repo),
+        {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        },
+    )
+
+
+def validate_authority(repo: Path, receipt: dict) -> None:
+    path = authority_path(repo)
+    try:
+        authority = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+    expected = {
+        "schema_version": 1,
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+    }
+    if authority != expected:
+        raise UpgradeError("automation receipt does not match successful-upgrade authority")
+
+
+def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
+    for path in paths:
+        relative = path.relative_to(repo).as_posix()
+        tracked = run(
+            ["git", "ls-files", "--error-unmatch", "--", relative],
+            cwd=repo,
+            check=False,
+        ).returncode == 0
+        if tracked:
+            raise UpgradeError(f"required Task State path is tracked: {relative}")
+        ignored = run(["git", "check-ignore", "-q", relative], cwd=repo, check=False).returncode == 0
+        if not ignored:
+            raise UpgradeError(f"required Task State path is not ignored: {relative}")
+
+
+def atomic_json_write(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
+    path = repo / Path(*raw_path.split("/"))
+    try:
+        state = path.lstat()
+    except FileNotFoundError:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    mode = stat.S_IMODE(state.st_mode)
+    if path.is_file() and not path.is_symlink():
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        return {"state": "file", "mode": mode, "content_sha256": digest}
+    if path.is_symlink():
+        digest = hashlib.sha256(os.readlink(path).encode("utf-8", "surrogateescape")).hexdigest()
+        return {"state": "symlink", "mode": mode, "content_sha256": digest}
+    if path.is_dir():
+        return {"state": "directory", "mode": mode, "content_sha256": None}
+    return {"state": "special", "mode": mode, "content_sha256": None}
+
+
+def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
+    if not TASK_ID_RE.fullmatch(task):
+        raise UpgradeError(f"invalid Task ID: {task!r}")
+    state_path = repo / ".task-state" / "task.md"
+    if not state_path.is_file():
+        raise UpgradeError("operation requires a Task worktree with Task State")
+    text = state_path.read_text(encoding="utf-8")
+    values: dict[str, str] = {}
+    for label in ("Task ID", "Branch", "Worktree"):
+        matches = re.findall(rf"(?m)^- {re.escape(label)}: (.+)$", text)
+        if len(matches) != 1 or not matches[0].strip():
+            raise UpgradeError(f"Task State must contain exactly one {label} identity field")
+        values[label] = matches[0].strip()
+    if values["Task ID"] != task:
+        raise UpgradeError("Task State identity does not match requested Task")
+    branch = values["Branch"]
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        raise UpgradeError(f"Task State branch is not the Task branch for {task}")
+    worktree = Path(values["Worktree"]).resolve()
+    if worktree != repo.resolve():
+        raise UpgradeError("Task State worktree does not match the current worktree")
+    return task, branch, worktree
+
+
+def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]]:
+    output = run(["git", "worktree", "list", "--porcelain"], cwd=repo).stdout
+    records: dict[Path, tuple[str | None, str | None]] = {}
+    current: dict[str, str] = {}
+    for line in output.splitlines() + [""]:
+        if not line:
+            if current.get("worktree"):
+                branch = current.get("branch", "").removeprefix("refs/heads/") or None
+                records[Path(current["worktree"]).resolve()] = (branch, current.get("HEAD"))
+            current = {}
+            continue
+        key, _, value = line.partition(" ")
+        current[key] = value
+    return records
+
+
+def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
+    _, branch, worktree = parse_task_identity(repo, task)
+    registered = registered_worktrees(repo)
+    actual = registered.get(worktree)
+    if actual is None or actual[0] != branch:
+        raise UpgradeError("current Task worktree is not registered with the expected branch")
+    default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
+    if not default:
+        raise UpgradeError("cannot resolve default branch")
+    if branch == default:
+        raise UpgradeError("operation refused on the default branch")
+    return task, branch, worktree
 
 
 @dataclass(frozen=True)
@@ -32,8 +221,58 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
-def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True)
+def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and key != "EMAIL"
+    }
+    if overrides:
+        environment.update(overrides)
+    return environment
+
+
+def git_executable() -> Path:
+    global _GIT_EXECUTABLE
+    if _GIT_EXECUTABLE is not None:
+        return _GIT_EXECUTABLE
+    candidate = shutil.which("git")
+    if not candidate:
+        raise UpgradeError("trusted Git executable is unavailable")
+    executable = Path(candidate).resolve()
+    try:
+        metadata = executable.stat()
+    except OSError as exc:
+        raise UpgradeError("trusted Git executable is unavailable") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+    ):
+        raise UpgradeError(f"Git executable is not root-owned and immutable: {executable}")
+    _GIT_EXECUTABLE = executable
+    return executable
+
+
+def run(
+    command: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+    env_overrides: dict[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    is_git = bool(command and command[0] == "git")
+    environment = git_environment(env_overrides) if is_git else None
+    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    result = subprocess.run(
+        executable_command,
+        cwd=cwd,
+        text=True,
+        input=input_text,
+        capture_output=True,
+        env=environment,
+    )
     if check and result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
         raise UpgradeError(f"{' '.join(command)}: {detail}")
@@ -41,8 +280,12 @@ def run(command: list[str], *, cwd: Path, check: bool = True) -> subprocess.Comp
 
 
 def root() -> Path:
-    result = run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())
-    return Path(result.stdout.strip()).resolve()
+    installed_root = Path(__file__).resolve().parents[2]
+    result = run(["git", "rev-parse", "--show-toplevel"], cwd=installed_root)
+    discovered = Path(result.stdout.strip()).resolve()
+    if discovered != installed_root:
+        raise UpgradeError("installed Agent Core path does not match the Git worktree root")
+    return installed_root
 
 
 def version(repo: Path) -> str:
@@ -424,31 +667,45 @@ def build_plan(repo: Path, source: Path) -> dict:
     }
 
 
-def require_maintenance(repo: Path) -> None:
+def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    default = run(
-        ["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
-        cwd=repo,
-        check=False,
-    ).stdout.strip().removeprefix("origin/")
-    if default and branch == default:
-        raise UpgradeError("upgrade refused on default branch")
-    if not (repo / ".task-state" / "task.md").is_file():
-        raise UpgradeError("upgrade requires a Task worktree with Task State")
+    state = repo / ".task-state" / "task.md"
+    task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
+    if not task_match:
+        raise UpgradeError("upgrade requires a registered non-default Task branch")
+    task_id = task_match.group(1).strip()
+    identity = require_registered_task(repo, task_id)
+    require_ignored_untracked(
+        repo,
+        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+    )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
+    return identity
 
 
 def apply(repo: Path, source: Path) -> dict:
-    require_maintenance(repo)
+    task_id, branch, worktree = require_maintenance(repo)
     plan = build_plan(repo, source)
     if plan["blockers"]:
         raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
     source_core = source / "components" / "agent-core"
     changed: list[str] = []
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    if not actionable:
+        return {
+            "status": "NO_CHANGES",
+            "repositoryRoot": str(repo),
+            "sourceCore": str(source_core),
+            "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+            "changedPaths": [],
+            "commitCreated": False,
+            "pushPerformed": False,
+            "mergePerformed": False,
+            "requiredNextChecks": [],
+        }
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
     preflight_blockers: list[str] = []
     for item in actionable:
@@ -516,7 +773,7 @@ def apply(repo: Path, source: Path) -> dict:
         else:
             raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
-    return {
+    result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
         "sourceCore": str(source_core),
@@ -532,6 +789,246 @@ def apply(repo: Path, source: Path) -> dict:
             "repository CI/smoke tests",
         ],
     }
+    changed_paths = sorted(set(changed))
+    result["changedPaths"] = changed_paths
+    receipt = {
+        "schema_version": 1,
+        "status": "active",
+        "task_id": task_id,
+        "branch": branch,
+        "worktree": str(worktree),
+        "source": str(source.resolve()),
+        "source_revision": source_revision(source),
+        "current_version": plan["currentVersion"],
+        "upstream_version": plan["upstreamVersion"],
+        "changed_paths": changed_paths,
+        "authority_head": git_head(repo),
+        "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return result
+
+
+def pending_paths(repo: Path) -> list[str]:
+    paths: set[str] = set()
+    for args in (
+        ("diff", "--no-ext-diff", "--name-only"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only"),
+        ("ls-files", "--others", "--exclude-standard"),
+    ):
+        output = run(["git", *args], cwd=repo).stdout
+        paths.update(output.splitlines())
+    return sorted(paths)
+
+
+def validate_receipt_path(raw: object) -> str:
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise UpgradeError("receipt contains an unsafe path")
+    pure = PurePosixPath(raw)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts) or pure.as_posix() != raw:
+        raise UpgradeError(f"receipt contains an unnormalized path: {raw!r}")
+    return raw
+
+
+def receipt_paths(repo: Path, receipt: dict) -> list[str]:
+    raw = receipt.get("changed_paths")
+    if not isinstance(raw, list) or not raw:
+        raise UpgradeError("automation receipt has no changed paths")
+    paths = [validate_receipt_path(item) for item in raw]
+    if paths != sorted(paths) or len(paths) != len(set(paths)):
+        raise UpgradeError("automation receipt paths must be sorted and unique")
+    secret_file = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(secret_file.read_text(encoding="utf-8")) if secret_file.is_file() else {}
+    secrets = policy.get("paths", {}).get("secret_patterns", [])
+    for path in paths:
+        relative = Path(*path.split("/"))
+        if path == ".task-state" or path.startswith(".task-state/") or not managed(relative):
+            raise UpgradeError(f"receipt path is not Agent Core managed: {path}")
+        if any(token.lower() in path.lower() for token in secrets):
+            raise UpgradeError(f"receipt path matches a configured secret pattern: {path}")
+    return paths
+
+
+def validate_receipt_schema(receipt: object) -> dict:
+    if not isinstance(receipt, dict) or set(receipt) != RECEIPT_FIELDS:
+        raise UpgradeError("automation upgrade receipt has an invalid schema")
+    if receipt.get("schema_version") != 1 or receipt.get("status") != "active":
+        raise UpgradeError("unsupported automation upgrade receipt")
+    required_strings = (
+        "task_id",
+        "branch",
+        "worktree",
+        "source",
+        "current_version",
+        "upstream_version",
+        "authority_head",
+        "authority_nonce",
+    )
+    if any(not isinstance(receipt.get(field), str) or not receipt[field] for field in required_strings):
+        raise UpgradeError("automation upgrade receipt has invalid provenance fields")
+    revision = receipt.get("source_revision")
+    if revision is not None and (not isinstance(revision, str) or not revision):
+        raise UpgradeError("automation upgrade receipt has an invalid source revision")
+    if not Path(receipt["source"]).is_absolute():
+        raise UpgradeError("automation upgrade receipt source must be absolute")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", receipt["authority_head"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority HEAD")
+    if not re.fullmatch(r"[0-9a-f]{64}", receipt["authority_nonce"]):
+        raise UpgradeError("automation upgrade receipt has an invalid authority nonce")
+    return receipt
+
+
+def staged_fingerprint(
+    repo: Path,
+    path: str,
+    *,
+    env_overrides: dict[str, str],
+) -> dict[str, object]:
+    entry = run(
+        ["git", "ls-files", "--stage", "--", path],
+        cwd=repo,
+        env_overrides=env_overrides,
+    ).stdout.strip()
+    if not entry:
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    fields = entry.split(maxsplit=3)
+    if len(fields) != 4 or fields[2] != "0":
+        raise UpgradeError(f"staged path has an unsupported index entry: {path}")
+    mode = fields[0]
+    result = subprocess.run(
+        [str(git_executable()), "show", f":{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(env_overrides),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read staged content for {path}")
+    if mode not in {"100644", "100755"}:
+        raise UpgradeError(f"staged path has an unsupported mode: {path}")
+    return {
+        "state": "file",
+        "mode": 0o755 if mode == "100755" else 0o644,
+        "content_sha256": hashlib.sha256(result.stdout).hexdigest(),
+    }
+
+
+def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
+    if not isinstance(fingerprint, dict):
+        raise UpgradeError("automation receipt contains an invalid path fingerprint")
+    state = fingerprint.get("state")
+    if state == "absent":
+        return {"state": "absent", "mode": None, "content_sha256": None}
+    if state != "file" or not isinstance(fingerprint.get("mode"), int):
+        raise UpgradeError("automation receipt authorizes an unsupported path state")
+    digest = fingerprint.get("content_sha256")
+    if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise UpgradeError("automation receipt contains an invalid content fingerprint")
+    return {
+        "state": "file",
+        "mode": 0o755 if fingerprint["mode"] & 0o111 else 0o644,
+        "content_sha256": digest,
+    }
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+    _, branch, worktree = require_registered_task(repo, task)
+    active = receipt_path(repo)
+    private_index = repo / ".task-state" / "automation-maintenance.index"
+    require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
+    if not active.is_file():
+        raise UpgradeError("no active successful automation upgrade receipt")
+    try:
+        receipt = json.loads(active.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt = validate_receipt_schema(receipt)
+    if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    if receipt.get("authority_head") != git_head(repo):
+        raise UpgradeError("automation receipt authority HEAD is stale")
+    paths = receipt_paths(repo, receipt)
+    fingerprints = receipt.get("path_fingerprints")
+    if not isinstance(fingerprints, dict) or set(fingerprints) != set(paths):
+        raise UpgradeError("automation receipt fingerprints do not match its paths")
+    if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+        raise UpgradeError("automation receipt path content/state fingerprint changed")
+    if pending_paths(repo) != paths:
+        raise UpgradeError("pending paths do not exactly match the automation receipt")
+    validate_authority(repo, receipt)
+
+    consumed = consumed_receipt_path(repo)
+    os.replace(active, consumed)
+    consumed_receipt = dict(receipt)
+    consumed_receipt["status"] = "consumed"
+    consumed_receipt["commit_sha"] = None
+    atomic_json_write(consumed, consumed_receipt)
+    authority = authority_path(repo)
+    authority.unlink(missing_ok=True)
+    private_index.unlink(missing_ok=True)
+    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    committed = False
+    commit_sha = ""
+    try:
+        run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
+        run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
+        run(
+            ["git", "diff", "--no-ext-diff", "--cached", "--check"],
+            cwd=repo,
+            env_overrides=index_environment,
+        )
+        staged = sorted(
+            run(
+                ["git", "diff", "--no-ext-diff", "--cached", "--name-only"],
+                cwd=repo,
+                env_overrides=index_environment,
+            ).stdout.splitlines()
+        )
+        if staged != paths:
+            raise UpgradeError("staged paths do not exactly match the automation receipt")
+        if any(file_fingerprint(repo, path) != fingerprints[path] for path in paths):
+            raise UpgradeError("automation receipt path changed while staging")
+        for path in paths:
+            if staged_fingerprint(
+                repo,
+                path,
+                env_overrides=index_environment,
+            ) != normalized_git_fingerprint(fingerprints[path]):
+                raise UpgradeError(f"staged content does not match the automation receipt: {path}")
+        commit_message = message.strip() or f"task: {task}"
+        if task not in commit_message:
+            commit_message = f"{commit_message}\n\nTask: {task}"
+        tree = run(
+            ["git", "write-tree"],
+            cwd=repo,
+            env_overrides=index_environment,
+        ).stdout.strip()
+        expected_head = receipt["authority_head"]
+        commit_sha = run(
+            ["git", "commit-tree", tree, "-p", expected_head],
+            cwd=repo,
+            input_text=commit_message + "\n",
+        ).stdout.strip()
+        run(
+            ["git", "update-ref", f"refs/heads/{branch}", commit_sha, expected_head],
+            cwd=repo,
+        )
+        committed = True
+        consumed_receipt["commit_sha"] = commit_sha
+        atomic_json_write(consumed, consumed_receipt)
+        run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
+    except UpgradeError:
+        if not committed and not active.exists():
+            atomic_json_write(active, receipt)
+            write_authority(repo, receipt)
+            consumed.unlink(missing_ok=True)
+        raise
+    finally:
+        private_index.unlink(missing_ok=True)
+    return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 
 def parser() -> argparse.ArgumentParser:
@@ -542,6 +1039,9 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    commit_parser = sub.add_parser("commit")
+    commit_parser.add_argument("task")
+    commit_parser.add_argument("message", nargs="?", default="")
     return p
 
 
@@ -555,6 +1055,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "commit":
+            result = commit(repo, args.task, args.message)
         else:  # pragma: no cover
             raise UpgradeError(f"unsupported command: {args.command}")
         print(json.dumps(result, indent=2, sort_keys=True))

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tomllib
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
@@ -196,7 +197,18 @@ def require_registered_task(repo: Path, task: str) -> tuple[str, str, Path]:
     _, branch, worktree = parse_task_identity(repo, task)
     registered = registered_worktrees(repo)
     actual = registered.get(worktree)
-    if actual is None or actual[0] != branch:
+    current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
+    head = git_head(repo)
+    branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo, check=False).stdout.strip()
+    if (
+        actual is None
+        or current_branch != branch
+        or actual[0] != branch
+        or not head
+        or not branch_oid
+        or actual[1] != head
+        or branch_oid != head
+    ):
         raise UpgradeError("current Task worktree is not registered with the expected branch")
     default = run(["git", "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"], cwd=repo, check=False).stdout.strip().removeprefix("origin/")
     if not default:
@@ -322,6 +334,36 @@ def resolve_source(path: Path | None) -> Path:
     if not (source / "components" / "agent-core" / ".automation" / "VERSION").is_file():
         raise UpgradeError(f"not a Templates source checkout: {source}")
     return source
+
+
+def git_bytes(command: list[str], *, cwd: Path) -> bytes:
+    if not command or command[0] != "git":
+        raise UpgradeError("byte helper only accepts Git commands")
+    result = subprocess.run(
+        [str(git_executable()), *command[1:]],
+        cwd=cwd,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
+        raise UpgradeError(f"{' '.join(command)}: {detail}")
+    return result.stdout
+
+
+def resolve_pinned_source(path: Path) -> tuple[Path, str]:
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    status = git_bytes(
+        ["git", "status", "--porcelain=v1", "-z", "--", "components/agent-core"], cwd=source
+    )
+    if status:
+        raise UpgradeError("source components/agent-core must be clean")
+    return source, head
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -621,6 +663,124 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
     return Action(rel, "replace", "Agent Core-owned path")
 
 
+def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
+    result = subprocess.run(
+        [str(git_executable()), "show", f"{revision}:{path}"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+        env=git_environment(),
+    )
+    if result.returncode != 0:
+        raise UpgradeError(f"cannot read Git object {path}")
+    return result.stdout
+
+
+def materialize_tree(
+    repo: Path, revision: str, destination: Path, prefix: str = "", *, surface_only: bool = False
+) -> None:
+    entries = git_bytes(["git", "ls-tree", "-r", "-z", revision, "--", prefix or "."], cwd=repo).split(b"\0")
+    destination.mkdir(parents=True, exist_ok=True)
+    prefix_bytes = (prefix.rstrip("/") + "/").encode() if prefix else b""
+    for entry in entries:
+        if not entry:
+            continue
+        header, raw_path = entry.split(b"\t", 1)
+        fields = header.split()
+        if prefix_bytes and not raw_path.startswith(prefix_bytes):
+            raise UpgradeError("Git returned an unexpected snapshot path")
+        relative_raw = raw_path[len(prefix_bytes):] if prefix_bytes else raw_path
+        try:
+            relative_text = relative_raw.decode("utf-8")
+            relative = PurePosixPath(relative_text)
+        except UnicodeDecodeError as exc:
+            raise UpgradeError("snapshot contains a non-UTF-8 path") from exc
+        if surface_only and not (
+            relative_text in {"AGENTS.md", "Justfile", "opencode.json"}
+            or relative_text.startswith(".automation/")
+            or relative_text.startswith(".opencode/")
+        ):
+            continue
+        if len(fields) != 3 or fields[0] not in {b"100644", b"100755"} or fields[1] != b"blob":
+            raise UpgradeError("Agent Core snapshot contains a symlink, submodule, or special Git entry")
+        if (
+            relative.is_absolute()
+            or not relative.parts
+            or any(part in {"", ".", ".."} for part in relative.parts)
+            or relative.as_posix() != relative_text
+        ):
+            raise UpgradeError("snapshot contains an unsafe or unnormalized path")
+        target = destination.joinpath(*relative.parts)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(git_object_bytes(repo, revision, raw_path.decode("utf-8")))
+        target.chmod(0o755 if fields[0] == b"100755" else 0o644)
+
+
+def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
+    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
+    blockers: list[str] = []
+    for item in actionable:
+        relative = Path(item["path"])
+        if item["action"] == "delete":
+            target = tree / relative
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                blockers.append(f"{item['path']}: delete has symlink ancestor {ancestor.as_posix()}")
+                continue
+            if path_present(target) and not (target.is_symlink() or target.is_file()):
+                blockers.append(f"{item['path']}: delete target changed to an unsafe type")
+        else:
+            blocker = write_topology_blocker(tree, relative, planned_deletes)
+            if blocker:
+                blockers.append(f"{item['path']}: {blocker}")
+    if blockers:
+        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(blockers))
+    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
+    ordered = sorted(
+        [item for item in actionable if item["path"] != ".automation/VERSION"],
+        key=lambda item: (phases.get(item["action"], 99), item["path"]),
+    ) + [item for item in actionable if item["path"] == ".automation/VERSION"]
+    changed: list[str] = []
+    for item in ordered:
+        relative = Path(item["path"])
+        target = tree / relative
+        source = source_core / relative
+        if item["action"] == "delete":
+            ancestor = symlink_ancestor(tree, relative)
+            if ancestor is not None:
+                raise UpgradeError(
+                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
+                )
+            if target.is_symlink() or target.is_file():
+                target.unlink()
+            elif path_present(target):
+                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
+        else:
+            blocker = write_topology_blocker(tree, relative, set())
+            if blocker:
+                raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {blocker}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
+            if item["action"] in {"create", "replace"}:
+                shutil.copy2(source, target)
+            elif item["action"] == "merge" and item["path"] == "AGENTS.md":
+                merged, detail = replace_agent_rules(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            elif item["action"] == "merge" and item["path"] == "Justfile":
+                merged, detail = merge_just_router(target.read_text(encoding="utf-8"), source.read_text(encoding="utf-8"))
+                if merged is None:
+                    raise UpgradeError(f"Justfile merge became unsafe: {detail}")
+                target.write_text(merged, encoding="utf-8")
+            else:
+                raise UpgradeError(f"unsupported upgrade action: {item}")
+        changed.append(item["path"])
+    return sorted(set(changed))
+
+
 def build_plan(repo: Path, source: Path) -> dict:
     local = version(repo)
     remote = version(source / "components" / "agent-core")
@@ -706,73 +866,7 @@ def apply(repo: Path, source: Path) -> dict:
             "mergePerformed": False,
             "requiredNextChecks": [],
         }
-    planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
-    preflight_blockers: list[str] = []
-    for item in actionable:
-        relative = Path(item["path"])
-        destination = repo / relative
-        if item["action"] == "delete":
-            if path_present(destination) and not (destination.is_symlink() or destination.is_file()):
-                preflight_blockers.append(f"{item['path']}: delete target changed to an unsafe type")
-        else:
-            blocker = write_topology_blocker(repo, relative, planned_deletes)
-            if blocker:
-                preflight_blockers.append(f"{item['path']}: {blocker}")
-    if preflight_blockers:
-        raise UpgradeError("upgrade blocked before mutation:\n- " + "\n- ".join(preflight_blockers))
-
-    version_actions = [item for item in actionable if item["path"] == ".automation/VERSION"]
-    ordinary_actions = [item for item in actionable if item["path"] != ".automation/VERSION"]
-    phases = {"delete": 0, "create": 1, "replace": 2, "merge": 3}
-    ordered_actions = sorted(
-        ordinary_actions,
-        key=lambda item: (phases.get(item["action"], 99), item["path"]),
-    ) + version_actions
-    for item in ordered_actions:
-        relative = Path(item["path"])
-        source_path = source_core / relative
-        destination = repo / relative
-        if item["action"] == "delete":
-            ancestor = symlink_ancestor(repo, relative)
-            if ancestor is not None:
-                raise UpgradeError(
-                    f"delete path gained symlink ancestor after planning: {ancestor.as_posix()}"
-                )
-            if destination.is_symlink() or destination.is_file():
-                destination.unlink()
-            elif path_present(destination):
-                raise UpgradeError(f"delete became unsafe after planning: {item['path']}")
-            changed.append(item["path"])
-            continue
-        topology_blocker = write_topology_blocker(repo, relative, set())
-        if topology_blocker:
-            raise UpgradeError(f"managed path became unsafe after planning: {item['path']}: {topology_blocker}")
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        if item["action"] in {"create", "replace"}:
-            if destination.is_symlink():
-                raise UpgradeError(f"destination became a symlink after planning: {item['path']}")
-            shutil.copy2(source_path, destination)
-        elif item["action"] == "merge" and item["path"] == "AGENTS.md":
-            if destination.is_symlink():
-                raise UpgradeError("AGENTS.md became a symlink after planning")
-            merged, detail = replace_agent_rules(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"AGENTS.md merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        elif item["action"] == "merge" and item["path"] == "Justfile":
-            if destination.is_symlink():
-                raise UpgradeError("Justfile became a symlink after planning")
-            merged, detail = merge_just_router(
-                destination.read_text(encoding="utf-8"), source_path.read_text(encoding="utf-8")
-            )
-            if merged is None:
-                raise UpgradeError(f"Justfile merge became unsafe: {detail}")
-            destination.write_text(merged, encoding="utf-8")
-        else:
-            raise UpgradeError(f"unsupported upgrade action: {item}")
-        changed.append(item["path"])
+    changed = apply_plan_to_tree(repo, source_core, plan)
     result = {
         "status": "APPLIED",
         "repositoryRoot": str(repo),
@@ -815,13 +909,117 @@ def apply(repo: Path, source: Path) -> dict:
 def pending_paths(repo: Path) -> list[str]:
     paths: set[str] = set()
     for args in (
-        ("diff", "--no-ext-diff", "--name-only"),
-        ("diff", "--no-ext-diff", "--cached", "--name-only"),
-        ("ls-files", "--others", "--exclude-standard"),
+        ("diff", "--no-ext-diff", "--name-only", "-z"),
+        ("diff", "--no-ext-diff", "--cached", "--name-only", "-z"),
+        ("ls-files", "--others", "--exclude-standard", "-z"),
     ):
-        output = run(["git", *args], cwd=repo).stdout
-        paths.update(output.splitlines())
+        output = git_bytes(["git", *args], cwd=repo)
+        for raw in output.split(b"\0"):
+            if not raw:
+                continue
+            try:
+                paths.add(raw.decode("utf-8"))
+            except UnicodeDecodeError as exc:
+                raise UpgradeError("Git reported a non-UTF-8 pending path") from exc
     return sorted(paths)
+
+
+def bootstrap_fingerprint(tree: Path, raw_path: str) -> dict[str, object]:
+    return file_fingerprint(tree, raw_path)
+
+
+def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
+    path = validate_receipt_path(raw_path)
+    relative = Path(*path.split("/"))
+    policy_path = repo / ".automation" / "policy.toml"
+    policy = tomllib.loads(policy_path.read_text(encoding="utf-8")) if policy_path.is_file() else {}
+    secret_patterns = policy.get("paths", {}).get("secret_patterns", [])
+    if path == ".task-state" or path.startswith(".task-state/"):
+        raise UpgradeError(f"pending path is Task State: {path}")
+    if any(token.lower() in path.lower() for token in secret_patterns):
+        raise UpgradeError(f"pending path matches a configured secret pattern: {path}")
+    if path.startswith("just/project/") or path == "just/local.just":
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path.startswith(".github/"):
+        raise UpgradeError(f"pending path is repository-owned: {path}")
+    if path == ".automation/ADAPTER" or path == ".automation/INIT.fragment.md" or path == ".automation/adoption.toml":
+        raise UpgradeError(f"pending path is Adapter-owned: {path}")
+    if not managed(relative):
+        raise UpgradeError(f"pending path is outside Agent Core: {path}")
+
+
+def bootstrap_receipt(repo: Path, source: Path) -> dict:
+    task_id, branch, worktree = require_maintenance(repo)
+    authority_head = git_head(repo)
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
+    if receipt_path(repo).exists() or authority_path(repo).exists():
+        raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    pending = pending_paths(repo)
+    if not pending:
+        raise UpgradeError("bootstrap requires non-empty pending paths")
+    for path in pending:
+        reject_bootstrap_path(repo, path)
+    source, source_head = resolve_pinned_source(source)
+    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+        baseline = Path(temporary) / "baseline"
+        source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
+        materialize_tree(repo, authority_head, baseline, surface_only=True)
+        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        before = {
+            p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
+            for p in baseline.rglob("*") if p.is_file()
+        }
+        plan = build_plan(baseline, source_snapshot.parent.parent)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [
+            migration for migration in load_migrations(source_snapshot)
+            if migration.to_version <= version_number(source_snapshot)
+        ]
+        _, migration_blockers, _ = migration_actions(repo, selected)
+        if migration_blockers:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(migration_blockers))
+        apply_plan_to_tree(baseline, source_snapshot, plan)
+        returned = set(item["path"] for item in plan["actions"] if item["action"] != "noop")
+        expected = sorted(
+            path for path in returned
+            if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+            != bootstrap_fingerprint(baseline, path)
+        )
+        if expected != pending:
+            raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
+        if not expected:
+            return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+    pinned_source, current_source_head = resolve_pinned_source(source)
+    if pinned_source != source or current_source_head != source_head:
+        raise UpgradeError("source changed during receipt reconstruction")
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed during receipt reconstruction")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed during receipt reconstruction")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content does not match the reconstructed upgrade")
+    receipt = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": str(source.resolve()), "source_revision": source_head,
+        "current_version": plan["currentVersion"], "upstream_version": plan["upstreamVersion"],
+        "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
+        "path_fingerprints": current_fingerprints,
+    }
+    atomic_json_write(receipt_path(repo), receipt)
+    write_authority(repo, receipt)
+    consumed_receipt_path(repo).unlink(missing_ok=True)
+    return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1039,6 +1237,8 @@ def parser() -> argparse.ArgumentParser:
     check.add_argument("--source", type=Path, required=True)
     upgrade = sub.add_parser("upgrade")
     upgrade.add_argument("--source", type=Path, required=True)
+    bootstrap = sub.add_parser("bootstrap-receipt")
+    bootstrap.add_argument("--source", type=Path, required=True)
     commit_parser = sub.add_parser("commit")
     commit_parser.add_argument("task")
     commit_parser.add_argument("message", nargs="?", default="")
@@ -1055,6 +1255,8 @@ def main() -> int:
             result = build_plan(repo, resolve_source(args.source))
         elif args.command == "upgrade":
             result = apply(repo, resolve_source(args.source))
+        elif args.command == "bootstrap-receipt":
+            result = bootstrap_receipt(repo, resolve_source(args.source))
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/templates/agent-rust/.automation/just/automation.just
+++ b/templates/agent-rust/.automation/just/automation.just
@@ -1,11 +1,18 @@
 root := justfile_directory() / ".." / ".."
 script := root / ".automation" / "bin" / "automation_upgrade.py"
 
+[working-directory: root]
 version:
-    python3 '{{script}}' version
+    python3 {{quote(script)}} version
 
+[working-directory: root]
 check-update source:
-    python3 '{{script}}' check-update --source '{{source}}'
+    python3 {{quote(script)}} check-update --source {{quote(source)}}
 
+[working-directory: root]
 upgrade source:
-    python3 '{{script}}' upgrade --source '{{source}}'
+    python3 {{quote(script)}} upgrade --source {{quote(source)}}
+
+[working-directory: root]
+commit task message="":
+    python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-rust/.automation/just/automation.just
+++ b/templates/agent-rust/.automation/just/automation.just
@@ -14,5 +14,9 @@ upgrade source:
     python3 {{quote(script)}} upgrade --source {{quote(source)}}
 
 [working-directory: root]
+bootstrap-receipt source:
+    python3 {{quote(script)}} bootstrap-receipt --source {{quote(source)}}
+
+[working-directory: root]
 commit task message="":
     python3 {{quote(script)}} commit {{quote(task)}} {{quote(message)}}

--- a/templates/agent-rust/opencode.json
+++ b/templates/agent-rust/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::bootstrap-receipt *": "ask",
       "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",

--- a/templates/agent-rust/opencode.json
+++ b/templates/agent-rust/opencode.json
@@ -71,6 +71,7 @@
       "just automation::version": "allow",
       "just automation::check-update *": "allow",
       "just automation::upgrade *": "ask",
+      "just automation::commit *": "allow",
       "just repository::policy-check": "allow",
       "just repository::policy-apply": "ask",
       "just agent::task-start *": "deny",

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -7,6 +7,8 @@ import tempfile
 import unittest
 import os
 import shutil
+import subprocess
+from contextlib import ExitStack
 from pathlib import Path
 from unittest import mock
 
@@ -17,6 +19,13 @@ assert SPEC and SPEC.loader
 upgrade = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = upgrade
 SPEC.loader.exec_module(upgrade)
+
+AGENT_SPEC = importlib.util.spec_from_file_location(
+    "agent_core_for_upgrade_tests", ROOT / "components" / "agent-core" / ".automation" / "bin" / "agent_core.py"
+)
+assert AGENT_SPEC and AGENT_SPEC.loader
+agent_core = importlib.util.module_from_spec(AGENT_SPEC)
+AGENT_SPEC.loader.exec_module(agent_core)
 
 
 class AutomationUpgradeContractTest(unittest.TestCase):
@@ -147,6 +156,64 @@ mod project 'just/project/mod.just'
             f"require_absent_paths = {render(require_absent_paths)}\n"
         )
 
+    def _git(self, args: list[str], cwd: Path) -> str:
+        result = subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True, check=True)
+        return result.stdout.strip()
+
+    def _task_repo(self, repo: Path, *, task: str = "TASK-78") -> Path:
+        repo.mkdir(parents=True)
+        self._git(["init", "-b", "main"], repo)
+        self._git(["config", "user.name", "Test User"], repo)
+        self._git(["config", "user.email", "test@example.invalid"], repo)
+        self._write_file(repo / "README.md", "repository\n")
+        self._git(["add", "README.md"], repo)
+        self._git(["commit", "-m", "initial"], repo)
+        self._git(["switch", "-c", f"task/{task}-maintenance"], repo)
+        head = self._git(["rev-parse", "HEAD"], repo)
+        self._git(["update-ref", "refs/remotes/origin/main", head], repo)
+        self._git(["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], repo)
+        state = f"- Task ID: {task}\n- Branch: task/{task}-maintenance\n- Worktree: {repo.resolve()}\n"
+        self._write_file(repo / ".task-state/task.md", state)
+        exclude = repo / ".git/info/exclude"
+        exclude.write_text("/.task-state/\n", encoding="utf-8")
+        return repo
+
+    def _apply_fixture(self, root: Path, *, source_git: bool = True) -> tuple[Path, Path]:
+        repo = self._task_repo(root / "repo")
+        self._destination_repo(repo, version=2)
+        self._git(["add", "-A"], repo)
+        self._git(["commit", "-m", "fixture"], repo)
+        source = self._core_root_source(root, version=3)
+        if source_git:
+            self._git(["init", "-b", "main"], root)
+            self._git(["config", "user.name", "Test User"], root)
+            self._git(["config", "user.email", "test@example.invalid"], root)
+            self._git(["add", "components"], root)
+            self._git(["commit", "-m", "source"], root)
+        with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+            upgrade.apply(repo, root)
+        return repo, source
+
+    def _receipt(self, repo: Path) -> dict:
+        return json.loads(upgrade.receipt_path(repo).read_text(encoding="utf-8"))
+
+    def _commit_error(self, repo: Path, task: str = "TASK-78") -> str:
+        with self.assertRaises(upgrade.UpgradeError) as raised:
+            upgrade.commit(repo, task, "maintenance")
+        return str(raised.exception)
+
+    def _mock_maintenance(self, repo: Path) -> ExitStack:
+        stack = ExitStack()
+        stack.enter_context(
+            mock.patch.object(
+                upgrade,
+                "require_maintenance",
+                return_value=("TASK-TEST", "task/TASK-TEST-test", repo),
+            )
+        )
+        stack.enter_context(mock.patch.object(upgrade, "write_authority"))
+        return stack
+
     def test_upstream_and_generated_parity(self) -> None:
         upstream = ROOT / "components" / "agent-core" / ".automation" / "UPSTREAM"
         ownership = ROOT / "components" / "agent-core" / ".automation" / "ownership.toml"
@@ -187,7 +254,7 @@ mod project 'just/project/mod.just'
         self.assertIn("just/project/**", readme)
         self.assertIn("repository CI", readme)
         self.assertIn("AUTOMATION_MAINTENANCE", script)
-        self.assertIn("upgrade refused on default branch", script)
+        self.assertIn("operation refused on the default branch", script)
         self.assertIn("commitCreated", script)
         self.assertIn("pushPerformed", script)
         self.assertIn("mergePerformed", script)
@@ -438,7 +505,7 @@ mod project 'just/project/mod.just'
             self._core_root_source(
                 root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/stale.py",))
             )
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 result = upgrade.apply(repo, root)
             self.assertIn(".automation/stale.py", result["changedPaths"])
             self.assertFalse((repo / ".automation/stale.py").exists())
@@ -457,7 +524,7 @@ mod project 'just/project/mod.just'
             self.assertTrue(plan["canApply"], plan["blockers"])
             self.assertEqual("delete", self._plan_action(plan, ".automation/legacy.py")["action"])
 
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 upgrade.apply(repo, root)
             self.assertFalse((repo / ".automation/legacy.py").exists())
             self.assertEqual("3\n", (repo / ".automation/VERSION").read_text())
@@ -473,7 +540,7 @@ mod project 'just/project/mod.just'
             self._core_root_source(
                 root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/link.py",))
             )
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 upgrade.apply(repo, root)
             self.assertFalse((repo / ".automation/link.py").exists())
             self.assertTrue(target.exists())
@@ -502,7 +569,7 @@ mod project 'just/project/mod.just'
             plan = upgrade.build_plan(repo, root)
             self.assertFalse(plan["canApply"])
             self.assertIn("destination symlink", "\n".join(plan["blockers"]))
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 with self.assertRaises(upgrade.UpgradeError):
                     upgrade.apply(repo, root)
             self.assertEqual("external\n", target.read_text())
@@ -519,7 +586,7 @@ mod project 'just/project/mod.just'
             plan = upgrade.build_plan(repo, root)
             self.assertFalse(plan["canApply"])
             self.assertIn("non-directory ancestor .opencode", "\n".join(plan["blockers"]))
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 with self.assertRaises(upgrade.UpgradeError):
                     upgrade.apply(repo, root)
             self.assertEqual("2\n", (repo / ".automation/VERSION").read_text())
@@ -548,7 +615,7 @@ mod project 'just/project/mod.just'
             self._core_root_source(
                 root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/obsolete",))
             )
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 with self.assertRaises(upgrade.UpgradeError):
                     upgrade.apply(repo, root)
             self.assertEqual((repo / ".automation" / "VERSION").read_text(), "2\n")
@@ -573,7 +640,7 @@ mod project 'just/project/mod.just'
                 calls.append(str(Path(dst)))
                 return original_copy2(src, dst, *args, **kwargs)
 
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 with mock.patch.object(upgrade.shutil, "copy2", side_effect=_mock_copy2):
                     upgrade.apply(repo, tmp)
             self.assertTrue(calls, calls)
@@ -593,7 +660,7 @@ mod project 'just/project/mod.just'
             self._write_file(source_adp, "python\n")
             plan = upgrade.build_plan(repo, tmp)
             self.assertIsNone(self._plan_action(plan, ".automation/ADAPTER"))
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 with mock.patch.object(upgrade.shutil, "copy2", side_effect=shutil.copy2):
                     upgrade.apply(repo, tmp)
             self.assertEqual((repo / ".automation" / "ADAPTER").read_text(), "base\n")
@@ -617,7 +684,7 @@ mod project 'just/project/mod.just'
             self.assertEqual(tuple(map(Path, self.V3_REMOVED_PATHS)), migration.remove_paths)
             self.assertEqual((Path(".task-state/recovery.json"),), migration.require_absent_paths)
 
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 upgrade.apply(repo, ROOT)
             for path in self.V3_REMOVED_PATHS:
                 self.assertFalse((repo / path).exists(), path)
@@ -636,7 +703,7 @@ mod project 'just/project/mod.just'
             plan = upgrade.build_plan(repo, ROOT)
             self.assertFalse(plan["canApply"])
             self.assertIn(".task-state/recovery.json", "\n".join(plan["blockers"]))
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 with self.assertRaises(upgrade.UpgradeError):
                     upgrade.apply(repo, ROOT)
             self.assertTrue(obsolete.is_file())
@@ -652,7 +719,7 @@ mod project 'just/project/mod.just'
             plan = upgrade.build_plan(repo, ROOT)
             self.assertTrue(plan["canApply"], plan["blockers"])
             self.assertEqual("delete", self._plan_action(plan, self.V3_REMOVED_PATHS[-1])["action"])
-            with mock.patch.object(upgrade, "require_maintenance"):
+            with self._mock_maintenance(repo):
                 upgrade.apply(repo, ROOT)
             self.assertFalse(obsolete.exists())
             self.assertEqual("3\n", (repo / ".automation" / "VERSION").read_text())
@@ -669,6 +736,297 @@ mod project 'just/project/mod.just'
                 SCRIPT.read_bytes(),
                 (template_core / ".automation" / "bin" / "automation_upgrade.py").read_bytes(),
             )
+
+    def test_generated_automation_script_just_and_opencode_parity(self) -> None:
+        generated = (
+            ".automation/bin/automation_upgrade.py",
+            ".automation/just/automation.just",
+            "opencode.json",
+        )
+        for template in self.TEMPLATE_NAMES:
+            with self.subTest(template=template):
+                template_root = ROOT / "templates" / template
+                for relative in generated:
+                    self.assertEqual(
+                        (ROOT / "components" / "agent-core" / relative).read_bytes(),
+                        (template_root / relative).read_bytes(),
+                        relative,
+                    )
+
+    def test_apply_writes_complete_receipt_and_replaces_managed_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, source = self._apply_fixture(Path(directory))
+            receipt = self._receipt(repo)
+            self.assertEqual(1, receipt["schema_version"])
+            self.assertEqual("TASK-78", receipt["task_id"])
+            self.assertEqual("task/TASK-78-maintenance", receipt["branch"])
+            self.assertEqual(str(repo.resolve()), receipt["worktree"])
+            self.assertEqual(str(Path(directory).resolve()), receipt["source"])
+            self.assertEqual(upgrade.source_revision(Path(directory)), receipt["source_revision"])
+            self.assertEqual(["2", "3"], [receipt["current_version"], receipt["upstream_version"]])
+            self.assertEqual(sorted(receipt["changed_paths"]), receipt["changed_paths"])
+            self.assertTrue(receipt["path_fingerprints"])
+            agents = (repo / "AGENTS.md").read_text()
+            self.assertIn("BEGIN AGENT CORE RULES", agents)
+            self.assertIn("core rules", agents)
+            self.assertIn("END AGENT CORE RULES", agents)
+            self.assertIn("mod agent", (repo / "Justfile").read_text())
+            self.assertEqual("{}\n", (repo / "opencode.json").read_text())
+            self.assertEqual("base\n", (repo / ".automation/ADAPTER").read_text())
+            self.assertEqual(source, Path(receipt["source"]) / "components" / "agent-core")
+
+    def test_valid_receipt_commit_uses_real_git_repo_and_consumes_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            result = upgrade.commit(repo, "TASK-78", "automation maintenance")
+            self.assertEqual("COMMITTED", result["status"])
+            self.assertEqual(result["commit_sha"], upgrade.git_head(repo))
+            self.assertFalse(upgrade.receipt_path(repo).exists())
+            consumed = json.loads(upgrade.consumed_receipt_path(repo).read_text())
+            self.assertEqual("consumed", consumed["status"])
+            self.assertEqual(result["commit_sha"], consumed["commit_sha"])
+            self.assertEqual([], upgrade.pending_paths(repo))
+
+    def test_second_successful_upgrade_replaces_consumed_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, _ = self._apply_fixture(root / "first")
+            first = self._receipt(repo)
+            upgrade.commit(repo, "TASK-78", "first maintenance")
+            consumed = upgrade.consumed_receipt_path(repo)
+            self.assertTrue(consumed.exists())
+
+            second_root = root / "second"
+            second_source = self._core_root_source(second_root, version=4)
+            (second_source / "AGENTS.md").write_bytes((repo / "AGENTS.md").read_bytes())
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                upgrade.apply(repo, second_root)
+            second = self._receipt(repo)
+            self.assertTrue(upgrade.receipt_path(repo).exists())
+            self.assertFalse(consumed.exists())
+            self.assertNotEqual(first["authority_head"], second["authority_head"])
+            self.assertEqual("3", second["current_version"])
+            self.assertEqual("4", second["upstream_version"])
+            self.assertEqual([".automation/VERSION"], second["changed_paths"])
+            self.assertNotIn("README.md", second["changed_paths"])
+
+    def test_no_change_upgrade_preserves_consumed_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, _ = self._apply_fixture(root)
+            upgrade.commit(repo, "TASK-78", "maintenance")
+            consumed_before = upgrade.consumed_receipt_path(repo).read_bytes()
+
+            no_changes = {
+                "currentVersion": "3",
+                "upstreamVersion": "3",
+                "actions": [],
+                "blockers": [],
+            }
+            with mock.patch.dict(
+                os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False
+            ), mock.patch.object(upgrade, "build_plan", return_value=no_changes):
+                result = upgrade.apply(repo, root)
+
+            self.assertEqual("NO_CHANGES", result["status"])
+            self.assertFalse(upgrade.receipt_path(repo).exists())
+            self.assertEqual(consumed_before, upgrade.consumed_receipt_path(repo).read_bytes())
+
+    def test_forged_receipt_without_upgrade_authority_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            upgrade.authority_path(repo).unlink()
+            self.assertIn("successful-upgrade authority", self._commit_error(repo))
+
+    def test_git_hooks_cannot_expand_maintenance_commit_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            hooks = Path(directory) / "hooks"
+            hooks.mkdir()
+            hook = hooks / "pre-commit"
+            hook.write_text(
+                "#!/bin/sh\nprintf 'hooked\\n' > product-from-hook.txt\ngit add product-from-hook.txt\n",
+                encoding="utf-8",
+            )
+            hook.chmod(0o755)
+            self._git(["config", "core.hooksPath", str(hooks)], repo)
+
+            upgrade.commit(repo, "TASK-78", "maintenance")
+
+            self.assertFalse((repo / "product-from-hook.txt").exists())
+            committed = self._git(["show", "--pretty=", "--name-only", "HEAD"], repo).splitlines()
+            self.assertNotIn("product-from-hook.txt", committed)
+
+    def test_ambient_git_execution_and_identity_overrides_are_scrubbed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            external_diff = Path(directory) / "external-diff"
+            marker = Path(directory) / "external-diff-ran"
+            external_diff.write_text(
+                f"#!/bin/sh\ntouch {marker}\n",
+                encoding="utf-8",
+            )
+            external_diff.chmod(0o755)
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GIT_EXTERNAL_DIFF": str(external_diff),
+                    "GIT_AUTHOR_NAME": "Injected Author",
+                    "GIT_AUTHOR_EMAIL": "injected@example.invalid",
+                    "GIT_COMMITTER_NAME": "Injected Committer",
+                    "GIT_COMMITTER_EMAIL": "injected@example.invalid",
+                },
+                clear=False,
+            ):
+                upgrade.commit(repo, "TASK-78", "maintenance")
+
+            self.assertFalse(marker.exists())
+            self.assertEqual("Test User", self._git(["show", "-s", "--format=%an", "HEAD"], repo))
+            self.assertEqual("Test User", self._git(["show", "-s", "--format=%cn", "HEAD"], repo))
+
+    def test_ordinary_task_commit_still_rejects_automation_core(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self._task_repo(Path(directory) / "repo")
+            self._write_file(repo / ".automation/policy.toml", '[paths]\nautomation_core = ["Justfile", ".automation/**"]\nsecret_patterns = []\n')
+            self._write_file(repo / "Justfile", "changed\n")
+            with mock.patch.object(agent_core, "ensure_task_branch", return_value="task/TASK-78-maintenance"), \
+                    mock.patch.object(agent_core, "pending_paths", return_value=["Justfile"]), \
+                    mock.patch.object(agent_core, "run") as run:
+                with self.assertRaisesRegex(agent_core.AutomationError, "Automation Core"):
+                    agent_core.commit_task(repo, "TASK-78", "ordinary")
+            run.assert_not_called()
+
+    def test_maintenance_environment_alone_is_not_commit_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self._task_repo(Path(directory) / "repo")
+            self._write_file(repo / ".automation/policy.toml", '[paths]\nautomation_core = []\nsecret_patterns = []\n')
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                error = self._commit_error(repo)
+            self.assertIn("no active successful automation upgrade receipt", error)
+
+    def test_receipt_rejects_product_adapter_repository_secret_and_task_state_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self._task_repo(Path(directory) / "repo")
+            self._write_file(repo / ".automation/policy.toml", '[paths]\nsecret_patterns = ["secret"]\n')
+            for path in ("product.txt", ".automation/ADAPTER", "just/project/mod.just", ".automation/secret.json", ".task-state/task.md"):
+                with self.subTest(path=path):
+                    with self.assertRaises(upgrade.UpgradeError):
+                        upgrade.receipt_paths(repo, {"changed_paths": [path]})
+
+    def test_receipt_rejects_missing_extra_and_identity_mismatched_diff(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            original = self._receipt(repo)
+            original["changed_paths"] = original["changed_paths"][:-1]
+            original["path_fingerprints"].pop(sorted(self._receipt(repo)["changed_paths"])[-1])
+            upgrade.atomic_json_write(upgrade.receipt_path(repo), original)
+            self.assertIn("pending paths do not exactly match", self._commit_error(repo))
+
+            receipt = self._receipt(repo)
+            self._write_file(repo / ".automation/extra", "extra\n")
+            self.assertIn("pending paths do not exactly match", self._commit_error(repo))
+
+    def test_receipt_rejects_wrong_task_branch_worktree_stale_head_and_fingerprint(self) -> None:
+        for field, value, expected in (
+            ("task_id", "OTHER", "identity"),
+            ("branch", "task/TASK-78-other", "identity"),
+            ("worktree", "/other/worktree", "identity"),
+            ("authority_head", "0" * 40, "HEAD"),
+        ):
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as directory:
+                repo, _ = self._apply_fixture(Path(directory))
+                receipt = self._receipt(repo)
+                receipt[field] = value
+                upgrade.atomic_json_write(upgrade.receipt_path(repo), receipt)
+                self.assertIn(expected, self._commit_error(repo))
+
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            path = self._receipt(repo)["changed_paths"][0]
+            target = repo / Path(*path.split("/"))
+            target.write_bytes(target.read_bytes() + b"changed")
+            self.assertIn("fingerprint changed", self._commit_error(repo))
+            target.chmod(target.stat().st_mode ^ 0o100)
+            # Restore content, then mode alone must still invalidate the receipt.
+            target.write_bytes(target.read_bytes()[:-7])
+            self.assertIn("fingerprint changed", self._commit_error(repo))
+
+    def test_task_state_identity_mismatches_are_rejected(self) -> None:
+        for replacement, expected in (
+            ("- Task ID: OTHER", "does not match requested Task"),
+            ("- Branch: task/OTHER-maintenance", "not the Task branch"),
+            ("- Worktree: /other/worktree", "does not match the current worktree"),
+        ):
+            with self.subTest(replacement=replacement), tempfile.TemporaryDirectory() as directory:
+                repo, _ = self._apply_fixture(Path(directory))
+                state = repo / ".task-state/task.md"
+                text = state.read_text(encoding="utf-8")
+                label, value = replacement.split(": ", 1)
+                lines = [line if not line.startswith(label) else replacement for line in text.splitlines()]
+                state.write_text("\n".join(lines) + "\n", encoding="utf-8")
+                self.assertIn(expected, self._commit_error(repo))
+
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            state = repo / ".task-state/task.md"
+            state.write_text(
+                state.read_text(encoding="utf-8").replace(
+                    "- Branch: task/TASK-78-maintenance", "- Branch: task/TASK-78-unregistered"
+                ),
+                encoding="utf-8",
+            )
+            self.assertIn("not registered", self._commit_error(repo))
+
+    def test_missing_consumed_receipt_and_cached_diff_failure_restore_active_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            receipt = self._receipt(repo)
+            upgrade.receipt_path(repo).unlink()
+            self.assertIn("no active", self._commit_error(repo))
+            upgrade.atomic_json_write(upgrade.receipt_path(repo), receipt)
+            upgrade.atomic_json_write(upgrade.consumed_receipt_path(repo), receipt | {"status": "consumed"})
+            upgrade.receipt_path(repo).unlink()
+            self.assertIn("no active", self._commit_error(repo))
+
+            upgrade.atomic_json_write(upgrade.receipt_path(repo), receipt)
+            path = receipt["changed_paths"][0]
+            target = repo / Path(*path.split("/"))
+            original_bytes = target.read_bytes()
+            target.write_bytes(original_bytes.rstrip(b"\n") + b"  \n")
+            updated = self._receipt(repo)
+            updated["path_fingerprints"][path] = upgrade.file_fingerprint(repo, path)
+            upgrade.atomic_json_write(upgrade.receipt_path(repo), updated)
+            upgrade.write_authority(repo, updated)
+            self.assertIn("git diff --no-ext-diff --cached --check", self._commit_error(repo))
+            target.write_bytes(original_bytes)
+            self._git(["reset", "--mixed", "HEAD"], repo)
+            upgrade.atomic_json_write(upgrade.receipt_path(repo), receipt)
+            upgrade.write_authority(repo, receipt)
+            original_run = upgrade.run
+
+            def fake_run(command, *, cwd, **kwargs):
+                if command == [
+                    "git",
+                    "diff",
+                    "--no-ext-diff",
+                    "--cached",
+                    "--name-only",
+                ]:
+                    return subprocess.CompletedProcess(command, 0, stdout="AGENTS.md\nextra\n", stderr="")
+                return original_run(command, cwd=cwd, **kwargs)
+
+            with mock.patch.object(
+                upgrade, "pending_paths", return_value=receipt["changed_paths"]
+            ), mock.patch.object(upgrade, "run", side_effect=fake_run):
+                self.assertIn("staged paths", self._commit_error(repo))
+            self.assertTrue(upgrade.receipt_path(repo).exists())
+            self.assertFalse(upgrade.consumed_receipt_path(repo).exists())
+
+    def test_source_revision_is_null_for_non_git_source(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, source = self._apply_fixture(Path(directory), source_git=False)
+            self.assertIsNone(self._receipt(repo)["source_revision"])
 
 
 if __name__ == "__main__":

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import sys
 import tempfile
@@ -8,6 +9,7 @@ import unittest
 import os
 import shutil
 import subprocess
+import tarfile
 from contextlib import ExitStack
 from pathlib import Path
 from unittest import mock
@@ -160,6 +162,93 @@ mod project 'just/project/mod.just'
         result = subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True, check=True)
         return result.stdout.strip()
 
+    def _materialize_release_template(self, destination: Path) -> None:
+        release = "a42ce1cc30e1a73e33c268a65c8957debc54d4cd"
+        self.assertEqual(release, self._git(["rev-parse", "v3.0.0^{commit}"], ROOT))
+        archive = subprocess.run(
+            ["git", "archive", "--format=tar", "v3.0.0", "templates/agent-base"],
+            cwd=ROOT, capture_output=True, check=True,
+        ).stdout
+        prefix = "templates/agent-base/"
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as tar:
+            for member in tar.getmembers():
+                relative = member.name.removeprefix(prefix)
+                if not relative or relative == member.name:
+                    continue
+                target = destination / relative
+                if member.isdir():
+                    target.mkdir(parents=True, exist_ok=True)
+                elif member.issym():
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.symlink_to(member.linkname)
+                elif member.isfile():
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    extracted = tar.extractfile(member)
+                    assert extracted is not None
+                    target.write_bytes(extracted.read())
+                    target.chmod(member.mode)
+
+    def _real_cli_fixture(self, root: Path) -> tuple[Path, Path, dict]:
+        main = root / "consumer-main"
+        main.mkdir(parents=True)
+        self._materialize_release_template(main)
+        self._write_file(root / "outside-product", "product\n")
+        (main / "product-link").symlink_to(root / "outside-product")
+        self._git(["init", "-b", "main"], main)
+        self._git(["config", "user.name", "Test User"], main)
+        self._git(["config", "user.email", "test@example.invalid"], main)
+        self._git(["add", "-A"], main)
+        self._git(["commit", "-m", "release fixture"], main)
+        head = self._git(["rev-parse", "HEAD"], main)
+        self._git(["update-ref", "refs/remotes/origin/main", head], main)
+        self._git(["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], main)
+        task = root / "consumer-task"
+        self._git(["worktree", "add", "-b", "task/TASK-78-maintenance", str(task)], main)
+        self._write_file(task / ".task-state/task.md", f"- Task ID: TASK-78\n- Branch: task/TASK-78-maintenance\n- Worktree: {task.resolve()}\n")
+        exclude = Path(self._git(["rev-parse", "--git-path", "info/exclude"], task))
+        if not exclude.is_absolute():
+            exclude = task / exclude
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        exclude.write_text("/.task-state/\n", encoding="utf-8")
+        self.assertEqual("origin/main", self._git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], task))
+        self.assertIn(str(task.resolve()), self._git(["worktree", "list", "--porcelain"], main))
+        ignored = subprocess.run(["git", "check-ignore", "-q", ".task-state/task.md"], cwd=task)
+        self.assertEqual(0, ignored.returncode)
+        source = root / "templates-source"
+        shutil.copytree(
+            ROOT / "components" / "agent-core",
+            source / "components" / "agent-core",
+            symlinks=True,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+        )
+        self._git(["init", "-b", "main"], source)
+        self._git(["config", "user.name", "Test User"], source)
+        self._git(["config", "user.email", "test@example.invalid"], source)
+        self._git(["add", "components/agent-core"], source)
+        self._git(["commit", "-m", "current Agent Core source"], source)
+        return task, source, {"release_head": head}
+
+    def _cli(self, repo: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["AUTOMATION_MAINTENANCE"] = "1"
+        result = subprocess.run(["python3", ".automation/bin/automation_upgrade.py", *args], cwd=repo, env=environment, text=True, capture_output=True, check=False)
+        if check:
+            self.assertEqual(0, result.returncode, result.stderr)
+        return result
+
+    def _old_process_fixture(self, root: Path) -> tuple[Path, Path, dict]:
+        task, source, metadata = self._real_cli_fixture(root)
+        metadata["release_version"] = (task / ".automation/VERSION").read_text(encoding="utf-8").strip()
+        metadata["source_version"] = (source / "components/agent-core/.automation/VERSION").read_text(encoding="utf-8").strip()
+        recipe = (task / ".automation/just/automation.just").read_text(encoding="utf-8")
+        self.assertIn("upgrade source:", recipe)
+        self.assertIn("python3 '{{script}}' upgrade --source '{{source}}'", recipe)
+        result = json.loads(self._cli(task, ["upgrade", "--source", str(source)]).stdout)
+        self.assertEqual("APPLIED", result["status"])
+        self.assertFalse(upgrade.receipt_path(task).exists())
+        self.assertFalse(upgrade.authority_path(task).exists())
+        return task, source, result | metadata
+
     def _task_repo(self, repo: Path, *, task: str = "TASK-78") -> Path:
         repo.mkdir(parents=True)
         self._git(["init", "-b", "main"], repo)
@@ -241,6 +330,10 @@ mod project 'just/project/mod.just'
         self.assertEqual(bash["just automation::version"], "allow")
         self.assertEqual(bash["just automation::check-update *"], "allow")
         self.assertEqual(bash["just automation::upgrade *"], "ask")
+        self.assertEqual(bash["just automation::bootstrap-receipt *"], "ask")
+        recipe = (ROOT / "components" / "agent-core" / ".automation" / "just" / "automation.just").read_text()
+        self.assertIn("bootstrap-receipt source:", recipe)
+        self.assertIn("python3 {{quote(script)}} bootstrap-receipt --source {{quote(source)}}", recipe)
 
     def test_upgrade_preserves_adapter_and_repository_owned_paths(self) -> None:
         script = SCRIPT.read_text()
@@ -1027,6 +1120,80 @@ mod project 'just/project/mod.just'
         with tempfile.TemporaryDirectory() as directory:
             repo, source = self._apply_fixture(Path(directory), source_git=False)
             self.assertIsNone(self._receipt(repo)["source_revision"])
+
+    def test_pending_paths_handles_nul_delimited_git_names(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self._task_repo(Path(directory) / "repo")
+            odd = repo / ".automation" / "pending\nname"
+            self._write_file(odd, "pending\n")
+            self.assertEqual([".automation/pending\nname"], upgrade.pending_paths(repo))
+
+    def test_real_two_generation_cli_bootstrap_and_commit_are_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            task, source, old_result = self._old_process_fixture(Path(directory))
+            self.assertEqual(old_result["release_head"], self._git(["rev-parse", "HEAD"], task))
+            self.assertEqual(sorted(old_result["changedPaths"]), upgrade.pending_paths(task))
+            self.assertEqual("product\n", (Path(directory) / "outside-product").read_text())
+            boot = json.loads(self._cli(task, ["bootstrap-receipt", "--source", str(source)]).stdout)
+            self.assertEqual("RECEIPT_BOOTSTRAPPED", boot["status"])
+            receipt = self._receipt(task)
+            self.assertEqual(str(source.resolve()), receipt["source"])
+            self.assertEqual(self._git(["rev-parse", "HEAD"], source), receipt["source_revision"])
+            self.assertEqual(
+                [old_result["release_version"], old_result["source_version"]],
+                [receipt["current_version"], receipt["upstream_version"]],
+            )
+            self.assertEqual(sorted(old_result["changedPaths"]), receipt["changed_paths"])
+            self.assertEqual(set(receipt["changed_paths"]), set(receipt["path_fingerprints"]))
+            self.assertTrue(upgrade.authority_path(task).is_file())
+            committed = json.loads(self._cli(task, ["commit", "TASK-78", "maintenance"]).stdout)
+            self.assertEqual("COMMITTED", committed["status"])
+            self.assertFalse(upgrade.receipt_path(task).exists())
+            paths = sorted(self._git(["show", "--pretty=", "--name-only", "HEAD"], task).splitlines())
+            self.assertEqual(receipt["changed_paths"], paths)
+            self.assertFalse(any(path.startswith("just/project/") for path in paths))
+            self.assertNotIn(".automation/ADAPTER", paths)
+            self.assertNotIn("product-link", paths)
+
+    def test_real_bridge_rejects_protected_paths_and_core_tampering(self) -> None:
+        for pending_path in ("product.txt", ".automation/ADAPTER", "just/project/mod.just"):
+            with self.subTest(pending_path=pending_path), tempfile.TemporaryDirectory() as directory:
+                task, source, _ = self._old_process_fixture(Path(directory))
+                self._write_file(task / pending_path, "unauthorized\n")
+                result = self._cli(task, ["bootstrap-receipt", "--source", str(source)], check=False)
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("pending path", result.stderr)
+                self.assertFalse(upgrade.receipt_path(task).exists())
+                self.assertFalse(upgrade.authority_path(task).exists())
+        with tempfile.TemporaryDirectory() as directory:
+            task, source, old_result = self._old_process_fixture(Path(directory))
+            path = old_result["changedPaths"][0]
+            target = task / Path(*path.split("/"))
+            target.write_bytes(target.read_bytes() + b"tampered\n")
+            result = self._cli(task, ["bootstrap-receipt", "--source", str(source)], check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("reconstructed", result.stderr)
+            self.assertFalse(upgrade.receipt_path(task).exists())
+            self.assertFalse(upgrade.authority_path(task).exists())
+
+        with tempfile.TemporaryDirectory() as directory:
+            task, source, _ = self._old_process_fixture(Path(directory))
+            self._write_file(source / "components/agent-core/.automation/dirty", "dirty\n")
+            result = self._cli(task, ["bootstrap-receipt", "--source", str(source)], check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("must be clean", result.stderr)
+            self.assertFalse(upgrade.receipt_path(task).exists())
+            self.assertFalse(upgrade.authority_path(task).exists())
+
+    def test_real_bridge_rejects_no_change_without_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            task, source, _ = self._old_process_fixture(Path(directory))
+            self._git(["add", "-A"], task)
+            self._git(["commit", "-m", "simulate already published upgrade"], task)
+            result = self._cli(task, ["bootstrap-receipt", "--source", str(source)], check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("non-empty pending paths", result.stderr)
+            self.assertFalse(upgrade.authority_path(task).exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- issue upgrade receipts bound to registered Task identity, exact Agent Core diff state, and protected successful-upgrade authority
- add `automation::commit` with fail-closed ownership, secret, Task State, staged-blob, private-index, and atomic branch guards
- add `automation::bootstrap-receipt` for pre-receipt self-upgrades, reconstructing canonical output from tracked HEAD and a clean pinned source before authority issuance
- preserve ordinary `agent::commit`, reuse guarded push/Draft PR flow, and document receipt lifecycle
- regenerate all templates and add real v3.0.0-to-PR-head two-generation coverage

## Verification
- `python3 -m unittest discover -s tests -v` (238 tests)
- focused automation tests (61 tests)
- `just template::check`
- `just template::distribution-verify`
- `git diff --check`
- independent correctness and security reviews: no findings

Closes #78