### PR TITLE
Pin Agent Core upgrade planning to tracked source

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ just automation::check-update /path/to/Templates
 
 This reports current/upstream versions and the ownership boundaries without mutating the repository. Agent Core upgrades must never be silently mixed into an ordinary Task.
 
+Both `automation::check-update` and `automation::upgrade` accept only a trusted
+Git worktree root for the Templates source. The source worktree must have a
+full, non-null `HEAD` and a clean `components/agent-core` scope: tracked
+modifications and non-ignored untracked paths there are rejected. Ignored
+generated artifacts are not part of the source input and are structurally
+absent from the operation. The command pins the source `HEAD`, materializes
+only the tracked `components/agent-core` objects into a temporary snapshot, and
+plans/copies only from that snapshot. A compatible Agent Core `VERSION` drift
+is still reported; a source race after pinning fails closed.
+
 ## Agent Core upgrade
 
 Use a dedicated, registered, non-default **Automation Maintenance Task** worktree. The complete canonical publication workflow is:
@@ -220,7 +230,16 @@ Use a dedicated, registered, non-default **Automation Maintenance Task** worktre
 AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
 ```
 
-The source must be a trusted local Templates checkout. The command refuses the default branch, an unregistered Task, missing Task State, or a non-ignored/tracked Task State path. The ambient `AUTOMATION_MAINTENANCE=1` variable grants upgrade opt-in only; it does not grant commit authority, and ordinary `just agent::commit <task>` still rejects Automation Core changes.
+The source must be a trusted clean local Templates Git worktree root. The
+command pins its full `HEAD`, materializes only tracked
+`components/agent-core` objects into a temporary snapshot, and plans/copies
+only from that snapshot. Tracked modifications or non-ignored untracked paths
+under Agent Core, a source race, or an invalid source root fail closed; ignored
+generated artifacts are structurally absent. The command also refuses the
+default branch, an unregistered Task, missing Task State, or a
+non-ignored/tracked Task State path. The ambient `AUTOMATION_MAINTENANCE=1`
+variable grants upgrade opt-in only; it does not grant commit authority, and
+ordinary `just agent::commit <task>` still rejects Automation Core changes.
 
 It materializes only Agent Core-owned paths and preserves Adapter-owned `.automation/ADAPTER`, `.automation/INIT.fragment.md`, `.automation/adoption.toml`, `just/project/**`, local modules, and repository CI. On success it creates or replaces the ignored `.task-state/automation-maintenance.json` receipt; it does not commit, push, or merge. Inspect the diff and run:
 
@@ -243,14 +262,16 @@ AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git T
 ```
 
 The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-pins the clean source revision, reconstructs expected output by materializing the
-tracked `HEAD` Agent Core baseline and applying canonical upgrade semantics in
-isolation, then requires exact pending paths, content, modes, and Task
-identity/`HEAD` before issuing the existing receipt and protected authority. Any
-product, Adapter, repository, secret-pattern, or `.task-state` path, or tampering,
-fails closed. Continue with the existing commit/push/Draft-PR flow; ordinary
-`agent::commit` rejection and the receipt/authority design remain unchanged.
-This is the PR #79 review fix only; it does not change Issue #77.
+uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+normal `automation::check-update` and `automation::upgrade`, reconstructs
+expected output by applying canonical upgrade semantics in isolation, then
+requires exact pending paths, content, modes, and Task identity/`HEAD` before
+issuing the existing receipt and protected authority. The receipt's
+`source_revision` is the pinned snapshot `HEAD`; any source race fails closed.
+Any product, Adapter, repository, secret-pattern, or `.task-state` path, or
+tampering, fails closed. Continue with the existing commit/push/Draft-PR flow;
+ordinary `agent::commit` rejection and the receipt/authority design remain
+unchanged.
 
 `automation::commit` is the only commit path for this upgrade. It fails closed unless the schema-1 JSON receipt contains Task `task_id`, `branch`, `worktree`, source/source revision, current/upstream versions, sorted unique `changed_paths`, `authority_head`, and matching `path_fingerprints`. Receipt identity must match the current Task/worktree and `authority_head` must equal current `HEAD`; every fingerprint and the complete pending path set must still match. A protected record under the shared Git directory binds the active receipt to the preceding successful upgrade, so an ambient variable or fabricated Task State receipt is not commit authority. Receipt paths must be Agent Core-managed only: mixed Adapter, repository, product, secret-pattern, or `.task-state` paths are rejected. The command scrubs ambient Git repository/index overrides, stages into a private Task State index, checks the exact staged blobs and modes, creates the commit from that verified tree without hooks, and atomically advances only the expected Task branch HEAD.
 

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -22,6 +22,14 @@ Templates checkout as the source:
 AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
 ```
 
+The source must be a trusted clean Git worktree root with a full, non-null
+`HEAD`. Both `automation::check-update` and `automation::upgrade` reject
+tracked modifications and non-ignored untracked paths under
+`components/agent-core`; ignored generated artifacts are structurally absent.
+They pin the source `HEAD`, materialize only tracked Agent Core objects into a
+temporary snapshot, and plan/copy only from that snapshot. Compatible
+`VERSION` drift remains detectable, while a source race fails closed.
+
 The environment variable is an upgrade opt-in only. It does not authorize a
 commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
 Upgrade does not commit, push, or merge and writes the ignored receipt
@@ -46,14 +54,15 @@ AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git T
 ```
 
 The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-pins the clean source revision, materializes the tracked `HEAD` Agent Core
-baseline, applies canonical upgrade semantics in isolation, and requires exact
-pending paths/content/modes plus Task identity and `HEAD` before issuing the
-existing receipt and protected authority. Product, Adapter, repository,
-secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
-with the existing `automation::commit` flow; ordinary `agent::commit` rejection
-and the receipt/authority design remain unchanged. This is the PR #79 review fix
-only; there are no Issue #77 changes.
+uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, applies canonical upgrade semantics in isolation,
+and requires exact pending paths/content/modes plus Task identity and `HEAD`
+before issuing the existing receipt and protected authority. The receipt's
+`source_revision` equals the pinned snapshot `HEAD`; any source race fails
+closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
+and any tampering, fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection and the
+receipt/authority design remain unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -233,6 +233,13 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
+@dataclass(frozen=True)
+class SavedPath:
+    kind: str
+    content: bytes | str | None
+    mode: int | None
+
+
 def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
@@ -716,6 +723,25 @@ def materialize_tree(
         target.chmod(0o755 if fields[0] == b"100755" else 0o644)
 
 
+def materialize_source_snapshot(source: Path, revision: str, temporary: Path) -> tuple[Path, Path]:
+    """Reconstruct only Agent Core from a pinned source revision.
+
+    The returned paths are (synthetic Templates root, synthetic Agent Core
+    root).  In particular, callers must not use the live source checkout for
+    planning or copying after this point.
+    """
+    snapshot_root = temporary / "source"
+    source_core = snapshot_root / "components" / "agent-core"
+    materialize_tree(source, revision, source_core, "components/agent-core")
+    return snapshot_root, source_core
+
+
+def revalidate_source(source: Path, revision: str) -> None:
+    current, current_revision = resolve_pinned_source(source)
+    if current != source or current_revision != revision:
+        raise UpgradeError("source changed during upgrade planning or mutation")
+
+
 def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
@@ -779,6 +805,44 @@ def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
                 raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
     return sorted(set(changed))
+
+
+def capture_paths(tree: Path, paths: list[str]) -> dict[str, SavedPath]:
+    saved: dict[str, SavedPath] = {}
+    for raw_path in paths:
+        target = tree / Path(*raw_path.split("/"))
+        try:
+            metadata = target.lstat()
+        except FileNotFoundError:
+            saved[raw_path] = SavedPath("absent", None, None)
+            continue
+        mode = stat.S_IMODE(metadata.st_mode)
+        if target.is_symlink():
+            saved[raw_path] = SavedPath("symlink", os.readlink(target), mode)
+        elif target.is_file():
+            saved[raw_path] = SavedPath("file", target.read_bytes(), mode)
+        else:
+            raise UpgradeError(f"cannot snapshot unsafe upgrade destination path: {raw_path}")
+    return saved
+
+
+def restore_paths(tree: Path, saved: dict[str, SavedPath]) -> None:
+    for raw_path, state in saved.items():
+        target = tree / Path(*raw_path.split("/"))
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif path_present(target):
+            raise UpgradeError(f"cannot restore upgrade destination path: {raw_path}")
+        if state.kind == "absent":
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if state.kind == "file" and isinstance(state.content, bytes) and state.mode is not None:
+            target.write_bytes(state.content)
+            target.chmod(state.mode)
+        elif state.kind == "symlink" and isinstance(state.content, str):
+            target.symlink_to(state.content)
+        else:  # pragma: no cover - capture_paths constructs only valid states
+            raise UpgradeError(f"invalid saved upgrade destination state: {raw_path}")
 
 
 def build_plan(repo: Path, source: Path) -> dict:
@@ -846,64 +910,93 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     return identity
 
 
-def apply(repo: Path, source: Path) -> dict:
+def check_update(repo: Path, source_path: Path) -> dict:
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-update-") as temporary:
+        snapshot, _ = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        revalidate_source(source, revision)
+    plan["source"] = str(source)
+    plan["sourceRevision"] = revision
+    return plan
+
+
+def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
-    plan = build_plan(repo, source)
-    if plan["blockers"]:
-        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
-    source_core = source / "components" / "agent-core"
-    changed: list[str] = []
-    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
-    if not actionable:
-        return {
-            "status": "NO_CHANGES",
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
+        snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        # This check is deliberately before any destination mutation, including
+        # the no-change return path.
+        revalidate_source(source, revision)
+        actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+        if not actionable:
+            return {
+                "status": "NO_CHANGES",
+                "repositoryRoot": str(repo),
+                "sourceCore": str(source / "components" / "agent-core"),
+                "sourceRevision": revision,
+                "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+                "changedPaths": [],
+                "commitCreated": False,
+                "pushPerformed": False,
+                "mergePerformed": False,
+                "requiredNextChecks": [],
+            }
+        expected_paths = sorted({item["path"] for item in actionable})
+        saved_paths = capture_paths(repo, expected_paths)
+        changed = apply_plan_to_tree(repo, source_core, plan)
+        # A source race after mutation fails closed: no receipt is issued.
+        try:
+            revalidate_source(source, revision)
+        except UpgradeError as source_error:
+            try:
+                restore_paths(repo, saved_paths)
+            except UpgradeError as restore_error:
+                raise UpgradeError(
+                    f"{source_error}; destination rollback failed: {restore_error}"
+                ) from restore_error
+            raise
+        changed_paths = sorted(set(changed))
+        result = {
+            "status": "APPLIED",
             "repositoryRoot": str(repo),
-            "sourceCore": str(source_core),
+            "sourceCore": str(source / "components" / "agent-core"),
+            "sourceRevision": revision,
             "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-            "changedPaths": [],
+            "changedPaths": changed_paths,
             "commitCreated": False,
             "pushPerformed": False,
             "mergePerformed": False,
-            "requiredNextChecks": [],
+            "requiredNextChecks": [
+                "git diff --check",
+                "just agent::doctor",
+                "just project::check",
+                "repository CI/smoke tests",
+            ],
         }
-    changed = apply_plan_to_tree(repo, source_core, plan)
-    result = {
-        "status": "APPLIED",
-        "repositoryRoot": str(repo),
-        "sourceCore": str(source_core),
-        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-        "changedPaths": changed,
-        "commitCreated": False,
-        "pushPerformed": False,
-        "mergePerformed": False,
-        "requiredNextChecks": [
-            "git diff --check",
-            "just agent::doctor",
-            "just project::check",
-            "repository CI/smoke tests",
-        ],
-    }
-    changed_paths = sorted(set(changed))
-    result["changedPaths"] = changed_paths
-    receipt = {
-        "schema_version": 1,
-        "status": "active",
-        "task_id": task_id,
-        "branch": branch,
-        "worktree": str(worktree),
-        "source": str(source.resolve()),
-        "source_revision": source_revision(source),
-        "current_version": plan["currentVersion"],
-        "upstream_version": plan["upstreamVersion"],
-        "changed_paths": changed_paths,
-        "authority_head": git_head(repo),
-        "authority_nonce": secrets.token_hex(32),
-        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
-    }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
-    return result
+        receipt = {
+            "schema_version": 1,
+            "status": "active",
+            "task_id": task_id,
+            "branch": branch,
+            "worktree": str(worktree),
+            "source": str(source),
+            "source_revision": revision,
+            "current_version": plan["currentVersion"],
+            "upstream_version": plan["upstreamVersion"],
+            "changed_paths": changed_paths,
+            "authority_head": git_head(repo),
+            "authority_nonce": secrets.token_hex(32),
+            "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+        }
+        atomic_json_write(receipt_path(repo), receipt)
+        write_authority(repo, receipt)
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+        return result
 
 
 def pending_paths(repo: Path) -> list[str]:
@@ -948,7 +1041,7 @@ def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
         raise UpgradeError(f"pending path is outside Agent Core: {path}")
 
 
-def bootstrap_receipt(repo: Path, source: Path) -> dict:
+def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
@@ -959,13 +1052,13 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
-    source, source_head = resolve_pinned_source(source)
+    source, source_head = resolve_pinned_source(source_path)
     require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
     with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
-        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        materialize_source_snapshot(source, source_head, Path(temporary))
         before = {
             p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
             for p in baseline.rglob("*") if p.is_file()
@@ -990,11 +1083,10 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         if expected != pending:
             raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
         if not expected:
+            revalidate_source(source, source_head)
             return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
         expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
-    pinned_source, current_source_head = resolve_pinned_source(source)
-    if pinned_source != source or current_source_head != source_head:
-        raise UpgradeError("source changed during receipt reconstruction")
+    revalidate_source(source, source_head)
     current_identity = require_registered_task(repo, task_id)
     current_registration = registered_worktrees(repo).get(worktree)
     if (
@@ -1252,11 +1344,11 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = build_plan(repo, resolve_source(args.source))
+            result = check_update(repo, args.source)
         elif args.command == "upgrade":
-            result = apply(repo, resolve_source(args.source))
+            result = apply(repo, args.source)
         elif args.command == "bootstrap-receipt":
-            result = bootstrap_receipt(repo, resolve_source(args.source))
+            result = bootstrap_receipt(repo, args.source)
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -616,7 +616,27 @@ Agent Core upgrades are a separate, dedicated publication workflow, not ordinary
 AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
 ```
 
-The ambient variable is only an upgrade opt-in. It cannot authorize a commit; ordinary `just agent::commit <task>` continues to reject Automation Core paths. Upgrade preserves Adapter, repository, product, and CI-owned paths, and performs no commit, push, or merge.
+The source must be a trusted clean local Templates Git worktree root. The
+command pins its full, non-null `HEAD`, materializes only tracked
+`components/agent-core` objects into a temporary snapshot, and plans/copies
+only from that snapshot. Tracked modifications or non-ignored untracked paths
+under Agent Core, an invalid source root, or a source race fail closed; ignored
+generated artifacts are structurally absent. The command also refuses the
+default branch, an unregistered Task, missing Task State, or a
+non-ignored/tracked Task State path. The ambient variable is only an upgrade
+opt-in. It cannot authorize a commit; ordinary `just agent::commit <task>`
+continues to reject Automation Core paths. Upgrade preserves Adapter,
+repository, product, and CI-owned paths, and performs no commit, push, or
+merge.
+
+The read-only `automation::check-update` operation applies the same source
+contract: its Templates argument must be a trusted clean Git worktree root
+with a full `HEAD`, and tracked or non-ignored untracked changes under
+`components/agent-core` are rejected. Ignored generated artifacts are
+structurally absent; compatible `VERSION` drift remains detectable. It pins
+the source `HEAD`, materializes only tracked Agent Core objects into a
+temporary snapshot, and plans only from that snapshot. A source race fails
+closed.
 
 The canonical publication flows are:
 
@@ -632,17 +652,19 @@ The canonical publication flows are:
    ```
 
    This bridge does not trust `NO_CHANGES`, the current diff, or the environment.
-   It pins the clean source revision, materializes the tracked `HEAD` Agent Core
-   baseline, and applies canonical upgrade semantics in isolation to reconstruct
-   expected output. It then requires exact pending paths, content, and modes,
-   plus matching Task identity and `HEAD`, before issuing the existing receipt
-   and protected authority. Product, Adapter, repository, secret-pattern, or
-   `.task-state` paths and any tampering fail closed.
+   It uses the same pinned clean-source and tracked Agent Core snapshot
+   semantics as normal `automation::check-update` and `automation::upgrade`,
+   then applies canonical upgrade semantics in isolation to reconstruct
+   expected output. It requires exact pending paths, content, and modes, plus
+   matching Task identity and `HEAD`, before issuing the existing receipt and
+   protected authority. The receipt's `source_revision` is the pinned snapshot
+   `HEAD`; any source race fails closed. Product, Adapter, repository,
+   secret-pattern, or `.task-state` paths and any tampering fail closed.
 
 The bridge only repairs missing pre-receipt evidence; the existing receipt and
 authority design remains in force, and ordinary `agent::commit` continues to
-reject Automation Core changes. This is the PR #79 review fix only; no Issue #77
-behavior or scope changes.
+reject Automation Core changes. Its source and snapshot semantics align with
+the normal upgrade workflow.
 
 Successful upgrade writes or replaces the ignored `.task-state/automation-maintenance.json` receipt. Its schema-1 content records Task identity (`task_id`, `branch`, `worktree`), source and source revision, current/upstream versions, sorted unique `changed_paths`, the authority `HEAD`, and per-path content/state fingerprints. A protected record in the shared Git directory binds that receipt to the successful upgrade. `automation::commit <task> [message]` fails closed unless both records match the current Task/worktree identity and `HEAD`, fingerprints, and complete pending path set. Receipt paths must be Agent Core-managed; any mixed Adapter, repository, product, configured-secret, or `.task-state` scope is rejected. Ambient Git repository/index overrides are scrubbed; exact blobs and modes are staged and rechecked in a private index, committed as that verified tree without hooks, and published only by an atomic expected-HEAD Task branch update. The receipt is moved to `.task-state/automation-maintenance.consumed.json` after successful commit; the next successful upgrade with changes replaces the active receipt and removes the prior consumed receipt. A no-change invocation returns `NO_CHANGES` and preserves existing lifecycle evidence.
 

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -22,6 +22,14 @@ Templates checkout as the source:
 AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
 ```
 
+The source must be a trusted clean Git worktree root with a full, non-null
+`HEAD`. Both `automation::check-update` and `automation::upgrade` reject
+tracked modifications and non-ignored untracked paths under
+`components/agent-core`; ignored generated artifacts are structurally absent.
+They pin the source `HEAD`, materialize only tracked Agent Core objects into a
+temporary snapshot, and plan/copy only from that snapshot. Compatible
+`VERSION` drift remains detectable, while a source race fails closed.
+
 The environment variable is an upgrade opt-in only. It does not authorize a
 commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
 Upgrade does not commit, push, or merge and writes the ignored receipt
@@ -46,14 +54,15 @@ AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git T
 ```
 
 The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-pins the clean source revision, materializes the tracked `HEAD` Agent Core
-baseline, applies canonical upgrade semantics in isolation, and requires exact
-pending paths/content/modes plus Task identity and `HEAD` before issuing the
-existing receipt and protected authority. Product, Adapter, repository,
-secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
-with the existing `automation::commit` flow; ordinary `agent::commit` rejection
-and the receipt/authority design remain unchanged. This is the PR #79 review fix
-only; there are no Issue #77 changes.
+uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, applies canonical upgrade semantics in isolation,
+and requires exact pending paths/content/modes plus Task identity and `HEAD`
+before issuing the existing receipt and protected authority. The receipt's
+`source_revision` equals the pinned snapshot `HEAD`; any source race fails
+closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
+and any tampering, fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection and the
+receipt/authority design remain unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -233,6 +233,13 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
+@dataclass(frozen=True)
+class SavedPath:
+    kind: str
+    content: bytes | str | None
+    mode: int | None
+
+
 def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
@@ -716,6 +723,25 @@ def materialize_tree(
         target.chmod(0o755 if fields[0] == b"100755" else 0o644)
 
 
+def materialize_source_snapshot(source: Path, revision: str, temporary: Path) -> tuple[Path, Path]:
+    """Reconstruct only Agent Core from a pinned source revision.
+
+    The returned paths are (synthetic Templates root, synthetic Agent Core
+    root).  In particular, callers must not use the live source checkout for
+    planning or copying after this point.
+    """
+    snapshot_root = temporary / "source"
+    source_core = snapshot_root / "components" / "agent-core"
+    materialize_tree(source, revision, source_core, "components/agent-core")
+    return snapshot_root, source_core
+
+
+def revalidate_source(source: Path, revision: str) -> None:
+    current, current_revision = resolve_pinned_source(source)
+    if current != source or current_revision != revision:
+        raise UpgradeError("source changed during upgrade planning or mutation")
+
+
 def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
@@ -779,6 +805,44 @@ def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
                 raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
     return sorted(set(changed))
+
+
+def capture_paths(tree: Path, paths: list[str]) -> dict[str, SavedPath]:
+    saved: dict[str, SavedPath] = {}
+    for raw_path in paths:
+        target = tree / Path(*raw_path.split("/"))
+        try:
+            metadata = target.lstat()
+        except FileNotFoundError:
+            saved[raw_path] = SavedPath("absent", None, None)
+            continue
+        mode = stat.S_IMODE(metadata.st_mode)
+        if target.is_symlink():
+            saved[raw_path] = SavedPath("symlink", os.readlink(target), mode)
+        elif target.is_file():
+            saved[raw_path] = SavedPath("file", target.read_bytes(), mode)
+        else:
+            raise UpgradeError(f"cannot snapshot unsafe upgrade destination path: {raw_path}")
+    return saved
+
+
+def restore_paths(tree: Path, saved: dict[str, SavedPath]) -> None:
+    for raw_path, state in saved.items():
+        target = tree / Path(*raw_path.split("/"))
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif path_present(target):
+            raise UpgradeError(f"cannot restore upgrade destination path: {raw_path}")
+        if state.kind == "absent":
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if state.kind == "file" and isinstance(state.content, bytes) and state.mode is not None:
+            target.write_bytes(state.content)
+            target.chmod(state.mode)
+        elif state.kind == "symlink" and isinstance(state.content, str):
+            target.symlink_to(state.content)
+        else:  # pragma: no cover - capture_paths constructs only valid states
+            raise UpgradeError(f"invalid saved upgrade destination state: {raw_path}")
 
 
 def build_plan(repo: Path, source: Path) -> dict:
@@ -846,64 +910,93 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     return identity
 
 
-def apply(repo: Path, source: Path) -> dict:
+def check_update(repo: Path, source_path: Path) -> dict:
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-update-") as temporary:
+        snapshot, _ = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        revalidate_source(source, revision)
+    plan["source"] = str(source)
+    plan["sourceRevision"] = revision
+    return plan
+
+
+def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
-    plan = build_plan(repo, source)
-    if plan["blockers"]:
-        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
-    source_core = source / "components" / "agent-core"
-    changed: list[str] = []
-    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
-    if not actionable:
-        return {
-            "status": "NO_CHANGES",
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
+        snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        # This check is deliberately before any destination mutation, including
+        # the no-change return path.
+        revalidate_source(source, revision)
+        actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+        if not actionable:
+            return {
+                "status": "NO_CHANGES",
+                "repositoryRoot": str(repo),
+                "sourceCore": str(source / "components" / "agent-core"),
+                "sourceRevision": revision,
+                "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+                "changedPaths": [],
+                "commitCreated": False,
+                "pushPerformed": False,
+                "mergePerformed": False,
+                "requiredNextChecks": [],
+            }
+        expected_paths = sorted({item["path"] for item in actionable})
+        saved_paths = capture_paths(repo, expected_paths)
+        changed = apply_plan_to_tree(repo, source_core, plan)
+        # A source race after mutation fails closed: no receipt is issued.
+        try:
+            revalidate_source(source, revision)
+        except UpgradeError as source_error:
+            try:
+                restore_paths(repo, saved_paths)
+            except UpgradeError as restore_error:
+                raise UpgradeError(
+                    f"{source_error}; destination rollback failed: {restore_error}"
+                ) from restore_error
+            raise
+        changed_paths = sorted(set(changed))
+        result = {
+            "status": "APPLIED",
             "repositoryRoot": str(repo),
-            "sourceCore": str(source_core),
+            "sourceCore": str(source / "components" / "agent-core"),
+            "sourceRevision": revision,
             "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-            "changedPaths": [],
+            "changedPaths": changed_paths,
             "commitCreated": False,
             "pushPerformed": False,
             "mergePerformed": False,
-            "requiredNextChecks": [],
+            "requiredNextChecks": [
+                "git diff --check",
+                "just agent::doctor",
+                "just project::check",
+                "repository CI/smoke tests",
+            ],
         }
-    changed = apply_plan_to_tree(repo, source_core, plan)
-    result = {
-        "status": "APPLIED",
-        "repositoryRoot": str(repo),
-        "sourceCore": str(source_core),
-        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-        "changedPaths": changed,
-        "commitCreated": False,
-        "pushPerformed": False,
-        "mergePerformed": False,
-        "requiredNextChecks": [
-            "git diff --check",
-            "just agent::doctor",
-            "just project::check",
-            "repository CI/smoke tests",
-        ],
-    }
-    changed_paths = sorted(set(changed))
-    result["changedPaths"] = changed_paths
-    receipt = {
-        "schema_version": 1,
-        "status": "active",
-        "task_id": task_id,
-        "branch": branch,
-        "worktree": str(worktree),
-        "source": str(source.resolve()),
-        "source_revision": source_revision(source),
-        "current_version": plan["currentVersion"],
-        "upstream_version": plan["upstreamVersion"],
-        "changed_paths": changed_paths,
-        "authority_head": git_head(repo),
-        "authority_nonce": secrets.token_hex(32),
-        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
-    }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
-    return result
+        receipt = {
+            "schema_version": 1,
+            "status": "active",
+            "task_id": task_id,
+            "branch": branch,
+            "worktree": str(worktree),
+            "source": str(source),
+            "source_revision": revision,
+            "current_version": plan["currentVersion"],
+            "upstream_version": plan["upstreamVersion"],
+            "changed_paths": changed_paths,
+            "authority_head": git_head(repo),
+            "authority_nonce": secrets.token_hex(32),
+            "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+        }
+        atomic_json_write(receipt_path(repo), receipt)
+        write_authority(repo, receipt)
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+        return result
 
 
 def pending_paths(repo: Path) -> list[str]:
@@ -948,7 +1041,7 @@ def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
         raise UpgradeError(f"pending path is outside Agent Core: {path}")
 
 
-def bootstrap_receipt(repo: Path, source: Path) -> dict:
+def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
@@ -959,13 +1052,13 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
-    source, source_head = resolve_pinned_source(source)
+    source, source_head = resolve_pinned_source(source_path)
     require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
     with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
-        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        materialize_source_snapshot(source, source_head, Path(temporary))
         before = {
             p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
             for p in baseline.rglob("*") if p.is_file()
@@ -990,11 +1083,10 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         if expected != pending:
             raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
         if not expected:
+            revalidate_source(source, source_head)
             return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
         expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
-    pinned_source, current_source_head = resolve_pinned_source(source)
-    if pinned_source != source or current_source_head != source_head:
-        raise UpgradeError("source changed during receipt reconstruction")
+    revalidate_source(source, source_head)
     current_identity = require_registered_task(repo, task_id)
     current_registration = registered_worktrees(repo).get(worktree)
     if (
@@ -1252,11 +1344,11 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = build_plan(repo, resolve_source(args.source))
+            result = check_update(repo, args.source)
         elif args.command == "upgrade":
-            result = apply(repo, resolve_source(args.source))
+            result = apply(repo, args.source)
         elif args.command == "bootstrap-receipt":
-            result = bootstrap_receipt(repo, resolve_source(args.source))
+            result = bootstrap_receipt(repo, args.source)
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -22,6 +22,14 @@ Templates checkout as the source:
 AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
 ```
 
+The source must be a trusted clean Git worktree root with a full, non-null
+`HEAD`. Both `automation::check-update` and `automation::upgrade` reject
+tracked modifications and non-ignored untracked paths under
+`components/agent-core`; ignored generated artifacts are structurally absent.
+They pin the source `HEAD`, materialize only tracked Agent Core objects into a
+temporary snapshot, and plan/copy only from that snapshot. Compatible
+`VERSION` drift remains detectable, while a source race fails closed.
+
 The environment variable is an upgrade opt-in only. It does not authorize a
 commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
 Upgrade does not commit, push, or merge and writes the ignored receipt
@@ -46,14 +54,15 @@ AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git T
 ```
 
 The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-pins the clean source revision, materializes the tracked `HEAD` Agent Core
-baseline, applies canonical upgrade semantics in isolation, and requires exact
-pending paths/content/modes plus Task identity and `HEAD` before issuing the
-existing receipt and protected authority. Product, Adapter, repository,
-secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
-with the existing `automation::commit` flow; ordinary `agent::commit` rejection
-and the receipt/authority design remain unchanged. This is the PR #79 review fix
-only; there are no Issue #77 changes.
+uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, applies canonical upgrade semantics in isolation,
+and requires exact pending paths/content/modes plus Task identity and `HEAD`
+before issuing the existing receipt and protected authority. The receipt's
+`source_revision` equals the pinned snapshot `HEAD`; any source race fails
+closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
+and any tampering, fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection and the
+receipt/authority design remain unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -233,6 +233,13 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
+@dataclass(frozen=True)
+class SavedPath:
+    kind: str
+    content: bytes | str | None
+    mode: int | None
+
+
 def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
@@ -716,6 +723,25 @@ def materialize_tree(
         target.chmod(0o755 if fields[0] == b"100755" else 0o644)
 
 
+def materialize_source_snapshot(source: Path, revision: str, temporary: Path) -> tuple[Path, Path]:
+    """Reconstruct only Agent Core from a pinned source revision.
+
+    The returned paths are (synthetic Templates root, synthetic Agent Core
+    root).  In particular, callers must not use the live source checkout for
+    planning or copying after this point.
+    """
+    snapshot_root = temporary / "source"
+    source_core = snapshot_root / "components" / "agent-core"
+    materialize_tree(source, revision, source_core, "components/agent-core")
+    return snapshot_root, source_core
+
+
+def revalidate_source(source: Path, revision: str) -> None:
+    current, current_revision = resolve_pinned_source(source)
+    if current != source or current_revision != revision:
+        raise UpgradeError("source changed during upgrade planning or mutation")
+
+
 def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
@@ -779,6 +805,44 @@ def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
                 raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
     return sorted(set(changed))
+
+
+def capture_paths(tree: Path, paths: list[str]) -> dict[str, SavedPath]:
+    saved: dict[str, SavedPath] = {}
+    for raw_path in paths:
+        target = tree / Path(*raw_path.split("/"))
+        try:
+            metadata = target.lstat()
+        except FileNotFoundError:
+            saved[raw_path] = SavedPath("absent", None, None)
+            continue
+        mode = stat.S_IMODE(metadata.st_mode)
+        if target.is_symlink():
+            saved[raw_path] = SavedPath("symlink", os.readlink(target), mode)
+        elif target.is_file():
+            saved[raw_path] = SavedPath("file", target.read_bytes(), mode)
+        else:
+            raise UpgradeError(f"cannot snapshot unsafe upgrade destination path: {raw_path}")
+    return saved
+
+
+def restore_paths(tree: Path, saved: dict[str, SavedPath]) -> None:
+    for raw_path, state in saved.items():
+        target = tree / Path(*raw_path.split("/"))
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif path_present(target):
+            raise UpgradeError(f"cannot restore upgrade destination path: {raw_path}")
+        if state.kind == "absent":
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if state.kind == "file" and isinstance(state.content, bytes) and state.mode is not None:
+            target.write_bytes(state.content)
+            target.chmod(state.mode)
+        elif state.kind == "symlink" and isinstance(state.content, str):
+            target.symlink_to(state.content)
+        else:  # pragma: no cover - capture_paths constructs only valid states
+            raise UpgradeError(f"invalid saved upgrade destination state: {raw_path}")
 
 
 def build_plan(repo: Path, source: Path) -> dict:
@@ -846,64 +910,93 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     return identity
 
 
-def apply(repo: Path, source: Path) -> dict:
+def check_update(repo: Path, source_path: Path) -> dict:
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-update-") as temporary:
+        snapshot, _ = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        revalidate_source(source, revision)
+    plan["source"] = str(source)
+    plan["sourceRevision"] = revision
+    return plan
+
+
+def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
-    plan = build_plan(repo, source)
-    if plan["blockers"]:
-        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
-    source_core = source / "components" / "agent-core"
-    changed: list[str] = []
-    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
-    if not actionable:
-        return {
-            "status": "NO_CHANGES",
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
+        snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        # This check is deliberately before any destination mutation, including
+        # the no-change return path.
+        revalidate_source(source, revision)
+        actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+        if not actionable:
+            return {
+                "status": "NO_CHANGES",
+                "repositoryRoot": str(repo),
+                "sourceCore": str(source / "components" / "agent-core"),
+                "sourceRevision": revision,
+                "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+                "changedPaths": [],
+                "commitCreated": False,
+                "pushPerformed": False,
+                "mergePerformed": False,
+                "requiredNextChecks": [],
+            }
+        expected_paths = sorted({item["path"] for item in actionable})
+        saved_paths = capture_paths(repo, expected_paths)
+        changed = apply_plan_to_tree(repo, source_core, plan)
+        # A source race after mutation fails closed: no receipt is issued.
+        try:
+            revalidate_source(source, revision)
+        except UpgradeError as source_error:
+            try:
+                restore_paths(repo, saved_paths)
+            except UpgradeError as restore_error:
+                raise UpgradeError(
+                    f"{source_error}; destination rollback failed: {restore_error}"
+                ) from restore_error
+            raise
+        changed_paths = sorted(set(changed))
+        result = {
+            "status": "APPLIED",
             "repositoryRoot": str(repo),
-            "sourceCore": str(source_core),
+            "sourceCore": str(source / "components" / "agent-core"),
+            "sourceRevision": revision,
             "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-            "changedPaths": [],
+            "changedPaths": changed_paths,
             "commitCreated": False,
             "pushPerformed": False,
             "mergePerformed": False,
-            "requiredNextChecks": [],
+            "requiredNextChecks": [
+                "git diff --check",
+                "just agent::doctor",
+                "just project::check",
+                "repository CI/smoke tests",
+            ],
         }
-    changed = apply_plan_to_tree(repo, source_core, plan)
-    result = {
-        "status": "APPLIED",
-        "repositoryRoot": str(repo),
-        "sourceCore": str(source_core),
-        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-        "changedPaths": changed,
-        "commitCreated": False,
-        "pushPerformed": False,
-        "mergePerformed": False,
-        "requiredNextChecks": [
-            "git diff --check",
-            "just agent::doctor",
-            "just project::check",
-            "repository CI/smoke tests",
-        ],
-    }
-    changed_paths = sorted(set(changed))
-    result["changedPaths"] = changed_paths
-    receipt = {
-        "schema_version": 1,
-        "status": "active",
-        "task_id": task_id,
-        "branch": branch,
-        "worktree": str(worktree),
-        "source": str(source.resolve()),
-        "source_revision": source_revision(source),
-        "current_version": plan["currentVersion"],
-        "upstream_version": plan["upstreamVersion"],
-        "changed_paths": changed_paths,
-        "authority_head": git_head(repo),
-        "authority_nonce": secrets.token_hex(32),
-        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
-    }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
-    return result
+        receipt = {
+            "schema_version": 1,
+            "status": "active",
+            "task_id": task_id,
+            "branch": branch,
+            "worktree": str(worktree),
+            "source": str(source),
+            "source_revision": revision,
+            "current_version": plan["currentVersion"],
+            "upstream_version": plan["upstreamVersion"],
+            "changed_paths": changed_paths,
+            "authority_head": git_head(repo),
+            "authority_nonce": secrets.token_hex(32),
+            "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+        }
+        atomic_json_write(receipt_path(repo), receipt)
+        write_authority(repo, receipt)
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+        return result
 
 
 def pending_paths(repo: Path) -> list[str]:
@@ -948,7 +1041,7 @@ def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
         raise UpgradeError(f"pending path is outside Agent Core: {path}")
 
 
-def bootstrap_receipt(repo: Path, source: Path) -> dict:
+def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
@@ -959,13 +1052,13 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
-    source, source_head = resolve_pinned_source(source)
+    source, source_head = resolve_pinned_source(source_path)
     require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
     with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
-        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        materialize_source_snapshot(source, source_head, Path(temporary))
         before = {
             p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
             for p in baseline.rglob("*") if p.is_file()
@@ -990,11 +1083,10 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         if expected != pending:
             raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
         if not expected:
+            revalidate_source(source, source_head)
             return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
         expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
-    pinned_source, current_source_head = resolve_pinned_source(source)
-    if pinned_source != source or current_source_head != source_head:
-        raise UpgradeError("source changed during receipt reconstruction")
+    revalidate_source(source, source_head)
     current_identity = require_registered_task(repo, task_id)
     current_registration = registered_worktrees(repo).get(worktree)
     if (
@@ -1252,11 +1344,11 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = build_plan(repo, resolve_source(args.source))
+            result = check_update(repo, args.source)
         elif args.command == "upgrade":
-            result = apply(repo, resolve_source(args.source))
+            result = apply(repo, args.source)
         elif args.command == "bootstrap-receipt":
-            result = bootstrap_receipt(repo, resolve_source(args.source))
+            result = bootstrap_receipt(repo, args.source)
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -22,6 +22,14 @@ Templates checkout as the source:
 AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
 ```
 
+The source must be a trusted clean Git worktree root with a full, non-null
+`HEAD`. Both `automation::check-update` and `automation::upgrade` reject
+tracked modifications and non-ignored untracked paths under
+`components/agent-core`; ignored generated artifacts are structurally absent.
+They pin the source `HEAD`, materialize only tracked Agent Core objects into a
+temporary snapshot, and plan/copy only from that snapshot. Compatible
+`VERSION` drift remains detectable, while a source race fails closed.
+
 The environment variable is an upgrade opt-in only. It does not authorize a
 commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
 Upgrade does not commit, push, or merge and writes the ignored receipt
@@ -46,14 +54,15 @@ AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git T
 ```
 
 The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-pins the clean source revision, materializes the tracked `HEAD` Agent Core
-baseline, applies canonical upgrade semantics in isolation, and requires exact
-pending paths/content/modes plus Task identity and `HEAD` before issuing the
-existing receipt and protected authority. Product, Adapter, repository,
-secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
-with the existing `automation::commit` flow; ordinary `agent::commit` rejection
-and the receipt/authority design remain unchanged. This is the PR #79 review fix
-only; there are no Issue #77 changes.
+uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, applies canonical upgrade semantics in isolation,
+and requires exact pending paths/content/modes plus Task identity and `HEAD`
+before issuing the existing receipt and protected authority. The receipt's
+`source_revision` equals the pinned snapshot `HEAD`; any source race fails
+closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
+and any tampering, fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection and the
+receipt/authority design remain unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -233,6 +233,13 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
+@dataclass(frozen=True)
+class SavedPath:
+    kind: str
+    content: bytes | str | None
+    mode: int | None
+
+
 def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
@@ -716,6 +723,25 @@ def materialize_tree(
         target.chmod(0o755 if fields[0] == b"100755" else 0o644)
 
 
+def materialize_source_snapshot(source: Path, revision: str, temporary: Path) -> tuple[Path, Path]:
+    """Reconstruct only Agent Core from a pinned source revision.
+
+    The returned paths are (synthetic Templates root, synthetic Agent Core
+    root).  In particular, callers must not use the live source checkout for
+    planning or copying after this point.
+    """
+    snapshot_root = temporary / "source"
+    source_core = snapshot_root / "components" / "agent-core"
+    materialize_tree(source, revision, source_core, "components/agent-core")
+    return snapshot_root, source_core
+
+
+def revalidate_source(source: Path, revision: str) -> None:
+    current, current_revision = resolve_pinned_source(source)
+    if current != source or current_revision != revision:
+        raise UpgradeError("source changed during upgrade planning or mutation")
+
+
 def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
@@ -779,6 +805,44 @@ def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
                 raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
     return sorted(set(changed))
+
+
+def capture_paths(tree: Path, paths: list[str]) -> dict[str, SavedPath]:
+    saved: dict[str, SavedPath] = {}
+    for raw_path in paths:
+        target = tree / Path(*raw_path.split("/"))
+        try:
+            metadata = target.lstat()
+        except FileNotFoundError:
+            saved[raw_path] = SavedPath("absent", None, None)
+            continue
+        mode = stat.S_IMODE(metadata.st_mode)
+        if target.is_symlink():
+            saved[raw_path] = SavedPath("symlink", os.readlink(target), mode)
+        elif target.is_file():
+            saved[raw_path] = SavedPath("file", target.read_bytes(), mode)
+        else:
+            raise UpgradeError(f"cannot snapshot unsafe upgrade destination path: {raw_path}")
+    return saved
+
+
+def restore_paths(tree: Path, saved: dict[str, SavedPath]) -> None:
+    for raw_path, state in saved.items():
+        target = tree / Path(*raw_path.split("/"))
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif path_present(target):
+            raise UpgradeError(f"cannot restore upgrade destination path: {raw_path}")
+        if state.kind == "absent":
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if state.kind == "file" and isinstance(state.content, bytes) and state.mode is not None:
+            target.write_bytes(state.content)
+            target.chmod(state.mode)
+        elif state.kind == "symlink" and isinstance(state.content, str):
+            target.symlink_to(state.content)
+        else:  # pragma: no cover - capture_paths constructs only valid states
+            raise UpgradeError(f"invalid saved upgrade destination state: {raw_path}")
 
 
 def build_plan(repo: Path, source: Path) -> dict:
@@ -846,64 +910,93 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     return identity
 
 
-def apply(repo: Path, source: Path) -> dict:
+def check_update(repo: Path, source_path: Path) -> dict:
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-update-") as temporary:
+        snapshot, _ = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        revalidate_source(source, revision)
+    plan["source"] = str(source)
+    plan["sourceRevision"] = revision
+    return plan
+
+
+def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
-    plan = build_plan(repo, source)
-    if plan["blockers"]:
-        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
-    source_core = source / "components" / "agent-core"
-    changed: list[str] = []
-    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
-    if not actionable:
-        return {
-            "status": "NO_CHANGES",
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
+        snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        # This check is deliberately before any destination mutation, including
+        # the no-change return path.
+        revalidate_source(source, revision)
+        actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+        if not actionable:
+            return {
+                "status": "NO_CHANGES",
+                "repositoryRoot": str(repo),
+                "sourceCore": str(source / "components" / "agent-core"),
+                "sourceRevision": revision,
+                "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+                "changedPaths": [],
+                "commitCreated": False,
+                "pushPerformed": False,
+                "mergePerformed": False,
+                "requiredNextChecks": [],
+            }
+        expected_paths = sorted({item["path"] for item in actionable})
+        saved_paths = capture_paths(repo, expected_paths)
+        changed = apply_plan_to_tree(repo, source_core, plan)
+        # A source race after mutation fails closed: no receipt is issued.
+        try:
+            revalidate_source(source, revision)
+        except UpgradeError as source_error:
+            try:
+                restore_paths(repo, saved_paths)
+            except UpgradeError as restore_error:
+                raise UpgradeError(
+                    f"{source_error}; destination rollback failed: {restore_error}"
+                ) from restore_error
+            raise
+        changed_paths = sorted(set(changed))
+        result = {
+            "status": "APPLIED",
             "repositoryRoot": str(repo),
-            "sourceCore": str(source_core),
+            "sourceCore": str(source / "components" / "agent-core"),
+            "sourceRevision": revision,
             "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-            "changedPaths": [],
+            "changedPaths": changed_paths,
             "commitCreated": False,
             "pushPerformed": False,
             "mergePerformed": False,
-            "requiredNextChecks": [],
+            "requiredNextChecks": [
+                "git diff --check",
+                "just agent::doctor",
+                "just project::check",
+                "repository CI/smoke tests",
+            ],
         }
-    changed = apply_plan_to_tree(repo, source_core, plan)
-    result = {
-        "status": "APPLIED",
-        "repositoryRoot": str(repo),
-        "sourceCore": str(source_core),
-        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-        "changedPaths": changed,
-        "commitCreated": False,
-        "pushPerformed": False,
-        "mergePerformed": False,
-        "requiredNextChecks": [
-            "git diff --check",
-            "just agent::doctor",
-            "just project::check",
-            "repository CI/smoke tests",
-        ],
-    }
-    changed_paths = sorted(set(changed))
-    result["changedPaths"] = changed_paths
-    receipt = {
-        "schema_version": 1,
-        "status": "active",
-        "task_id": task_id,
-        "branch": branch,
-        "worktree": str(worktree),
-        "source": str(source.resolve()),
-        "source_revision": source_revision(source),
-        "current_version": plan["currentVersion"],
-        "upstream_version": plan["upstreamVersion"],
-        "changed_paths": changed_paths,
-        "authority_head": git_head(repo),
-        "authority_nonce": secrets.token_hex(32),
-        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
-    }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
-    return result
+        receipt = {
+            "schema_version": 1,
+            "status": "active",
+            "task_id": task_id,
+            "branch": branch,
+            "worktree": str(worktree),
+            "source": str(source),
+            "source_revision": revision,
+            "current_version": plan["currentVersion"],
+            "upstream_version": plan["upstreamVersion"],
+            "changed_paths": changed_paths,
+            "authority_head": git_head(repo),
+            "authority_nonce": secrets.token_hex(32),
+            "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+        }
+        atomic_json_write(receipt_path(repo), receipt)
+        write_authority(repo, receipt)
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+        return result
 
 
 def pending_paths(repo: Path) -> list[str]:
@@ -948,7 +1041,7 @@ def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
         raise UpgradeError(f"pending path is outside Agent Core: {path}")
 
 
-def bootstrap_receipt(repo: Path, source: Path) -> dict:
+def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
@@ -959,13 +1052,13 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
-    source, source_head = resolve_pinned_source(source)
+    source, source_head = resolve_pinned_source(source_path)
     require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
     with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
-        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        materialize_source_snapshot(source, source_head, Path(temporary))
         before = {
             p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
             for p in baseline.rglob("*") if p.is_file()
@@ -990,11 +1083,10 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         if expected != pending:
             raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
         if not expected:
+            revalidate_source(source, source_head)
             return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
         expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
-    pinned_source, current_source_head = resolve_pinned_source(source)
-    if pinned_source != source or current_source_head != source_head:
-        raise UpgradeError("source changed during receipt reconstruction")
+    revalidate_source(source, source_head)
     current_identity = require_registered_task(repo, task_id)
     current_registration = registered_worktrees(repo).get(worktree)
     if (
@@ -1252,11 +1344,11 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = build_plan(repo, resolve_source(args.source))
+            result = check_update(repo, args.source)
         elif args.command == "upgrade":
-            result = apply(repo, resolve_source(args.source))
+            result = apply(repo, args.source)
         elif args.command == "bootstrap-receipt":
-            result = bootstrap_receipt(repo, resolve_source(args.source))
+            result = bootstrap_receipt(repo, args.source)
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -22,6 +22,14 @@ Templates checkout as the source:
 AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
 ```
 
+The source must be a trusted clean Git worktree root with a full, non-null
+`HEAD`. Both `automation::check-update` and `automation::upgrade` reject
+tracked modifications and non-ignored untracked paths under
+`components/agent-core`; ignored generated artifacts are structurally absent.
+They pin the source `HEAD`, materialize only tracked Agent Core objects into a
+temporary snapshot, and plan/copy only from that snapshot. Compatible
+`VERSION` drift remains detectable, while a source race fails closed.
+
 The environment variable is an upgrade opt-in only. It does not authorize a
 commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
 Upgrade does not commit, push, or merge and writes the ignored receipt
@@ -46,14 +54,15 @@ AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git T
 ```
 
 The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-pins the clean source revision, materializes the tracked `HEAD` Agent Core
-baseline, applies canonical upgrade semantics in isolation, and requires exact
-pending paths/content/modes plus Task identity and `HEAD` before issuing the
-existing receipt and protected authority. Product, Adapter, repository,
-secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
-with the existing `automation::commit` flow; ordinary `agent::commit` rejection
-and the receipt/authority design remain unchanged. This is the PR #79 review fix
-only; there are no Issue #77 changes.
+uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, applies canonical upgrade semantics in isolation,
+and requires exact pending paths/content/modes plus Task identity and `HEAD`
+before issuing the existing receipt and protected authority. The receipt's
+`source_revision` equals the pinned snapshot `HEAD`; any source race fails
+closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
+and any tampering, fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection and the
+receipt/authority design remain unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -233,6 +233,13 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
+@dataclass(frozen=True)
+class SavedPath:
+    kind: str
+    content: bytes | str | None
+    mode: int | None
+
+
 def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
@@ -716,6 +723,25 @@ def materialize_tree(
         target.chmod(0o755 if fields[0] == b"100755" else 0o644)
 
 
+def materialize_source_snapshot(source: Path, revision: str, temporary: Path) -> tuple[Path, Path]:
+    """Reconstruct only Agent Core from a pinned source revision.
+
+    The returned paths are (synthetic Templates root, synthetic Agent Core
+    root).  In particular, callers must not use the live source checkout for
+    planning or copying after this point.
+    """
+    snapshot_root = temporary / "source"
+    source_core = snapshot_root / "components" / "agent-core"
+    materialize_tree(source, revision, source_core, "components/agent-core")
+    return snapshot_root, source_core
+
+
+def revalidate_source(source: Path, revision: str) -> None:
+    current, current_revision = resolve_pinned_source(source)
+    if current != source or current_revision != revision:
+        raise UpgradeError("source changed during upgrade planning or mutation")
+
+
 def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
@@ -779,6 +805,44 @@ def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
                 raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
     return sorted(set(changed))
+
+
+def capture_paths(tree: Path, paths: list[str]) -> dict[str, SavedPath]:
+    saved: dict[str, SavedPath] = {}
+    for raw_path in paths:
+        target = tree / Path(*raw_path.split("/"))
+        try:
+            metadata = target.lstat()
+        except FileNotFoundError:
+            saved[raw_path] = SavedPath("absent", None, None)
+            continue
+        mode = stat.S_IMODE(metadata.st_mode)
+        if target.is_symlink():
+            saved[raw_path] = SavedPath("symlink", os.readlink(target), mode)
+        elif target.is_file():
+            saved[raw_path] = SavedPath("file", target.read_bytes(), mode)
+        else:
+            raise UpgradeError(f"cannot snapshot unsafe upgrade destination path: {raw_path}")
+    return saved
+
+
+def restore_paths(tree: Path, saved: dict[str, SavedPath]) -> None:
+    for raw_path, state in saved.items():
+        target = tree / Path(*raw_path.split("/"))
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif path_present(target):
+            raise UpgradeError(f"cannot restore upgrade destination path: {raw_path}")
+        if state.kind == "absent":
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if state.kind == "file" and isinstance(state.content, bytes) and state.mode is not None:
+            target.write_bytes(state.content)
+            target.chmod(state.mode)
+        elif state.kind == "symlink" and isinstance(state.content, str):
+            target.symlink_to(state.content)
+        else:  # pragma: no cover - capture_paths constructs only valid states
+            raise UpgradeError(f"invalid saved upgrade destination state: {raw_path}")
 
 
 def build_plan(repo: Path, source: Path) -> dict:
@@ -846,64 +910,93 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     return identity
 
 
-def apply(repo: Path, source: Path) -> dict:
+def check_update(repo: Path, source_path: Path) -> dict:
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-update-") as temporary:
+        snapshot, _ = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        revalidate_source(source, revision)
+    plan["source"] = str(source)
+    plan["sourceRevision"] = revision
+    return plan
+
+
+def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
-    plan = build_plan(repo, source)
-    if plan["blockers"]:
-        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
-    source_core = source / "components" / "agent-core"
-    changed: list[str] = []
-    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
-    if not actionable:
-        return {
-            "status": "NO_CHANGES",
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
+        snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        # This check is deliberately before any destination mutation, including
+        # the no-change return path.
+        revalidate_source(source, revision)
+        actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+        if not actionable:
+            return {
+                "status": "NO_CHANGES",
+                "repositoryRoot": str(repo),
+                "sourceCore": str(source / "components" / "agent-core"),
+                "sourceRevision": revision,
+                "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+                "changedPaths": [],
+                "commitCreated": False,
+                "pushPerformed": False,
+                "mergePerformed": False,
+                "requiredNextChecks": [],
+            }
+        expected_paths = sorted({item["path"] for item in actionable})
+        saved_paths = capture_paths(repo, expected_paths)
+        changed = apply_plan_to_tree(repo, source_core, plan)
+        # A source race after mutation fails closed: no receipt is issued.
+        try:
+            revalidate_source(source, revision)
+        except UpgradeError as source_error:
+            try:
+                restore_paths(repo, saved_paths)
+            except UpgradeError as restore_error:
+                raise UpgradeError(
+                    f"{source_error}; destination rollback failed: {restore_error}"
+                ) from restore_error
+            raise
+        changed_paths = sorted(set(changed))
+        result = {
+            "status": "APPLIED",
             "repositoryRoot": str(repo),
-            "sourceCore": str(source_core),
+            "sourceCore": str(source / "components" / "agent-core"),
+            "sourceRevision": revision,
             "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-            "changedPaths": [],
+            "changedPaths": changed_paths,
             "commitCreated": False,
             "pushPerformed": False,
             "mergePerformed": False,
-            "requiredNextChecks": [],
+            "requiredNextChecks": [
+                "git diff --check",
+                "just agent::doctor",
+                "just project::check",
+                "repository CI/smoke tests",
+            ],
         }
-    changed = apply_plan_to_tree(repo, source_core, plan)
-    result = {
-        "status": "APPLIED",
-        "repositoryRoot": str(repo),
-        "sourceCore": str(source_core),
-        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-        "changedPaths": changed,
-        "commitCreated": False,
-        "pushPerformed": False,
-        "mergePerformed": False,
-        "requiredNextChecks": [
-            "git diff --check",
-            "just agent::doctor",
-            "just project::check",
-            "repository CI/smoke tests",
-        ],
-    }
-    changed_paths = sorted(set(changed))
-    result["changedPaths"] = changed_paths
-    receipt = {
-        "schema_version": 1,
-        "status": "active",
-        "task_id": task_id,
-        "branch": branch,
-        "worktree": str(worktree),
-        "source": str(source.resolve()),
-        "source_revision": source_revision(source),
-        "current_version": plan["currentVersion"],
-        "upstream_version": plan["upstreamVersion"],
-        "changed_paths": changed_paths,
-        "authority_head": git_head(repo),
-        "authority_nonce": secrets.token_hex(32),
-        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
-    }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
-    return result
+        receipt = {
+            "schema_version": 1,
+            "status": "active",
+            "task_id": task_id,
+            "branch": branch,
+            "worktree": str(worktree),
+            "source": str(source),
+            "source_revision": revision,
+            "current_version": plan["currentVersion"],
+            "upstream_version": plan["upstreamVersion"],
+            "changed_paths": changed_paths,
+            "authority_head": git_head(repo),
+            "authority_nonce": secrets.token_hex(32),
+            "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+        }
+        atomic_json_write(receipt_path(repo), receipt)
+        write_authority(repo, receipt)
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+        return result
 
 
 def pending_paths(repo: Path) -> list[str]:
@@ -948,7 +1041,7 @@ def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
         raise UpgradeError(f"pending path is outside Agent Core: {path}")
 
 
-def bootstrap_receipt(repo: Path, source: Path) -> dict:
+def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
@@ -959,13 +1052,13 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
-    source, source_head = resolve_pinned_source(source)
+    source, source_head = resolve_pinned_source(source_path)
     require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
     with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
-        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        materialize_source_snapshot(source, source_head, Path(temporary))
         before = {
             p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
             for p in baseline.rglob("*") if p.is_file()
@@ -990,11 +1083,10 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         if expected != pending:
             raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
         if not expected:
+            revalidate_source(source, source_head)
             return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
         expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
-    pinned_source, current_source_head = resolve_pinned_source(source)
-    if pinned_source != source or current_source_head != source_head:
-        raise UpgradeError("source changed during receipt reconstruction")
+    revalidate_source(source, source_head)
     current_identity = require_registered_task(repo, task_id)
     current_registration = registered_worktrees(repo).get(worktree)
     if (
@@ -1252,11 +1344,11 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = build_plan(repo, resolve_source(args.source))
+            result = check_update(repo, args.source)
         elif args.command == "upgrade":
-            result = apply(repo, resolve_source(args.source))
+            result = apply(repo, args.source)
         elif args.command == "bootstrap-receipt":
-            result = bootstrap_receipt(repo, resolve_source(args.source))
+            result = bootstrap_receipt(repo, args.source)
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -22,6 +22,14 @@ Templates checkout as the source:
 AUTOMATION_MAINTENANCE=1 just automation::upgrade <trusted local Templates checkout>
 ```
 
+The source must be a trusted clean Git worktree root with a full, non-null
+`HEAD`. Both `automation::check-update` and `automation::upgrade` reject
+tracked modifications and non-ignored untracked paths under
+`components/agent-core`; ignored generated artifacts are structurally absent.
+They pin the source `HEAD`, materialize only tracked Agent Core objects into a
+temporary snapshot, and plan/copy only from that snapshot. Compatible
+`VERSION` drift remains detectable, while a source race fails closed.
+
 The environment variable is an upgrade opt-in only. It does not authorize a
 commit; ordinary `just agent::commit <task>` rejects Automation Core changes.
 Upgrade does not commit, push, or merge and writes the ignored receipt
@@ -46,14 +54,15 @@ AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git T
 ```
 
 The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-pins the clean source revision, materializes the tracked `HEAD` Agent Core
-baseline, applies canonical upgrade semantics in isolation, and requires exact
-pending paths/content/modes plus Task identity and `HEAD` before issuing the
-existing receipt and protected authority. Product, Adapter, repository,
-secret-pattern, or `.task-state` paths, and any tampering, fail closed. Continue
-with the existing `automation::commit` flow; ordinary `agent::commit` rejection
-and the receipt/authority design remain unchanged. This is the PR #79 review fix
-only; there are no Issue #77 changes.
+uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, applies canonical upgrade semantics in isolation,
+and requires exact pending paths/content/modes plus Task identity and `HEAD`
+before issuing the existing receipt and protected authority. The receipt's
+`source_revision` equals the pinned snapshot `HEAD`; any source race fails
+closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
+and any tampering, fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection and the
+receipt/authority design remain unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -233,6 +233,13 @@ class Migration:
     require_absent_paths: tuple[Path, ...]
 
 
+@dataclass(frozen=True)
+class SavedPath:
+    kind: str
+    content: bytes | str | None
+    mode: int | None
+
+
 def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
@@ -716,6 +723,25 @@ def materialize_tree(
         target.chmod(0o755 if fields[0] == b"100755" else 0o644)
 
 
+def materialize_source_snapshot(source: Path, revision: str, temporary: Path) -> tuple[Path, Path]:
+    """Reconstruct only Agent Core from a pinned source revision.
+
+    The returned paths are (synthetic Templates root, synthetic Agent Core
+    root).  In particular, callers must not use the live source checkout for
+    planning or copying after this point.
+    """
+    snapshot_root = temporary / "source"
+    source_core = snapshot_root / "components" / "agent-core"
+    materialize_tree(source, revision, source_core, "components/agent-core")
+    return snapshot_root, source_core
+
+
+def revalidate_source(source: Path, revision: str) -> None:
+    current, current_revision = resolve_pinned_source(source)
+    if current != source or current_revision != revision:
+        raise UpgradeError("source changed during upgrade planning or mutation")
+
+
 def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
     actionable = [item for item in plan["actions"] if item["action"] != "noop"]
     planned_deletes = {Path(item["path"]) for item in actionable if item["action"] == "delete"}
@@ -779,6 +805,44 @@ def apply_plan_to_tree(tree: Path, source_core: Path, plan: dict) -> list[str]:
                 raise UpgradeError(f"unsupported upgrade action: {item}")
         changed.append(item["path"])
     return sorted(set(changed))
+
+
+def capture_paths(tree: Path, paths: list[str]) -> dict[str, SavedPath]:
+    saved: dict[str, SavedPath] = {}
+    for raw_path in paths:
+        target = tree / Path(*raw_path.split("/"))
+        try:
+            metadata = target.lstat()
+        except FileNotFoundError:
+            saved[raw_path] = SavedPath("absent", None, None)
+            continue
+        mode = stat.S_IMODE(metadata.st_mode)
+        if target.is_symlink():
+            saved[raw_path] = SavedPath("symlink", os.readlink(target), mode)
+        elif target.is_file():
+            saved[raw_path] = SavedPath("file", target.read_bytes(), mode)
+        else:
+            raise UpgradeError(f"cannot snapshot unsafe upgrade destination path: {raw_path}")
+    return saved
+
+
+def restore_paths(tree: Path, saved: dict[str, SavedPath]) -> None:
+    for raw_path, state in saved.items():
+        target = tree / Path(*raw_path.split("/"))
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif path_present(target):
+            raise UpgradeError(f"cannot restore upgrade destination path: {raw_path}")
+        if state.kind == "absent":
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if state.kind == "file" and isinstance(state.content, bytes) and state.mode is not None:
+            target.write_bytes(state.content)
+            target.chmod(state.mode)
+        elif state.kind == "symlink" and isinstance(state.content, str):
+            target.symlink_to(state.content)
+        else:  # pragma: no cover - capture_paths constructs only valid states
+            raise UpgradeError(f"invalid saved upgrade destination state: {raw_path}")
 
 
 def build_plan(repo: Path, source: Path) -> dict:
@@ -846,64 +910,93 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     return identity
 
 
-def apply(repo: Path, source: Path) -> dict:
+def check_update(repo: Path, source_path: Path) -> dict:
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-update-") as temporary:
+        snapshot, _ = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        revalidate_source(source, revision)
+    plan["source"] = str(source)
+    plan["sourceRevision"] = revision
+    return plan
+
+
+def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
-    plan = build_plan(repo, source)
-    if plan["blockers"]:
-        raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
-    source_core = source / "components" / "agent-core"
-    changed: list[str] = []
-    actionable = [item for item in plan["actions"] if item["action"] != "noop"]
-    if not actionable:
-        return {
-            "status": "NO_CHANGES",
+    source, revision = resolve_pinned_source(source_path)
+    with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
+        snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
+        plan = build_plan(repo, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("upgrade blocked:\n- " + "\n- ".join(plan["blockers"]))
+        # This check is deliberately before any destination mutation, including
+        # the no-change return path.
+        revalidate_source(source, revision)
+        actionable = [item for item in plan["actions"] if item["action"] != "noop"]
+        if not actionable:
+            return {
+                "status": "NO_CHANGES",
+                "repositoryRoot": str(repo),
+                "sourceCore": str(source / "components" / "agent-core"),
+                "sourceRevision": revision,
+                "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
+                "changedPaths": [],
+                "commitCreated": False,
+                "pushPerformed": False,
+                "mergePerformed": False,
+                "requiredNextChecks": [],
+            }
+        expected_paths = sorted({item["path"] for item in actionable})
+        saved_paths = capture_paths(repo, expected_paths)
+        changed = apply_plan_to_tree(repo, source_core, plan)
+        # A source race after mutation fails closed: no receipt is issued.
+        try:
+            revalidate_source(source, revision)
+        except UpgradeError as source_error:
+            try:
+                restore_paths(repo, saved_paths)
+            except UpgradeError as restore_error:
+                raise UpgradeError(
+                    f"{source_error}; destination rollback failed: {restore_error}"
+                ) from restore_error
+            raise
+        changed_paths = sorted(set(changed))
+        result = {
+            "status": "APPLIED",
             "repositoryRoot": str(repo),
-            "sourceCore": str(source_core),
+            "sourceCore": str(source / "components" / "agent-core"),
+            "sourceRevision": revision,
             "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-            "changedPaths": [],
+            "changedPaths": changed_paths,
             "commitCreated": False,
             "pushPerformed": False,
             "mergePerformed": False,
-            "requiredNextChecks": [],
+            "requiredNextChecks": [
+                "git diff --check",
+                "just agent::doctor",
+                "just project::check",
+                "repository CI/smoke tests",
+            ],
         }
-    changed = apply_plan_to_tree(repo, source_core, plan)
-    result = {
-        "status": "APPLIED",
-        "repositoryRoot": str(repo),
-        "sourceCore": str(source_core),
-        "adapter": (repo / ".automation" / "ADAPTER").read_text(encoding="utf-8").strip(),
-        "changedPaths": changed,
-        "commitCreated": False,
-        "pushPerformed": False,
-        "mergePerformed": False,
-        "requiredNextChecks": [
-            "git diff --check",
-            "just agent::doctor",
-            "just project::check",
-            "repository CI/smoke tests",
-        ],
-    }
-    changed_paths = sorted(set(changed))
-    result["changedPaths"] = changed_paths
-    receipt = {
-        "schema_version": 1,
-        "status": "active",
-        "task_id": task_id,
-        "branch": branch,
-        "worktree": str(worktree),
-        "source": str(source.resolve()),
-        "source_revision": source_revision(source),
-        "current_version": plan["currentVersion"],
-        "upstream_version": plan["upstreamVersion"],
-        "changed_paths": changed_paths,
-        "authority_head": git_head(repo),
-        "authority_nonce": secrets.token_hex(32),
-        "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
-    }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
-    return result
+        receipt = {
+            "schema_version": 1,
+            "status": "active",
+            "task_id": task_id,
+            "branch": branch,
+            "worktree": str(worktree),
+            "source": str(source),
+            "source_revision": revision,
+            "current_version": plan["currentVersion"],
+            "upstream_version": plan["upstreamVersion"],
+            "changed_paths": changed_paths,
+            "authority_head": git_head(repo),
+            "authority_nonce": secrets.token_hex(32),
+            "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
+        }
+        atomic_json_write(receipt_path(repo), receipt)
+        write_authority(repo, receipt)
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+        return result
 
 
 def pending_paths(repo: Path) -> list[str]:
@@ -948,7 +1041,7 @@ def reject_bootstrap_path(repo: Path, raw_path: str) -> None:
         raise UpgradeError(f"pending path is outside Agent Core: {path}")
 
 
-def bootstrap_receipt(repo: Path, source: Path) -> dict:
+def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
@@ -959,13 +1052,13 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
-    source, source_head = resolve_pinned_source(source)
+    source, source_head = resolve_pinned_source(source_path)
     require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
     with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
-        materialize_tree(source, source_head, source_snapshot, "components/agent-core")
+        materialize_source_snapshot(source, source_head, Path(temporary))
         before = {
             p.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, p.relative_to(baseline).as_posix())
             for p in baseline.rglob("*") if p.is_file()
@@ -990,11 +1083,10 @@ def bootstrap_receipt(repo: Path, source: Path) -> dict:
         if expected != pending:
             raise UpgradeError("pending paths do not exactly match the reconstructed upgrade")
         if not expected:
+            revalidate_source(source, source_head)
             return {"status": "NO_CHANGES", "changedPaths": [], "authorityIssued": False}
         expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
-    pinned_source, current_source_head = resolve_pinned_source(source)
-    if pinned_source != source or current_source_head != source_head:
-        raise UpgradeError("source changed during receipt reconstruction")
+    revalidate_source(source, source_head)
     current_identity = require_registered_task(repo, task_id)
     current_registration = registered_worktrees(repo).get(worktree)
     if (
@@ -1252,11 +1344,11 @@ def main() -> int:
         if args.command == "version":
             result = context(repo)
         elif args.command == "check-update":
-            result = build_plan(repo, resolve_source(args.source))
+            result = check_update(repo, args.source)
         elif args.command == "upgrade":
-            result = apply(repo, resolve_source(args.source))
+            result = apply(repo, args.source)
         elif args.command == "bootstrap-receipt":
-            result = bootstrap_receipt(repo, resolve_source(args.source))
+            result = bootstrap_receipt(repo, args.source)
         elif args.command == "commit":
             result = commit(repo, args.task, args.message)
         else:  # pragma: no cover

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -162,6 +162,30 @@ mod project 'just/project/mod.just'
         result = subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True, check=True)
         return result.stdout.strip()
 
+    def _init_source_git(self, source_root: Path) -> str:
+        self._git(["init", "-b", "main"], source_root)
+        self._git(["config", "user.name", "Test User"], source_root)
+        self._git(["config", "user.email", "test@example.invalid"], source_root)
+        self._git(["add", "components/agent-core"], source_root)
+        self._git(["commit", "-m", "source fixture"], source_root)
+        return self._git(["rev-parse", "HEAD"], source_root)
+
+    def _ignore_source_path(self, source_root: Path, pattern: str) -> None:
+        exclude = source_root / ".git" / "info" / "exclude"
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        with exclude.open("a", encoding="utf-8") as stream:
+            stream.write(pattern + "\n")
+
+    def _current_source_copy(self, source_root: Path) -> Path:
+        shutil.copytree(
+            ROOT / "components" / "agent-core",
+            source_root / "components" / "agent-core",
+            symlinks=True,
+            ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "*.pyo"),
+        )
+        self._init_source_git(source_root)
+        return source_root
+
     def _materialize_release_template(self, destination: Path) -> None:
         release = "a42ce1cc30e1a73e33c268a65c8957debc54d4cd"
         self.assertEqual(release, self._git(["rev-parse", "v3.0.0^{commit}"], ROOT))
@@ -267,18 +291,17 @@ mod project 'just/project/mod.just'
         exclude.write_text("/.task-state/\n", encoding="utf-8")
         return repo
 
-    def _apply_fixture(self, root: Path, *, source_git: bool = True) -> tuple[Path, Path]:
+    def _maintenance_fixture(self, root: Path, *, destination_version: int = 2) -> tuple[Path, Path]:
         repo = self._task_repo(root / "repo")
-        self._destination_repo(repo, version=2)
+        self._destination_repo(repo, version=destination_version)
         self._git(["add", "-A"], repo)
         self._git(["commit", "-m", "fixture"], repo)
         source = self._core_root_source(root, version=3)
-        if source_git:
-            self._git(["init", "-b", "main"], root)
-            self._git(["config", "user.name", "Test User"], root)
-            self._git(["config", "user.email", "test@example.invalid"], root)
-            self._git(["add", "components"], root)
-            self._git(["commit", "-m", "source"], root)
+        self._init_source_git(root)
+        return repo, source
+
+    def _apply_fixture(self, root: Path, *, destination_version: int = 2) -> tuple[Path, Path]:
+        repo, source = self._maintenance_fixture(root, destination_version=destination_version)
         with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
             upgrade.apply(repo, root)
         return repo, source
@@ -598,6 +621,7 @@ mod project 'just/project/mod.just'
             self._core_root_source(
                 root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/stale.py",))
             )
+            self._init_source_git(root)
             with self._mock_maintenance(repo):
                 result = upgrade.apply(repo, root)
             self.assertIn(".automation/stale.py", result["changedPaths"])
@@ -612,6 +636,7 @@ mod project 'just/project/mod.just'
             self._write_file(repo / "opencode.json", "before\n")
             source = self._core_root_source(root, version=3, migrations=manifest)
             self._write_file(source / "opencode.json", "after\n")
+            self._init_source_git(root)
 
             plan = upgrade.build_plan(repo, root)
             self.assertTrue(plan["canApply"], plan["blockers"])
@@ -633,6 +658,7 @@ mod project 'just/project/mod.just'
             self._core_root_source(
                 root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/link.py",))
             )
+            self._init_source_git(root)
             with self._mock_maintenance(repo):
                 upgrade.apply(repo, root)
             self.assertFalse((repo / ".automation/link.py").exists())
@@ -646,6 +672,7 @@ mod project 'just/project/mod.just'
             self._core_root_source(
                 root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/obsolete",))
             )
+            self._init_source_git(root)
             plan = upgrade.build_plan(repo, root)
             self.assertFalse(plan["canApply"])
             self.assertIn("refuses directory deletion", "\n".join(plan["blockers"]))
@@ -659,6 +686,7 @@ mod project 'just/project/mod.just'
             (repo / "opencode.json").unlink()
             os.symlink(target, repo / "opencode.json")
             self._core_root_source(root, version=2)
+            self._init_source_git(root)
             plan = upgrade.build_plan(repo, root)
             self.assertFalse(plan["canApply"])
             self.assertIn("destination symlink", "\n".join(plan["blockers"]))
@@ -676,6 +704,7 @@ mod project 'just/project/mod.just'
             self._write_file(source / ".opencode/agents/new.md", "new\n")
             self._write_file(repo / "opencode.json", "before\n")
             self._write_file(source / "opencode.json", "after\n")
+            self._init_source_git(root)
             plan = upgrade.build_plan(repo, root)
             self.assertFalse(plan["canApply"])
             self.assertIn("non-directory ancestor .opencode", "\n".join(plan["blockers"]))
@@ -708,6 +737,7 @@ mod project 'just/project/mod.just'
             self._core_root_source(
                 root, version=3, migrations=self._migration_manifest(remove_paths=(".automation/obsolete",))
             )
+            self._init_source_git(root)
             with self._mock_maintenance(repo):
                 with self.assertRaises(upgrade.UpgradeError):
                     upgrade.apply(repo, root)
@@ -723,6 +753,7 @@ mod project 'just/project/mod.just'
             self._write_file(repo / "opencode.json", "{\"before\":1}\n")
             source = self._core_root_source(tmp, version=3, migrations=manifest)
             self._write_file(source / "opencode.json", "{\"before\":2}\n")
+            self._init_source_git(tmp)
 
             calls: list[str] = []
             original_copy2 = upgrade.shutil.copy2
@@ -751,6 +782,7 @@ mod project 'just/project/mod.just'
             source_parent = source_adp.parent
             source_parent.mkdir(parents=True, exist_ok=True)
             self._write_file(source_adp, "python\n")
+            self._init_source_git(tmp)
             plan = upgrade.build_plan(repo, tmp)
             self.assertIsNone(self._plan_action(plan, ".automation/ADAPTER"))
             with self._mock_maintenance(repo):
@@ -760,7 +792,9 @@ mod project 'just/project/mod.just'
 
     def test_current_v2_to_v3_migration_removes_obsolete_surfaces(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            repo = Path(directory) / "repo"
+            root = Path(directory)
+            repo = root / "repo"
+            source_root = self._current_source_copy(root / "source")
             shutil.copytree(ROOT / "templates/agent-base", repo, symlinks=True)
             (repo / ".automation" / "VERSION").write_text("2\n", encoding="utf-8")
             for path in self.V3_REMOVED_PATHS:
@@ -778,14 +812,16 @@ mod project 'just/project/mod.just'
             self.assertEqual((Path(".task-state/recovery.json"),), migration.require_absent_paths)
 
             with self._mock_maintenance(repo):
-                upgrade.apply(repo, ROOT)
+                upgrade.apply(repo, source_root)
             for path in self.V3_REMOVED_PATHS:
                 self.assertFalse((repo / path).exists(), path)
             self.assertEqual("3\n", (repo / ".automation" / "VERSION").read_text())
 
     def test_current_v2_to_v3_active_recovery_blocks_without_mutation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            repo = Path(directory) / "repo"
+            root = Path(directory)
+            repo = root / "repo"
+            source_root = self._current_source_copy(root / "source")
             shutil.copytree(ROOT / "templates/agent-base", repo, symlinks=True)
             (repo / ".automation" / "VERSION").write_text("2\n", encoding="utf-8")
             obsolete = repo / self.V3_REMOVED_PATHS[0]
@@ -797,15 +833,17 @@ mod project 'just/project/mod.just'
             self.assertFalse(plan["canApply"])
             self.assertIn(".task-state/recovery.json", "\n".join(plan["blockers"]))
             with self._mock_maintenance(repo):
-                with self.assertRaises(upgrade.UpgradeError):
-                    upgrade.apply(repo, ROOT)
+                with self.assertRaisesRegex(upgrade.UpgradeError, "recovery.json"):
+                    upgrade.apply(repo, source_root)
             self.assertTrue(obsolete.is_file())
             self.assertTrue(recovery.is_file())
             self.assertEqual("2\n", (repo / ".automation" / "VERSION").read_text())
 
     def test_current_v3_catches_up_obsolete_residue(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            repo = Path(directory) / "repo"
+            root = Path(directory)
+            repo = root / "repo"
+            source_root = self._current_source_copy(root / "source")
             shutil.copytree(ROOT / "templates/agent-base", repo, symlinks=True)
             obsolete = repo / self.V3_REMOVED_PATHS[-1]
             self._write_file(obsolete, "obsolete\n")
@@ -813,7 +851,7 @@ mod project 'just/project/mod.just'
             self.assertTrue(plan["canApply"], plan["blockers"])
             self.assertEqual("delete", self._plan_action(plan, self.V3_REMOVED_PATHS[-1])["action"])
             with self._mock_maintenance(repo):
-                upgrade.apply(repo, ROOT)
+                upgrade.apply(repo, source_root)
             self.assertFalse(obsolete.exists())
             self.assertEqual("3\n", (repo / ".automation" / "VERSION").read_text())
 
@@ -892,6 +930,7 @@ mod project 'just/project/mod.just'
             second_root = root / "second"
             second_source = self._core_root_source(second_root, version=4)
             (second_source / "AGENTS.md").write_bytes((repo / "AGENTS.md").read_bytes())
+            self._init_source_git(second_root)
             with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
                 upgrade.apply(repo, second_root)
             second = self._receipt(repo)
@@ -1116,10 +1155,110 @@ mod project 'just/project/mod.just'
             self.assertTrue(upgrade.receipt_path(repo).exists())
             self.assertFalse(upgrade.consumed_receipt_path(repo).exists())
 
-    def test_source_revision_is_null_for_non_git_source(self) -> None:
+    def test_ignored_source_artifacts_are_absent_from_public_plan(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            repo, source = self._apply_fixture(Path(directory), source_git=False)
-            self.assertIsNone(self._receipt(repo)["source_revision"])
+            root = Path(directory)
+            repo, source = self._maintenance_fixture(root)
+            self._ignore_source_path(root, "__pycache__/")
+            self._ignore_source_path(root, "*.pyc")
+            self._ignore_source_path(root, "*.pyo")
+            pyc = source / ".automation/bin/__pycache__/upgrade.cpython-313.pyc"
+            stale = source / ".automation/bin/model_fallback.pyc"
+            generated = source / ".automation/generated/cache.txt"
+            self._write_file(pyc, "pyc\n")
+            self._write_file(stale, "stale\n")
+            self._ignore_source_path(root, "/components/agent-core/.automation/generated/")
+            self._write_file(generated, "generated\n")
+
+            plan = upgrade.check_update(repo, root)
+            planned = {item["path"] for item in plan["actions"]}
+            self.assertNotIn(".automation/bin/__pycache__/upgrade.cpython-313.pyc", planned)
+            self.assertNotIn(".automation/bin/model_fallback.pyc", planned)
+            self.assertNotIn(".automation/generated/cache.txt", planned)
+            self.assertFalse(any(".pyc" in path for path in planned))
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                result = upgrade.apply(repo, root)
+            self.assertEqual("APPLIED", result["status"])
+            for relative in (pyc, stale, generated):
+                self.assertFalse((repo / relative.relative_to(source)).exists())
+
+    def test_untracked_nonignored_source_rejects_check_update_and_apply(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, source = self._maintenance_fixture(root)
+            self._write_file(source / ".automation/bin/new.py", "new\n")
+            with self.assertRaisesRegex(upgrade.UpgradeError, "source components/agent-core must be clean"):
+                upgrade.check_update(repo, root)
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                with self.assertRaisesRegex(upgrade.UpgradeError, "source components/agent-core must be clean"):
+                    upgrade.apply(repo, root)
+            self.assertFalse(upgrade.receipt_path(repo).exists())
+
+    def test_tracked_source_modification_rejects_check_update_and_apply(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, source = self._maintenance_fixture(root)
+            self._write_file(source / "opencode.json", "changed\n")
+            with self.assertRaisesRegex(upgrade.UpgradeError, "source components/agent-core must be clean"):
+                upgrade.check_update(repo, root)
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                with self.assertRaisesRegex(upgrade.UpgradeError, "source components/agent-core must be clean"):
+                    upgrade.apply(repo, root)
+            self.assertFalse(upgrade.receipt_path(repo).exists())
+
+    def test_clean_tracked_source_plan_apply_and_revision_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, source = self._maintenance_fixture(root)
+            head = self._git(["rev-parse", "HEAD"], root)
+            plan = upgrade.check_update(repo, root)
+            self.assertEqual(head, plan["sourceRevision"])
+            self.assertTrue(plan["canApply"], plan["blockers"])
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                result = upgrade.apply(repo, root)
+            self.assertEqual("APPLIED", result["status"])
+            self.assertEqual(head, result["sourceRevision"])
+            self.assertEqual(head, self._receipt(repo)["source_revision"])
+            self.assertEqual(head, upgrade.source_revision(root))
+
+    def test_same_version_committed_compatible_drift_is_detected_and_applied(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, source = self._maintenance_fixture(root, destination_version=3)
+            self._write_file(source / "opencode.json", '{"drift": true}\n')
+            self._git(["add", "components/agent-core/opencode.json"], root)
+            self._git(["commit", "-m", "compatible source drift"], root)
+            plan = upgrade.check_update(repo, root)
+            self.assertEqual(3, int(plan["currentVersion"]))
+            self.assertEqual(3, int(plan["upstreamVersion"]))
+            self.assertEqual("replace", self._plan_action(plan, "opencode.json")["action"])
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                upgrade.apply(repo, root)
+            self.assertEqual('{"drift": true}\n', (repo / "opencode.json").read_text())
+
+    def test_source_race_fails_closed_without_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, _ = self._maintenance_fixture(root)
+            status_before = self._git(["status", "--porcelain"], repo)
+            version_before = (repo / ".automation/VERSION").read_bytes()
+            calls = 0
+
+            def race(_source: Path, _revision: str) -> None:
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise upgrade.UpgradeError("source changed during upgrade planning or mutation")
+
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                with mock.patch.object(upgrade, "revalidate_source", side_effect=race):
+                    with self.assertRaisesRegex(upgrade.UpgradeError, "source changed during"):
+                        upgrade.apply(repo, root)
+            self.assertEqual(2, calls)
+            self.assertFalse(upgrade.receipt_path(repo).exists())
+            self.assertFalse(upgrade.authority_path(repo).exists())
+            self.assertEqual(status_before, self._git(["status", "--porcelain"], repo))
+            self.assertEqual(version_before, (repo / ".automation/VERSION").read_bytes())
 
     def test_pending_paths_handles_nul_delimited_git_names(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- require normal `automation::check-update` and `automation::upgrade` sources to be clean Git worktree roots with a full pinned HEAD
- materialize tracked `components/agent-core` objects and plan/apply exclusively from that immutable snapshot
- exclude ignored generated artifacts structurally while rejecting tracked changes and non-ignored untracked Agent Core files
- bind plans and maintenance receipts to the exact snapshot revision and roll back destination changes on a detected source race
- preserve same-VERSION compatible drift and the #79 bootstrap/maintenance publication flow

## Verification
- `python3 -m unittest discover -s tests -v` (243 tests)
- focused automation tests (66 tests)
- `just template::check`
- `just template::distribution-verify`
- `git diff --check`
- independent correctness and security reviews: no findings

Closes #77