### PR TITLE
Make maintenance authority worktree-safe and recoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,19 +261,20 @@ verification and immediately before `automation::commit`, recover it with:
 AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
 ```
 
-The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-uses the same pinned clean-source and tracked Agent Core snapshot semantics as
-normal `automation::check-update` and `automation::upgrade`, reconstructs
-expected output by applying canonical upgrade semantics in isolation, then
-requires exact pending paths, content, modes, and Task identity/`HEAD` before
-issuing the existing receipt and protected authority. The receipt's
-`source_revision` is the pinned snapshot `HEAD`; any source race fails closed.
-Any product, Adapter, repository, secret-pattern, or `.task-state` path, or
-tampering, fails closed. Continue with the existing commit/push/Draft-PR flow;
-ordinary `agent::commit` rejection and the receipt/authority design remain
-unchanged.
+The bridge supports exactly two strict cases: canonical pre-receipt
+reconstruction, and recovery of an exact active receipt whose authority is
+missing. It does not trust `NO_CHANGES`, the current diff, or the environment.
+In either case it uses the same pinned clean-source and tracked Agent Core
+snapshot semantics as normal `automation::check-update` and
+`automation::upgrade`, reconstructs canonical output in isolation, and checks
+Task/branch/worktree/`HEAD`, the pinned source revision, and exact pending safe
+paths, content, modes, and fingerprints. Recovery additionally requires the
+active receipt to be exactly equal and unchanged, then issues only the missing
+authority. A receipt with authority, or stale, forged, or tampered state, fails
+closed. Continue with the existing commit/push/Draft-PR flow; ordinary
+`agent::commit` rejection remains unchanged.
 
-`automation::commit` is the only commit path for this upgrade. It fails closed unless the schema-1 JSON receipt contains Task `task_id`, `branch`, `worktree`, source/source revision, current/upstream versions, sorted unique `changed_paths`, `authority_head`, and matching `path_fingerprints`. Receipt identity must match the current Task/worktree and `authority_head` must equal current `HEAD`; every fingerprint and the complete pending path set must still match. A protected record under the shared Git directory binds the active receipt to the preceding successful upgrade, so an ambient variable or fabricated Task State receipt is not commit authority. Receipt paths must be Agent Core-managed only: mixed Adapter, repository, product, secret-pattern, or `.task-state` paths are rejected. The command scrubs ambient Git repository/index overrides, stages into a private Task State index, checks the exact staged blobs and modes, creates the commit from that verified tree without hooks, and atomically advances only the expected Task branch HEAD.
+`automation::commit` is the only commit path for this upgrade. It fails closed unless the schema-1 JSON receipt contains Task `task_id`, `branch`, `worktree`, source/source revision, current/upstream versions, sorted unique `changed_paths`, `authority_head`, and matching `path_fingerprints`. Receipt identity must match the current Task/worktree and `authority_head` must equal current `HEAD`; every fingerprint and the complete pending path set must still match. Receipt and authority are a logical pair. Authority records live under the Git-resolved per-worktree administrative directory returned by `--absolute-git-dir`, not an assumed visible `.git` or shared Git directory; linked and special administrative topologies are supported, and worktrees do not share authority. Existing safe legacy shared-common-dir hashed records remain validation/commit compatible. A protected record binds the active receipt to the preceding successful upgrade, so an ambient variable or fabricated Task State receipt is not commit authority. Receipt paths must be Agent Core-managed only: mixed Adapter, repository, product, secret-pattern, or `.task-state` paths are rejected. The command scrubs ambient Git repository/index overrides, stages into a private Task State index, checks the exact staged blobs and modes, creates the commit from that verified tree without hooks, and atomically advances only the expected Task branch HEAD. A handled authority-write failure removes the newly written receipt if it is unchanged; an interruption half-state is recoverable only through the strict bootstrap path. No cross-filesystem atomicity is claimed.
 
 After a successful commit, the active receipt is consumed as `.task-state/automation-maintenance.consumed.json`. A later successful upgrade with changes replaces the active receipt and removes the prior consumed receipt; a no-change invocation returns `NO_CHANGES` and preserves existing receipt lifecycle evidence. There is no raw Git/GitHub bypass, and merge is excluded: the Main Orchestrator performs the separately gated integration/merge workflow.
 

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -53,30 +53,40 @@ bridge:
 AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
 ```
 
-The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-uses the same pinned clean-source and tracked Agent Core snapshot semantics as
-the normal update operations, applies canonical upgrade semantics in isolation,
-and requires exact pending paths/content/modes plus Task identity and `HEAD`
-before issuing the existing receipt and protected authority. The receipt's
-`source_revision` equals the pinned snapshot `HEAD`; any source race fails
-closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
-and any tampering, fail closed. Continue with the existing
-`automation::commit` flow; ordinary `agent::commit` rejection and the
-receipt/authority design remain unchanged.
+The bridge supports exactly two strict cases: canonical pre-receipt
+reconstruction, and recovery of an exact active receipt whose authority is
+missing. It does not trust `NO_CHANGES`, the current diff, or the environment.
+It uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, reruns pinned clean-source canonical
+reconstruction, and requires Task/branch/worktree/`HEAD`, the pinned source
+revision, and exact pending safe paths/content/modes and fingerprints. Recovery
+additionally requires receipt exact equality and that it is unchanged, then
+issues only the missing authority. A receipt with authority, or stale, forged,
+or tampered state, fails closed. Product, Adapter, repository, secret-pattern,
+or `.task-state` paths also fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection remains unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state
 `path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
 stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
-or does not exactly equal all pending paths. A protected shared-Git-directory
-record binds it to the preceding successful upgrade; a fabricated Task State
-receipt is not authority. Ambient Git repository/index overrides are scrubbed.
-The exact paths are staged and rechecked in a private Task State index, then the
-commit is created from that verified tree without hooks and the expected Task
-branch HEAD is advanced atomically. Only Agent Core-managed paths are
-accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
-scopes are rejected. After a successful commit it is consumed at
+or does not exactly equal all pending paths. Receipt and authority publication
+is a logical pair. Authority records live under the Git-resolved per-worktree
+administrative directory returned by `--absolute-git-dir`, not an assumed
+visible `.git` or shared Git directory; linked and special administrative
+topologies are supported, and worktrees do not share authority. Existing safe
+legacy shared-common-dir hashed records remain validation/commit compatible. A
+protected record binds it to the preceding successful upgrade; a fabricated
+Task State receipt is not authority. Ambient Git repository/index overrides are
+scrubbed. The exact paths are staged and rechecked in a private Task State
+index, then the commit is created from that verified tree without hooks and the
+expected Task branch HEAD is advanced atomically. Only Agent Core-managed paths
+are accepted; mixed Adapter, repository, product, secret-pattern, or
+`.task-state` scopes are rejected. A handled authority-write failure removes the
+newly written receipt if it is unchanged; an interruption half-state is
+recoverable only through the strict bootstrap path. No cross-filesystem
+atomicity is claimed. After a successful commit it is consumed at
 `.task-state/automation-maintenance.consumed.json`; a subsequent successful
 upgrade with changes replaces the active receipt and removes the previous consumed
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -92,7 +92,7 @@ def worktree_admin_dir(repo: Path) -> Path:
         if not admin.is_dir():
             raise UpgradeError("worktree administrative directory does not exist")
         return admin
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve worktree administrative directory") from exc
 
 
@@ -101,19 +101,29 @@ def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     new_parent = admin / "opencode" / "automation-maintenance"
     try:
         resolved_parent = new_parent.resolve()
-    except OSError as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy: Path | None = None
+    legacy_location = _safe_legacy_location(repo)
+    legacy = legacy_location[0] if legacy_location is not None else None
+    return new_parent / "authority.json", legacy
+
+
+def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
+    """Return the legacy record and its containment guard only when safe."""
     try:
         common = common_git_dir(repo)
-        if common.is_dir():
-            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
-    except (OSError, UpgradeError):
-        legacy = None
-    return new_parent / "authority.json", legacy
+        if not common.is_dir():
+            return None
+        parent = common / "opencode" / "automation-maintenance"
+        resolved_parent = parent.resolve()
+        if resolved_parent != common and common not in resolved_parent.parents:
+            return None
+        key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+        return parent / f"{key}.json", common
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def authority_path(repo: Path) -> Path:
@@ -168,8 +178,17 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             os.link(temporary, path)
         finally:
             temporary.unlink(missing_ok=True)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    legacy = _safe_legacy_location(repo)
+    if legacy is not None and authority == legacy[0]:
+        return legacy[1]
+    if authority == authority_path(repo):
+        return worktree_admin_dir(repo)
+    raise UpgradeError("cannot safely resolve authority location for rollback")
 
 
 def validate_authority(repo: Path, receipt: dict) -> Path:
@@ -1568,7 +1587,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
                         "authority_nonce": receipt["authority_nonce"],
                         "receipt_sha256": receipt_digest(receipt),
                     },
-                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                    admin=_rollback_authority_guard(repo, authority),
                 )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -42,6 +42,23 @@ RECEIPT_FIELDS = {
 _GIT_EXECUTABLE: Path | None = None
 
 
+def task_state_dir(repo: Path) -> Path:
+    try:
+        root = repo.resolve()
+        state = root / ".task-state"
+        metadata = state.lstat()
+        resolved = state.resolve()
+    except OSError as exc:
+        raise UpgradeError("Task State directory is unavailable") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or (resolved != root and root not in resolved.parents)
+    ):
+        raise UpgradeError("Task State directory is unsafe")
+    return resolved
+
+
 def git_head(repo: Path) -> str:
     result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
     return result.stdout.strip() if result.returncode == 0 else ""
@@ -53,11 +70,11 @@ def source_revision(source: Path) -> str | None:
 
 
 def receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / RECEIPT_NAME
+    return task_state_dir(repo) / RECEIPT_NAME
 
 
 def consumed_receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+    return task_state_dir(repo) / CONSUMED_RECEIPT_NAME
 
 
 def common_git_dir(repo: Path) -> Path:
@@ -65,9 +82,42 @@ def common_git_dir(repo: Path) -> Path:
     return value.resolve() if value.is_absolute() else (repo / value).resolve()
 
 
+def worktree_admin_dir(repo: Path) -> Path:
+    try:
+        raw = run(["git", "rev-parse", "--absolute-git-dir"], cwd=repo).stdout.strip()
+        candidate = Path(raw)
+        if not raw or not candidate.is_absolute():
+            raise UpgradeError("Git returned an invalid absolute worktree administrative directory")
+        admin = candidate.resolve()
+        if not admin.is_dir():
+            raise UpgradeError("worktree administrative directory does not exist")
+        return admin
+    except (OSError, ValueError) as exc:
+        raise UpgradeError("cannot resolve worktree administrative directory") from exc
+
+
+def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
+    admin = worktree_admin_dir(repo)
+    new_parent = admin / "opencode" / "automation-maintenance"
+    try:
+        resolved_parent = new_parent.resolve()
+    except OSError as exc:
+        raise UpgradeError("cannot resolve authority directory") from exc
+    if resolved_parent != admin and admin not in resolved_parent.parents:
+        raise UpgradeError("authority directory escapes the worktree administrative directory")
+    legacy: Path | None = None
+    try:
+        common = common_git_dir(repo)
+        if common.is_dir():
+            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
+    except (OSError, UpgradeError):
+        legacy = None
+    return new_parent / "authority.json", legacy
+
+
 def authority_path(repo: Path) -> Path:
-    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+    return _authority_locations(repo)[0]
 
 
 def canonical_json(value: dict) -> bytes:
@@ -79,7 +129,7 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
-    atomic_json_write(
+    _write_authority_at(
         authority_path(repo),
         {
             "schema_version": 1,
@@ -89,12 +139,50 @@ def write_authority(repo: Path, receipt: dict) -> None:
             "authority_nonce": receipt["authority_nonce"],
             "receipt_sha256": receipt_digest(receipt),
         },
+        admin=worktree_admin_dir(repo),
     )
 
 
-def validate_authority(repo: Path, receipt: dict) -> None:
-    path = authority_path(repo)
+def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
     try:
+        if admin is not None:
+            parent_before = path.parent.resolve()
+            if parent_before != admin and admin not in parent_before.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if admin is not None:
+            parent_after = path.parent.resolve()
+            if parent_after != admin and admin not in parent_after.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        # The caller has validated the parent; do not replace an existing record.
+        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+                stream.flush()
+                try:
+                    os.fsync(stream.fileno())
+                except OSError:
+                    pass
+            os.link(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+    except (OSError, ValueError) as exc:
+        raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def validate_authority(repo: Path, receipt: dict) -> Path:
+    new_path, legacy_path = _authority_locations(repo)
+    path = new_path
+    if not os.path.lexists(path):
+        if legacy_path is None or not os.path.lexists(legacy_path):
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
+        path = legacy_path
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
         authority = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
@@ -108,6 +196,29 @@ def validate_authority(repo: Path, receipt: dict) -> None:
     }
     if authority != expected:
         raise UpgradeError("automation receipt does not match successful-upgrade authority")
+    return path
+
+
+def authority_exists(repo: Path) -> bool:
+    new_path, legacy_path = _authority_locations(repo)
+    return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
+
+
+def issue_pair(repo: Path, receipt: dict) -> None:
+    destination = receipt_path(repo)
+    published: tuple[int, int] | None = None
+    try:
+        published = exclusive_json_write(destination, receipt)
+        write_authority(repo, receipt)
+    except (OSError, UpgradeError):
+        if published is not None:
+            try:
+                current = destination.lstat()
+                if (current.st_dev, current.st_ino) == published:
+                    destination.unlink()
+            except OSError as exc:
+                raise UpgradeError("receipt publication failed and rollback failed") from exc
+        raise
 
 
 def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
@@ -126,13 +237,53 @@ def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
 
 
 def atomic_json_write(path: Path, value: dict) -> None:
+    atomic_bytes_write(path, (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def atomic_bytes_write(path: Path, content: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
     try:
-        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
         os.replace(temporary, path)
     finally:
-        temporary.unlink(missing_ok=True)
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError("cannot publish an automation receipt over an existing receipt") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish JSON record: {path}") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -156,7 +307,7 @@ def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
 def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
     if not TASK_ID_RE.fullmatch(task):
         raise UpgradeError(f"invalid Task ID: {task!r}")
-    state_path = repo / ".task-state" / "task.md"
+    state_path = task_state_dir(repo) / "task.md"
     if not state_path.is_file():
         raise UpgradeError("operation requires a Task worktree with Task State")
     text = state_path.read_text(encoding="utf-8")
@@ -190,6 +341,21 @@ def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]
             continue
         key, _, value = line.partition(" ")
         current[key] = value
+    visible_top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=repo).stdout.strip())
+    if visible_top.is_absolute():
+        visible_top = visible_top.resolve()
+        current_repo = repo.resolve()
+        admin = worktree_admin_dir(repo)
+        current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip() or None
+        current_head = git_head(repo) or None
+        admin_record = records.get(admin)
+        if (
+            visible_top == current_repo
+            and visible_top not in records
+            and admin_record is not None
+            and admin_record == (current_branch, current_head)
+        ):
+            records[visible_top] = admin_record
     return records
 
 
@@ -895,7 +1061,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    state = repo / ".task-state" / "task.md"
+    state = task_state_dir(repo) / "task.md"
     task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
     if not task_match:
         raise UpgradeError("upgrade requires a registered non-default Task branch")
@@ -903,7 +1069,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     identity = require_registered_task(repo, task_id)
     require_ignored_untracked(
         repo,
-        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+        (task_state_dir(repo) / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
     )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
@@ -923,6 +1089,8 @@ def check_update(repo: Path, source_path: Path) -> dict:
 
 def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
+    if os.path.lexists(receipt_path(repo)) or authority_exists(repo):
+        raise UpgradeError("cannot apply with an existing receipt or authority record")
     source, revision = resolve_pinned_source(source_path)
     with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
         snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
@@ -993,9 +1161,11 @@ def apply(repo: Path, source_path: Path) -> dict:
             "authority_nonce": secrets.token_hex(32),
             "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
         }
-        atomic_json_write(receipt_path(repo), receipt)
-        write_authority(repo, receipt)
-        consumed_receipt_path(repo).unlink(missing_ok=True)
+        issue_pair(repo, receipt)
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
         return result
 
 
@@ -1045,16 +1215,33 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
-    if receipt_path(repo).exists() or authority_path(repo).exists():
+    existing: dict | None = None
+    existing_bytes: bytes | None = None
+    if os.path.lexists(receipt_path(repo)):
+        try:
+            existing_bytes = receipt_path(repo).read_bytes()
+            existing = validate_receipt_schema(json.loads(existing_bytes.decode("utf-8")))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("invalid automation upgrade receipt") from exc
+        if (existing["task_id"], existing["branch"], existing["worktree"]) != (task_id, branch, str(worktree)):
+            raise UpgradeError("automation receipt identity does not match the current Task worktree")
+        if authority_exists(repo):
+            raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    elif authority_exists(repo):
         raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
     pending = pending_paths(repo)
-    if not pending:
+    if not pending and existing is None:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
     source, source_head = resolve_pinned_source(source_path)
-    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
-    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+    if existing is not None:
+        if str(source) != existing["source"] or source_head != existing["source_revision"]:
+            raise UpgradeError("receipt source or revision is stale")
+        pending = receipt_paths(repo, existing)
+    state_dir = task_state_dir(repo)
+    require_ignored_untracked(repo, (state_dir / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=state_dir) as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
@@ -1108,9 +1295,47 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
         "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
         "path_fingerprints": current_fingerprints,
     }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
+    revalidate_source(source, source_head)
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed before authority publication")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed before authority publication")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content changed before authority publication")
+    if existing is not None:
+        receipt["authority_nonce"] = existing["authority_nonce"]
+        receipt["path_fingerprints"] = current_fingerprints
+        if receipt != existing:
+            raise UpgradeError("existing receipt does not match the reconstructed upgrade")
+        if receipt_path(repo).read_bytes() != existing_bytes or authority_exists(repo):
+            raise UpgradeError("receipt or authority changed during authority recovery")
+        _write_authority_at(authority_path(repo), {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        }, admin=worktree_admin_dir(repo))
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
+        return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected, "authorityIssued": True}
+    revalidate_source(source, source_head)
+    issue_pair(repo, receipt)
+    try:
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+    except OSError as exc:
+        raise UpgradeError("cannot remove stale consumed receipt") from exc
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
@@ -1227,7 +1452,8 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
 def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
-    private_index = repo / ".task-state" / "automation-maintenance.index"
+    state_dir = task_state_dir(repo)
+    private_index = state_dir / "automation-maintenance.index"
     require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
     if not active.is_file():
         raise UpgradeError("no active successful automation upgrade receipt")
@@ -1248,21 +1474,35 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    validate_authority(repo, receipt)
+    authority = validate_authority(repo, receipt)
 
     consumed = consumed_receipt_path(repo)
-    os.replace(active, consumed)
     consumed_receipt = dict(receipt)
     consumed_receipt["status"] = "consumed"
     consumed_receipt["commit_sha"] = None
-    atomic_json_write(consumed, consumed_receipt)
-    authority = authority_path(repo)
-    authority.unlink(missing_ok=True)
-    private_index.unlink(missing_ok=True)
-    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    private_index = state_dir / "automation-maintenance.index"
     committed = False
     commit_sha = ""
+    active_moved = False
+    authority_removed = False
+    consumed_instances: set[tuple[int, int]] = set()
     try:
+        if os.path.lexists(consumed):
+            existing = consumed.lstat()
+            if not stat.S_ISREG(existing.st_mode) or stat.S_ISLNK(existing.st_mode):
+                raise UpgradeError("existing consumed receipt has an unsafe type")
+        os.replace(active, consumed)
+        active_moved = True
+        moved_metadata = consumed.lstat()
+        consumed_instances.add((moved_metadata.st_dev, moved_metadata.st_ino))
+        atomic_json_write(consumed, consumed_receipt)
+        consumed_metadata = consumed.lstat()
+        consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
+        authority.unlink(missing_ok=True)
+        authority_removed = True
+        task_state_dir(repo)
+        private_index.unlink(missing_ok=True)
+        index_environment = {"GIT_INDEX_FILE": str(private_index)}
         run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
         run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
         run(
@@ -1310,14 +1550,59 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except UpgradeError:
-        if not committed and not active.exists():
-            atomic_json_write(active, receipt)
-            write_authority(repo, receipt)
-            consumed.unlink(missing_ok=True)
+    except (UpgradeError, OSError) as failure:
+        if committed:
+            if isinstance(failure, OSError):
+                raise UpgradeError("commit finalization failed") from failure
+            raise
+        rollback_errors: list[str] = []
+        try:
+            if authority_removed:
+                _write_authority_at(
+                    authority,
+                    {
+                        "schema_version": 1,
+                        "task_id": receipt["task_id"],
+                        "branch": receipt["branch"],
+                        "worktree": receipt["worktree"],
+                        "authority_nonce": receipt["authority_nonce"],
+                        "receipt_sha256": receipt_digest(receipt),
+                    },
+                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                )
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"authority restore failed: {rollback_error}")
+        try:
+            if consumed_instances:
+                current = consumed.lstat()
+                if (current.st_dev, current.st_ino) in consumed_instances:
+                    consumed.unlink()
+                else:
+                    raise UpgradeError("consumed receipt changed during rollback")
+        except OSError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        except UpgradeError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        try:
+            if active_moved:
+                if os.path.lexists(active):
+                    raise UpgradeError("active receipt appeared during rollback")
+                exclusive_json_write(active, receipt)
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"active receipt restore failed: {rollback_error}")
+        if rollback_errors:
+            raise UpgradeError(
+                f"commit failed: {failure}; rollback failed: {'; '.join(rollback_errors)}"
+            ) from failure
+        if isinstance(failure, OSError):
+            raise UpgradeError("commit failed during filesystem operation") from failure
         raise
     finally:
-        private_index.unlink(missing_ok=True)
+        try:
+            task_state_dir(repo)
+            private_index.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            raise UpgradeError("private index cleanup failed") from cleanup_error
     return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -651,22 +651,25 @@ The canonical publication flows are:
    AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
    ```
 
-   This bridge does not trust `NO_CHANGES`, the current diff, or the environment.
-   It uses the same pinned clean-source and tracked Agent Core snapshot
-   semantics as normal `automation::check-update` and `automation::upgrade`,
-   then applies canonical upgrade semantics in isolation to reconstruct
-   expected output. It requires exact pending paths, content, and modes, plus
-   matching Task identity and `HEAD`, before issuing the existing receipt and
-   protected authority. The receipt's `source_revision` is the pinned snapshot
-   `HEAD`; any source race fails closed. Product, Adapter, repository,
-   secret-pattern, or `.task-state` paths and any tampering fail closed.
+    This bridge supports exactly two strict cases: canonical pre-receipt
+    reconstruction, and recovery of an exact active receipt whose authority is
+    missing. It does not trust `NO_CHANGES`, the current diff, or the
+    environment. It uses the same pinned clean-source and tracked Agent Core
+    snapshot semantics as normal `automation::check-update` and
+    `automation::upgrade`, then reruns pinned clean-source canonical
+    reconstruction. It requires Task/branch/worktree/`HEAD`, the pinned source
+    revision, and exact pending safe paths, content, modes, and fingerprints.
+    Recovery additionally requires receipt exact equality and that it is
+    unchanged, then issues only the missing authority. A receipt with authority,
+    or stale, forged, or tampered state, fails closed. Product, Adapter,
+    repository, secret-pattern, or `.task-state` paths also fail closed.
 
-The bridge only repairs missing pre-receipt evidence; the existing receipt and
-authority design remains in force, and ordinary `agent::commit` continues to
+The bridge only reconstructs a canonical pre-receipt or repairs missing
+authority for an exact active receipt; ordinary `agent::commit` continues to
 reject Automation Core changes. Its source and snapshot semantics align with
 the normal upgrade workflow.
 
-Successful upgrade writes or replaces the ignored `.task-state/automation-maintenance.json` receipt. Its schema-1 content records Task identity (`task_id`, `branch`, `worktree`), source and source revision, current/upstream versions, sorted unique `changed_paths`, the authority `HEAD`, and per-path content/state fingerprints. A protected record in the shared Git directory binds that receipt to the successful upgrade. `automation::commit <task> [message]` fails closed unless both records match the current Task/worktree identity and `HEAD`, fingerprints, and complete pending path set. Receipt paths must be Agent Core-managed; any mixed Adapter, repository, product, configured-secret, or `.task-state` scope is rejected. Ambient Git repository/index overrides are scrubbed; exact blobs and modes are staged and rechecked in a private index, committed as that verified tree without hooks, and published only by an atomic expected-HEAD Task branch update. The receipt is moved to `.task-state/automation-maintenance.consumed.json` after successful commit; the next successful upgrade with changes replaces the active receipt and removes the prior consumed receipt. A no-change invocation returns `NO_CHANGES` and preserves existing lifecycle evidence.
+Successful upgrade writes or replaces the ignored `.task-state/automation-maintenance.json` receipt. Its schema-1 content records Task identity (`task_id`, `branch`, `worktree`), source and source revision, current/upstream versions, sorted unique `changed_paths`, the authority `HEAD`, and per-path content/state fingerprints. Receipt and authority publication is a logical pair. Authority records live under the Git-resolved per-worktree administrative directory returned by `--absolute-git-dir`, not an assumed visible `.git` or shared Git directory; linked and special administrative topologies are supported, and worktrees do not share authority. Existing safe legacy shared-common-dir hashed records remain validation/commit compatible. `automation::commit <task> [message]` fails closed unless both records match the current Task/worktree identity and `HEAD`, fingerprints, and complete pending path set. Receipt paths must be Agent Core-managed; any mixed Adapter, repository, product, configured-secret, or `.task-state` scope is rejected. Ambient Git repository/index overrides are scrubbed; exact blobs and modes are staged and rechecked in a private index, committed as that verified tree without hooks, and published only by an atomic expected-HEAD Task branch update. A handled authority-write failure removes the newly written receipt if it is unchanged; an interruption half-state is recoverable only through the strict bootstrap path. No cross-filesystem atomicity is claimed. The receipt is moved to `.task-state/automation-maintenance.consumed.json` after successful commit; the next successful upgrade with changes replaces the active receipt and removes the prior consumed receipt. A no-change invocation returns `NO_CHANGES` and preserves existing lifecycle evidence.
 
 The required sequence is `git diff --check`, `just agent::doctor`, `just project::check`, and the repository CI/smoke suite, followed by `just automation::commit <task> [message]`, existing `just agent::push <task>`, and `just agent::pr-create <task>` (Draft PR). Raw Git/GitHub bypass is not permitted. Merge is excluded from this workflow and remains a separately gated Main Orchestrator operation.
 

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -53,30 +53,40 @@ bridge:
 AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
 ```
 
-The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-uses the same pinned clean-source and tracked Agent Core snapshot semantics as
-the normal update operations, applies canonical upgrade semantics in isolation,
-and requires exact pending paths/content/modes plus Task identity and `HEAD`
-before issuing the existing receipt and protected authority. The receipt's
-`source_revision` equals the pinned snapshot `HEAD`; any source race fails
-closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
-and any tampering, fail closed. Continue with the existing
-`automation::commit` flow; ordinary `agent::commit` rejection and the
-receipt/authority design remain unchanged.
+The bridge supports exactly two strict cases: canonical pre-receipt
+reconstruction, and recovery of an exact active receipt whose authority is
+missing. It does not trust `NO_CHANGES`, the current diff, or the environment.
+It uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, reruns pinned clean-source canonical
+reconstruction, and requires Task/branch/worktree/`HEAD`, the pinned source
+revision, and exact pending safe paths/content/modes and fingerprints. Recovery
+additionally requires receipt exact equality and that it is unchanged, then
+issues only the missing authority. A receipt with authority, or stale, forged,
+or tampered state, fails closed. Product, Adapter, repository, secret-pattern,
+or `.task-state` paths also fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection remains unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state
 `path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
 stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
-or does not exactly equal all pending paths. A protected shared-Git-directory
-record binds it to the preceding successful upgrade; a fabricated Task State
-receipt is not authority. Ambient Git repository/index overrides are scrubbed.
-The exact paths are staged and rechecked in a private Task State index, then the
-commit is created from that verified tree without hooks and the expected Task
-branch HEAD is advanced atomically. Only Agent Core-managed paths are
-accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
-scopes are rejected. After a successful commit it is consumed at
+or does not exactly equal all pending paths. Receipt and authority publication
+is a logical pair. Authority records live under the Git-resolved per-worktree
+administrative directory returned by `--absolute-git-dir`, not an assumed
+visible `.git` or shared Git directory; linked and special administrative
+topologies are supported, and worktrees do not share authority. Existing safe
+legacy shared-common-dir hashed records remain validation/commit compatible. A
+protected record binds it to the preceding successful upgrade; a fabricated
+Task State receipt is not authority. Ambient Git repository/index overrides are
+scrubbed. The exact paths are staged and rechecked in a private Task State
+index, then the commit is created from that verified tree without hooks and the
+expected Task branch HEAD is advanced atomically. Only Agent Core-managed paths
+are accepted; mixed Adapter, repository, product, secret-pattern, or
+`.task-state` scopes are rejected. A handled authority-write failure removes the
+newly written receipt if it is unchanged; an interruption half-state is
+recoverable only through the strict bootstrap path. No cross-filesystem
+atomicity is claimed. After a successful commit it is consumed at
 `.task-state/automation-maintenance.consumed.json`; a subsequent successful
 upgrade with changes replaces the active receipt and removes the previous consumed
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -92,7 +92,7 @@ def worktree_admin_dir(repo: Path) -> Path:
         if not admin.is_dir():
             raise UpgradeError("worktree administrative directory does not exist")
         return admin
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve worktree administrative directory") from exc
 
 
@@ -101,19 +101,29 @@ def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     new_parent = admin / "opencode" / "automation-maintenance"
     try:
         resolved_parent = new_parent.resolve()
-    except OSError as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy: Path | None = None
+    legacy_location = _safe_legacy_location(repo)
+    legacy = legacy_location[0] if legacy_location is not None else None
+    return new_parent / "authority.json", legacy
+
+
+def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
+    """Return the legacy record and its containment guard only when safe."""
     try:
         common = common_git_dir(repo)
-        if common.is_dir():
-            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
-    except (OSError, UpgradeError):
-        legacy = None
-    return new_parent / "authority.json", legacy
+        if not common.is_dir():
+            return None
+        parent = common / "opencode" / "automation-maintenance"
+        resolved_parent = parent.resolve()
+        if resolved_parent != common and common not in resolved_parent.parents:
+            return None
+        key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+        return parent / f"{key}.json", common
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def authority_path(repo: Path) -> Path:
@@ -168,8 +178,17 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             os.link(temporary, path)
         finally:
             temporary.unlink(missing_ok=True)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    legacy = _safe_legacy_location(repo)
+    if legacy is not None and authority == legacy[0]:
+        return legacy[1]
+    if authority == authority_path(repo):
+        return worktree_admin_dir(repo)
+    raise UpgradeError("cannot safely resolve authority location for rollback")
 
 
 def validate_authority(repo: Path, receipt: dict) -> Path:
@@ -1568,7 +1587,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
                         "authority_nonce": receipt["authority_nonce"],
                         "receipt_sha256": receipt_digest(receipt),
                     },
-                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                    admin=_rollback_authority_guard(repo, authority),
                 )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -42,6 +42,23 @@ RECEIPT_FIELDS = {
 _GIT_EXECUTABLE: Path | None = None
 
 
+def task_state_dir(repo: Path) -> Path:
+    try:
+        root = repo.resolve()
+        state = root / ".task-state"
+        metadata = state.lstat()
+        resolved = state.resolve()
+    except OSError as exc:
+        raise UpgradeError("Task State directory is unavailable") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or (resolved != root and root not in resolved.parents)
+    ):
+        raise UpgradeError("Task State directory is unsafe")
+    return resolved
+
+
 def git_head(repo: Path) -> str:
     result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
     return result.stdout.strip() if result.returncode == 0 else ""
@@ -53,11 +70,11 @@ def source_revision(source: Path) -> str | None:
 
 
 def receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / RECEIPT_NAME
+    return task_state_dir(repo) / RECEIPT_NAME
 
 
 def consumed_receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+    return task_state_dir(repo) / CONSUMED_RECEIPT_NAME
 
 
 def common_git_dir(repo: Path) -> Path:
@@ -65,9 +82,42 @@ def common_git_dir(repo: Path) -> Path:
     return value.resolve() if value.is_absolute() else (repo / value).resolve()
 
 
+def worktree_admin_dir(repo: Path) -> Path:
+    try:
+        raw = run(["git", "rev-parse", "--absolute-git-dir"], cwd=repo).stdout.strip()
+        candidate = Path(raw)
+        if not raw or not candidate.is_absolute():
+            raise UpgradeError("Git returned an invalid absolute worktree administrative directory")
+        admin = candidate.resolve()
+        if not admin.is_dir():
+            raise UpgradeError("worktree administrative directory does not exist")
+        return admin
+    except (OSError, ValueError) as exc:
+        raise UpgradeError("cannot resolve worktree administrative directory") from exc
+
+
+def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
+    admin = worktree_admin_dir(repo)
+    new_parent = admin / "opencode" / "automation-maintenance"
+    try:
+        resolved_parent = new_parent.resolve()
+    except OSError as exc:
+        raise UpgradeError("cannot resolve authority directory") from exc
+    if resolved_parent != admin and admin not in resolved_parent.parents:
+        raise UpgradeError("authority directory escapes the worktree administrative directory")
+    legacy: Path | None = None
+    try:
+        common = common_git_dir(repo)
+        if common.is_dir():
+            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
+    except (OSError, UpgradeError):
+        legacy = None
+    return new_parent / "authority.json", legacy
+
+
 def authority_path(repo: Path) -> Path:
-    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+    return _authority_locations(repo)[0]
 
 
 def canonical_json(value: dict) -> bytes:
@@ -79,7 +129,7 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
-    atomic_json_write(
+    _write_authority_at(
         authority_path(repo),
         {
             "schema_version": 1,
@@ -89,12 +139,50 @@ def write_authority(repo: Path, receipt: dict) -> None:
             "authority_nonce": receipt["authority_nonce"],
             "receipt_sha256": receipt_digest(receipt),
         },
+        admin=worktree_admin_dir(repo),
     )
 
 
-def validate_authority(repo: Path, receipt: dict) -> None:
-    path = authority_path(repo)
+def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
     try:
+        if admin is not None:
+            parent_before = path.parent.resolve()
+            if parent_before != admin and admin not in parent_before.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if admin is not None:
+            parent_after = path.parent.resolve()
+            if parent_after != admin and admin not in parent_after.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        # The caller has validated the parent; do not replace an existing record.
+        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+                stream.flush()
+                try:
+                    os.fsync(stream.fileno())
+                except OSError:
+                    pass
+            os.link(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+    except (OSError, ValueError) as exc:
+        raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def validate_authority(repo: Path, receipt: dict) -> Path:
+    new_path, legacy_path = _authority_locations(repo)
+    path = new_path
+    if not os.path.lexists(path):
+        if legacy_path is None or not os.path.lexists(legacy_path):
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
+        path = legacy_path
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
         authority = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
@@ -108,6 +196,29 @@ def validate_authority(repo: Path, receipt: dict) -> None:
     }
     if authority != expected:
         raise UpgradeError("automation receipt does not match successful-upgrade authority")
+    return path
+
+
+def authority_exists(repo: Path) -> bool:
+    new_path, legacy_path = _authority_locations(repo)
+    return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
+
+
+def issue_pair(repo: Path, receipt: dict) -> None:
+    destination = receipt_path(repo)
+    published: tuple[int, int] | None = None
+    try:
+        published = exclusive_json_write(destination, receipt)
+        write_authority(repo, receipt)
+    except (OSError, UpgradeError):
+        if published is not None:
+            try:
+                current = destination.lstat()
+                if (current.st_dev, current.st_ino) == published:
+                    destination.unlink()
+            except OSError as exc:
+                raise UpgradeError("receipt publication failed and rollback failed") from exc
+        raise
 
 
 def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
@@ -126,13 +237,53 @@ def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
 
 
 def atomic_json_write(path: Path, value: dict) -> None:
+    atomic_bytes_write(path, (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def atomic_bytes_write(path: Path, content: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
     try:
-        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
         os.replace(temporary, path)
     finally:
-        temporary.unlink(missing_ok=True)
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError("cannot publish an automation receipt over an existing receipt") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish JSON record: {path}") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -156,7 +307,7 @@ def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
 def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
     if not TASK_ID_RE.fullmatch(task):
         raise UpgradeError(f"invalid Task ID: {task!r}")
-    state_path = repo / ".task-state" / "task.md"
+    state_path = task_state_dir(repo) / "task.md"
     if not state_path.is_file():
         raise UpgradeError("operation requires a Task worktree with Task State")
     text = state_path.read_text(encoding="utf-8")
@@ -190,6 +341,21 @@ def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]
             continue
         key, _, value = line.partition(" ")
         current[key] = value
+    visible_top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=repo).stdout.strip())
+    if visible_top.is_absolute():
+        visible_top = visible_top.resolve()
+        current_repo = repo.resolve()
+        admin = worktree_admin_dir(repo)
+        current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip() or None
+        current_head = git_head(repo) or None
+        admin_record = records.get(admin)
+        if (
+            visible_top == current_repo
+            and visible_top not in records
+            and admin_record is not None
+            and admin_record == (current_branch, current_head)
+        ):
+            records[visible_top] = admin_record
     return records
 
 
@@ -895,7 +1061,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    state = repo / ".task-state" / "task.md"
+    state = task_state_dir(repo) / "task.md"
     task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
     if not task_match:
         raise UpgradeError("upgrade requires a registered non-default Task branch")
@@ -903,7 +1069,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     identity = require_registered_task(repo, task_id)
     require_ignored_untracked(
         repo,
-        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+        (task_state_dir(repo) / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
     )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
@@ -923,6 +1089,8 @@ def check_update(repo: Path, source_path: Path) -> dict:
 
 def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
+    if os.path.lexists(receipt_path(repo)) or authority_exists(repo):
+        raise UpgradeError("cannot apply with an existing receipt or authority record")
     source, revision = resolve_pinned_source(source_path)
     with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
         snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
@@ -993,9 +1161,11 @@ def apply(repo: Path, source_path: Path) -> dict:
             "authority_nonce": secrets.token_hex(32),
             "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
         }
-        atomic_json_write(receipt_path(repo), receipt)
-        write_authority(repo, receipt)
-        consumed_receipt_path(repo).unlink(missing_ok=True)
+        issue_pair(repo, receipt)
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
         return result
 
 
@@ -1045,16 +1215,33 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
-    if receipt_path(repo).exists() or authority_path(repo).exists():
+    existing: dict | None = None
+    existing_bytes: bytes | None = None
+    if os.path.lexists(receipt_path(repo)):
+        try:
+            existing_bytes = receipt_path(repo).read_bytes()
+            existing = validate_receipt_schema(json.loads(existing_bytes.decode("utf-8")))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("invalid automation upgrade receipt") from exc
+        if (existing["task_id"], existing["branch"], existing["worktree"]) != (task_id, branch, str(worktree)):
+            raise UpgradeError("automation receipt identity does not match the current Task worktree")
+        if authority_exists(repo):
+            raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    elif authority_exists(repo):
         raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
     pending = pending_paths(repo)
-    if not pending:
+    if not pending and existing is None:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
     source, source_head = resolve_pinned_source(source_path)
-    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
-    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+    if existing is not None:
+        if str(source) != existing["source"] or source_head != existing["source_revision"]:
+            raise UpgradeError("receipt source or revision is stale")
+        pending = receipt_paths(repo, existing)
+    state_dir = task_state_dir(repo)
+    require_ignored_untracked(repo, (state_dir / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=state_dir) as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
@@ -1108,9 +1295,47 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
         "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
         "path_fingerprints": current_fingerprints,
     }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
+    revalidate_source(source, source_head)
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed before authority publication")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed before authority publication")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content changed before authority publication")
+    if existing is not None:
+        receipt["authority_nonce"] = existing["authority_nonce"]
+        receipt["path_fingerprints"] = current_fingerprints
+        if receipt != existing:
+            raise UpgradeError("existing receipt does not match the reconstructed upgrade")
+        if receipt_path(repo).read_bytes() != existing_bytes or authority_exists(repo):
+            raise UpgradeError("receipt or authority changed during authority recovery")
+        _write_authority_at(authority_path(repo), {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        }, admin=worktree_admin_dir(repo))
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
+        return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected, "authorityIssued": True}
+    revalidate_source(source, source_head)
+    issue_pair(repo, receipt)
+    try:
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+    except OSError as exc:
+        raise UpgradeError("cannot remove stale consumed receipt") from exc
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
@@ -1227,7 +1452,8 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
 def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
-    private_index = repo / ".task-state" / "automation-maintenance.index"
+    state_dir = task_state_dir(repo)
+    private_index = state_dir / "automation-maintenance.index"
     require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
     if not active.is_file():
         raise UpgradeError("no active successful automation upgrade receipt")
@@ -1248,21 +1474,35 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    validate_authority(repo, receipt)
+    authority = validate_authority(repo, receipt)
 
     consumed = consumed_receipt_path(repo)
-    os.replace(active, consumed)
     consumed_receipt = dict(receipt)
     consumed_receipt["status"] = "consumed"
     consumed_receipt["commit_sha"] = None
-    atomic_json_write(consumed, consumed_receipt)
-    authority = authority_path(repo)
-    authority.unlink(missing_ok=True)
-    private_index.unlink(missing_ok=True)
-    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    private_index = state_dir / "automation-maintenance.index"
     committed = False
     commit_sha = ""
+    active_moved = False
+    authority_removed = False
+    consumed_instances: set[tuple[int, int]] = set()
     try:
+        if os.path.lexists(consumed):
+            existing = consumed.lstat()
+            if not stat.S_ISREG(existing.st_mode) or stat.S_ISLNK(existing.st_mode):
+                raise UpgradeError("existing consumed receipt has an unsafe type")
+        os.replace(active, consumed)
+        active_moved = True
+        moved_metadata = consumed.lstat()
+        consumed_instances.add((moved_metadata.st_dev, moved_metadata.st_ino))
+        atomic_json_write(consumed, consumed_receipt)
+        consumed_metadata = consumed.lstat()
+        consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
+        authority.unlink(missing_ok=True)
+        authority_removed = True
+        task_state_dir(repo)
+        private_index.unlink(missing_ok=True)
+        index_environment = {"GIT_INDEX_FILE": str(private_index)}
         run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
         run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
         run(
@@ -1310,14 +1550,59 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except UpgradeError:
-        if not committed and not active.exists():
-            atomic_json_write(active, receipt)
-            write_authority(repo, receipt)
-            consumed.unlink(missing_ok=True)
+    except (UpgradeError, OSError) as failure:
+        if committed:
+            if isinstance(failure, OSError):
+                raise UpgradeError("commit finalization failed") from failure
+            raise
+        rollback_errors: list[str] = []
+        try:
+            if authority_removed:
+                _write_authority_at(
+                    authority,
+                    {
+                        "schema_version": 1,
+                        "task_id": receipt["task_id"],
+                        "branch": receipt["branch"],
+                        "worktree": receipt["worktree"],
+                        "authority_nonce": receipt["authority_nonce"],
+                        "receipt_sha256": receipt_digest(receipt),
+                    },
+                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                )
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"authority restore failed: {rollback_error}")
+        try:
+            if consumed_instances:
+                current = consumed.lstat()
+                if (current.st_dev, current.st_ino) in consumed_instances:
+                    consumed.unlink()
+                else:
+                    raise UpgradeError("consumed receipt changed during rollback")
+        except OSError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        except UpgradeError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        try:
+            if active_moved:
+                if os.path.lexists(active):
+                    raise UpgradeError("active receipt appeared during rollback")
+                exclusive_json_write(active, receipt)
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"active receipt restore failed: {rollback_error}")
+        if rollback_errors:
+            raise UpgradeError(
+                f"commit failed: {failure}; rollback failed: {'; '.join(rollback_errors)}"
+            ) from failure
+        if isinstance(failure, OSError):
+            raise UpgradeError("commit failed during filesystem operation") from failure
         raise
     finally:
-        private_index.unlink(missing_ok=True)
+        try:
+            task_state_dir(repo)
+            private_index.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            raise UpgradeError("private index cleanup failed") from cleanup_error
     return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -53,30 +53,40 @@ bridge:
 AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
 ```
 
-The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-uses the same pinned clean-source and tracked Agent Core snapshot semantics as
-the normal update operations, applies canonical upgrade semantics in isolation,
-and requires exact pending paths/content/modes plus Task identity and `HEAD`
-before issuing the existing receipt and protected authority. The receipt's
-`source_revision` equals the pinned snapshot `HEAD`; any source race fails
-closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
-and any tampering, fail closed. Continue with the existing
-`automation::commit` flow; ordinary `agent::commit` rejection and the
-receipt/authority design remain unchanged.
+The bridge supports exactly two strict cases: canonical pre-receipt
+reconstruction, and recovery of an exact active receipt whose authority is
+missing. It does not trust `NO_CHANGES`, the current diff, or the environment.
+It uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, reruns pinned clean-source canonical
+reconstruction, and requires Task/branch/worktree/`HEAD`, the pinned source
+revision, and exact pending safe paths/content/modes and fingerprints. Recovery
+additionally requires receipt exact equality and that it is unchanged, then
+issues only the missing authority. A receipt with authority, or stale, forged,
+or tampered state, fails closed. Product, Adapter, repository, secret-pattern,
+or `.task-state` paths also fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection remains unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state
 `path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
 stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
-or does not exactly equal all pending paths. A protected shared-Git-directory
-record binds it to the preceding successful upgrade; a fabricated Task State
-receipt is not authority. Ambient Git repository/index overrides are scrubbed.
-The exact paths are staged and rechecked in a private Task State index, then the
-commit is created from that verified tree without hooks and the expected Task
-branch HEAD is advanced atomically. Only Agent Core-managed paths are
-accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
-scopes are rejected. After a successful commit it is consumed at
+or does not exactly equal all pending paths. Receipt and authority publication
+is a logical pair. Authority records live under the Git-resolved per-worktree
+administrative directory returned by `--absolute-git-dir`, not an assumed
+visible `.git` or shared Git directory; linked and special administrative
+topologies are supported, and worktrees do not share authority. Existing safe
+legacy shared-common-dir hashed records remain validation/commit compatible. A
+protected record binds it to the preceding successful upgrade; a fabricated
+Task State receipt is not authority. Ambient Git repository/index overrides are
+scrubbed. The exact paths are staged and rechecked in a private Task State
+index, then the commit is created from that verified tree without hooks and the
+expected Task branch HEAD is advanced atomically. Only Agent Core-managed paths
+are accepted; mixed Adapter, repository, product, secret-pattern, or
+`.task-state` scopes are rejected. A handled authority-write failure removes the
+newly written receipt if it is unchanged; an interruption half-state is
+recoverable only through the strict bootstrap path. No cross-filesystem
+atomicity is claimed. After a successful commit it is consumed at
 `.task-state/automation-maintenance.consumed.json`; a subsequent successful
 upgrade with changes replaces the active receipt and removes the previous consumed
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -92,7 +92,7 @@ def worktree_admin_dir(repo: Path) -> Path:
         if not admin.is_dir():
             raise UpgradeError("worktree administrative directory does not exist")
         return admin
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve worktree administrative directory") from exc
 
 
@@ -101,19 +101,29 @@ def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     new_parent = admin / "opencode" / "automation-maintenance"
     try:
         resolved_parent = new_parent.resolve()
-    except OSError as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy: Path | None = None
+    legacy_location = _safe_legacy_location(repo)
+    legacy = legacy_location[0] if legacy_location is not None else None
+    return new_parent / "authority.json", legacy
+
+
+def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
+    """Return the legacy record and its containment guard only when safe."""
     try:
         common = common_git_dir(repo)
-        if common.is_dir():
-            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
-    except (OSError, UpgradeError):
-        legacy = None
-    return new_parent / "authority.json", legacy
+        if not common.is_dir():
+            return None
+        parent = common / "opencode" / "automation-maintenance"
+        resolved_parent = parent.resolve()
+        if resolved_parent != common and common not in resolved_parent.parents:
+            return None
+        key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+        return parent / f"{key}.json", common
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def authority_path(repo: Path) -> Path:
@@ -168,8 +178,17 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             os.link(temporary, path)
         finally:
             temporary.unlink(missing_ok=True)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    legacy = _safe_legacy_location(repo)
+    if legacy is not None and authority == legacy[0]:
+        return legacy[1]
+    if authority == authority_path(repo):
+        return worktree_admin_dir(repo)
+    raise UpgradeError("cannot safely resolve authority location for rollback")
 
 
 def validate_authority(repo: Path, receipt: dict) -> Path:
@@ -1568,7 +1587,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
                         "authority_nonce": receipt["authority_nonce"],
                         "receipt_sha256": receipt_digest(receipt),
                     },
-                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                    admin=_rollback_authority_guard(repo, authority),
                 )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -42,6 +42,23 @@ RECEIPT_FIELDS = {
 _GIT_EXECUTABLE: Path | None = None
 
 
+def task_state_dir(repo: Path) -> Path:
+    try:
+        root = repo.resolve()
+        state = root / ".task-state"
+        metadata = state.lstat()
+        resolved = state.resolve()
+    except OSError as exc:
+        raise UpgradeError("Task State directory is unavailable") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or (resolved != root and root not in resolved.parents)
+    ):
+        raise UpgradeError("Task State directory is unsafe")
+    return resolved
+
+
 def git_head(repo: Path) -> str:
     result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
     return result.stdout.strip() if result.returncode == 0 else ""
@@ -53,11 +70,11 @@ def source_revision(source: Path) -> str | None:
 
 
 def receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / RECEIPT_NAME
+    return task_state_dir(repo) / RECEIPT_NAME
 
 
 def consumed_receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+    return task_state_dir(repo) / CONSUMED_RECEIPT_NAME
 
 
 def common_git_dir(repo: Path) -> Path:
@@ -65,9 +82,42 @@ def common_git_dir(repo: Path) -> Path:
     return value.resolve() if value.is_absolute() else (repo / value).resolve()
 
 
+def worktree_admin_dir(repo: Path) -> Path:
+    try:
+        raw = run(["git", "rev-parse", "--absolute-git-dir"], cwd=repo).stdout.strip()
+        candidate = Path(raw)
+        if not raw or not candidate.is_absolute():
+            raise UpgradeError("Git returned an invalid absolute worktree administrative directory")
+        admin = candidate.resolve()
+        if not admin.is_dir():
+            raise UpgradeError("worktree administrative directory does not exist")
+        return admin
+    except (OSError, ValueError) as exc:
+        raise UpgradeError("cannot resolve worktree administrative directory") from exc
+
+
+def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
+    admin = worktree_admin_dir(repo)
+    new_parent = admin / "opencode" / "automation-maintenance"
+    try:
+        resolved_parent = new_parent.resolve()
+    except OSError as exc:
+        raise UpgradeError("cannot resolve authority directory") from exc
+    if resolved_parent != admin and admin not in resolved_parent.parents:
+        raise UpgradeError("authority directory escapes the worktree administrative directory")
+    legacy: Path | None = None
+    try:
+        common = common_git_dir(repo)
+        if common.is_dir():
+            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
+    except (OSError, UpgradeError):
+        legacy = None
+    return new_parent / "authority.json", legacy
+
+
 def authority_path(repo: Path) -> Path:
-    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+    return _authority_locations(repo)[0]
 
 
 def canonical_json(value: dict) -> bytes:
@@ -79,7 +129,7 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
-    atomic_json_write(
+    _write_authority_at(
         authority_path(repo),
         {
             "schema_version": 1,
@@ -89,12 +139,50 @@ def write_authority(repo: Path, receipt: dict) -> None:
             "authority_nonce": receipt["authority_nonce"],
             "receipt_sha256": receipt_digest(receipt),
         },
+        admin=worktree_admin_dir(repo),
     )
 
 
-def validate_authority(repo: Path, receipt: dict) -> None:
-    path = authority_path(repo)
+def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
     try:
+        if admin is not None:
+            parent_before = path.parent.resolve()
+            if parent_before != admin and admin not in parent_before.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if admin is not None:
+            parent_after = path.parent.resolve()
+            if parent_after != admin and admin not in parent_after.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        # The caller has validated the parent; do not replace an existing record.
+        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+                stream.flush()
+                try:
+                    os.fsync(stream.fileno())
+                except OSError:
+                    pass
+            os.link(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+    except (OSError, ValueError) as exc:
+        raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def validate_authority(repo: Path, receipt: dict) -> Path:
+    new_path, legacy_path = _authority_locations(repo)
+    path = new_path
+    if not os.path.lexists(path):
+        if legacy_path is None or not os.path.lexists(legacy_path):
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
+        path = legacy_path
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
         authority = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
@@ -108,6 +196,29 @@ def validate_authority(repo: Path, receipt: dict) -> None:
     }
     if authority != expected:
         raise UpgradeError("automation receipt does not match successful-upgrade authority")
+    return path
+
+
+def authority_exists(repo: Path) -> bool:
+    new_path, legacy_path = _authority_locations(repo)
+    return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
+
+
+def issue_pair(repo: Path, receipt: dict) -> None:
+    destination = receipt_path(repo)
+    published: tuple[int, int] | None = None
+    try:
+        published = exclusive_json_write(destination, receipt)
+        write_authority(repo, receipt)
+    except (OSError, UpgradeError):
+        if published is not None:
+            try:
+                current = destination.lstat()
+                if (current.st_dev, current.st_ino) == published:
+                    destination.unlink()
+            except OSError as exc:
+                raise UpgradeError("receipt publication failed and rollback failed") from exc
+        raise
 
 
 def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
@@ -126,13 +237,53 @@ def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
 
 
 def atomic_json_write(path: Path, value: dict) -> None:
+    atomic_bytes_write(path, (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def atomic_bytes_write(path: Path, content: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
     try:
-        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
         os.replace(temporary, path)
     finally:
-        temporary.unlink(missing_ok=True)
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError("cannot publish an automation receipt over an existing receipt") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish JSON record: {path}") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -156,7 +307,7 @@ def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
 def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
     if not TASK_ID_RE.fullmatch(task):
         raise UpgradeError(f"invalid Task ID: {task!r}")
-    state_path = repo / ".task-state" / "task.md"
+    state_path = task_state_dir(repo) / "task.md"
     if not state_path.is_file():
         raise UpgradeError("operation requires a Task worktree with Task State")
     text = state_path.read_text(encoding="utf-8")
@@ -190,6 +341,21 @@ def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]
             continue
         key, _, value = line.partition(" ")
         current[key] = value
+    visible_top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=repo).stdout.strip())
+    if visible_top.is_absolute():
+        visible_top = visible_top.resolve()
+        current_repo = repo.resolve()
+        admin = worktree_admin_dir(repo)
+        current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip() or None
+        current_head = git_head(repo) or None
+        admin_record = records.get(admin)
+        if (
+            visible_top == current_repo
+            and visible_top not in records
+            and admin_record is not None
+            and admin_record == (current_branch, current_head)
+        ):
+            records[visible_top] = admin_record
     return records
 
 
@@ -895,7 +1061,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    state = repo / ".task-state" / "task.md"
+    state = task_state_dir(repo) / "task.md"
     task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
     if not task_match:
         raise UpgradeError("upgrade requires a registered non-default Task branch")
@@ -903,7 +1069,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     identity = require_registered_task(repo, task_id)
     require_ignored_untracked(
         repo,
-        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+        (task_state_dir(repo) / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
     )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
@@ -923,6 +1089,8 @@ def check_update(repo: Path, source_path: Path) -> dict:
 
 def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
+    if os.path.lexists(receipt_path(repo)) or authority_exists(repo):
+        raise UpgradeError("cannot apply with an existing receipt or authority record")
     source, revision = resolve_pinned_source(source_path)
     with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
         snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
@@ -993,9 +1161,11 @@ def apply(repo: Path, source_path: Path) -> dict:
             "authority_nonce": secrets.token_hex(32),
             "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
         }
-        atomic_json_write(receipt_path(repo), receipt)
-        write_authority(repo, receipt)
-        consumed_receipt_path(repo).unlink(missing_ok=True)
+        issue_pair(repo, receipt)
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
         return result
 
 
@@ -1045,16 +1215,33 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
-    if receipt_path(repo).exists() or authority_path(repo).exists():
+    existing: dict | None = None
+    existing_bytes: bytes | None = None
+    if os.path.lexists(receipt_path(repo)):
+        try:
+            existing_bytes = receipt_path(repo).read_bytes()
+            existing = validate_receipt_schema(json.loads(existing_bytes.decode("utf-8")))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("invalid automation upgrade receipt") from exc
+        if (existing["task_id"], existing["branch"], existing["worktree"]) != (task_id, branch, str(worktree)):
+            raise UpgradeError("automation receipt identity does not match the current Task worktree")
+        if authority_exists(repo):
+            raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    elif authority_exists(repo):
         raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
     pending = pending_paths(repo)
-    if not pending:
+    if not pending and existing is None:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
     source, source_head = resolve_pinned_source(source_path)
-    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
-    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+    if existing is not None:
+        if str(source) != existing["source"] or source_head != existing["source_revision"]:
+            raise UpgradeError("receipt source or revision is stale")
+        pending = receipt_paths(repo, existing)
+    state_dir = task_state_dir(repo)
+    require_ignored_untracked(repo, (state_dir / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=state_dir) as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
@@ -1108,9 +1295,47 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
         "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
         "path_fingerprints": current_fingerprints,
     }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
+    revalidate_source(source, source_head)
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed before authority publication")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed before authority publication")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content changed before authority publication")
+    if existing is not None:
+        receipt["authority_nonce"] = existing["authority_nonce"]
+        receipt["path_fingerprints"] = current_fingerprints
+        if receipt != existing:
+            raise UpgradeError("existing receipt does not match the reconstructed upgrade")
+        if receipt_path(repo).read_bytes() != existing_bytes or authority_exists(repo):
+            raise UpgradeError("receipt or authority changed during authority recovery")
+        _write_authority_at(authority_path(repo), {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        }, admin=worktree_admin_dir(repo))
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
+        return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected, "authorityIssued": True}
+    revalidate_source(source, source_head)
+    issue_pair(repo, receipt)
+    try:
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+    except OSError as exc:
+        raise UpgradeError("cannot remove stale consumed receipt") from exc
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
@@ -1227,7 +1452,8 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
 def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
-    private_index = repo / ".task-state" / "automation-maintenance.index"
+    state_dir = task_state_dir(repo)
+    private_index = state_dir / "automation-maintenance.index"
     require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
     if not active.is_file():
         raise UpgradeError("no active successful automation upgrade receipt")
@@ -1248,21 +1474,35 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    validate_authority(repo, receipt)
+    authority = validate_authority(repo, receipt)
 
     consumed = consumed_receipt_path(repo)
-    os.replace(active, consumed)
     consumed_receipt = dict(receipt)
     consumed_receipt["status"] = "consumed"
     consumed_receipt["commit_sha"] = None
-    atomic_json_write(consumed, consumed_receipt)
-    authority = authority_path(repo)
-    authority.unlink(missing_ok=True)
-    private_index.unlink(missing_ok=True)
-    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    private_index = state_dir / "automation-maintenance.index"
     committed = False
     commit_sha = ""
+    active_moved = False
+    authority_removed = False
+    consumed_instances: set[tuple[int, int]] = set()
     try:
+        if os.path.lexists(consumed):
+            existing = consumed.lstat()
+            if not stat.S_ISREG(existing.st_mode) or stat.S_ISLNK(existing.st_mode):
+                raise UpgradeError("existing consumed receipt has an unsafe type")
+        os.replace(active, consumed)
+        active_moved = True
+        moved_metadata = consumed.lstat()
+        consumed_instances.add((moved_metadata.st_dev, moved_metadata.st_ino))
+        atomic_json_write(consumed, consumed_receipt)
+        consumed_metadata = consumed.lstat()
+        consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
+        authority.unlink(missing_ok=True)
+        authority_removed = True
+        task_state_dir(repo)
+        private_index.unlink(missing_ok=True)
+        index_environment = {"GIT_INDEX_FILE": str(private_index)}
         run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
         run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
         run(
@@ -1310,14 +1550,59 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except UpgradeError:
-        if not committed and not active.exists():
-            atomic_json_write(active, receipt)
-            write_authority(repo, receipt)
-            consumed.unlink(missing_ok=True)
+    except (UpgradeError, OSError) as failure:
+        if committed:
+            if isinstance(failure, OSError):
+                raise UpgradeError("commit finalization failed") from failure
+            raise
+        rollback_errors: list[str] = []
+        try:
+            if authority_removed:
+                _write_authority_at(
+                    authority,
+                    {
+                        "schema_version": 1,
+                        "task_id": receipt["task_id"],
+                        "branch": receipt["branch"],
+                        "worktree": receipt["worktree"],
+                        "authority_nonce": receipt["authority_nonce"],
+                        "receipt_sha256": receipt_digest(receipt),
+                    },
+                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                )
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"authority restore failed: {rollback_error}")
+        try:
+            if consumed_instances:
+                current = consumed.lstat()
+                if (current.st_dev, current.st_ino) in consumed_instances:
+                    consumed.unlink()
+                else:
+                    raise UpgradeError("consumed receipt changed during rollback")
+        except OSError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        except UpgradeError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        try:
+            if active_moved:
+                if os.path.lexists(active):
+                    raise UpgradeError("active receipt appeared during rollback")
+                exclusive_json_write(active, receipt)
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"active receipt restore failed: {rollback_error}")
+        if rollback_errors:
+            raise UpgradeError(
+                f"commit failed: {failure}; rollback failed: {'; '.join(rollback_errors)}"
+            ) from failure
+        if isinstance(failure, OSError):
+            raise UpgradeError("commit failed during filesystem operation") from failure
         raise
     finally:
-        private_index.unlink(missing_ok=True)
+        try:
+            task_state_dir(repo)
+            private_index.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            raise UpgradeError("private index cleanup failed") from cleanup_error
     return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -53,30 +53,40 @@ bridge:
 AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
 ```
 
-The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-uses the same pinned clean-source and tracked Agent Core snapshot semantics as
-the normal update operations, applies canonical upgrade semantics in isolation,
-and requires exact pending paths/content/modes plus Task identity and `HEAD`
-before issuing the existing receipt and protected authority. The receipt's
-`source_revision` equals the pinned snapshot `HEAD`; any source race fails
-closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
-and any tampering, fail closed. Continue with the existing
-`automation::commit` flow; ordinary `agent::commit` rejection and the
-receipt/authority design remain unchanged.
+The bridge supports exactly two strict cases: canonical pre-receipt
+reconstruction, and recovery of an exact active receipt whose authority is
+missing. It does not trust `NO_CHANGES`, the current diff, or the environment.
+It uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, reruns pinned clean-source canonical
+reconstruction, and requires Task/branch/worktree/`HEAD`, the pinned source
+revision, and exact pending safe paths/content/modes and fingerprints. Recovery
+additionally requires receipt exact equality and that it is unchanged, then
+issues only the missing authority. A receipt with authority, or stale, forged,
+or tampered state, fails closed. Product, Adapter, repository, secret-pattern,
+or `.task-state` paths also fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection remains unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state
 `path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
 stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
-or does not exactly equal all pending paths. A protected shared-Git-directory
-record binds it to the preceding successful upgrade; a fabricated Task State
-receipt is not authority. Ambient Git repository/index overrides are scrubbed.
-The exact paths are staged and rechecked in a private Task State index, then the
-commit is created from that verified tree without hooks and the expected Task
-branch HEAD is advanced atomically. Only Agent Core-managed paths are
-accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
-scopes are rejected. After a successful commit it is consumed at
+or does not exactly equal all pending paths. Receipt and authority publication
+is a logical pair. Authority records live under the Git-resolved per-worktree
+administrative directory returned by `--absolute-git-dir`, not an assumed
+visible `.git` or shared Git directory; linked and special administrative
+topologies are supported, and worktrees do not share authority. Existing safe
+legacy shared-common-dir hashed records remain validation/commit compatible. A
+protected record binds it to the preceding successful upgrade; a fabricated
+Task State receipt is not authority. Ambient Git repository/index overrides are
+scrubbed. The exact paths are staged and rechecked in a private Task State
+index, then the commit is created from that verified tree without hooks and the
+expected Task branch HEAD is advanced atomically. Only Agent Core-managed paths
+are accepted; mixed Adapter, repository, product, secret-pattern, or
+`.task-state` scopes are rejected. A handled authority-write failure removes the
+newly written receipt if it is unchanged; an interruption half-state is
+recoverable only through the strict bootstrap path. No cross-filesystem
+atomicity is claimed. After a successful commit it is consumed at
 `.task-state/automation-maintenance.consumed.json`; a subsequent successful
 upgrade with changes replaces the active receipt and removes the previous consumed
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -92,7 +92,7 @@ def worktree_admin_dir(repo: Path) -> Path:
         if not admin.is_dir():
             raise UpgradeError("worktree administrative directory does not exist")
         return admin
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve worktree administrative directory") from exc
 
 
@@ -101,19 +101,29 @@ def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     new_parent = admin / "opencode" / "automation-maintenance"
     try:
         resolved_parent = new_parent.resolve()
-    except OSError as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy: Path | None = None
+    legacy_location = _safe_legacy_location(repo)
+    legacy = legacy_location[0] if legacy_location is not None else None
+    return new_parent / "authority.json", legacy
+
+
+def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
+    """Return the legacy record and its containment guard only when safe."""
     try:
         common = common_git_dir(repo)
-        if common.is_dir():
-            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
-    except (OSError, UpgradeError):
-        legacy = None
-    return new_parent / "authority.json", legacy
+        if not common.is_dir():
+            return None
+        parent = common / "opencode" / "automation-maintenance"
+        resolved_parent = parent.resolve()
+        if resolved_parent != common and common not in resolved_parent.parents:
+            return None
+        key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+        return parent / f"{key}.json", common
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def authority_path(repo: Path) -> Path:
@@ -168,8 +178,17 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             os.link(temporary, path)
         finally:
             temporary.unlink(missing_ok=True)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    legacy = _safe_legacy_location(repo)
+    if legacy is not None and authority == legacy[0]:
+        return legacy[1]
+    if authority == authority_path(repo):
+        return worktree_admin_dir(repo)
+    raise UpgradeError("cannot safely resolve authority location for rollback")
 
 
 def validate_authority(repo: Path, receipt: dict) -> Path:
@@ -1568,7 +1587,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
                         "authority_nonce": receipt["authority_nonce"],
                         "receipt_sha256": receipt_digest(receipt),
                     },
-                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                    admin=_rollback_authority_guard(repo, authority),
                 )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -42,6 +42,23 @@ RECEIPT_FIELDS = {
 _GIT_EXECUTABLE: Path | None = None
 
 
+def task_state_dir(repo: Path) -> Path:
+    try:
+        root = repo.resolve()
+        state = root / ".task-state"
+        metadata = state.lstat()
+        resolved = state.resolve()
+    except OSError as exc:
+        raise UpgradeError("Task State directory is unavailable") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or (resolved != root and root not in resolved.parents)
+    ):
+        raise UpgradeError("Task State directory is unsafe")
+    return resolved
+
+
 def git_head(repo: Path) -> str:
     result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
     return result.stdout.strip() if result.returncode == 0 else ""
@@ -53,11 +70,11 @@ def source_revision(source: Path) -> str | None:
 
 
 def receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / RECEIPT_NAME
+    return task_state_dir(repo) / RECEIPT_NAME
 
 
 def consumed_receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+    return task_state_dir(repo) / CONSUMED_RECEIPT_NAME
 
 
 def common_git_dir(repo: Path) -> Path:
@@ -65,9 +82,42 @@ def common_git_dir(repo: Path) -> Path:
     return value.resolve() if value.is_absolute() else (repo / value).resolve()
 
 
+def worktree_admin_dir(repo: Path) -> Path:
+    try:
+        raw = run(["git", "rev-parse", "--absolute-git-dir"], cwd=repo).stdout.strip()
+        candidate = Path(raw)
+        if not raw or not candidate.is_absolute():
+            raise UpgradeError("Git returned an invalid absolute worktree administrative directory")
+        admin = candidate.resolve()
+        if not admin.is_dir():
+            raise UpgradeError("worktree administrative directory does not exist")
+        return admin
+    except (OSError, ValueError) as exc:
+        raise UpgradeError("cannot resolve worktree administrative directory") from exc
+
+
+def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
+    admin = worktree_admin_dir(repo)
+    new_parent = admin / "opencode" / "automation-maintenance"
+    try:
+        resolved_parent = new_parent.resolve()
+    except OSError as exc:
+        raise UpgradeError("cannot resolve authority directory") from exc
+    if resolved_parent != admin and admin not in resolved_parent.parents:
+        raise UpgradeError("authority directory escapes the worktree administrative directory")
+    legacy: Path | None = None
+    try:
+        common = common_git_dir(repo)
+        if common.is_dir():
+            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
+    except (OSError, UpgradeError):
+        legacy = None
+    return new_parent / "authority.json", legacy
+
+
 def authority_path(repo: Path) -> Path:
-    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+    return _authority_locations(repo)[0]
 
 
 def canonical_json(value: dict) -> bytes:
@@ -79,7 +129,7 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
-    atomic_json_write(
+    _write_authority_at(
         authority_path(repo),
         {
             "schema_version": 1,
@@ -89,12 +139,50 @@ def write_authority(repo: Path, receipt: dict) -> None:
             "authority_nonce": receipt["authority_nonce"],
             "receipt_sha256": receipt_digest(receipt),
         },
+        admin=worktree_admin_dir(repo),
     )
 
 
-def validate_authority(repo: Path, receipt: dict) -> None:
-    path = authority_path(repo)
+def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
     try:
+        if admin is not None:
+            parent_before = path.parent.resolve()
+            if parent_before != admin and admin not in parent_before.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if admin is not None:
+            parent_after = path.parent.resolve()
+            if parent_after != admin and admin not in parent_after.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        # The caller has validated the parent; do not replace an existing record.
+        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+                stream.flush()
+                try:
+                    os.fsync(stream.fileno())
+                except OSError:
+                    pass
+            os.link(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+    except (OSError, ValueError) as exc:
+        raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def validate_authority(repo: Path, receipt: dict) -> Path:
+    new_path, legacy_path = _authority_locations(repo)
+    path = new_path
+    if not os.path.lexists(path):
+        if legacy_path is None or not os.path.lexists(legacy_path):
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
+        path = legacy_path
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
         authority = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
@@ -108,6 +196,29 @@ def validate_authority(repo: Path, receipt: dict) -> None:
     }
     if authority != expected:
         raise UpgradeError("automation receipt does not match successful-upgrade authority")
+    return path
+
+
+def authority_exists(repo: Path) -> bool:
+    new_path, legacy_path = _authority_locations(repo)
+    return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
+
+
+def issue_pair(repo: Path, receipt: dict) -> None:
+    destination = receipt_path(repo)
+    published: tuple[int, int] | None = None
+    try:
+        published = exclusive_json_write(destination, receipt)
+        write_authority(repo, receipt)
+    except (OSError, UpgradeError):
+        if published is not None:
+            try:
+                current = destination.lstat()
+                if (current.st_dev, current.st_ino) == published:
+                    destination.unlink()
+            except OSError as exc:
+                raise UpgradeError("receipt publication failed and rollback failed") from exc
+        raise
 
 
 def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
@@ -126,13 +237,53 @@ def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
 
 
 def atomic_json_write(path: Path, value: dict) -> None:
+    atomic_bytes_write(path, (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def atomic_bytes_write(path: Path, content: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
     try:
-        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
         os.replace(temporary, path)
     finally:
-        temporary.unlink(missing_ok=True)
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError("cannot publish an automation receipt over an existing receipt") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish JSON record: {path}") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -156,7 +307,7 @@ def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
 def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
     if not TASK_ID_RE.fullmatch(task):
         raise UpgradeError(f"invalid Task ID: {task!r}")
-    state_path = repo / ".task-state" / "task.md"
+    state_path = task_state_dir(repo) / "task.md"
     if not state_path.is_file():
         raise UpgradeError("operation requires a Task worktree with Task State")
     text = state_path.read_text(encoding="utf-8")
@@ -190,6 +341,21 @@ def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]
             continue
         key, _, value = line.partition(" ")
         current[key] = value
+    visible_top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=repo).stdout.strip())
+    if visible_top.is_absolute():
+        visible_top = visible_top.resolve()
+        current_repo = repo.resolve()
+        admin = worktree_admin_dir(repo)
+        current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip() or None
+        current_head = git_head(repo) or None
+        admin_record = records.get(admin)
+        if (
+            visible_top == current_repo
+            and visible_top not in records
+            and admin_record is not None
+            and admin_record == (current_branch, current_head)
+        ):
+            records[visible_top] = admin_record
     return records
 
 
@@ -895,7 +1061,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    state = repo / ".task-state" / "task.md"
+    state = task_state_dir(repo) / "task.md"
     task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
     if not task_match:
         raise UpgradeError("upgrade requires a registered non-default Task branch")
@@ -903,7 +1069,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     identity = require_registered_task(repo, task_id)
     require_ignored_untracked(
         repo,
-        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+        (task_state_dir(repo) / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
     )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
@@ -923,6 +1089,8 @@ def check_update(repo: Path, source_path: Path) -> dict:
 
 def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
+    if os.path.lexists(receipt_path(repo)) or authority_exists(repo):
+        raise UpgradeError("cannot apply with an existing receipt or authority record")
     source, revision = resolve_pinned_source(source_path)
     with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
         snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
@@ -993,9 +1161,11 @@ def apply(repo: Path, source_path: Path) -> dict:
             "authority_nonce": secrets.token_hex(32),
             "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
         }
-        atomic_json_write(receipt_path(repo), receipt)
-        write_authority(repo, receipt)
-        consumed_receipt_path(repo).unlink(missing_ok=True)
+        issue_pair(repo, receipt)
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
         return result
 
 
@@ -1045,16 +1215,33 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
-    if receipt_path(repo).exists() or authority_path(repo).exists():
+    existing: dict | None = None
+    existing_bytes: bytes | None = None
+    if os.path.lexists(receipt_path(repo)):
+        try:
+            existing_bytes = receipt_path(repo).read_bytes()
+            existing = validate_receipt_schema(json.loads(existing_bytes.decode("utf-8")))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("invalid automation upgrade receipt") from exc
+        if (existing["task_id"], existing["branch"], existing["worktree"]) != (task_id, branch, str(worktree)):
+            raise UpgradeError("automation receipt identity does not match the current Task worktree")
+        if authority_exists(repo):
+            raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    elif authority_exists(repo):
         raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
     pending = pending_paths(repo)
-    if not pending:
+    if not pending and existing is None:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
     source, source_head = resolve_pinned_source(source_path)
-    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
-    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+    if existing is not None:
+        if str(source) != existing["source"] or source_head != existing["source_revision"]:
+            raise UpgradeError("receipt source or revision is stale")
+        pending = receipt_paths(repo, existing)
+    state_dir = task_state_dir(repo)
+    require_ignored_untracked(repo, (state_dir / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=state_dir) as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
@@ -1108,9 +1295,47 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
         "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
         "path_fingerprints": current_fingerprints,
     }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
+    revalidate_source(source, source_head)
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed before authority publication")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed before authority publication")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content changed before authority publication")
+    if existing is not None:
+        receipt["authority_nonce"] = existing["authority_nonce"]
+        receipt["path_fingerprints"] = current_fingerprints
+        if receipt != existing:
+            raise UpgradeError("existing receipt does not match the reconstructed upgrade")
+        if receipt_path(repo).read_bytes() != existing_bytes or authority_exists(repo):
+            raise UpgradeError("receipt or authority changed during authority recovery")
+        _write_authority_at(authority_path(repo), {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        }, admin=worktree_admin_dir(repo))
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
+        return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected, "authorityIssued": True}
+    revalidate_source(source, source_head)
+    issue_pair(repo, receipt)
+    try:
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+    except OSError as exc:
+        raise UpgradeError("cannot remove stale consumed receipt") from exc
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
@@ -1227,7 +1452,8 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
 def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
-    private_index = repo / ".task-state" / "automation-maintenance.index"
+    state_dir = task_state_dir(repo)
+    private_index = state_dir / "automation-maintenance.index"
     require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
     if not active.is_file():
         raise UpgradeError("no active successful automation upgrade receipt")
@@ -1248,21 +1474,35 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    validate_authority(repo, receipt)
+    authority = validate_authority(repo, receipt)
 
     consumed = consumed_receipt_path(repo)
-    os.replace(active, consumed)
     consumed_receipt = dict(receipt)
     consumed_receipt["status"] = "consumed"
     consumed_receipt["commit_sha"] = None
-    atomic_json_write(consumed, consumed_receipt)
-    authority = authority_path(repo)
-    authority.unlink(missing_ok=True)
-    private_index.unlink(missing_ok=True)
-    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    private_index = state_dir / "automation-maintenance.index"
     committed = False
     commit_sha = ""
+    active_moved = False
+    authority_removed = False
+    consumed_instances: set[tuple[int, int]] = set()
     try:
+        if os.path.lexists(consumed):
+            existing = consumed.lstat()
+            if not stat.S_ISREG(existing.st_mode) or stat.S_ISLNK(existing.st_mode):
+                raise UpgradeError("existing consumed receipt has an unsafe type")
+        os.replace(active, consumed)
+        active_moved = True
+        moved_metadata = consumed.lstat()
+        consumed_instances.add((moved_metadata.st_dev, moved_metadata.st_ino))
+        atomic_json_write(consumed, consumed_receipt)
+        consumed_metadata = consumed.lstat()
+        consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
+        authority.unlink(missing_ok=True)
+        authority_removed = True
+        task_state_dir(repo)
+        private_index.unlink(missing_ok=True)
+        index_environment = {"GIT_INDEX_FILE": str(private_index)}
         run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
         run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
         run(
@@ -1310,14 +1550,59 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except UpgradeError:
-        if not committed and not active.exists():
-            atomic_json_write(active, receipt)
-            write_authority(repo, receipt)
-            consumed.unlink(missing_ok=True)
+    except (UpgradeError, OSError) as failure:
+        if committed:
+            if isinstance(failure, OSError):
+                raise UpgradeError("commit finalization failed") from failure
+            raise
+        rollback_errors: list[str] = []
+        try:
+            if authority_removed:
+                _write_authority_at(
+                    authority,
+                    {
+                        "schema_version": 1,
+                        "task_id": receipt["task_id"],
+                        "branch": receipt["branch"],
+                        "worktree": receipt["worktree"],
+                        "authority_nonce": receipt["authority_nonce"],
+                        "receipt_sha256": receipt_digest(receipt),
+                    },
+                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                )
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"authority restore failed: {rollback_error}")
+        try:
+            if consumed_instances:
+                current = consumed.lstat()
+                if (current.st_dev, current.st_ino) in consumed_instances:
+                    consumed.unlink()
+                else:
+                    raise UpgradeError("consumed receipt changed during rollback")
+        except OSError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        except UpgradeError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        try:
+            if active_moved:
+                if os.path.lexists(active):
+                    raise UpgradeError("active receipt appeared during rollback")
+                exclusive_json_write(active, receipt)
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"active receipt restore failed: {rollback_error}")
+        if rollback_errors:
+            raise UpgradeError(
+                f"commit failed: {failure}; rollback failed: {'; '.join(rollback_errors)}"
+            ) from failure
+        if isinstance(failure, OSError):
+            raise UpgradeError("commit failed during filesystem operation") from failure
         raise
     finally:
-        private_index.unlink(missing_ok=True)
+        try:
+            task_state_dir(repo)
+            private_index.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            raise UpgradeError("private index cleanup failed") from cleanup_error
     return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -53,30 +53,40 @@ bridge:
 AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
 ```
 
-The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-uses the same pinned clean-source and tracked Agent Core snapshot semantics as
-the normal update operations, applies canonical upgrade semantics in isolation,
-and requires exact pending paths/content/modes plus Task identity and `HEAD`
-before issuing the existing receipt and protected authority. The receipt's
-`source_revision` equals the pinned snapshot `HEAD`; any source race fails
-closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
-and any tampering, fail closed. Continue with the existing
-`automation::commit` flow; ordinary `agent::commit` rejection and the
-receipt/authority design remain unchanged.
+The bridge supports exactly two strict cases: canonical pre-receipt
+reconstruction, and recovery of an exact active receipt whose authority is
+missing. It does not trust `NO_CHANGES`, the current diff, or the environment.
+It uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, reruns pinned clean-source canonical
+reconstruction, and requires Task/branch/worktree/`HEAD`, the pinned source
+revision, and exact pending safe paths/content/modes and fingerprints. Recovery
+additionally requires receipt exact equality and that it is unchanged, then
+issues only the missing authority. A receipt with authority, or stale, forged,
+or tampered state, fails closed. Product, Adapter, repository, secret-pattern,
+or `.task-state` paths also fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection remains unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state
 `path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
 stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
-or does not exactly equal all pending paths. A protected shared-Git-directory
-record binds it to the preceding successful upgrade; a fabricated Task State
-receipt is not authority. Ambient Git repository/index overrides are scrubbed.
-The exact paths are staged and rechecked in a private Task State index, then the
-commit is created from that verified tree without hooks and the expected Task
-branch HEAD is advanced atomically. Only Agent Core-managed paths are
-accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
-scopes are rejected. After a successful commit it is consumed at
+or does not exactly equal all pending paths. Receipt and authority publication
+is a logical pair. Authority records live under the Git-resolved per-worktree
+administrative directory returned by `--absolute-git-dir`, not an assumed
+visible `.git` or shared Git directory; linked and special administrative
+topologies are supported, and worktrees do not share authority. Existing safe
+legacy shared-common-dir hashed records remain validation/commit compatible. A
+protected record binds it to the preceding successful upgrade; a fabricated
+Task State receipt is not authority. Ambient Git repository/index overrides are
+scrubbed. The exact paths are staged and rechecked in a private Task State
+index, then the commit is created from that verified tree without hooks and the
+expected Task branch HEAD is advanced atomically. Only Agent Core-managed paths
+are accepted; mixed Adapter, repository, product, secret-pattern, or
+`.task-state` scopes are rejected. A handled authority-write failure removes the
+newly written receipt if it is unchanged; an interruption half-state is
+recoverable only through the strict bootstrap path. No cross-filesystem
+atomicity is claimed. After a successful commit it is consumed at
 `.task-state/automation-maintenance.consumed.json`; a subsequent successful
 upgrade with changes replaces the active receipt and removes the previous consumed
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -92,7 +92,7 @@ def worktree_admin_dir(repo: Path) -> Path:
         if not admin.is_dir():
             raise UpgradeError("worktree administrative directory does not exist")
         return admin
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve worktree administrative directory") from exc
 
 
@@ -101,19 +101,29 @@ def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     new_parent = admin / "opencode" / "automation-maintenance"
     try:
         resolved_parent = new_parent.resolve()
-    except OSError as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy: Path | None = None
+    legacy_location = _safe_legacy_location(repo)
+    legacy = legacy_location[0] if legacy_location is not None else None
+    return new_parent / "authority.json", legacy
+
+
+def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
+    """Return the legacy record and its containment guard only when safe."""
     try:
         common = common_git_dir(repo)
-        if common.is_dir():
-            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
-    except (OSError, UpgradeError):
-        legacy = None
-    return new_parent / "authority.json", legacy
+        if not common.is_dir():
+            return None
+        parent = common / "opencode" / "automation-maintenance"
+        resolved_parent = parent.resolve()
+        if resolved_parent != common and common not in resolved_parent.parents:
+            return None
+        key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+        return parent / f"{key}.json", common
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def authority_path(repo: Path) -> Path:
@@ -168,8 +178,17 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             os.link(temporary, path)
         finally:
             temporary.unlink(missing_ok=True)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    legacy = _safe_legacy_location(repo)
+    if legacy is not None and authority == legacy[0]:
+        return legacy[1]
+    if authority == authority_path(repo):
+        return worktree_admin_dir(repo)
+    raise UpgradeError("cannot safely resolve authority location for rollback")
 
 
 def validate_authority(repo: Path, receipt: dict) -> Path:
@@ -1568,7 +1587,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
                         "authority_nonce": receipt["authority_nonce"],
                         "receipt_sha256": receipt_digest(receipt),
                     },
-                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                    admin=_rollback_authority_guard(repo, authority),
                 )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -42,6 +42,23 @@ RECEIPT_FIELDS = {
 _GIT_EXECUTABLE: Path | None = None
 
 
+def task_state_dir(repo: Path) -> Path:
+    try:
+        root = repo.resolve()
+        state = root / ".task-state"
+        metadata = state.lstat()
+        resolved = state.resolve()
+    except OSError as exc:
+        raise UpgradeError("Task State directory is unavailable") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or (resolved != root and root not in resolved.parents)
+    ):
+        raise UpgradeError("Task State directory is unsafe")
+    return resolved
+
+
 def git_head(repo: Path) -> str:
     result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
     return result.stdout.strip() if result.returncode == 0 else ""
@@ -53,11 +70,11 @@ def source_revision(source: Path) -> str | None:
 
 
 def receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / RECEIPT_NAME
+    return task_state_dir(repo) / RECEIPT_NAME
 
 
 def consumed_receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+    return task_state_dir(repo) / CONSUMED_RECEIPT_NAME
 
 
 def common_git_dir(repo: Path) -> Path:
@@ -65,9 +82,42 @@ def common_git_dir(repo: Path) -> Path:
     return value.resolve() if value.is_absolute() else (repo / value).resolve()
 
 
+def worktree_admin_dir(repo: Path) -> Path:
+    try:
+        raw = run(["git", "rev-parse", "--absolute-git-dir"], cwd=repo).stdout.strip()
+        candidate = Path(raw)
+        if not raw or not candidate.is_absolute():
+            raise UpgradeError("Git returned an invalid absolute worktree administrative directory")
+        admin = candidate.resolve()
+        if not admin.is_dir():
+            raise UpgradeError("worktree administrative directory does not exist")
+        return admin
+    except (OSError, ValueError) as exc:
+        raise UpgradeError("cannot resolve worktree administrative directory") from exc
+
+
+def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
+    admin = worktree_admin_dir(repo)
+    new_parent = admin / "opencode" / "automation-maintenance"
+    try:
+        resolved_parent = new_parent.resolve()
+    except OSError as exc:
+        raise UpgradeError("cannot resolve authority directory") from exc
+    if resolved_parent != admin and admin not in resolved_parent.parents:
+        raise UpgradeError("authority directory escapes the worktree administrative directory")
+    legacy: Path | None = None
+    try:
+        common = common_git_dir(repo)
+        if common.is_dir():
+            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
+    except (OSError, UpgradeError):
+        legacy = None
+    return new_parent / "authority.json", legacy
+
+
 def authority_path(repo: Path) -> Path:
-    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+    return _authority_locations(repo)[0]
 
 
 def canonical_json(value: dict) -> bytes:
@@ -79,7 +129,7 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
-    atomic_json_write(
+    _write_authority_at(
         authority_path(repo),
         {
             "schema_version": 1,
@@ -89,12 +139,50 @@ def write_authority(repo: Path, receipt: dict) -> None:
             "authority_nonce": receipt["authority_nonce"],
             "receipt_sha256": receipt_digest(receipt),
         },
+        admin=worktree_admin_dir(repo),
     )
 
 
-def validate_authority(repo: Path, receipt: dict) -> None:
-    path = authority_path(repo)
+def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
     try:
+        if admin is not None:
+            parent_before = path.parent.resolve()
+            if parent_before != admin and admin not in parent_before.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if admin is not None:
+            parent_after = path.parent.resolve()
+            if parent_after != admin and admin not in parent_after.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        # The caller has validated the parent; do not replace an existing record.
+        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+                stream.flush()
+                try:
+                    os.fsync(stream.fileno())
+                except OSError:
+                    pass
+            os.link(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+    except (OSError, ValueError) as exc:
+        raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def validate_authority(repo: Path, receipt: dict) -> Path:
+    new_path, legacy_path = _authority_locations(repo)
+    path = new_path
+    if not os.path.lexists(path):
+        if legacy_path is None or not os.path.lexists(legacy_path):
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
+        path = legacy_path
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
         authority = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
@@ -108,6 +196,29 @@ def validate_authority(repo: Path, receipt: dict) -> None:
     }
     if authority != expected:
         raise UpgradeError("automation receipt does not match successful-upgrade authority")
+    return path
+
+
+def authority_exists(repo: Path) -> bool:
+    new_path, legacy_path = _authority_locations(repo)
+    return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
+
+
+def issue_pair(repo: Path, receipt: dict) -> None:
+    destination = receipt_path(repo)
+    published: tuple[int, int] | None = None
+    try:
+        published = exclusive_json_write(destination, receipt)
+        write_authority(repo, receipt)
+    except (OSError, UpgradeError):
+        if published is not None:
+            try:
+                current = destination.lstat()
+                if (current.st_dev, current.st_ino) == published:
+                    destination.unlink()
+            except OSError as exc:
+                raise UpgradeError("receipt publication failed and rollback failed") from exc
+        raise
 
 
 def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
@@ -126,13 +237,53 @@ def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
 
 
 def atomic_json_write(path: Path, value: dict) -> None:
+    atomic_bytes_write(path, (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def atomic_bytes_write(path: Path, content: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
     try:
-        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
         os.replace(temporary, path)
     finally:
-        temporary.unlink(missing_ok=True)
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError("cannot publish an automation receipt over an existing receipt") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish JSON record: {path}") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -156,7 +307,7 @@ def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
 def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
     if not TASK_ID_RE.fullmatch(task):
         raise UpgradeError(f"invalid Task ID: {task!r}")
-    state_path = repo / ".task-state" / "task.md"
+    state_path = task_state_dir(repo) / "task.md"
     if not state_path.is_file():
         raise UpgradeError("operation requires a Task worktree with Task State")
     text = state_path.read_text(encoding="utf-8")
@@ -190,6 +341,21 @@ def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]
             continue
         key, _, value = line.partition(" ")
         current[key] = value
+    visible_top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=repo).stdout.strip())
+    if visible_top.is_absolute():
+        visible_top = visible_top.resolve()
+        current_repo = repo.resolve()
+        admin = worktree_admin_dir(repo)
+        current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip() or None
+        current_head = git_head(repo) or None
+        admin_record = records.get(admin)
+        if (
+            visible_top == current_repo
+            and visible_top not in records
+            and admin_record is not None
+            and admin_record == (current_branch, current_head)
+        ):
+            records[visible_top] = admin_record
     return records
 
 
@@ -895,7 +1061,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    state = repo / ".task-state" / "task.md"
+    state = task_state_dir(repo) / "task.md"
     task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
     if not task_match:
         raise UpgradeError("upgrade requires a registered non-default Task branch")
@@ -903,7 +1069,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     identity = require_registered_task(repo, task_id)
     require_ignored_untracked(
         repo,
-        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+        (task_state_dir(repo) / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
     )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
@@ -923,6 +1089,8 @@ def check_update(repo: Path, source_path: Path) -> dict:
 
 def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
+    if os.path.lexists(receipt_path(repo)) or authority_exists(repo):
+        raise UpgradeError("cannot apply with an existing receipt or authority record")
     source, revision = resolve_pinned_source(source_path)
     with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
         snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
@@ -993,9 +1161,11 @@ def apply(repo: Path, source_path: Path) -> dict:
             "authority_nonce": secrets.token_hex(32),
             "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
         }
-        atomic_json_write(receipt_path(repo), receipt)
-        write_authority(repo, receipt)
-        consumed_receipt_path(repo).unlink(missing_ok=True)
+        issue_pair(repo, receipt)
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
         return result
 
 
@@ -1045,16 +1215,33 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
-    if receipt_path(repo).exists() or authority_path(repo).exists():
+    existing: dict | None = None
+    existing_bytes: bytes | None = None
+    if os.path.lexists(receipt_path(repo)):
+        try:
+            existing_bytes = receipt_path(repo).read_bytes()
+            existing = validate_receipt_schema(json.loads(existing_bytes.decode("utf-8")))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("invalid automation upgrade receipt") from exc
+        if (existing["task_id"], existing["branch"], existing["worktree"]) != (task_id, branch, str(worktree)):
+            raise UpgradeError("automation receipt identity does not match the current Task worktree")
+        if authority_exists(repo):
+            raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    elif authority_exists(repo):
         raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
     pending = pending_paths(repo)
-    if not pending:
+    if not pending and existing is None:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
     source, source_head = resolve_pinned_source(source_path)
-    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
-    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+    if existing is not None:
+        if str(source) != existing["source"] or source_head != existing["source_revision"]:
+            raise UpgradeError("receipt source or revision is stale")
+        pending = receipt_paths(repo, existing)
+    state_dir = task_state_dir(repo)
+    require_ignored_untracked(repo, (state_dir / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=state_dir) as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
@@ -1108,9 +1295,47 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
         "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
         "path_fingerprints": current_fingerprints,
     }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
+    revalidate_source(source, source_head)
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed before authority publication")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed before authority publication")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content changed before authority publication")
+    if existing is not None:
+        receipt["authority_nonce"] = existing["authority_nonce"]
+        receipt["path_fingerprints"] = current_fingerprints
+        if receipt != existing:
+            raise UpgradeError("existing receipt does not match the reconstructed upgrade")
+        if receipt_path(repo).read_bytes() != existing_bytes or authority_exists(repo):
+            raise UpgradeError("receipt or authority changed during authority recovery")
+        _write_authority_at(authority_path(repo), {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        }, admin=worktree_admin_dir(repo))
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
+        return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected, "authorityIssued": True}
+    revalidate_source(source, source_head)
+    issue_pair(repo, receipt)
+    try:
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+    except OSError as exc:
+        raise UpgradeError("cannot remove stale consumed receipt") from exc
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
@@ -1227,7 +1452,8 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
 def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
-    private_index = repo / ".task-state" / "automation-maintenance.index"
+    state_dir = task_state_dir(repo)
+    private_index = state_dir / "automation-maintenance.index"
     require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
     if not active.is_file():
         raise UpgradeError("no active successful automation upgrade receipt")
@@ -1248,21 +1474,35 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    validate_authority(repo, receipt)
+    authority = validate_authority(repo, receipt)
 
     consumed = consumed_receipt_path(repo)
-    os.replace(active, consumed)
     consumed_receipt = dict(receipt)
     consumed_receipt["status"] = "consumed"
     consumed_receipt["commit_sha"] = None
-    atomic_json_write(consumed, consumed_receipt)
-    authority = authority_path(repo)
-    authority.unlink(missing_ok=True)
-    private_index.unlink(missing_ok=True)
-    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    private_index = state_dir / "automation-maintenance.index"
     committed = False
     commit_sha = ""
+    active_moved = False
+    authority_removed = False
+    consumed_instances: set[tuple[int, int]] = set()
     try:
+        if os.path.lexists(consumed):
+            existing = consumed.lstat()
+            if not stat.S_ISREG(existing.st_mode) or stat.S_ISLNK(existing.st_mode):
+                raise UpgradeError("existing consumed receipt has an unsafe type")
+        os.replace(active, consumed)
+        active_moved = True
+        moved_metadata = consumed.lstat()
+        consumed_instances.add((moved_metadata.st_dev, moved_metadata.st_ino))
+        atomic_json_write(consumed, consumed_receipt)
+        consumed_metadata = consumed.lstat()
+        consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
+        authority.unlink(missing_ok=True)
+        authority_removed = True
+        task_state_dir(repo)
+        private_index.unlink(missing_ok=True)
+        index_environment = {"GIT_INDEX_FILE": str(private_index)}
         run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
         run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
         run(
@@ -1310,14 +1550,59 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except UpgradeError:
-        if not committed and not active.exists():
-            atomic_json_write(active, receipt)
-            write_authority(repo, receipt)
-            consumed.unlink(missing_ok=True)
+    except (UpgradeError, OSError) as failure:
+        if committed:
+            if isinstance(failure, OSError):
+                raise UpgradeError("commit finalization failed") from failure
+            raise
+        rollback_errors: list[str] = []
+        try:
+            if authority_removed:
+                _write_authority_at(
+                    authority,
+                    {
+                        "schema_version": 1,
+                        "task_id": receipt["task_id"],
+                        "branch": receipt["branch"],
+                        "worktree": receipt["worktree"],
+                        "authority_nonce": receipt["authority_nonce"],
+                        "receipt_sha256": receipt_digest(receipt),
+                    },
+                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                )
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"authority restore failed: {rollback_error}")
+        try:
+            if consumed_instances:
+                current = consumed.lstat()
+                if (current.st_dev, current.st_ino) in consumed_instances:
+                    consumed.unlink()
+                else:
+                    raise UpgradeError("consumed receipt changed during rollback")
+        except OSError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        except UpgradeError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        try:
+            if active_moved:
+                if os.path.lexists(active):
+                    raise UpgradeError("active receipt appeared during rollback")
+                exclusive_json_write(active, receipt)
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"active receipt restore failed: {rollback_error}")
+        if rollback_errors:
+            raise UpgradeError(
+                f"commit failed: {failure}; rollback failed: {'; '.join(rollback_errors)}"
+            ) from failure
+        if isinstance(failure, OSError):
+            raise UpgradeError("commit failed during filesystem operation") from failure
         raise
     finally:
-        private_index.unlink(missing_ok=True)
+        try:
+            task_state_dir(repo)
+            private_index.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            raise UpgradeError("private index cleanup failed") from cleanup_error
     return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -53,30 +53,40 @@ bridge:
 AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
 ```
 
-The bridge does not trust `NO_CHANGES`, the current diff, or the environment. It
-uses the same pinned clean-source and tracked Agent Core snapshot semantics as
-the normal update operations, applies canonical upgrade semantics in isolation,
-and requires exact pending paths/content/modes plus Task identity and `HEAD`
-before issuing the existing receipt and protected authority. The receipt's
-`source_revision` equals the pinned snapshot `HEAD`; any source race fails
-closed. Product, Adapter, repository, secret-pattern, or `.task-state` paths,
-and any tampering, fail closed. Continue with the existing
-`automation::commit` flow; ordinary `agent::commit` rejection and the
-receipt/authority design remain unchanged.
+The bridge supports exactly two strict cases: canonical pre-receipt
+reconstruction, and recovery of an exact active receipt whose authority is
+missing. It does not trust `NO_CHANGES`, the current diff, or the environment.
+It uses the same pinned clean-source and tracked Agent Core snapshot semantics as
+the normal update operations, reruns pinned clean-source canonical
+reconstruction, and requires Task/branch/worktree/`HEAD`, the pinned source
+revision, and exact pending safe paths/content/modes and fingerprints. Recovery
+additionally requires receipt exact equality and that it is unchanged, then
+issues only the missing authority. A receipt with authority, or stale, forged,
+or tampered state, fails closed. Product, Adapter, repository, secret-pattern,
+or `.task-state` paths also fail closed. Continue with the existing
+`automation::commit` flow; ordinary `agent::commit` rejection remains unchanged.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
 `worktree`), source/source revision, current/upstream versions, sorted unique
 `changed_paths`, `authority_head`, and exact per-path content/state
 `path_fingerprints`. Commit fails closed if the receipt is absent, malformed,
 stale, from another Task/worktree, has a different `HEAD`, changed fingerprints,
-or does not exactly equal all pending paths. A protected shared-Git-directory
-record binds it to the preceding successful upgrade; a fabricated Task State
-receipt is not authority. Ambient Git repository/index overrides are scrubbed.
-The exact paths are staged and rechecked in a private Task State index, then the
-commit is created from that verified tree without hooks and the expected Task
-branch HEAD is advanced atomically. Only Agent Core-managed paths are
-accepted; mixed Adapter, repository, product, secret-pattern, or `.task-state`
-scopes are rejected. After a successful commit it is consumed at
+or does not exactly equal all pending paths. Receipt and authority publication
+is a logical pair. Authority records live under the Git-resolved per-worktree
+administrative directory returned by `--absolute-git-dir`, not an assumed
+visible `.git` or shared Git directory; linked and special administrative
+topologies are supported, and worktrees do not share authority. Existing safe
+legacy shared-common-dir hashed records remain validation/commit compatible. A
+protected record binds it to the preceding successful upgrade; a fabricated
+Task State receipt is not authority. Ambient Git repository/index overrides are
+scrubbed. The exact paths are staged and rechecked in a private Task State
+index, then the commit is created from that verified tree without hooks and the
+expected Task branch HEAD is advanced atomically. Only Agent Core-managed paths
+are accepted; mixed Adapter, repository, product, secret-pattern, or
+`.task-state` scopes are rejected. A handled authority-write failure removes the
+newly written receipt if it is unchanged; an interruption half-state is
+recoverable only through the strict bootstrap path. No cross-filesystem
+atomicity is claimed. After a successful commit it is consumed at
 `.task-state/automation-maintenance.consumed.json`; a subsequent successful
 upgrade with changes replaces the active receipt and removes the previous consumed
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -92,7 +92,7 @@ def worktree_admin_dir(repo: Path) -> Path:
         if not admin.is_dir():
             raise UpgradeError("worktree administrative directory does not exist")
         return admin
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve worktree administrative directory") from exc
 
 
@@ -101,19 +101,29 @@ def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     new_parent = admin / "opencode" / "automation-maintenance"
     try:
         resolved_parent = new_parent.resolve()
-    except OSError as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy: Path | None = None
+    legacy_location = _safe_legacy_location(repo)
+    legacy = legacy_location[0] if legacy_location is not None else None
+    return new_parent / "authority.json", legacy
+
+
+def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
+    """Return the legacy record and its containment guard only when safe."""
     try:
         common = common_git_dir(repo)
-        if common.is_dir():
-            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
-    except (OSError, UpgradeError):
-        legacy = None
-    return new_parent / "authority.json", legacy
+        if not common.is_dir():
+            return None
+        parent = common / "opencode" / "automation-maintenance"
+        resolved_parent = parent.resolve()
+        if resolved_parent != common and common not in resolved_parent.parents:
+            return None
+        key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+        return parent / f"{key}.json", common
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def authority_path(repo: Path) -> Path:
@@ -168,8 +178,17 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             os.link(temporary, path)
         finally:
             temporary.unlink(missing_ok=True)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    legacy = _safe_legacy_location(repo)
+    if legacy is not None and authority == legacy[0]:
+        return legacy[1]
+    if authority == authority_path(repo):
+        return worktree_admin_dir(repo)
+    raise UpgradeError("cannot safely resolve authority location for rollback")
 
 
 def validate_authority(repo: Path, receipt: dict) -> Path:
@@ -1568,7 +1587,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
                         "authority_nonce": receipt["authority_nonce"],
                         "receipt_sha256": receipt_digest(receipt),
                     },
-                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                    admin=_rollback_authority_guard(repo, authority),
                 )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -42,6 +42,23 @@ RECEIPT_FIELDS = {
 _GIT_EXECUTABLE: Path | None = None
 
 
+def task_state_dir(repo: Path) -> Path:
+    try:
+        root = repo.resolve()
+        state = root / ".task-state"
+        metadata = state.lstat()
+        resolved = state.resolve()
+    except OSError as exc:
+        raise UpgradeError("Task State directory is unavailable") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or (resolved != root and root not in resolved.parents)
+    ):
+        raise UpgradeError("Task State directory is unsafe")
+    return resolved
+
+
 def git_head(repo: Path) -> str:
     result = run(["git", "rev-parse", "HEAD"], cwd=repo, check=False)
     return result.stdout.strip() if result.returncode == 0 else ""
@@ -53,11 +70,11 @@ def source_revision(source: Path) -> str | None:
 
 
 def receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / RECEIPT_NAME
+    return task_state_dir(repo) / RECEIPT_NAME
 
 
 def consumed_receipt_path(repo: Path) -> Path:
-    return repo / ".task-state" / CONSUMED_RECEIPT_NAME
+    return task_state_dir(repo) / CONSUMED_RECEIPT_NAME
 
 
 def common_git_dir(repo: Path) -> Path:
@@ -65,9 +82,42 @@ def common_git_dir(repo: Path) -> Path:
     return value.resolve() if value.is_absolute() else (repo / value).resolve()
 
 
+def worktree_admin_dir(repo: Path) -> Path:
+    try:
+        raw = run(["git", "rev-parse", "--absolute-git-dir"], cwd=repo).stdout.strip()
+        candidate = Path(raw)
+        if not raw or not candidate.is_absolute():
+            raise UpgradeError("Git returned an invalid absolute worktree administrative directory")
+        admin = candidate.resolve()
+        if not admin.is_dir():
+            raise UpgradeError("worktree administrative directory does not exist")
+        return admin
+    except (OSError, ValueError) as exc:
+        raise UpgradeError("cannot resolve worktree administrative directory") from exc
+
+
+def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
+    admin = worktree_admin_dir(repo)
+    new_parent = admin / "opencode" / "automation-maintenance"
+    try:
+        resolved_parent = new_parent.resolve()
+    except OSError as exc:
+        raise UpgradeError("cannot resolve authority directory") from exc
+    if resolved_parent != admin and admin not in resolved_parent.parents:
+        raise UpgradeError("authority directory escapes the worktree administrative directory")
+    legacy: Path | None = None
+    try:
+        common = common_git_dir(repo)
+        if common.is_dir():
+            key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+            legacy = common / "opencode" / "automation-maintenance" / f"{key}.json"
+    except (OSError, UpgradeError):
+        legacy = None
+    return new_parent / "authority.json", legacy
+
+
 def authority_path(repo: Path) -> Path:
-    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
-    return common_git_dir(repo) / "opencode" / "automation-maintenance" / f"{key}.json"
+    return _authority_locations(repo)[0]
 
 
 def canonical_json(value: dict) -> bytes:
@@ -79,7 +129,7 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
-    atomic_json_write(
+    _write_authority_at(
         authority_path(repo),
         {
             "schema_version": 1,
@@ -89,12 +139,50 @@ def write_authority(repo: Path, receipt: dict) -> None:
             "authority_nonce": receipt["authority_nonce"],
             "receipt_sha256": receipt_digest(receipt),
         },
+        admin=worktree_admin_dir(repo),
     )
 
 
-def validate_authority(repo: Path, receipt: dict) -> None:
-    path = authority_path(repo)
+def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
     try:
+        if admin is not None:
+            parent_before = path.parent.resolve()
+            if parent_before != admin and admin not in parent_before.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if admin is not None:
+            parent_after = path.parent.resolve()
+            if parent_after != admin and admin not in parent_after.parents:
+                raise UpgradeError("authority directory escapes the worktree administrative directory")
+        # The caller has validated the parent; do not replace an existing record.
+        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+                stream.flush()
+                try:
+                    os.fsync(stream.fileno())
+                except OSError:
+                    pass
+            os.link(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+    except (OSError, ValueError) as exc:
+        raise UpgradeError(f"cannot publish authority record: {path}") from exc
+
+
+def validate_authority(repo: Path, receipt: dict) -> Path:
+    new_path, legacy_path = _authority_locations(repo)
+    path = new_path
+    if not os.path.lexists(path):
+        if legacy_path is None or not os.path.lexists(legacy_path):
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
+        path = legacy_path
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError("missing or invalid successful-upgrade authority record")
         authority = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
@@ -108,6 +196,29 @@ def validate_authority(repo: Path, receipt: dict) -> None:
     }
     if authority != expected:
         raise UpgradeError("automation receipt does not match successful-upgrade authority")
+    return path
+
+
+def authority_exists(repo: Path) -> bool:
+    new_path, legacy_path = _authority_locations(repo)
+    return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
+
+
+def issue_pair(repo: Path, receipt: dict) -> None:
+    destination = receipt_path(repo)
+    published: tuple[int, int] | None = None
+    try:
+        published = exclusive_json_write(destination, receipt)
+        write_authority(repo, receipt)
+    except (OSError, UpgradeError):
+        if published is not None:
+            try:
+                current = destination.lstat()
+                if (current.st_dev, current.st_ino) == published:
+                    destination.unlink()
+            except OSError as exc:
+                raise UpgradeError("receipt publication failed and rollback failed") from exc
+        raise
 
 
 def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
@@ -126,13 +237,53 @@ def require_ignored_untracked(repo: Path, paths: tuple[Path, ...]) -> None:
 
 
 def atomic_json_write(path: Path, value: dict) -> None:
+    atomic_bytes_write(path, (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8"))
+
+
+def atomic_bytes_write(path: Path, content: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
     try:
-        temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
         os.replace(temporary, path)
     finally:
-        temporary.unlink(missing_ok=True)
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError("cannot publish an automation receipt over an existing receipt") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish JSON record: {path}") from exc
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -156,7 +307,7 @@ def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
 def parse_task_identity(repo: Path, task: str) -> tuple[str, str, Path]:
     if not TASK_ID_RE.fullmatch(task):
         raise UpgradeError(f"invalid Task ID: {task!r}")
-    state_path = repo / ".task-state" / "task.md"
+    state_path = task_state_dir(repo) / "task.md"
     if not state_path.is_file():
         raise UpgradeError("operation requires a Task worktree with Task State")
     text = state_path.read_text(encoding="utf-8")
@@ -190,6 +341,21 @@ def registered_worktrees(repo: Path) -> dict[Path, tuple[str | None, str | None]
             continue
         key, _, value = line.partition(" ")
         current[key] = value
+    visible_top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=repo).stdout.strip())
+    if visible_top.is_absolute():
+        visible_top = visible_top.resolve()
+        current_repo = repo.resolve()
+        admin = worktree_admin_dir(repo)
+        current_branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip() or None
+        current_head = git_head(repo) or None
+        admin_record = records.get(admin)
+        if (
+            visible_top == current_repo
+            and visible_top not in records
+            and admin_record is not None
+            and admin_record == (current_branch, current_head)
+        ):
+            records[visible_top] = admin_record
     return records
 
 
@@ -895,7 +1061,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     branch = run(["git", "branch", "--show-current"], cwd=repo).stdout.strip()
     if not branch:
         raise UpgradeError("detached HEAD is not supported")
-    state = repo / ".task-state" / "task.md"
+    state = task_state_dir(repo) / "task.md"
     task_match = re.search(r"(?m)^- Task ID: (.+)$", state.read_text(encoding="utf-8")) if state.is_file() else None
     if not task_match:
         raise UpgradeError("upgrade requires a registered non-default Task branch")
@@ -903,7 +1069,7 @@ def require_maintenance(repo: Path) -> tuple[str, str, Path]:
     identity = require_registered_task(repo, task_id)
     require_ignored_untracked(
         repo,
-        (repo / ".task-state" / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
+        (task_state_dir(repo) / "task.md", receipt_path(repo), consumed_receipt_path(repo)),
     )
     if os.environ.get("AUTOMATION_MAINTENANCE") != "1":
         raise UpgradeError("upgrade requires AUTOMATION_MAINTENANCE=1 in a dedicated Automation Maintenance Task")
@@ -923,6 +1089,8 @@ def check_update(repo: Path, source_path: Path) -> dict:
 
 def apply(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
+    if os.path.lexists(receipt_path(repo)) or authority_exists(repo):
+        raise UpgradeError("cannot apply with an existing receipt or authority record")
     source, revision = resolve_pinned_source(source_path)
     with tempfile.TemporaryDirectory(prefix="automation-upgrade-") as temporary:
         snapshot, source_core = materialize_source_snapshot(source, revision, Path(temporary))
@@ -993,9 +1161,11 @@ def apply(repo: Path, source_path: Path) -> dict:
             "authority_nonce": secrets.token_hex(32),
             "path_fingerprints": {path: file_fingerprint(repo, path) for path in changed_paths},
         }
-        atomic_json_write(receipt_path(repo), receipt)
-        write_authority(repo, receipt)
-        consumed_receipt_path(repo).unlink(missing_ok=True)
+        issue_pair(repo, receipt)
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
         return result
 
 
@@ -1045,16 +1215,33 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     task_id, branch, worktree = require_maintenance(repo)
     authority_head = git_head(repo)
     authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip()
-    if receipt_path(repo).exists() or authority_path(repo).exists():
+    existing: dict | None = None
+    existing_bytes: bytes | None = None
+    if os.path.lexists(receipt_path(repo)):
+        try:
+            existing_bytes = receipt_path(repo).read_bytes()
+            existing = validate_receipt_schema(json.loads(existing_bytes.decode("utf-8")))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("invalid automation upgrade receipt") from exc
+        if (existing["task_id"], existing["branch"], existing["worktree"]) != (task_id, branch, str(worktree)):
+            raise UpgradeError("automation receipt identity does not match the current Task worktree")
+        if authority_exists(repo):
+            raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
+    elif authority_exists(repo):
         raise UpgradeError("cannot bootstrap with an existing receipt or authority record")
     pending = pending_paths(repo)
-    if not pending:
+    if not pending and existing is None:
         raise UpgradeError("bootstrap requires non-empty pending paths")
     for path in pending:
         reject_bootstrap_path(repo, path)
     source, source_head = resolve_pinned_source(source_path)
-    require_ignored_untracked(repo, (repo / ".task-state" / "automation-bootstrap.tmp",))
-    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=repo / ".task-state") as temporary:
+    if existing is not None:
+        if str(source) != existing["source"] or source_head != existing["source_revision"]:
+            raise UpgradeError("receipt source or revision is stale")
+        pending = receipt_paths(repo, existing)
+    state_dir = task_state_dir(repo)
+    require_ignored_untracked(repo, (state_dir / "automation-bootstrap.tmp",))
+    with tempfile.TemporaryDirectory(prefix="automation-bootstrap-", dir=state_dir) as temporary:
         baseline = Path(temporary) / "baseline"
         source_snapshot = Path(temporary) / "source" / "components" / "agent-core"
         materialize_tree(repo, authority_head, baseline, surface_only=True)
@@ -1108,9 +1295,47 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
         "changed_paths": expected, "authority_head": authority_head, "authority_nonce": secrets.token_hex(32),
         "path_fingerprints": current_fingerprints,
     }
-    atomic_json_write(receipt_path(repo), receipt)
-    write_authority(repo, receipt)
-    consumed_receipt_path(repo).unlink(missing_ok=True)
+    revalidate_source(source, source_head)
+    current_identity = require_registered_task(repo, task_id)
+    current_registration = registered_worktrees(repo).get(worktree)
+    if (
+        current_identity != (task_id, branch, worktree)
+        or current_registration != (branch, authority_head)
+        or git_head(repo) != authority_head
+        or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=repo).stdout.strip() != authority_branch_oid
+    ):
+        raise UpgradeError("Task identity or HEAD changed before authority publication")
+    if pending_paths(repo) != pending:
+        raise UpgradeError("pending paths changed before authority publication")
+    current_fingerprints = {path: file_fingerprint(repo, path) for path in expected}
+    if current_fingerprints != expected_fingerprints:
+        raise UpgradeError("pending Agent Core content changed before authority publication")
+    if existing is not None:
+        receipt["authority_nonce"] = existing["authority_nonce"]
+        receipt["path_fingerprints"] = current_fingerprints
+        if receipt != existing:
+            raise UpgradeError("existing receipt does not match the reconstructed upgrade")
+        if receipt_path(repo).read_bytes() != existing_bytes or authority_exists(repo):
+            raise UpgradeError("receipt or authority changed during authority recovery")
+        _write_authority_at(authority_path(repo), {
+            "schema_version": 1,
+            "task_id": receipt["task_id"],
+            "branch": receipt["branch"],
+            "worktree": receipt["worktree"],
+            "authority_nonce": receipt["authority_nonce"],
+            "receipt_sha256": receipt_digest(receipt),
+        }, admin=worktree_admin_dir(repo))
+        try:
+            consumed_receipt_path(repo).unlink(missing_ok=True)
+        except OSError as exc:
+            raise UpgradeError("cannot remove stale consumed receipt") from exc
+        return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected, "authorityIssued": True}
+    revalidate_source(source, source_head)
+    issue_pair(repo, receipt)
+    try:
+        consumed_receipt_path(repo).unlink(missing_ok=True)
+    except OSError as exc:
+        raise UpgradeError("cannot remove stale consumed receipt") from exc
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
@@ -1227,7 +1452,8 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
 def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
-    private_index = repo / ".task-state" / "automation-maintenance.index"
+    state_dir = task_state_dir(repo)
+    private_index = state_dir / "automation-maintenance.index"
     require_ignored_untracked(repo, (active, consumed_receipt_path(repo), private_index))
     if not active.is_file():
         raise UpgradeError("no active successful automation upgrade receipt")
@@ -1248,21 +1474,35 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    validate_authority(repo, receipt)
+    authority = validate_authority(repo, receipt)
 
     consumed = consumed_receipt_path(repo)
-    os.replace(active, consumed)
     consumed_receipt = dict(receipt)
     consumed_receipt["status"] = "consumed"
     consumed_receipt["commit_sha"] = None
-    atomic_json_write(consumed, consumed_receipt)
-    authority = authority_path(repo)
-    authority.unlink(missing_ok=True)
-    private_index.unlink(missing_ok=True)
-    index_environment = {"GIT_INDEX_FILE": str(private_index)}
+    private_index = state_dir / "automation-maintenance.index"
     committed = False
     commit_sha = ""
+    active_moved = False
+    authority_removed = False
+    consumed_instances: set[tuple[int, int]] = set()
     try:
+        if os.path.lexists(consumed):
+            existing = consumed.lstat()
+            if not stat.S_ISREG(existing.st_mode) or stat.S_ISLNK(existing.st_mode):
+                raise UpgradeError("existing consumed receipt has an unsafe type")
+        os.replace(active, consumed)
+        active_moved = True
+        moved_metadata = consumed.lstat()
+        consumed_instances.add((moved_metadata.st_dev, moved_metadata.st_ino))
+        atomic_json_write(consumed, consumed_receipt)
+        consumed_metadata = consumed.lstat()
+        consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
+        authority.unlink(missing_ok=True)
+        authority_removed = True
+        task_state_dir(repo)
+        private_index.unlink(missing_ok=True)
+        index_environment = {"GIT_INDEX_FILE": str(private_index)}
         run(["git", "read-tree", "HEAD"], cwd=repo, env_overrides=index_environment)
         run(["git", "add", "--", *paths], cwd=repo, env_overrides=index_environment)
         run(
@@ -1310,14 +1550,59 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except UpgradeError:
-        if not committed and not active.exists():
-            atomic_json_write(active, receipt)
-            write_authority(repo, receipt)
-            consumed.unlink(missing_ok=True)
+    except (UpgradeError, OSError) as failure:
+        if committed:
+            if isinstance(failure, OSError):
+                raise UpgradeError("commit finalization failed") from failure
+            raise
+        rollback_errors: list[str] = []
+        try:
+            if authority_removed:
+                _write_authority_at(
+                    authority,
+                    {
+                        "schema_version": 1,
+                        "task_id": receipt["task_id"],
+                        "branch": receipt["branch"],
+                        "worktree": receipt["worktree"],
+                        "authority_nonce": receipt["authority_nonce"],
+                        "receipt_sha256": receipt_digest(receipt),
+                    },
+                    admin=worktree_admin_dir(repo) if authority == authority_path(repo) else None,
+                )
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"authority restore failed: {rollback_error}")
+        try:
+            if consumed_instances:
+                current = consumed.lstat()
+                if (current.st_dev, current.st_ino) in consumed_instances:
+                    consumed.unlink()
+                else:
+                    raise UpgradeError("consumed receipt changed during rollback")
+        except OSError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        except UpgradeError as rollback_error:
+            rollback_errors.append(f"consumed receipt cleanup failed: {rollback_error}")
+        try:
+            if active_moved:
+                if os.path.lexists(active):
+                    raise UpgradeError("active receipt appeared during rollback")
+                exclusive_json_write(active, receipt)
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"active receipt restore failed: {rollback_error}")
+        if rollback_errors:
+            raise UpgradeError(
+                f"commit failed: {failure}; rollback failed: {'; '.join(rollback_errors)}"
+            ) from failure
+        if isinstance(failure, OSError):
+            raise UpgradeError("commit failed during filesystem operation") from failure
         raise
     finally:
-        private_index.unlink(missing_ok=True)
+        try:
+            task_state_dir(repo)
+            private_index.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            raise UpgradeError("private index cleanup failed") from cleanup_error
     return {"status": "COMMITTED", "commit_sha": commit_sha}
 
 

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import subprocess
 import tarfile
+import threading
 from contextlib import ExitStack
 from pathlib import Path
 from unittest import mock
@@ -273,6 +274,39 @@ mod project 'just/project/mod.just'
         self.assertFalse(upgrade.authority_path(task).exists())
         return task, source, result | metadata
 
+    def _separate_git_topology_fixture(self, root: Path) -> tuple[Path, Path, Path]:
+        """Create a separate-git-dir checkout and a linked worktree from it."""
+        primary = root / "primary"
+        primary.mkdir(parents=True)
+        self._materialize_release_template(primary)
+        admin = root / "primary-admin"
+        self._git(["init", "-b", "main", "--separate-git-dir", str(admin)], primary)
+        self._git(["config", "user.name", "Test User"], primary)
+        self._git(["config", "user.email", "test@example.invalid"], primary)
+        self._git(["add", "-A"], primary)
+        self._git(["commit", "-m", "release fixture"], primary)
+        head = self._git(["rev-parse", "HEAD"], primary)
+        self._git(["update-ref", "refs/remotes/origin/main", head], primary)
+        self._git(["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], primary)
+        self._git(["switch", "-c", "task/TASK-83-primary"], primary)
+        linked = root / "linked"
+        self._git(["worktree", "add", "-b", "task/TASK-83-linked", str(linked), "HEAD"], primary)
+        for repo, branch in ((primary, "task/TASK-83-primary"), (linked, "task/TASK-83-linked")):
+            self._write_file(
+                repo / ".task-state/task.md",
+                f"- Task ID: TASK-83\n- Branch: {branch}\n- Worktree: {repo.resolve()}\n",
+            )
+            exclude = Path(self._git(["rev-parse", "--git-path", "info/exclude"], repo))
+            if not exclude.is_absolute():
+                exclude = repo / exclude
+            exclude.parent.mkdir(parents=True, exist_ok=True)
+            with exclude.open("a", encoding="utf-8") as stream:
+                stream.write("/.task-state/\n")
+        source_root = root / "source"
+        self._core_root_source(source_root, version=3)
+        self._init_source_git(source_root)
+        return primary, linked, source_root
+
     def _task_repo(self, repo: Path, *, task: str = "TASK-78") -> Path:
         repo.mkdir(parents=True)
         self._git(["init", "-b", "main"], repo)
@@ -309,12 +343,17 @@ mod project 'just/project/mod.just'
     def _receipt(self, repo: Path) -> dict:
         return json.loads(upgrade.receipt_path(repo).read_text(encoding="utf-8"))
 
+    def _bootstrap_receipt(self, repo: Path, source_root: Path) -> dict:
+        with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+            return upgrade.bootstrap_receipt(repo, source_root)
+
     def _commit_error(self, repo: Path, task: str = "TASK-78") -> str:
         with self.assertRaises(upgrade.UpgradeError) as raised:
             upgrade.commit(repo, task, "maintenance")
         return str(raised.exception)
 
     def _mock_maintenance(self, repo: Path) -> ExitStack:
+        (repo / ".task-state").mkdir(parents=True, exist_ok=True)
         stack = ExitStack()
         stack.enter_context(
             mock.patch.object(
@@ -323,6 +362,7 @@ mod project 'just/project/mod.just'
                 return_value=("TASK-TEST", "task/TASK-TEST-test", repo),
             )
         )
+        stack.enter_context(mock.patch.object(upgrade, "authority_exists", return_value=False))
         stack.enter_context(mock.patch.object(upgrade, "write_authority"))
         return stack
 
@@ -918,6 +958,59 @@ mod project 'just/project/mod.just'
             self.assertEqual(result["commit_sha"], consumed["commit_sha"])
             self.assertEqual([], upgrade.pending_paths(repo))
 
+    def test_normal_primary_and_linked_worktree_authority_topology(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            primary = self._task_repo(root / "primary")
+            linked = root / "linked"
+            self._git(["worktree", "add", "-b", "task/TASK-79-linked", str(linked), "HEAD"], primary)
+
+            primary_admin = Path(self._git(["rev-parse", "--absolute-git-dir"], primary))
+            linked_admin = Path(self._git(["rev-parse", "--absolute-git-dir"], linked))
+            self.assertTrue((primary / ".git").is_dir())
+            self.assertTrue((linked / ".git").is_file())
+            for repo, admin in ((primary, primary_admin), (linked, linked_admin)):
+                with self.subTest(repo=repo.name):
+                    self.assertTrue(admin.is_absolute())
+                    self.assertTrue(admin.is_dir())
+                    authority = upgrade.authority_path(repo).resolve()
+                    self.assertIn(admin.resolve(), authority.parents)
+                    if (repo / ".git").is_file():
+                        self.assertNotIn(repo / ".git", authority.parents)
+            self.assertNotEqual(primary_admin.resolve(), linked_admin.resolve())
+            self.assertNotEqual(upgrade.authority_path(primary), upgrade.authority_path(linked))
+
+    def test_authority_is_beneath_exact_admin_dir_for_separate_and_linked_worktrees(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            primary, linked, source = self._separate_git_topology_fixture(Path(directory))
+            for repo, task, branch in (
+                (primary, "TASK-83", "task/TASK-83-primary"),
+                (linked, "TASK-83", "task/TASK-83-linked"),
+            ):
+                with self.subTest(repo=repo.name):
+                    admin = Path(self._git(["rev-parse", "--absolute-git-dir"], repo))
+                    self.assertTrue(admin.is_absolute())
+                    self.assertTrue(admin.is_dir())
+                    visible_git = repo / ".git"
+                    self.assertTrue(visible_git.is_file())
+                    self.assertNotIn(visible_git, upgrade.authority_path(repo).parents)
+                    with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                        upgrade.apply(repo, source)
+                    authority = upgrade.authority_path(repo).resolve()
+                    self.assertIn(admin.resolve(), authority.parents)
+                    self.assertNotIn(visible_git, authority.parents)
+            self.assertNotEqual(upgrade.authority_path(primary), upgrade.authority_path(linked))
+            self.assertNotEqual(
+                upgrade.authority_path(primary).parent.resolve(),
+                upgrade.authority_path(linked).parent.resolve(),
+            )
+            with self.assertRaises(upgrade.UpgradeError):
+                upgrade.validate_authority(primary, self._receipt(linked))
+            with self.assertRaises(upgrade.UpgradeError):
+                upgrade.validate_authority(linked, self._receipt(primary))
+            self.assertEqual("COMMITTED", upgrade.commit(primary, "TASK-83", "maintenance")["status"])
+            self.assertEqual("COMMITTED", upgrade.commit(linked, "TASK-83", "maintenance")["status"])
+
     def test_second_successful_upgrade_replaces_consumed_receipt(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -941,6 +1034,241 @@ mod project 'just/project/mod.just'
             self.assertEqual("4", second["upstream_version"])
             self.assertEqual([".automation/VERSION"], second["changed_paths"])
             self.assertNotIn("README.md", second["changed_paths"])
+
+    def test_apply_rolls_back_receipt_when_authority_publication_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, source = self._maintenance_fixture(root)
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False), \
+                    mock.patch.object(upgrade, "write_authority", side_effect=upgrade.UpgradeError("injected authority failure")):
+                with self.assertRaisesRegex(upgrade.UpgradeError, "injected authority failure"):
+                    upgrade.apply(repo, source.parents[1])
+            self.assertFalse(upgrade.receipt_path(repo).exists())
+            self.assertFalse(upgrade.authority_path(repo).exists())
+            recovered = self._bootstrap_receipt(repo, source.parents[1])
+            self.assertEqual("RECEIPT_BOOTSTRAPPED", recovered["status"])
+            self.assertEqual("COMMITTED", upgrade.commit(repo, "TASK-78", "maintenance")["status"])
+
+    def test_issue_pair_does_not_overwrite_a_concurrent_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            receipt = self._receipt(repo)
+            authority = upgrade.authority_path(repo)
+            upgrade.receipt_path(repo).unlink()
+            authority.unlink()
+            first = dict(receipt)
+            second = dict(receipt, authority_nonce="1" * 64)
+            entered = threading.Event()
+            release = threading.Event()
+            first_errors: list[BaseException] = []
+            second_errors: list[BaseException] = []
+            original_write = upgrade.write_authority
+
+            def blocked_write(target: Path, value: dict) -> None:
+                if value["authority_nonce"] == first["authority_nonce"]:
+                    entered.set()
+                    if not release.wait(timeout=5):
+                        raise AssertionError("timed out waiting to release first issuer")
+                original_write(target, value)
+
+            def issue(value: dict, errors: list[BaseException]) -> None:
+                try:
+                    upgrade.issue_pair(repo, value)
+                except BaseException as exc:  # capture thread failures for the test thread
+                    errors.append(exc)
+
+            with mock.patch.object(upgrade, "write_authority", side_effect=blocked_write):
+                first_thread = threading.Thread(target=issue, args=(first, first_errors))
+                first_thread.start()
+                self.assertTrue(entered.wait(timeout=5))
+                second_thread = threading.Thread(target=issue, args=(second, second_errors))
+                second_thread.start()
+                second_thread.join(timeout=5)
+                self.assertFalse(second_thread.is_alive())
+                release.set()
+                first_thread.join(timeout=5)
+            self.assertFalse(first_thread.is_alive())
+            self.assertEqual([], first_errors)
+            self.assertEqual(1, len(second_errors))
+            self.assertIsInstance(second_errors[0], upgrade.UpgradeError)
+            self.assertEqual(first, self._receipt(repo))
+            self.assertEqual(authority, upgrade.validate_authority(repo, first))
+
+    def test_task_state_symlink_is_rejected_without_writing_outside_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, source = self._maintenance_fixture(root)
+            state = repo / ".task-state"
+            outside = root / "outside-state"
+            outside.mkdir()
+            shutil.rmtree(state)
+            state.symlink_to(outside, target_is_directory=True)
+            with self.assertRaises(upgrade.UpgradeError):
+                self._bootstrap_receipt(repo, source.parents[1])
+            self.assertEqual([], list(outside.iterdir()))
+
+    def test_commit_rolls_back_when_consumed_receipt_replace_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            active = upgrade.receipt_path(repo)
+            authority = upgrade.authority_path(repo)
+            active_bytes = active.read_bytes()
+            authority_bytes = authority.read_bytes()
+            original_replace = upgrade.os.replace
+
+            def fail_active_replace(source: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+                if Path(source) == active and Path(destination) == upgrade.consumed_receipt_path(repo):
+                    raise OSError("injected receipt consume failure")
+                original_replace(source, destination)
+
+            with mock.patch.object(upgrade.os, "replace", side_effect=fail_active_replace):
+                with self.assertRaises(upgrade.UpgradeError):
+                    upgrade.commit(repo, "TASK-78", "maintenance")
+            self.assertEqual(active_bytes, active.read_bytes())
+            self.assertEqual(authority_bytes, authority.read_bytes())
+            self.assertFalse(upgrade.consumed_receipt_path(repo).exists())
+            self.assertEqual("COMMITTED", upgrade.commit(repo, "TASK-78", "maintenance")["status"])
+
+    def test_commit_rolls_back_when_authority_unlink_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            active = upgrade.receipt_path(repo)
+            authority = upgrade.authority_path(repo)
+            active_bytes = active.read_bytes()
+            authority_bytes = authority.read_bytes()
+            original_unlink = Path.unlink
+
+            def fail_authority_unlink(path: Path, *args, **kwargs) -> None:
+                if path == authority:
+                    raise OSError("injected authority consume failure")
+                original_unlink(path, *args, **kwargs)
+
+            with mock.patch.object(Path, "unlink", autospec=True, side_effect=fail_authority_unlink):
+                with self.assertRaises(upgrade.UpgradeError):
+                    upgrade.commit(repo, "TASK-78", "maintenance")
+            self.assertEqual(active_bytes, active.read_bytes())
+            self.assertEqual(authority_bytes, authority.read_bytes())
+            self.assertFalse(upgrade.consumed_receipt_path(repo).exists())
+            self.assertEqual("COMMITTED", upgrade.commit(repo, "TASK-78", "maintenance")["status"])
+
+    def test_fresh_bootstrap_rolls_back_receipt_when_authority_publication_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            task, source, _ = self._old_process_fixture(Path(directory))
+            with mock.patch.object(
+                upgrade,
+                "write_authority",
+                side_effect=upgrade.UpgradeError("injected authority failure"),
+            ):
+                with self.assertRaisesRegex(upgrade.UpgradeError, "injected authority failure"):
+                    self._bootstrap_receipt(task, source)
+            self.assertFalse(upgrade.receipt_path(task).exists())
+            self.assertFalse(upgrade.authority_path(task).exists())
+            result = self._bootstrap_receipt(task, source)
+            self.assertEqual("RECEIPT_BOOTSTRAPPED", result["status"])
+            self.assertEqual("COMMITTED", upgrade.commit(task, "TASK-78", "maintenance")["status"])
+
+    def test_existing_receipt_without_authority_is_recovered_without_rewriting_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, source = self._apply_fixture(Path(directory))
+            receipt_path = upgrade.receipt_path(repo)
+            receipt_bytes = receipt_path.read_bytes()
+            upgrade.authority_path(repo).unlink()
+            result = self._bootstrap_receipt(repo, source.parents[1])
+            self.assertEqual("AUTHORITY_RECOVERED", result["status"])
+            self.assertEqual(receipt_bytes, receipt_path.read_bytes())
+            self.assertTrue(upgrade.authority_path(repo).is_file())
+            self.assertEqual("COMMITTED", upgrade.commit(repo, "TASK-78", "maintenance")["status"])
+
+    def test_rebootstrap_with_receipt_and_authority_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, source = self._apply_fixture(Path(directory))
+            with self.assertRaisesRegex(upgrade.UpgradeError, "existing receipt or authority"):
+                self._bootstrap_receipt(repo, source.parents[1])
+
+    def test_bootstrap_recovery_fails_closed_for_receipt_and_pending_state_tampering(self) -> None:
+        receipt_fields = (
+            ("schema_version", 2),
+            ("task_id", "OTHER"),
+            ("branch", "task/OTHER-maintenance"),
+            ("worktree", "/other/worktree"),
+            ("source", "/other/source"),
+            ("source_revision", "0" * 40),
+            ("authority_head", "0" * 40),
+        )
+        for field, value in receipt_fields:
+            with self.subTest(kind=f"receipt:{field}"), tempfile.TemporaryDirectory() as directory:
+                repo, source = self._apply_fixture(Path(directory))
+                upgrade.authority_path(repo).unlink()
+                receipt = self._receipt(repo)
+                receipt[field] = value
+                upgrade.atomic_json_write(upgrade.receipt_path(repo), receipt)
+                with self.assertRaises(upgrade.UpgradeError):
+                    self._bootstrap_receipt(repo, source.parents[1])
+                self.assertFalse(upgrade.authority_path(repo).exists())
+
+        for kind in ("changed_paths", "fingerprint", "head", "source_revision", "pending_added", "pending_removed", "content", "mode"):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                repo, source = self._apply_fixture(root)
+                upgrade.authority_path(repo).unlink()
+                receipt = self._receipt(repo)
+                if kind == "changed_paths":
+                    receipt["changed_paths"] = receipt["changed_paths"][:-1]
+                elif kind == "fingerprint":
+                    path = receipt["changed_paths"][0]
+                    receipt["path_fingerprints"][path]["content_sha256"] = "0" * 64
+                elif kind == "head":
+                    self._write_file(repo / "README.md", "head changed\n")
+                    self._git(["add", "README.md"], repo)
+                    self._git(["commit", "-m", "changed head"], repo)
+                elif kind == "source_revision":
+                    self._write_file(source / "source-change", "changed\n")
+                    self._git(["add", "source-change"], source)
+                    self._git(["commit", "-m", "changed source"], source)
+                elif kind == "pending_added":
+                    self._write_file(repo / ".automation/pending-added", "added\n")
+                else:
+                    path = receipt["changed_paths"][0]
+                    target = repo / Path(*path.split("/"))
+                    if kind == "pending_removed":
+                        self._git(["restore", "--source=HEAD", "--", path], repo)
+                    elif kind == "content":
+                        target.write_bytes(target.read_bytes() + b"tampered")
+                    elif kind == "mode":
+                        target.chmod(target.stat().st_mode ^ 0o100)
+                if kind in ("changed_paths", "fingerprint"):
+                    upgrade.atomic_json_write(upgrade.receipt_path(repo), receipt)
+                with self.assertRaises(upgrade.UpgradeError):
+                    self._bootstrap_receipt(repo, source.parents[1])
+                self.assertFalse(upgrade.authority_path(repo).exists())
+
+    def test_legacy_authority_is_consumed_only_when_new_record_is_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            new_path, legacy_path = upgrade._authority_locations(repo)
+            self.assertIsNotNone(legacy_path)
+            assert legacy_path is not None
+            legacy_path.parent.mkdir(parents=True, exist_ok=True)
+            legacy_path.write_bytes(new_path.read_bytes())
+            new_path.unlink()
+            self.assertEqual("COMMITTED", upgrade.commit(repo, "TASK-78", "legacy maintenance")["status"])
+            self.assertFalse(legacy_path.exists())
+
+    def test_malformed_new_authority_blocks_legacy_fallback_and_non_directory_common_git_is_unusable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo, _ = self._apply_fixture(root)
+            new_path, legacy_path = upgrade._authority_locations(repo)
+            assert legacy_path is not None
+            legacy_path.parent.mkdir(parents=True, exist_ok=True)
+            legacy_path.write_bytes(new_path.read_bytes())
+            new_path.write_text("not json\n", encoding="utf-8")
+            self.assertIn("invalid successful-upgrade authority", self._commit_error(repo))
+            new_path.unlink()
+            common_file = root / "common-file"
+            common_file.write_text("not a git directory\n", encoding="utf-8")
+            with mock.patch.object(upgrade, "common_git_dir", return_value=common_file):
+                self.assertIn("missing or invalid successful-upgrade authority", self._commit_error(repo))
 
     def test_no_change_upgrade_preserves_consumed_receipt(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -1129,11 +1457,13 @@ mod project 'just/project/mod.just'
             updated = self._receipt(repo)
             updated["path_fingerprints"][path] = upgrade.file_fingerprint(repo, path)
             upgrade.atomic_json_write(upgrade.receipt_path(repo), updated)
+            upgrade.authority_path(repo).unlink()
             upgrade.write_authority(repo, updated)
             self.assertIn("git diff --no-ext-diff --cached --check", self._commit_error(repo))
             target.write_bytes(original_bytes)
             self._git(["reset", "--mixed", "HEAD"], repo)
             upgrade.atomic_json_write(upgrade.receipt_path(repo), receipt)
+            upgrade.authority_path(repo).unlink()
             upgrade.write_authority(repo, receipt)
             original_run = upgrade.run
 

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -1254,6 +1254,77 @@ mod project 'just/project/mod.just'
             self.assertEqual("COMMITTED", upgrade.commit(repo, "TASK-78", "legacy maintenance")["status"])
             self.assertFalse(legacy_path.exists())
 
+    def test_linked_worktree_ignores_legacy_authority_under_escaped_common_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _, linked, source = self._separate_git_topology_fixture(root)
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                upgrade.apply(linked, source)
+            receipt = self._receipt(linked)
+            new_path, legacy_path = upgrade._authority_locations(linked)
+            self.assertIsNotNone(legacy_path)
+            assert legacy_path is not None
+            authority_bytes = new_path.read_bytes()
+            new_path.unlink()
+            self.assertFalse(new_path.exists())
+
+            common = upgrade.common_git_dir(linked)
+            external = root / "escaped-authority"
+            external.mkdir()
+            common_opencode = common / "opencode"
+            self.assertFalse(common_opencode.exists())
+            common_opencode.symlink_to(external, target_is_directory=True)
+            (external / "automation-maintenance").mkdir()
+            legacy_path.write_bytes(authority_bytes)
+            external_authority = external / "automation-maintenance" / legacy_path.name
+            external_before = external_authority.read_bytes()
+
+            locations = upgrade._authority_locations(linked)
+            self.assertIsNone(locations[1])
+            with self.assertRaises(upgrade.UpgradeError):
+                upgrade.validate_authority(linked, receipt)
+            with self.assertRaises(upgrade.UpgradeError):
+                upgrade.commit(linked, "TASK-83", "maintenance")
+            self.assertEqual(external_before, external_authority.read_bytes())
+            self.assertEqual(authority_bytes, external_authority.read_bytes())
+
+            with self.assertRaises(upgrade.UpgradeError):
+                upgrade._write_authority_at(
+                    common / "opencode" / "automation-maintenance" / "escaped.json",
+                    json.loads(authority_bytes),
+                    admin=common.resolve(),
+                )
+            self.assertEqual(external_before, external_authority.read_bytes())
+
+    def test_legacy_authority_is_restored_when_commit_fails_after_consumption(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            new_path, legacy_path = upgrade._authority_locations(repo)
+            self.assertIsNotNone(legacy_path)
+            assert legacy_path is not None
+            authority_bytes = new_path.read_bytes()
+            active_bytes = upgrade.receipt_path(repo).read_bytes()
+            legacy_path.parent.mkdir(parents=True, exist_ok=True)
+            legacy_path.write_bytes(authority_bytes)
+            new_path.unlink()
+
+            original_run = upgrade.run
+
+            def fail_staging_check(command, *args, **kwargs):
+                if command == ["git", "diff", "--no-ext-diff", "--cached", "--check"]:
+                    raise upgrade.UpgradeError("injected staging check failure")
+                return original_run(command, *args, **kwargs)
+
+            with mock.patch.object(upgrade, "run", side_effect=fail_staging_check):
+                with self.assertRaisesRegex(upgrade.UpgradeError, "injected staging check failure"):
+                    upgrade.commit(repo, "TASK-78", "legacy rollback")
+            self.assertEqual(active_bytes, upgrade.receipt_path(repo).read_bytes())
+            self.assertEqual(authority_bytes, legacy_path.read_bytes())
+            self.assertFalse(new_path.exists())
+            self.assertFalse(upgrade.consumed_receipt_path(repo).exists())
+            self.assertEqual("COMMITTED", upgrade.commit(repo, "TASK-78", "legacy retry")["status"])
+            self.assertFalse(legacy_path.exists())
+
     def test_malformed_new_authority_blocks_legacy_fallback_and_non_directory_common_git_is_unusable(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Summary
- store new maintenance authority records in Git-resolved per-worktree administrative directories, with safe legacy authority validation compatibility
- publish receipt and authority as a guarded logical pair and recover exact receipt-without-authority states through canonical bootstrap reconstruction
- harden receipt publication and commit rollback, including concurrent issuance and Task State path checks
- cover primary, linked, separate-git-dir, and linked-from-separate topologies plus tamper/failure recovery
- regenerate all agent templates and document the recovery contract

## Verification
- `nix develop -c python3 -m unittest discover -s tests -v` (260 tests, 0 skipped)
- `nix develop -c python3 -m unittest tests.test_automation_upgrade -v` (74 tests, 0 skipped)
- `nix develop -c just template::check`
- `nix develop -c just template::distribution-verify`
- `git diff --check`
- `nix flake check --all-systems --no-build --no-update-lock-file`
- `nix build .#checks.x86_64-linux.opencode-policy --no-link --no-update-lock-file`

Closes #83