### PR TITLE
Add source-side maintenance recovery bridge

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,7 @@ set minimum-version := "1.55.0"
 
 mod template 'just/template.just'
 mod runtime 'just/runtime.just'
+mod agent-core 'just/agent-core.just'
 
 default:
     @just --list

--- a/README.md
+++ b/README.md
@@ -253,28 +253,34 @@ just agent::push <task>
 just agent::pr-create <task>
 ```
 
-The normal flow creates the receipt before verification. A self-hosted pre-receipt
-upgrade may instead leave the exact upgraded diff without a receipt. After normal
-verification and immediately before `automation::commit`, recover it with:
+Issue #85 provides a narrower Templates source-side bridge for a consumer
+worktree with the exact active receipt but missing authority. From the Templates
+checkout, run:
 
 ```sh
-AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+just agent-core::recover-maintenance-authority <consumer-task-worktree>
+just agent-core::commit-recovered-maintenance <consumer-task-worktree> <task> [message]
 ```
 
-The bridge supports exactly two strict cases: canonical pre-receipt
-reconstruction, and recovery of an exact active receipt whose authority is
-missing. It does not trust `NO_CHANGES`, the current diff, or the environment.
-In either case it uses the same pinned clean-source and tracked Agent Core
-snapshot semantics as normal `automation::check-update` and
-`automation::upgrade`, reconstructs canonical output in isolation, and checks
-Task/branch/worktree/`HEAD`, the pinned source revision, and exact pending safe
-paths, content, modes, and fingerprints. Recovery additionally requires the
-active receipt to be exactly equal and unchanged, then issues only the missing
-authority. A receipt with authority, or stale, forged, or tampered state, fails
-closed. Continue with the existing commit/push/Draft-PR flow; ordinary
-`agent::commit` rejection remains unchanged.
+Use it only before fixing that consumer. Do not edit or delete the receipt,
+replace receipt-bound Agent Core files, use `python -c` or a monkeypatch, or
+modify downstream files directly outside the bridge. Recovery uses the current
+clean, pinned Templates `HEAD`; the receipt source revision remains historical
+and is materialized from tracked Git objects, without checking out current
+source to that old revision or using live files. `receipt.source` must be the
+exact same Templates Git repository/common object store worktree; unrelated or
+missing sources are rejected.
 
-`automation::commit` is the only commit path for this upgrade. It fails closed unless the schema-1 JSON receipt contains Task `task_id`, `branch`, `worktree`, source/source revision, current/upstream versions, sorted unique `changed_paths`, `authority_head`, and matching `path_fingerprints`. Receipt identity must match the current Task/worktree and `authority_head` must equal current `HEAD`; every fingerprint and the complete pending path set must still match. Receipt and authority are a logical pair. Authority records live under the Git-resolved per-worktree administrative directory returned by `--absolute-git-dir`, not an assumed visible `.git` or shared Git directory; linked and special administrative topologies are supported, and worktrees do not share authority. Existing safe legacy shared-common-dir hashed records remain validation/commit compatible. A protected record binds the active receipt to the preceding successful upgrade, so an ambient variable or fabricated Task State receipt is not commit authority. Receipt paths must be Agent Core-managed only: mixed Adapter, repository, product, secret-pattern, or `.task-state` paths are rejected. The command scrubs ambient Git repository/index overrides, stages into a private Task State index, checks the exact staged blobs and modes, creates the commit from that verified tree without hooks, and atomically advances only the expected Task branch HEAD. A handled authority-write failure removes the newly written receipt if it is unchanged; an interruption half-state is recoverable only through the strict bootstrap path. No cross-filesystem atomicity is claimed.
+Recovery leaves the receipt and target files unchanged, writes per-worktree
+schema-2 bridge authority and proof, and reports `AUTHORITY_RECOVERED`.
+Publication uses current guarded semantics: exact receipt paths, private-index
+blob-and-mode validation, `commit-tree`, and expected-`HEAD` `update-ref`. A
+failure before the atomic branch update restores the retryable pair; successful
+expected-`HEAD` `update-ref` is the publication boundary. A later finalization
+error is reported as already published and must not be retried as an
+uncommitted pair. There is no push or merge. The existing consumer script need not and must not
+be replaced first. This is not a generic external apply/upgrade/commit
+primitive; normal consumer bootstrap and commit remain separate workflows.
 
 After a successful commit, the active receipt is consumed as `.task-state/automation-maintenance.consumed.json`. A later successful upgrade with changes replaces the active receipt and removes the prior consumed receipt; a no-change invocation returns `NO_CHANGES` and preserves existing receipt lifecycle evidence. There is no raw Git/GitHub bypass, and merge is excluded: the Main Orchestrator performs the separately gated integration/merge workflow.
 

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -23,6 +23,7 @@ class UpgradeError(RuntimeError):
 
 RECEIPT_NAME = "automation-maintenance.json"
 CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+SOURCE_RECOVERY_PROOF_NAME = "source-recovery-proof.json"
 TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 RECEIPT_FIELDS = {
     "schema_version",
@@ -130,6 +131,12 @@ def authority_path(repo: Path) -> Path:
     return _authority_locations(repo)[0]
 
 
+def source_recovery_proof_path(repo: Path) -> Path:
+    """Return the proof path, using the same containment guard as authority."""
+    authority = authority_path(repo)
+    return authority.parent / SOURCE_RECOVERY_PROOF_NAME
+
+
 def canonical_json(value: dict) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
@@ -218,6 +225,48 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
     return path
 
 
+def _read_json_record(path: Path, error: str) -> dict:
+    _, value = _read_json_record_bytes(path, error)
+    return value
+
+
+def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError(error)
+        raw = path.read_bytes()
+        value = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError(error) from exc
+    if not isinstance(value, dict):
+        raise UpgradeError(error)
+    return raw, value
+
+
+def _bridge_authority_path(repo: Path) -> Path:
+    return authority_path(repo)
+
+
+def _bridge_authority(receipt: dict, proof_digest: str) -> dict:
+    return {
+        "schema_version": 2,
+        "kind": "source-recovery-bridge",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "proof_sha256": proof_digest,
+    }
+
+
+def _validate_no_authority(repo: Path) -> None:
+    new_path, legacy_path = _authority_locations(repo)
+    if os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path)):
+        raise UpgradeError("cannot recover with an existing authority record")
+
+
 def authority_exists(repo: Path) -> bool:
     new_path, legacy_path = _authority_locations(repo)
     return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
@@ -303,6 +352,53 @@ def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
             temporary.unlink(missing_ok=True)
         except OSError as exc:
             raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_bytes_write(path: Path, content: bytes) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError(f"cannot publish record over an existing record: {path}") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish record: {path}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _validate_admin_record_parent(path: Path, admin: Path) -> None:
+    try:
+        resolved_admin = admin.resolve()
+        parent = path.parent.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise UpgradeError("record path containment cannot be validated") from exc
+    if parent != resolved_admin and resolved_admin not in parent.parents:
+        raise UpgradeError("record path escapes the worktree administrative directory")
+
+
+def exclusive_json_write_contained(path: Path, value: dict, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_json_write(path, value)
+    _validate_admin_record_parent(path, admin)
+    return result
+
+
+def exclusive_bytes_write_contained(path: Path, content: bytes, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_bytes_write(path, content)
+    _validate_admin_record_parent(path, admin)
+    return result
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -556,6 +652,41 @@ def resolve_pinned_source(path: Path) -> tuple[Path, str]:
     if status:
         raise UpgradeError("source components/agent-core must be clean")
     return source, head
+
+
+def resolve_clean_source_worktree(path: Path) -> tuple[Path, str]:
+    """Validate the whole Templates checkout for source-side recovery."""
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    if git_bytes(["git", "status", "--porcelain=v1", "-z"], cwd=source):
+        raise UpgradeError("Templates source worktree must be clean")
+    return source, head
+
+
+def _source_is_compatible(receipt_source: str, source: Path) -> bool:
+    candidate = Path(receipt_source)
+    if not candidate.is_absolute() or not candidate.exists() or not candidate.is_dir():
+        return False
+    try:
+        candidate = candidate.resolve()
+        top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=candidate).stdout.strip()).resolve()
+        return top == candidate and (
+            candidate == source or common_git_dir(candidate) == common_git_dir(source)
+        )
+    except (OSError, UpgradeError, ValueError, RuntimeError):
+        return False
+
+
+def _validate_source_revision(source: Path, revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError("receipt source_revision must be a full lowercase hexadecimal Git revision")
+    result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
+    if result.returncode != 0 or result.stdout.strip() != revision:
+        raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -1358,6 +1489,178 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
+PROOF_FIELDS = {
+    "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+    "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+    "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+    "receipt_source", "receipt_source_revision",
+}
+
+
+def _recovery_proof(receipt: dict, *, implementation_source: Path, implementation_revision: str,
+                    raw_receipt: bytes, paths: list[str], fingerprints: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "kind": "source-recovery-proof",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_head": receipt["authority_head"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "receipt_bytes_sha256": hashlib.sha256(raw_receipt).hexdigest(),
+        "changed_paths_sha256": hashlib.sha256(canonical_json({"changed_paths": paths})).hexdigest(),
+        "path_fingerprints_sha256": hashlib.sha256(canonical_json(fingerprints)).hexdigest(),
+        "implementation_source": str(implementation_source),
+        "implementation_revision": implementation_revision,
+        "receipt_source": receipt["source"],
+        "receipt_source_revision": receipt["source_revision"],
+    }
+
+
+def _validate_recovery_proof(proof: object) -> dict:
+    if not isinstance(proof, dict) or set(proof) != PROOF_FIELDS or proof.get("schema_version") != 1 \
+            or proof.get("kind") != "source-recovery-proof":
+        raise UpgradeError("missing or invalid source-recovery proof")
+    for key in ("task_id", "branch", "worktree", "authority_head", "authority_nonce",
+                "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+                "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+                "receipt_source", "receipt_source_revision"):
+        if not isinstance(proof[key], str) or not proof[key]:
+            raise UpgradeError("missing or invalid source-recovery proof")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", proof["implementation_revision"]):
+        raise UpgradeError("invalid source-recovery implementation revision")
+    for key in ("receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256"):
+        if not re.fullmatch(r"[0-9a-f]{64}", proof[key]):
+            raise UpgradeError("invalid source-recovery proof digest")
+    return proof
+
+
+def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, proof: dict) -> Path:
+    expected = _recovery_proof(
+        receipt,
+        implementation_source=Path(proof["implementation_source"]),
+        implementation_revision=proof["implementation_revision"],
+        raw_receipt=raw_receipt,
+        paths=receipt["changed_paths"],
+        fingerprints=receipt["path_fingerprints"],
+    )
+    if proof != expected:
+        raise UpgradeError("source-recovery proof does not match the reconstructed receipt")
+    authority = _read_json_record(_bridge_authority_path(repo), "missing or invalid source-recovery authority")
+    if authority != _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()):
+        raise UpgradeError("source-recovery authority does not match its proof")
+    return _bridge_authority_path(repo)
+
+
+def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+    """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    task_id, branch, worktree = require_maintenance(target_repo)
+    source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    active = receipt_path(target_repo)
+    if not active.is_file():
+        raise UpgradeError("no active automation upgrade receipt")
+    try:
+        raw_receipt = active.read_bytes()
+        receipt = validate_receipt_schema(json.loads(raw_receipt.decode("utf-8")))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt_scope = receipt_paths(target_repo, receipt)
+    if receipt["source_revision"] is None or not _source_is_compatible(receipt["source"], source):
+        raise UpgradeError("receipt source is not compatible with the current Templates source")
+    receipt_revision = _validate_source_revision(source, receipt["source_revision"])
+    if (receipt["task_id"], receipt["branch"], receipt["worktree"]) != (task_id, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    _validate_no_authority(target_repo)
+    authority_head = receipt["authority_head"]
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip()
+    authority_registration = registered_worktrees(target_repo).get(worktree)
+    pending_before = pending_paths(target_repo)
+    for pending in pending_before:
+        reject_bootstrap_path(target_repo, pending)
+    with tempfile.TemporaryDirectory(prefix="automation-source-recovery-", dir=task_state_dir(target_repo)) as temporary:
+        baseline = Path(temporary) / "baseline"
+        snapshot, source_core = materialize_source_snapshot(source, receipt_revision, Path(temporary))
+        materialize_tree(target_repo, authority_head, baseline, surface_only=True)
+        before = {
+            path.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, path.relative_to(baseline).as_posix())
+            for path in baseline.rglob("*") if path.is_file()
+        }
+        plan = build_plan(baseline, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [migration for migration in load_migrations(source_core)
+                    if migration.to_version <= version_number(source_core)]
+        _, migration_blockers, _ = migration_actions(target_repo, selected)
+        if migration_blockers:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(migration_blockers))
+        returned = {item["path"] for item in plan["actions"] if item["action"] != "noop"}
+        apply_plan_to_tree(baseline, source_core, plan)
+        expected = sorted(path for path in returned
+                          if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+                          != bootstrap_fingerprint(baseline, path))
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+        candidate_versions = (plan["currentVersion"], plan["upstreamVersion"])
+    if pending_before != expected or expected != receipt_scope \
+            or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected):
+        raise UpgradeError("pending target paths do not match the reconstructed upgrade")
+    if git_head(target_repo) != authority_head or authority_branch_oid != authority_head \
+            or require_registered_task(target_repo, task_id) != (task_id, branch, worktree) \
+            or registered_worktrees(target_repo).get(worktree) != authority_registration:
+        raise UpgradeError("Task identity or HEAD changed during source recovery")
+    actual_fingerprints = {p: file_fingerprint(target_repo, p) for p in expected}
+    candidate = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": receipt["source"], "source_revision": receipt_revision,
+        "current_version": candidate_versions[0], "upstream_version": candidate_versions[1],
+        "changed_paths": receipt_scope, "authority_head": authority_head,
+        "authority_nonce": receipt["authority_nonce"], "path_fingerprints": actual_fingerprints,
+    }
+    if active.read_bytes() != raw_receipt or candidate != receipt:
+        raise UpgradeError("receipt or target changed during source recovery")
+    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+                            raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
+    proof_path = source_recovery_proof_path(target_repo)
+    created_proof: tuple[int, int] | None = None
+    try:
+        proof_admin = worktree_admin_dir(target_repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        if os.path.lexists(proof_path):
+            existing = _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof"))
+            if existing != proof:
+                raise UpgradeError("existing source-recovery proof does not match reconstruction")
+        else:
+            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+        current_source, current_implementation_revision = resolve_clean_source_worktree(source)
+        if current_source != source or current_implementation_revision != implementation_revision:
+            raise UpgradeError("source changed before source-recovery publication")
+        if active.read_bytes() != raw_receipt or authority_exists(target_repo):
+            raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
+        if (git_head(target_repo) != authority_head
+                or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip() != authority_branch_oid
+                or require_registered_task(target_repo, task_id) != (task_id, branch, worktree)
+                or registered_worktrees(target_repo).get(worktree) != authority_registration
+                or pending_paths(target_repo) != pending_before
+                or receipt_paths(target_repo, receipt) != receipt_scope
+                or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected)):
+            raise UpgradeError("target changed before source-recovery bridge publication")
+        if _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof")) != proof:
+            raise UpgradeError("source-recovery proof changed before bridge publication")
+        _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
+                            admin=worktree_admin_dir(target_repo))
+    except (OSError, UpgradeError):
+        if created_proof is not None:
+            try:
+                metadata = proof_path.lstat()
+                if (metadata.st_dev, metadata.st_ino) == created_proof:
+                    proof_path.unlink()
+            except OSError as exc:
+                raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
+        raise
+    return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
+            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+
+
 def validate_receipt_path(raw: object) -> str:
     if not isinstance(raw, str) or not raw or "\\" in raw:
         raise UpgradeError("receipt contains an unsafe path")
@@ -1468,7 +1771,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1478,7 +1781,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("no active successful automation upgrade receipt")
     try:
         receipt = json.loads(active.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise UpgradeError("invalid automation upgrade receipt") from exc
     receipt = validate_receipt_schema(receipt)
     if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
@@ -1493,7 +1796,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    authority = validate_authority(repo, receipt)
+    proof_path = source_recovery_proof_path(repo)
+    proof: dict | None = None
+    proof_raw: bytes | None = None
+    if mode == "standard":
+        authority = validate_authority(repo, receipt)
+    elif mode == "source_recovery":
+        proof_admin = worktree_admin_dir(repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        proof = _validate_recovery_proof(proof_record)
+        source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
+        if (proof["implementation_source"] != str(source)
+                or proof["implementation_revision"] != current_revision
+                or (source_root is not None and source_root != source)):
+            raise UpgradeError("source-recovery proof implementation is stale")
+        if not _source_is_compatible(receipt["source"], source):
+            raise UpgradeError("source-recovery receipt source is incompatible")
+        _validate_source_revision(source, receipt["source_revision"])
+        authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
+        if proof_path.read_bytes() != proof_raw:
+            raise UpgradeError("source-recovery proof changed before commit mutation")
+    else:  # pragma: no cover
+        raise UpgradeError("unsupported commit mode")
 
     consumed = consumed_receipt_path(repo)
     consumed_receipt = dict(receipt)
@@ -1504,6 +1829,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     commit_sha = ""
     active_moved = False
     authority_removed = False
+    proof_removed = False
     consumed_instances: set[tuple[int, int]] = set()
     try:
         if os.path.lexists(consumed):
@@ -1519,6 +1845,9 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
         authority.unlink(missing_ok=True)
         authority_removed = True
+        if mode == "source_recovery" and proof is not None:
+            proof_path.unlink()
+            proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
         index_environment = {"GIT_INDEX_FILE": str(private_index)}
@@ -1571,24 +1900,25 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
     except (UpgradeError, OSError) as failure:
         if committed:
-            if isinstance(failure, OSError):
-                raise UpgradeError("commit finalization failed") from failure
-            raise
+            raise UpgradeError(
+                f"commit {commit_sha} was published but finalization failed"
+            ) from failure
         rollback_errors: list[str] = []
         try:
+            if proof_removed and proof is not None:
+                if proof_raw is None:
+                    raise UpgradeError("source-recovery proof bytes were not captured")
+                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"proof restore failed: {rollback_error}")
+        try:
             if authority_removed:
-                _write_authority_at(
-                    authority,
-                    {
-                        "schema_version": 1,
-                        "task_id": receipt["task_id"],
-                        "branch": receipt["branch"],
-                        "worktree": receipt["worktree"],
-                        "authority_nonce": receipt["authority_nonce"],
-                        "receipt_sha256": receipt_digest(receipt),
-                    },
-                    admin=_rollback_authority_guard(repo, authority),
-                )
+                restored = _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()) if mode == "source_recovery" and proof is not None else {
+                    "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                    "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                    "receipt_sha256": receipt_digest(receipt),
+                }
+                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -1622,7 +1952,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
             private_index.unlink(missing_ok=True)
         except OSError as cleanup_error:
             raise UpgradeError("private index cleanup failed") from cleanup_error
-    return {"status": "COMMITTED", "commit_sha": commit_sha}
+    result: dict[str, str | bool | list[str]] = {
+        "status": "COMMITTED", "commit_sha": commit_sha,
+    }
+    if mode == "source_recovery":
+        result.update({
+            "commitCreated": True,
+            "changedPaths": paths,
+            "pushPerformed": False,
+            "mergePerformed": False,
+        })
+    return result
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, object]:
+    return _commit_mode(repo, task, message, "standard")
+
+
+def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+    """Commit only a proof-bound source recovery; no network or merge operation is performed."""
+    # The source argument is deliberately checked before the receipt is opened, and
+    # is not a target mutation/apply hook.
+    source, _ = resolve_clean_source_worktree(templates_source_root)
+    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -643,33 +643,34 @@ The canonical publication flows are:
 1. **Normal upgrade:** run `automation::upgrade` from the dedicated Automation
    Maintenance Task, inspect the resulting diff, perform normal verification,
    then use `automation::commit`, `agent::push`, and `agent::pr-create`.
-2. **Pre-receipt consumer recovery:** a self-hosted upgrade may leave the exact
-   upgraded diff without a receipt. After normal verification and before
-   `automation::commit`, run:
+2. **Issue #85 source-side recovery:** only when fixing a consumer worktree with
+   the exact active receipt and missing authority, run from the Templates
+   checkout:
 
    ```sh
-   AUTOMATION_MAINTENANCE=1 just automation::bootstrap-receipt <trusted clean Git Templates checkout>
+   just agent-core::recover-maintenance-authority <consumer-task-worktree>
+   just agent-core::commit-recovered-maintenance <consumer-task-worktree> <task> [message]
    ```
 
-    This bridge supports exactly two strict cases: canonical pre-receipt
-    reconstruction, and recovery of an exact active receipt whose authority is
-    missing. It does not trust `NO_CHANGES`, the current diff, or the
-    environment. It uses the same pinned clean-source and tracked Agent Core
-    snapshot semantics as normal `automation::check-update` and
-    `automation::upgrade`, then reruns pinned clean-source canonical
-    reconstruction. It requires Task/branch/worktree/`HEAD`, the pinned source
-    revision, and exact pending safe paths, content, modes, and fingerprints.
-    Recovery additionally requires receipt exact equality and that it is
-    unchanged, then issues only the missing authority. A receipt with authority,
-    or stale, forged, or tampered state, fails closed. Product, Adapter,
-    repository, secret-pattern, or `.task-state` paths also fail closed.
+   Do not edit or delete the receipt, replace receipt-bound Agent Core files,
+   use `python -c`/monkeypatches, or modify downstream files directly outside
+   the bridge. Recovery uses the current clean, pinned Templates `HEAD`; the
+   receipt source revision remains historical and is materialized from tracked
+   Git objects, without checking out current source to that old revision or
+   using live files. `receipt.source` must be the exact same Templates Git
+   repository/common object store worktree; unrelated or missing sources fail.
+   Recovery leaves the receipt and target files unchanged, writes per-worktree
+   schema-2 bridge authority and proof, and reports `AUTHORITY_RECOVERED`.
+   Publication uses exact receipt paths, private-index blob/mode validation,
+   `commit-tree`, and expected-`HEAD` `update-ref`. A failure before the atomic
+   branch update restores the retryable pair; successful expected-`HEAD`
+   `update-ref` is the publication boundary. A later finalization error is
+   reported as already published and must not be retried as an uncommitted pair.
+   It consumes receipt, authority, and proof. It does not push or merge. The existing consumer script need not and must not be
+   replaced first. This is not a generic external apply/upgrade/commit
+   primitive; normal consumer bootstrap and commit remain distinct.
 
-The bridge only reconstructs a canonical pre-receipt or repairs missing
-authority for an exact active receipt; ordinary `agent::commit` continues to
-reject Automation Core changes. Its source and snapshot semantics align with
-the normal upgrade workflow.
-
-Successful upgrade writes or replaces the ignored `.task-state/automation-maintenance.json` receipt. Its schema-1 content records Task identity (`task_id`, `branch`, `worktree`), source and source revision, current/upstream versions, sorted unique `changed_paths`, the authority `HEAD`, and per-path content/state fingerprints. Receipt and authority publication is a logical pair. Authority records live under the Git-resolved per-worktree administrative directory returned by `--absolute-git-dir`, not an assumed visible `.git` or shared Git directory; linked and special administrative topologies are supported, and worktrees do not share authority. Existing safe legacy shared-common-dir hashed records remain validation/commit compatible. `automation::commit <task> [message]` fails closed unless both records match the current Task/worktree identity and `HEAD`, fingerprints, and complete pending path set. Receipt paths must be Agent Core-managed; any mixed Adapter, repository, product, configured-secret, or `.task-state` scope is rejected. Ambient Git repository/index overrides are scrubbed; exact blobs and modes are staged and rechecked in a private index, committed as that verified tree without hooks, and published only by an atomic expected-HEAD Task branch update. A handled authority-write failure removes the newly written receipt if it is unchanged; an interruption half-state is recoverable only through the strict bootstrap path. No cross-filesystem atomicity is claimed. The receipt is moved to `.task-state/automation-maintenance.consumed.json` after successful commit; the next successful upgrade with changes replaces the active receipt and removes the prior consumed receipt. A no-change invocation returns `NO_CHANGES` and preserves existing lifecycle evidence.
+ Successful upgrade writes or replaces the ignored `.task-state/automation-maintenance.json` receipt. Its schema-1 content records Task identity (`task_id`, `branch`, `worktree`), source and source revision, current/upstream versions, sorted unique `changed_paths`, the authority `HEAD`, and per-path content/state fingerprints. Receipt and authority publication is a logical pair. Authority records live under the Git-resolved per-worktree administrative directory returned by `--absolute-git-dir`, not an assumed visible `.git` or shared Git directory; linked and special administrative topologies are supported, and worktrees do not share authority. Existing safe legacy shared-common-dir hashed records remain validation/commit compatible. `automation::commit <task> [message]` fails closed unless both records match the current Task/worktree identity and `HEAD`, fingerprints, and complete pending path set. Receipt paths must be Agent Core-managed; any mixed Adapter, repository, product, configured-secret, or `.task-state` scope is rejected. Ambient Git repository/index overrides are scrubbed; exact blobs and modes are staged and rechecked in a private index, committed as that verified tree without hooks, and published only by an expected-HEAD Task branch update. A handled authority-write failure removes the newly written receipt if it is unchanged; an interruption half-state is recoverable only through the strict source-side bridge above. No cross-filesystem atomicity is claimed. The receipt is moved to `.task-state/automation-maintenance.consumed.json` after successful commit; the next successful upgrade with changes replaces the active receipt and removes the prior consumed receipt. A no-change invocation returns `NO_CHANGES` and preserves existing lifecycle evidence.
 
 The required sequence is `git diff --check`, `just agent::doctor`, `just project::check`, and the repository CI/smoke suite, followed by `just automation::commit <task> [message]`, existing `just agent::push <task>`, and `just agent::pr-create <task>` (Draft PR). Raw Git/GitHub bypass is not permitted. Merge is excluded from this workflow and remains a separately gated Main Orchestrator operation.
 

--- a/just/agent-core.just
+++ b/just/agent-core.just
@@ -1,0 +1,10 @@
+root := justfile_directory()
+tool := root / "tools/automation_recovery_bridge.py"
+
+[working-directory: root]
+recover-maintenance-authority target:
+    python3 {{quote(tool)}} recover-maintenance-authority {{quote(target)}}
+
+[working-directory: root]
+commit-recovered-maintenance target task message="":
+    python3 {{quote(tool)}} commit-recovered-maintenance {{quote(target)}} {{quote(task)}} {{quote(message)}}

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -23,6 +23,7 @@ class UpgradeError(RuntimeError):
 
 RECEIPT_NAME = "automation-maintenance.json"
 CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+SOURCE_RECOVERY_PROOF_NAME = "source-recovery-proof.json"
 TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 RECEIPT_FIELDS = {
     "schema_version",
@@ -130,6 +131,12 @@ def authority_path(repo: Path) -> Path:
     return _authority_locations(repo)[0]
 
 
+def source_recovery_proof_path(repo: Path) -> Path:
+    """Return the proof path, using the same containment guard as authority."""
+    authority = authority_path(repo)
+    return authority.parent / SOURCE_RECOVERY_PROOF_NAME
+
+
 def canonical_json(value: dict) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
@@ -218,6 +225,48 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
     return path
 
 
+def _read_json_record(path: Path, error: str) -> dict:
+    _, value = _read_json_record_bytes(path, error)
+    return value
+
+
+def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError(error)
+        raw = path.read_bytes()
+        value = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError(error) from exc
+    if not isinstance(value, dict):
+        raise UpgradeError(error)
+    return raw, value
+
+
+def _bridge_authority_path(repo: Path) -> Path:
+    return authority_path(repo)
+
+
+def _bridge_authority(receipt: dict, proof_digest: str) -> dict:
+    return {
+        "schema_version": 2,
+        "kind": "source-recovery-bridge",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "proof_sha256": proof_digest,
+    }
+
+
+def _validate_no_authority(repo: Path) -> None:
+    new_path, legacy_path = _authority_locations(repo)
+    if os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path)):
+        raise UpgradeError("cannot recover with an existing authority record")
+
+
 def authority_exists(repo: Path) -> bool:
     new_path, legacy_path = _authority_locations(repo)
     return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
@@ -303,6 +352,53 @@ def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
             temporary.unlink(missing_ok=True)
         except OSError as exc:
             raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_bytes_write(path: Path, content: bytes) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError(f"cannot publish record over an existing record: {path}") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish record: {path}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _validate_admin_record_parent(path: Path, admin: Path) -> None:
+    try:
+        resolved_admin = admin.resolve()
+        parent = path.parent.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise UpgradeError("record path containment cannot be validated") from exc
+    if parent != resolved_admin and resolved_admin not in parent.parents:
+        raise UpgradeError("record path escapes the worktree administrative directory")
+
+
+def exclusive_json_write_contained(path: Path, value: dict, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_json_write(path, value)
+    _validate_admin_record_parent(path, admin)
+    return result
+
+
+def exclusive_bytes_write_contained(path: Path, content: bytes, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_bytes_write(path, content)
+    _validate_admin_record_parent(path, admin)
+    return result
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -556,6 +652,41 @@ def resolve_pinned_source(path: Path) -> tuple[Path, str]:
     if status:
         raise UpgradeError("source components/agent-core must be clean")
     return source, head
+
+
+def resolve_clean_source_worktree(path: Path) -> tuple[Path, str]:
+    """Validate the whole Templates checkout for source-side recovery."""
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    if git_bytes(["git", "status", "--porcelain=v1", "-z"], cwd=source):
+        raise UpgradeError("Templates source worktree must be clean")
+    return source, head
+
+
+def _source_is_compatible(receipt_source: str, source: Path) -> bool:
+    candidate = Path(receipt_source)
+    if not candidate.is_absolute() or not candidate.exists() or not candidate.is_dir():
+        return False
+    try:
+        candidate = candidate.resolve()
+        top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=candidate).stdout.strip()).resolve()
+        return top == candidate and (
+            candidate == source or common_git_dir(candidate) == common_git_dir(source)
+        )
+    except (OSError, UpgradeError, ValueError, RuntimeError):
+        return False
+
+
+def _validate_source_revision(source: Path, revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError("receipt source_revision must be a full lowercase hexadecimal Git revision")
+    result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
+    if result.returncode != 0 or result.stdout.strip() != revision:
+        raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -1358,6 +1489,178 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
+PROOF_FIELDS = {
+    "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+    "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+    "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+    "receipt_source", "receipt_source_revision",
+}
+
+
+def _recovery_proof(receipt: dict, *, implementation_source: Path, implementation_revision: str,
+                    raw_receipt: bytes, paths: list[str], fingerprints: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "kind": "source-recovery-proof",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_head": receipt["authority_head"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "receipt_bytes_sha256": hashlib.sha256(raw_receipt).hexdigest(),
+        "changed_paths_sha256": hashlib.sha256(canonical_json({"changed_paths": paths})).hexdigest(),
+        "path_fingerprints_sha256": hashlib.sha256(canonical_json(fingerprints)).hexdigest(),
+        "implementation_source": str(implementation_source),
+        "implementation_revision": implementation_revision,
+        "receipt_source": receipt["source"],
+        "receipt_source_revision": receipt["source_revision"],
+    }
+
+
+def _validate_recovery_proof(proof: object) -> dict:
+    if not isinstance(proof, dict) or set(proof) != PROOF_FIELDS or proof.get("schema_version") != 1 \
+            or proof.get("kind") != "source-recovery-proof":
+        raise UpgradeError("missing or invalid source-recovery proof")
+    for key in ("task_id", "branch", "worktree", "authority_head", "authority_nonce",
+                "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+                "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+                "receipt_source", "receipt_source_revision"):
+        if not isinstance(proof[key], str) or not proof[key]:
+            raise UpgradeError("missing or invalid source-recovery proof")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", proof["implementation_revision"]):
+        raise UpgradeError("invalid source-recovery implementation revision")
+    for key in ("receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256"):
+        if not re.fullmatch(r"[0-9a-f]{64}", proof[key]):
+            raise UpgradeError("invalid source-recovery proof digest")
+    return proof
+
+
+def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, proof: dict) -> Path:
+    expected = _recovery_proof(
+        receipt,
+        implementation_source=Path(proof["implementation_source"]),
+        implementation_revision=proof["implementation_revision"],
+        raw_receipt=raw_receipt,
+        paths=receipt["changed_paths"],
+        fingerprints=receipt["path_fingerprints"],
+    )
+    if proof != expected:
+        raise UpgradeError("source-recovery proof does not match the reconstructed receipt")
+    authority = _read_json_record(_bridge_authority_path(repo), "missing or invalid source-recovery authority")
+    if authority != _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()):
+        raise UpgradeError("source-recovery authority does not match its proof")
+    return _bridge_authority_path(repo)
+
+
+def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+    """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    task_id, branch, worktree = require_maintenance(target_repo)
+    source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    active = receipt_path(target_repo)
+    if not active.is_file():
+        raise UpgradeError("no active automation upgrade receipt")
+    try:
+        raw_receipt = active.read_bytes()
+        receipt = validate_receipt_schema(json.loads(raw_receipt.decode("utf-8")))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt_scope = receipt_paths(target_repo, receipt)
+    if receipt["source_revision"] is None or not _source_is_compatible(receipt["source"], source):
+        raise UpgradeError("receipt source is not compatible with the current Templates source")
+    receipt_revision = _validate_source_revision(source, receipt["source_revision"])
+    if (receipt["task_id"], receipt["branch"], receipt["worktree"]) != (task_id, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    _validate_no_authority(target_repo)
+    authority_head = receipt["authority_head"]
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip()
+    authority_registration = registered_worktrees(target_repo).get(worktree)
+    pending_before = pending_paths(target_repo)
+    for pending in pending_before:
+        reject_bootstrap_path(target_repo, pending)
+    with tempfile.TemporaryDirectory(prefix="automation-source-recovery-", dir=task_state_dir(target_repo)) as temporary:
+        baseline = Path(temporary) / "baseline"
+        snapshot, source_core = materialize_source_snapshot(source, receipt_revision, Path(temporary))
+        materialize_tree(target_repo, authority_head, baseline, surface_only=True)
+        before = {
+            path.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, path.relative_to(baseline).as_posix())
+            for path in baseline.rglob("*") if path.is_file()
+        }
+        plan = build_plan(baseline, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [migration for migration in load_migrations(source_core)
+                    if migration.to_version <= version_number(source_core)]
+        _, migration_blockers, _ = migration_actions(target_repo, selected)
+        if migration_blockers:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(migration_blockers))
+        returned = {item["path"] for item in plan["actions"] if item["action"] != "noop"}
+        apply_plan_to_tree(baseline, source_core, plan)
+        expected = sorted(path for path in returned
+                          if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+                          != bootstrap_fingerprint(baseline, path))
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+        candidate_versions = (plan["currentVersion"], plan["upstreamVersion"])
+    if pending_before != expected or expected != receipt_scope \
+            or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected):
+        raise UpgradeError("pending target paths do not match the reconstructed upgrade")
+    if git_head(target_repo) != authority_head or authority_branch_oid != authority_head \
+            or require_registered_task(target_repo, task_id) != (task_id, branch, worktree) \
+            or registered_worktrees(target_repo).get(worktree) != authority_registration:
+        raise UpgradeError("Task identity or HEAD changed during source recovery")
+    actual_fingerprints = {p: file_fingerprint(target_repo, p) for p in expected}
+    candidate = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": receipt["source"], "source_revision": receipt_revision,
+        "current_version": candidate_versions[0], "upstream_version": candidate_versions[1],
+        "changed_paths": receipt_scope, "authority_head": authority_head,
+        "authority_nonce": receipt["authority_nonce"], "path_fingerprints": actual_fingerprints,
+    }
+    if active.read_bytes() != raw_receipt or candidate != receipt:
+        raise UpgradeError("receipt or target changed during source recovery")
+    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+                            raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
+    proof_path = source_recovery_proof_path(target_repo)
+    created_proof: tuple[int, int] | None = None
+    try:
+        proof_admin = worktree_admin_dir(target_repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        if os.path.lexists(proof_path):
+            existing = _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof"))
+            if existing != proof:
+                raise UpgradeError("existing source-recovery proof does not match reconstruction")
+        else:
+            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+        current_source, current_implementation_revision = resolve_clean_source_worktree(source)
+        if current_source != source or current_implementation_revision != implementation_revision:
+            raise UpgradeError("source changed before source-recovery publication")
+        if active.read_bytes() != raw_receipt or authority_exists(target_repo):
+            raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
+        if (git_head(target_repo) != authority_head
+                or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip() != authority_branch_oid
+                or require_registered_task(target_repo, task_id) != (task_id, branch, worktree)
+                or registered_worktrees(target_repo).get(worktree) != authority_registration
+                or pending_paths(target_repo) != pending_before
+                or receipt_paths(target_repo, receipt) != receipt_scope
+                or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected)):
+            raise UpgradeError("target changed before source-recovery bridge publication")
+        if _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof")) != proof:
+            raise UpgradeError("source-recovery proof changed before bridge publication")
+        _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
+                            admin=worktree_admin_dir(target_repo))
+    except (OSError, UpgradeError):
+        if created_proof is not None:
+            try:
+                metadata = proof_path.lstat()
+                if (metadata.st_dev, metadata.st_ino) == created_proof:
+                    proof_path.unlink()
+            except OSError as exc:
+                raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
+        raise
+    return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
+            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+
+
 def validate_receipt_path(raw: object) -> str:
     if not isinstance(raw, str) or not raw or "\\" in raw:
         raise UpgradeError("receipt contains an unsafe path")
@@ -1468,7 +1771,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1478,7 +1781,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("no active successful automation upgrade receipt")
     try:
         receipt = json.loads(active.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise UpgradeError("invalid automation upgrade receipt") from exc
     receipt = validate_receipt_schema(receipt)
     if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
@@ -1493,7 +1796,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    authority = validate_authority(repo, receipt)
+    proof_path = source_recovery_proof_path(repo)
+    proof: dict | None = None
+    proof_raw: bytes | None = None
+    if mode == "standard":
+        authority = validate_authority(repo, receipt)
+    elif mode == "source_recovery":
+        proof_admin = worktree_admin_dir(repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        proof = _validate_recovery_proof(proof_record)
+        source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
+        if (proof["implementation_source"] != str(source)
+                or proof["implementation_revision"] != current_revision
+                or (source_root is not None and source_root != source)):
+            raise UpgradeError("source-recovery proof implementation is stale")
+        if not _source_is_compatible(receipt["source"], source):
+            raise UpgradeError("source-recovery receipt source is incompatible")
+        _validate_source_revision(source, receipt["source_revision"])
+        authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
+        if proof_path.read_bytes() != proof_raw:
+            raise UpgradeError("source-recovery proof changed before commit mutation")
+    else:  # pragma: no cover
+        raise UpgradeError("unsupported commit mode")
 
     consumed = consumed_receipt_path(repo)
     consumed_receipt = dict(receipt)
@@ -1504,6 +1829,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     commit_sha = ""
     active_moved = False
     authority_removed = False
+    proof_removed = False
     consumed_instances: set[tuple[int, int]] = set()
     try:
         if os.path.lexists(consumed):
@@ -1519,6 +1845,9 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
         authority.unlink(missing_ok=True)
         authority_removed = True
+        if mode == "source_recovery" and proof is not None:
+            proof_path.unlink()
+            proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
         index_environment = {"GIT_INDEX_FILE": str(private_index)}
@@ -1571,24 +1900,25 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
     except (UpgradeError, OSError) as failure:
         if committed:
-            if isinstance(failure, OSError):
-                raise UpgradeError("commit finalization failed") from failure
-            raise
+            raise UpgradeError(
+                f"commit {commit_sha} was published but finalization failed"
+            ) from failure
         rollback_errors: list[str] = []
         try:
+            if proof_removed and proof is not None:
+                if proof_raw is None:
+                    raise UpgradeError("source-recovery proof bytes were not captured")
+                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"proof restore failed: {rollback_error}")
+        try:
             if authority_removed:
-                _write_authority_at(
-                    authority,
-                    {
-                        "schema_version": 1,
-                        "task_id": receipt["task_id"],
-                        "branch": receipt["branch"],
-                        "worktree": receipt["worktree"],
-                        "authority_nonce": receipt["authority_nonce"],
-                        "receipt_sha256": receipt_digest(receipt),
-                    },
-                    admin=_rollback_authority_guard(repo, authority),
-                )
+                restored = _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()) if mode == "source_recovery" and proof is not None else {
+                    "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                    "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                    "receipt_sha256": receipt_digest(receipt),
+                }
+                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -1622,7 +1952,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
             private_index.unlink(missing_ok=True)
         except OSError as cleanup_error:
             raise UpgradeError("private index cleanup failed") from cleanup_error
-    return {"status": "COMMITTED", "commit_sha": commit_sha}
+    result: dict[str, str | bool | list[str]] = {
+        "status": "COMMITTED", "commit_sha": commit_sha,
+    }
+    if mode == "source_recovery":
+        result.update({
+            "commitCreated": True,
+            "changedPaths": paths,
+            "pushPerformed": False,
+            "mergePerformed": False,
+        })
+    return result
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, object]:
+    return _commit_mode(repo, task, message, "standard")
+
+
+def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+    """Commit only a proof-bound source recovery; no network or merge operation is performed."""
+    # The source argument is deliberately checked before the receipt is opened, and
+    # is not a target mutation/apply hook.
+    source, _ = resolve_clean_source_worktree(templates_source_root)
+    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -23,6 +23,7 @@ class UpgradeError(RuntimeError):
 
 RECEIPT_NAME = "automation-maintenance.json"
 CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+SOURCE_RECOVERY_PROOF_NAME = "source-recovery-proof.json"
 TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 RECEIPT_FIELDS = {
     "schema_version",
@@ -130,6 +131,12 @@ def authority_path(repo: Path) -> Path:
     return _authority_locations(repo)[0]
 
 
+def source_recovery_proof_path(repo: Path) -> Path:
+    """Return the proof path, using the same containment guard as authority."""
+    authority = authority_path(repo)
+    return authority.parent / SOURCE_RECOVERY_PROOF_NAME
+
+
 def canonical_json(value: dict) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
@@ -218,6 +225,48 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
     return path
 
 
+def _read_json_record(path: Path, error: str) -> dict:
+    _, value = _read_json_record_bytes(path, error)
+    return value
+
+
+def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError(error)
+        raw = path.read_bytes()
+        value = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError(error) from exc
+    if not isinstance(value, dict):
+        raise UpgradeError(error)
+    return raw, value
+
+
+def _bridge_authority_path(repo: Path) -> Path:
+    return authority_path(repo)
+
+
+def _bridge_authority(receipt: dict, proof_digest: str) -> dict:
+    return {
+        "schema_version": 2,
+        "kind": "source-recovery-bridge",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "proof_sha256": proof_digest,
+    }
+
+
+def _validate_no_authority(repo: Path) -> None:
+    new_path, legacy_path = _authority_locations(repo)
+    if os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path)):
+        raise UpgradeError("cannot recover with an existing authority record")
+
+
 def authority_exists(repo: Path) -> bool:
     new_path, legacy_path = _authority_locations(repo)
     return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
@@ -303,6 +352,53 @@ def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
             temporary.unlink(missing_ok=True)
         except OSError as exc:
             raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_bytes_write(path: Path, content: bytes) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError(f"cannot publish record over an existing record: {path}") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish record: {path}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _validate_admin_record_parent(path: Path, admin: Path) -> None:
+    try:
+        resolved_admin = admin.resolve()
+        parent = path.parent.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise UpgradeError("record path containment cannot be validated") from exc
+    if parent != resolved_admin and resolved_admin not in parent.parents:
+        raise UpgradeError("record path escapes the worktree administrative directory")
+
+
+def exclusive_json_write_contained(path: Path, value: dict, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_json_write(path, value)
+    _validate_admin_record_parent(path, admin)
+    return result
+
+
+def exclusive_bytes_write_contained(path: Path, content: bytes, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_bytes_write(path, content)
+    _validate_admin_record_parent(path, admin)
+    return result
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -556,6 +652,41 @@ def resolve_pinned_source(path: Path) -> tuple[Path, str]:
     if status:
         raise UpgradeError("source components/agent-core must be clean")
     return source, head
+
+
+def resolve_clean_source_worktree(path: Path) -> tuple[Path, str]:
+    """Validate the whole Templates checkout for source-side recovery."""
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    if git_bytes(["git", "status", "--porcelain=v1", "-z"], cwd=source):
+        raise UpgradeError("Templates source worktree must be clean")
+    return source, head
+
+
+def _source_is_compatible(receipt_source: str, source: Path) -> bool:
+    candidate = Path(receipt_source)
+    if not candidate.is_absolute() or not candidate.exists() or not candidate.is_dir():
+        return False
+    try:
+        candidate = candidate.resolve()
+        top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=candidate).stdout.strip()).resolve()
+        return top == candidate and (
+            candidate == source or common_git_dir(candidate) == common_git_dir(source)
+        )
+    except (OSError, UpgradeError, ValueError, RuntimeError):
+        return False
+
+
+def _validate_source_revision(source: Path, revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError("receipt source_revision must be a full lowercase hexadecimal Git revision")
+    result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
+    if result.returncode != 0 or result.stdout.strip() != revision:
+        raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -1358,6 +1489,178 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
+PROOF_FIELDS = {
+    "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+    "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+    "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+    "receipt_source", "receipt_source_revision",
+}
+
+
+def _recovery_proof(receipt: dict, *, implementation_source: Path, implementation_revision: str,
+                    raw_receipt: bytes, paths: list[str], fingerprints: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "kind": "source-recovery-proof",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_head": receipt["authority_head"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "receipt_bytes_sha256": hashlib.sha256(raw_receipt).hexdigest(),
+        "changed_paths_sha256": hashlib.sha256(canonical_json({"changed_paths": paths})).hexdigest(),
+        "path_fingerprints_sha256": hashlib.sha256(canonical_json(fingerprints)).hexdigest(),
+        "implementation_source": str(implementation_source),
+        "implementation_revision": implementation_revision,
+        "receipt_source": receipt["source"],
+        "receipt_source_revision": receipt["source_revision"],
+    }
+
+
+def _validate_recovery_proof(proof: object) -> dict:
+    if not isinstance(proof, dict) or set(proof) != PROOF_FIELDS or proof.get("schema_version") != 1 \
+            or proof.get("kind") != "source-recovery-proof":
+        raise UpgradeError("missing or invalid source-recovery proof")
+    for key in ("task_id", "branch", "worktree", "authority_head", "authority_nonce",
+                "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+                "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+                "receipt_source", "receipt_source_revision"):
+        if not isinstance(proof[key], str) or not proof[key]:
+            raise UpgradeError("missing or invalid source-recovery proof")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", proof["implementation_revision"]):
+        raise UpgradeError("invalid source-recovery implementation revision")
+    for key in ("receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256"):
+        if not re.fullmatch(r"[0-9a-f]{64}", proof[key]):
+            raise UpgradeError("invalid source-recovery proof digest")
+    return proof
+
+
+def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, proof: dict) -> Path:
+    expected = _recovery_proof(
+        receipt,
+        implementation_source=Path(proof["implementation_source"]),
+        implementation_revision=proof["implementation_revision"],
+        raw_receipt=raw_receipt,
+        paths=receipt["changed_paths"],
+        fingerprints=receipt["path_fingerprints"],
+    )
+    if proof != expected:
+        raise UpgradeError("source-recovery proof does not match the reconstructed receipt")
+    authority = _read_json_record(_bridge_authority_path(repo), "missing or invalid source-recovery authority")
+    if authority != _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()):
+        raise UpgradeError("source-recovery authority does not match its proof")
+    return _bridge_authority_path(repo)
+
+
+def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+    """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    task_id, branch, worktree = require_maintenance(target_repo)
+    source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    active = receipt_path(target_repo)
+    if not active.is_file():
+        raise UpgradeError("no active automation upgrade receipt")
+    try:
+        raw_receipt = active.read_bytes()
+        receipt = validate_receipt_schema(json.loads(raw_receipt.decode("utf-8")))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt_scope = receipt_paths(target_repo, receipt)
+    if receipt["source_revision"] is None or not _source_is_compatible(receipt["source"], source):
+        raise UpgradeError("receipt source is not compatible with the current Templates source")
+    receipt_revision = _validate_source_revision(source, receipt["source_revision"])
+    if (receipt["task_id"], receipt["branch"], receipt["worktree"]) != (task_id, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    _validate_no_authority(target_repo)
+    authority_head = receipt["authority_head"]
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip()
+    authority_registration = registered_worktrees(target_repo).get(worktree)
+    pending_before = pending_paths(target_repo)
+    for pending in pending_before:
+        reject_bootstrap_path(target_repo, pending)
+    with tempfile.TemporaryDirectory(prefix="automation-source-recovery-", dir=task_state_dir(target_repo)) as temporary:
+        baseline = Path(temporary) / "baseline"
+        snapshot, source_core = materialize_source_snapshot(source, receipt_revision, Path(temporary))
+        materialize_tree(target_repo, authority_head, baseline, surface_only=True)
+        before = {
+            path.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, path.relative_to(baseline).as_posix())
+            for path in baseline.rglob("*") if path.is_file()
+        }
+        plan = build_plan(baseline, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [migration for migration in load_migrations(source_core)
+                    if migration.to_version <= version_number(source_core)]
+        _, migration_blockers, _ = migration_actions(target_repo, selected)
+        if migration_blockers:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(migration_blockers))
+        returned = {item["path"] for item in plan["actions"] if item["action"] != "noop"}
+        apply_plan_to_tree(baseline, source_core, plan)
+        expected = sorted(path for path in returned
+                          if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+                          != bootstrap_fingerprint(baseline, path))
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+        candidate_versions = (plan["currentVersion"], plan["upstreamVersion"])
+    if pending_before != expected or expected != receipt_scope \
+            or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected):
+        raise UpgradeError("pending target paths do not match the reconstructed upgrade")
+    if git_head(target_repo) != authority_head or authority_branch_oid != authority_head \
+            or require_registered_task(target_repo, task_id) != (task_id, branch, worktree) \
+            or registered_worktrees(target_repo).get(worktree) != authority_registration:
+        raise UpgradeError("Task identity or HEAD changed during source recovery")
+    actual_fingerprints = {p: file_fingerprint(target_repo, p) for p in expected}
+    candidate = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": receipt["source"], "source_revision": receipt_revision,
+        "current_version": candidate_versions[0], "upstream_version": candidate_versions[1],
+        "changed_paths": receipt_scope, "authority_head": authority_head,
+        "authority_nonce": receipt["authority_nonce"], "path_fingerprints": actual_fingerprints,
+    }
+    if active.read_bytes() != raw_receipt or candidate != receipt:
+        raise UpgradeError("receipt or target changed during source recovery")
+    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+                            raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
+    proof_path = source_recovery_proof_path(target_repo)
+    created_proof: tuple[int, int] | None = None
+    try:
+        proof_admin = worktree_admin_dir(target_repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        if os.path.lexists(proof_path):
+            existing = _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof"))
+            if existing != proof:
+                raise UpgradeError("existing source-recovery proof does not match reconstruction")
+        else:
+            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+        current_source, current_implementation_revision = resolve_clean_source_worktree(source)
+        if current_source != source or current_implementation_revision != implementation_revision:
+            raise UpgradeError("source changed before source-recovery publication")
+        if active.read_bytes() != raw_receipt or authority_exists(target_repo):
+            raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
+        if (git_head(target_repo) != authority_head
+                or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip() != authority_branch_oid
+                or require_registered_task(target_repo, task_id) != (task_id, branch, worktree)
+                or registered_worktrees(target_repo).get(worktree) != authority_registration
+                or pending_paths(target_repo) != pending_before
+                or receipt_paths(target_repo, receipt) != receipt_scope
+                or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected)):
+            raise UpgradeError("target changed before source-recovery bridge publication")
+        if _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof")) != proof:
+            raise UpgradeError("source-recovery proof changed before bridge publication")
+        _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
+                            admin=worktree_admin_dir(target_repo))
+    except (OSError, UpgradeError):
+        if created_proof is not None:
+            try:
+                metadata = proof_path.lstat()
+                if (metadata.st_dev, metadata.st_ino) == created_proof:
+                    proof_path.unlink()
+            except OSError as exc:
+                raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
+        raise
+    return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
+            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+
+
 def validate_receipt_path(raw: object) -> str:
     if not isinstance(raw, str) or not raw or "\\" in raw:
         raise UpgradeError("receipt contains an unsafe path")
@@ -1468,7 +1771,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1478,7 +1781,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("no active successful automation upgrade receipt")
     try:
         receipt = json.loads(active.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise UpgradeError("invalid automation upgrade receipt") from exc
     receipt = validate_receipt_schema(receipt)
     if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
@@ -1493,7 +1796,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    authority = validate_authority(repo, receipt)
+    proof_path = source_recovery_proof_path(repo)
+    proof: dict | None = None
+    proof_raw: bytes | None = None
+    if mode == "standard":
+        authority = validate_authority(repo, receipt)
+    elif mode == "source_recovery":
+        proof_admin = worktree_admin_dir(repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        proof = _validate_recovery_proof(proof_record)
+        source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
+        if (proof["implementation_source"] != str(source)
+                or proof["implementation_revision"] != current_revision
+                or (source_root is not None and source_root != source)):
+            raise UpgradeError("source-recovery proof implementation is stale")
+        if not _source_is_compatible(receipt["source"], source):
+            raise UpgradeError("source-recovery receipt source is incompatible")
+        _validate_source_revision(source, receipt["source_revision"])
+        authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
+        if proof_path.read_bytes() != proof_raw:
+            raise UpgradeError("source-recovery proof changed before commit mutation")
+    else:  # pragma: no cover
+        raise UpgradeError("unsupported commit mode")
 
     consumed = consumed_receipt_path(repo)
     consumed_receipt = dict(receipt)
@@ -1504,6 +1829,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     commit_sha = ""
     active_moved = False
     authority_removed = False
+    proof_removed = False
     consumed_instances: set[tuple[int, int]] = set()
     try:
         if os.path.lexists(consumed):
@@ -1519,6 +1845,9 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
         authority.unlink(missing_ok=True)
         authority_removed = True
+        if mode == "source_recovery" and proof is not None:
+            proof_path.unlink()
+            proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
         index_environment = {"GIT_INDEX_FILE": str(private_index)}
@@ -1571,24 +1900,25 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
     except (UpgradeError, OSError) as failure:
         if committed:
-            if isinstance(failure, OSError):
-                raise UpgradeError("commit finalization failed") from failure
-            raise
+            raise UpgradeError(
+                f"commit {commit_sha} was published but finalization failed"
+            ) from failure
         rollback_errors: list[str] = []
         try:
+            if proof_removed and proof is not None:
+                if proof_raw is None:
+                    raise UpgradeError("source-recovery proof bytes were not captured")
+                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"proof restore failed: {rollback_error}")
+        try:
             if authority_removed:
-                _write_authority_at(
-                    authority,
-                    {
-                        "schema_version": 1,
-                        "task_id": receipt["task_id"],
-                        "branch": receipt["branch"],
-                        "worktree": receipt["worktree"],
-                        "authority_nonce": receipt["authority_nonce"],
-                        "receipt_sha256": receipt_digest(receipt),
-                    },
-                    admin=_rollback_authority_guard(repo, authority),
-                )
+                restored = _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()) if mode == "source_recovery" and proof is not None else {
+                    "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                    "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                    "receipt_sha256": receipt_digest(receipt),
+                }
+                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -1622,7 +1952,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
             private_index.unlink(missing_ok=True)
         except OSError as cleanup_error:
             raise UpgradeError("private index cleanup failed") from cleanup_error
-    return {"status": "COMMITTED", "commit_sha": commit_sha}
+    result: dict[str, str | bool | list[str]] = {
+        "status": "COMMITTED", "commit_sha": commit_sha,
+    }
+    if mode == "source_recovery":
+        result.update({
+            "commitCreated": True,
+            "changedPaths": paths,
+            "pushPerformed": False,
+            "mergePerformed": False,
+        })
+    return result
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, object]:
+    return _commit_mode(repo, task, message, "standard")
+
+
+def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+    """Commit only a proof-bound source recovery; no network or merge operation is performed."""
+    # The source argument is deliberately checked before the receipt is opened, and
+    # is not a target mutation/apply hook.
+    source, _ = resolve_clean_source_worktree(templates_source_root)
+    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -23,6 +23,7 @@ class UpgradeError(RuntimeError):
 
 RECEIPT_NAME = "automation-maintenance.json"
 CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+SOURCE_RECOVERY_PROOF_NAME = "source-recovery-proof.json"
 TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 RECEIPT_FIELDS = {
     "schema_version",
@@ -130,6 +131,12 @@ def authority_path(repo: Path) -> Path:
     return _authority_locations(repo)[0]
 
 
+def source_recovery_proof_path(repo: Path) -> Path:
+    """Return the proof path, using the same containment guard as authority."""
+    authority = authority_path(repo)
+    return authority.parent / SOURCE_RECOVERY_PROOF_NAME
+
+
 def canonical_json(value: dict) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
@@ -218,6 +225,48 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
     return path
 
 
+def _read_json_record(path: Path, error: str) -> dict:
+    _, value = _read_json_record_bytes(path, error)
+    return value
+
+
+def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError(error)
+        raw = path.read_bytes()
+        value = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError(error) from exc
+    if not isinstance(value, dict):
+        raise UpgradeError(error)
+    return raw, value
+
+
+def _bridge_authority_path(repo: Path) -> Path:
+    return authority_path(repo)
+
+
+def _bridge_authority(receipt: dict, proof_digest: str) -> dict:
+    return {
+        "schema_version": 2,
+        "kind": "source-recovery-bridge",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "proof_sha256": proof_digest,
+    }
+
+
+def _validate_no_authority(repo: Path) -> None:
+    new_path, legacy_path = _authority_locations(repo)
+    if os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path)):
+        raise UpgradeError("cannot recover with an existing authority record")
+
+
 def authority_exists(repo: Path) -> bool:
     new_path, legacy_path = _authority_locations(repo)
     return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
@@ -303,6 +352,53 @@ def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
             temporary.unlink(missing_ok=True)
         except OSError as exc:
             raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_bytes_write(path: Path, content: bytes) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError(f"cannot publish record over an existing record: {path}") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish record: {path}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _validate_admin_record_parent(path: Path, admin: Path) -> None:
+    try:
+        resolved_admin = admin.resolve()
+        parent = path.parent.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise UpgradeError("record path containment cannot be validated") from exc
+    if parent != resolved_admin and resolved_admin not in parent.parents:
+        raise UpgradeError("record path escapes the worktree administrative directory")
+
+
+def exclusive_json_write_contained(path: Path, value: dict, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_json_write(path, value)
+    _validate_admin_record_parent(path, admin)
+    return result
+
+
+def exclusive_bytes_write_contained(path: Path, content: bytes, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_bytes_write(path, content)
+    _validate_admin_record_parent(path, admin)
+    return result
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -556,6 +652,41 @@ def resolve_pinned_source(path: Path) -> tuple[Path, str]:
     if status:
         raise UpgradeError("source components/agent-core must be clean")
     return source, head
+
+
+def resolve_clean_source_worktree(path: Path) -> tuple[Path, str]:
+    """Validate the whole Templates checkout for source-side recovery."""
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    if git_bytes(["git", "status", "--porcelain=v1", "-z"], cwd=source):
+        raise UpgradeError("Templates source worktree must be clean")
+    return source, head
+
+
+def _source_is_compatible(receipt_source: str, source: Path) -> bool:
+    candidate = Path(receipt_source)
+    if not candidate.is_absolute() or not candidate.exists() or not candidate.is_dir():
+        return False
+    try:
+        candidate = candidate.resolve()
+        top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=candidate).stdout.strip()).resolve()
+        return top == candidate and (
+            candidate == source or common_git_dir(candidate) == common_git_dir(source)
+        )
+    except (OSError, UpgradeError, ValueError, RuntimeError):
+        return False
+
+
+def _validate_source_revision(source: Path, revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError("receipt source_revision must be a full lowercase hexadecimal Git revision")
+    result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
+    if result.returncode != 0 or result.stdout.strip() != revision:
+        raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -1358,6 +1489,178 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
+PROOF_FIELDS = {
+    "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+    "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+    "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+    "receipt_source", "receipt_source_revision",
+}
+
+
+def _recovery_proof(receipt: dict, *, implementation_source: Path, implementation_revision: str,
+                    raw_receipt: bytes, paths: list[str], fingerprints: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "kind": "source-recovery-proof",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_head": receipt["authority_head"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "receipt_bytes_sha256": hashlib.sha256(raw_receipt).hexdigest(),
+        "changed_paths_sha256": hashlib.sha256(canonical_json({"changed_paths": paths})).hexdigest(),
+        "path_fingerprints_sha256": hashlib.sha256(canonical_json(fingerprints)).hexdigest(),
+        "implementation_source": str(implementation_source),
+        "implementation_revision": implementation_revision,
+        "receipt_source": receipt["source"],
+        "receipt_source_revision": receipt["source_revision"],
+    }
+
+
+def _validate_recovery_proof(proof: object) -> dict:
+    if not isinstance(proof, dict) or set(proof) != PROOF_FIELDS or proof.get("schema_version") != 1 \
+            or proof.get("kind") != "source-recovery-proof":
+        raise UpgradeError("missing or invalid source-recovery proof")
+    for key in ("task_id", "branch", "worktree", "authority_head", "authority_nonce",
+                "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+                "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+                "receipt_source", "receipt_source_revision"):
+        if not isinstance(proof[key], str) or not proof[key]:
+            raise UpgradeError("missing or invalid source-recovery proof")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", proof["implementation_revision"]):
+        raise UpgradeError("invalid source-recovery implementation revision")
+    for key in ("receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256"):
+        if not re.fullmatch(r"[0-9a-f]{64}", proof[key]):
+            raise UpgradeError("invalid source-recovery proof digest")
+    return proof
+
+
+def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, proof: dict) -> Path:
+    expected = _recovery_proof(
+        receipt,
+        implementation_source=Path(proof["implementation_source"]),
+        implementation_revision=proof["implementation_revision"],
+        raw_receipt=raw_receipt,
+        paths=receipt["changed_paths"],
+        fingerprints=receipt["path_fingerprints"],
+    )
+    if proof != expected:
+        raise UpgradeError("source-recovery proof does not match the reconstructed receipt")
+    authority = _read_json_record(_bridge_authority_path(repo), "missing or invalid source-recovery authority")
+    if authority != _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()):
+        raise UpgradeError("source-recovery authority does not match its proof")
+    return _bridge_authority_path(repo)
+
+
+def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+    """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    task_id, branch, worktree = require_maintenance(target_repo)
+    source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    active = receipt_path(target_repo)
+    if not active.is_file():
+        raise UpgradeError("no active automation upgrade receipt")
+    try:
+        raw_receipt = active.read_bytes()
+        receipt = validate_receipt_schema(json.loads(raw_receipt.decode("utf-8")))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt_scope = receipt_paths(target_repo, receipt)
+    if receipt["source_revision"] is None or not _source_is_compatible(receipt["source"], source):
+        raise UpgradeError("receipt source is not compatible with the current Templates source")
+    receipt_revision = _validate_source_revision(source, receipt["source_revision"])
+    if (receipt["task_id"], receipt["branch"], receipt["worktree"]) != (task_id, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    _validate_no_authority(target_repo)
+    authority_head = receipt["authority_head"]
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip()
+    authority_registration = registered_worktrees(target_repo).get(worktree)
+    pending_before = pending_paths(target_repo)
+    for pending in pending_before:
+        reject_bootstrap_path(target_repo, pending)
+    with tempfile.TemporaryDirectory(prefix="automation-source-recovery-", dir=task_state_dir(target_repo)) as temporary:
+        baseline = Path(temporary) / "baseline"
+        snapshot, source_core = materialize_source_snapshot(source, receipt_revision, Path(temporary))
+        materialize_tree(target_repo, authority_head, baseline, surface_only=True)
+        before = {
+            path.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, path.relative_to(baseline).as_posix())
+            for path in baseline.rglob("*") if path.is_file()
+        }
+        plan = build_plan(baseline, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [migration for migration in load_migrations(source_core)
+                    if migration.to_version <= version_number(source_core)]
+        _, migration_blockers, _ = migration_actions(target_repo, selected)
+        if migration_blockers:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(migration_blockers))
+        returned = {item["path"] for item in plan["actions"] if item["action"] != "noop"}
+        apply_plan_to_tree(baseline, source_core, plan)
+        expected = sorted(path for path in returned
+                          if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+                          != bootstrap_fingerprint(baseline, path))
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+        candidate_versions = (plan["currentVersion"], plan["upstreamVersion"])
+    if pending_before != expected or expected != receipt_scope \
+            or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected):
+        raise UpgradeError("pending target paths do not match the reconstructed upgrade")
+    if git_head(target_repo) != authority_head or authority_branch_oid != authority_head \
+            or require_registered_task(target_repo, task_id) != (task_id, branch, worktree) \
+            or registered_worktrees(target_repo).get(worktree) != authority_registration:
+        raise UpgradeError("Task identity or HEAD changed during source recovery")
+    actual_fingerprints = {p: file_fingerprint(target_repo, p) for p in expected}
+    candidate = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": receipt["source"], "source_revision": receipt_revision,
+        "current_version": candidate_versions[0], "upstream_version": candidate_versions[1],
+        "changed_paths": receipt_scope, "authority_head": authority_head,
+        "authority_nonce": receipt["authority_nonce"], "path_fingerprints": actual_fingerprints,
+    }
+    if active.read_bytes() != raw_receipt or candidate != receipt:
+        raise UpgradeError("receipt or target changed during source recovery")
+    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+                            raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
+    proof_path = source_recovery_proof_path(target_repo)
+    created_proof: tuple[int, int] | None = None
+    try:
+        proof_admin = worktree_admin_dir(target_repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        if os.path.lexists(proof_path):
+            existing = _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof"))
+            if existing != proof:
+                raise UpgradeError("existing source-recovery proof does not match reconstruction")
+        else:
+            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+        current_source, current_implementation_revision = resolve_clean_source_worktree(source)
+        if current_source != source or current_implementation_revision != implementation_revision:
+            raise UpgradeError("source changed before source-recovery publication")
+        if active.read_bytes() != raw_receipt or authority_exists(target_repo):
+            raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
+        if (git_head(target_repo) != authority_head
+                or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip() != authority_branch_oid
+                or require_registered_task(target_repo, task_id) != (task_id, branch, worktree)
+                or registered_worktrees(target_repo).get(worktree) != authority_registration
+                or pending_paths(target_repo) != pending_before
+                or receipt_paths(target_repo, receipt) != receipt_scope
+                or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected)):
+            raise UpgradeError("target changed before source-recovery bridge publication")
+        if _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof")) != proof:
+            raise UpgradeError("source-recovery proof changed before bridge publication")
+        _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
+                            admin=worktree_admin_dir(target_repo))
+    except (OSError, UpgradeError):
+        if created_proof is not None:
+            try:
+                metadata = proof_path.lstat()
+                if (metadata.st_dev, metadata.st_ino) == created_proof:
+                    proof_path.unlink()
+            except OSError as exc:
+                raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
+        raise
+    return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
+            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+
+
 def validate_receipt_path(raw: object) -> str:
     if not isinstance(raw, str) or not raw or "\\" in raw:
         raise UpgradeError("receipt contains an unsafe path")
@@ -1468,7 +1771,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1478,7 +1781,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("no active successful automation upgrade receipt")
     try:
         receipt = json.loads(active.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise UpgradeError("invalid automation upgrade receipt") from exc
     receipt = validate_receipt_schema(receipt)
     if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
@@ -1493,7 +1796,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    authority = validate_authority(repo, receipt)
+    proof_path = source_recovery_proof_path(repo)
+    proof: dict | None = None
+    proof_raw: bytes | None = None
+    if mode == "standard":
+        authority = validate_authority(repo, receipt)
+    elif mode == "source_recovery":
+        proof_admin = worktree_admin_dir(repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        proof = _validate_recovery_proof(proof_record)
+        source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
+        if (proof["implementation_source"] != str(source)
+                or proof["implementation_revision"] != current_revision
+                or (source_root is not None and source_root != source)):
+            raise UpgradeError("source-recovery proof implementation is stale")
+        if not _source_is_compatible(receipt["source"], source):
+            raise UpgradeError("source-recovery receipt source is incompatible")
+        _validate_source_revision(source, receipt["source_revision"])
+        authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
+        if proof_path.read_bytes() != proof_raw:
+            raise UpgradeError("source-recovery proof changed before commit mutation")
+    else:  # pragma: no cover
+        raise UpgradeError("unsupported commit mode")
 
     consumed = consumed_receipt_path(repo)
     consumed_receipt = dict(receipt)
@@ -1504,6 +1829,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     commit_sha = ""
     active_moved = False
     authority_removed = False
+    proof_removed = False
     consumed_instances: set[tuple[int, int]] = set()
     try:
         if os.path.lexists(consumed):
@@ -1519,6 +1845,9 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
         authority.unlink(missing_ok=True)
         authority_removed = True
+        if mode == "source_recovery" and proof is not None:
+            proof_path.unlink()
+            proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
         index_environment = {"GIT_INDEX_FILE": str(private_index)}
@@ -1571,24 +1900,25 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
     except (UpgradeError, OSError) as failure:
         if committed:
-            if isinstance(failure, OSError):
-                raise UpgradeError("commit finalization failed") from failure
-            raise
+            raise UpgradeError(
+                f"commit {commit_sha} was published but finalization failed"
+            ) from failure
         rollback_errors: list[str] = []
         try:
+            if proof_removed and proof is not None:
+                if proof_raw is None:
+                    raise UpgradeError("source-recovery proof bytes were not captured")
+                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"proof restore failed: {rollback_error}")
+        try:
             if authority_removed:
-                _write_authority_at(
-                    authority,
-                    {
-                        "schema_version": 1,
-                        "task_id": receipt["task_id"],
-                        "branch": receipt["branch"],
-                        "worktree": receipt["worktree"],
-                        "authority_nonce": receipt["authority_nonce"],
-                        "receipt_sha256": receipt_digest(receipt),
-                    },
-                    admin=_rollback_authority_guard(repo, authority),
-                )
+                restored = _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()) if mode == "source_recovery" and proof is not None else {
+                    "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                    "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                    "receipt_sha256": receipt_digest(receipt),
+                }
+                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -1622,7 +1952,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
             private_index.unlink(missing_ok=True)
         except OSError as cleanup_error:
             raise UpgradeError("private index cleanup failed") from cleanup_error
-    return {"status": "COMMITTED", "commit_sha": commit_sha}
+    result: dict[str, str | bool | list[str]] = {
+        "status": "COMMITTED", "commit_sha": commit_sha,
+    }
+    if mode == "source_recovery":
+        result.update({
+            "commitCreated": True,
+            "changedPaths": paths,
+            "pushPerformed": False,
+            "mergePerformed": False,
+        })
+    return result
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, object]:
+    return _commit_mode(repo, task, message, "standard")
+
+
+def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+    """Commit only a proof-bound source recovery; no network or merge operation is performed."""
+    # The source argument is deliberately checked before the receipt is opened, and
+    # is not a target mutation/apply hook.
+    source, _ = resolve_clean_source_worktree(templates_source_root)
+    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -23,6 +23,7 @@ class UpgradeError(RuntimeError):
 
 RECEIPT_NAME = "automation-maintenance.json"
 CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+SOURCE_RECOVERY_PROOF_NAME = "source-recovery-proof.json"
 TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 RECEIPT_FIELDS = {
     "schema_version",
@@ -130,6 +131,12 @@ def authority_path(repo: Path) -> Path:
     return _authority_locations(repo)[0]
 
 
+def source_recovery_proof_path(repo: Path) -> Path:
+    """Return the proof path, using the same containment guard as authority."""
+    authority = authority_path(repo)
+    return authority.parent / SOURCE_RECOVERY_PROOF_NAME
+
+
 def canonical_json(value: dict) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
@@ -218,6 +225,48 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
     return path
 
 
+def _read_json_record(path: Path, error: str) -> dict:
+    _, value = _read_json_record_bytes(path, error)
+    return value
+
+
+def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError(error)
+        raw = path.read_bytes()
+        value = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError(error) from exc
+    if not isinstance(value, dict):
+        raise UpgradeError(error)
+    return raw, value
+
+
+def _bridge_authority_path(repo: Path) -> Path:
+    return authority_path(repo)
+
+
+def _bridge_authority(receipt: dict, proof_digest: str) -> dict:
+    return {
+        "schema_version": 2,
+        "kind": "source-recovery-bridge",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "proof_sha256": proof_digest,
+    }
+
+
+def _validate_no_authority(repo: Path) -> None:
+    new_path, legacy_path = _authority_locations(repo)
+    if os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path)):
+        raise UpgradeError("cannot recover with an existing authority record")
+
+
 def authority_exists(repo: Path) -> bool:
     new_path, legacy_path = _authority_locations(repo)
     return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
@@ -303,6 +352,53 @@ def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
             temporary.unlink(missing_ok=True)
         except OSError as exc:
             raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_bytes_write(path: Path, content: bytes) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError(f"cannot publish record over an existing record: {path}") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish record: {path}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _validate_admin_record_parent(path: Path, admin: Path) -> None:
+    try:
+        resolved_admin = admin.resolve()
+        parent = path.parent.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise UpgradeError("record path containment cannot be validated") from exc
+    if parent != resolved_admin and resolved_admin not in parent.parents:
+        raise UpgradeError("record path escapes the worktree administrative directory")
+
+
+def exclusive_json_write_contained(path: Path, value: dict, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_json_write(path, value)
+    _validate_admin_record_parent(path, admin)
+    return result
+
+
+def exclusive_bytes_write_contained(path: Path, content: bytes, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_bytes_write(path, content)
+    _validate_admin_record_parent(path, admin)
+    return result
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -556,6 +652,41 @@ def resolve_pinned_source(path: Path) -> tuple[Path, str]:
     if status:
         raise UpgradeError("source components/agent-core must be clean")
     return source, head
+
+
+def resolve_clean_source_worktree(path: Path) -> tuple[Path, str]:
+    """Validate the whole Templates checkout for source-side recovery."""
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    if git_bytes(["git", "status", "--porcelain=v1", "-z"], cwd=source):
+        raise UpgradeError("Templates source worktree must be clean")
+    return source, head
+
+
+def _source_is_compatible(receipt_source: str, source: Path) -> bool:
+    candidate = Path(receipt_source)
+    if not candidate.is_absolute() or not candidate.exists() or not candidate.is_dir():
+        return False
+    try:
+        candidate = candidate.resolve()
+        top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=candidate).stdout.strip()).resolve()
+        return top == candidate and (
+            candidate == source or common_git_dir(candidate) == common_git_dir(source)
+        )
+    except (OSError, UpgradeError, ValueError, RuntimeError):
+        return False
+
+
+def _validate_source_revision(source: Path, revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError("receipt source_revision must be a full lowercase hexadecimal Git revision")
+    result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
+    if result.returncode != 0 or result.stdout.strip() != revision:
+        raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -1358,6 +1489,178 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
+PROOF_FIELDS = {
+    "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+    "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+    "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+    "receipt_source", "receipt_source_revision",
+}
+
+
+def _recovery_proof(receipt: dict, *, implementation_source: Path, implementation_revision: str,
+                    raw_receipt: bytes, paths: list[str], fingerprints: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "kind": "source-recovery-proof",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_head": receipt["authority_head"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "receipt_bytes_sha256": hashlib.sha256(raw_receipt).hexdigest(),
+        "changed_paths_sha256": hashlib.sha256(canonical_json({"changed_paths": paths})).hexdigest(),
+        "path_fingerprints_sha256": hashlib.sha256(canonical_json(fingerprints)).hexdigest(),
+        "implementation_source": str(implementation_source),
+        "implementation_revision": implementation_revision,
+        "receipt_source": receipt["source"],
+        "receipt_source_revision": receipt["source_revision"],
+    }
+
+
+def _validate_recovery_proof(proof: object) -> dict:
+    if not isinstance(proof, dict) or set(proof) != PROOF_FIELDS or proof.get("schema_version") != 1 \
+            or proof.get("kind") != "source-recovery-proof":
+        raise UpgradeError("missing or invalid source-recovery proof")
+    for key in ("task_id", "branch", "worktree", "authority_head", "authority_nonce",
+                "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+                "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+                "receipt_source", "receipt_source_revision"):
+        if not isinstance(proof[key], str) or not proof[key]:
+            raise UpgradeError("missing or invalid source-recovery proof")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", proof["implementation_revision"]):
+        raise UpgradeError("invalid source-recovery implementation revision")
+    for key in ("receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256"):
+        if not re.fullmatch(r"[0-9a-f]{64}", proof[key]):
+            raise UpgradeError("invalid source-recovery proof digest")
+    return proof
+
+
+def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, proof: dict) -> Path:
+    expected = _recovery_proof(
+        receipt,
+        implementation_source=Path(proof["implementation_source"]),
+        implementation_revision=proof["implementation_revision"],
+        raw_receipt=raw_receipt,
+        paths=receipt["changed_paths"],
+        fingerprints=receipt["path_fingerprints"],
+    )
+    if proof != expected:
+        raise UpgradeError("source-recovery proof does not match the reconstructed receipt")
+    authority = _read_json_record(_bridge_authority_path(repo), "missing or invalid source-recovery authority")
+    if authority != _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()):
+        raise UpgradeError("source-recovery authority does not match its proof")
+    return _bridge_authority_path(repo)
+
+
+def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+    """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    task_id, branch, worktree = require_maintenance(target_repo)
+    source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    active = receipt_path(target_repo)
+    if not active.is_file():
+        raise UpgradeError("no active automation upgrade receipt")
+    try:
+        raw_receipt = active.read_bytes()
+        receipt = validate_receipt_schema(json.loads(raw_receipt.decode("utf-8")))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt_scope = receipt_paths(target_repo, receipt)
+    if receipt["source_revision"] is None or not _source_is_compatible(receipt["source"], source):
+        raise UpgradeError("receipt source is not compatible with the current Templates source")
+    receipt_revision = _validate_source_revision(source, receipt["source_revision"])
+    if (receipt["task_id"], receipt["branch"], receipt["worktree"]) != (task_id, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    _validate_no_authority(target_repo)
+    authority_head = receipt["authority_head"]
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip()
+    authority_registration = registered_worktrees(target_repo).get(worktree)
+    pending_before = pending_paths(target_repo)
+    for pending in pending_before:
+        reject_bootstrap_path(target_repo, pending)
+    with tempfile.TemporaryDirectory(prefix="automation-source-recovery-", dir=task_state_dir(target_repo)) as temporary:
+        baseline = Path(temporary) / "baseline"
+        snapshot, source_core = materialize_source_snapshot(source, receipt_revision, Path(temporary))
+        materialize_tree(target_repo, authority_head, baseline, surface_only=True)
+        before = {
+            path.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, path.relative_to(baseline).as_posix())
+            for path in baseline.rglob("*") if path.is_file()
+        }
+        plan = build_plan(baseline, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [migration for migration in load_migrations(source_core)
+                    if migration.to_version <= version_number(source_core)]
+        _, migration_blockers, _ = migration_actions(target_repo, selected)
+        if migration_blockers:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(migration_blockers))
+        returned = {item["path"] for item in plan["actions"] if item["action"] != "noop"}
+        apply_plan_to_tree(baseline, source_core, plan)
+        expected = sorted(path for path in returned
+                          if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+                          != bootstrap_fingerprint(baseline, path))
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+        candidate_versions = (plan["currentVersion"], plan["upstreamVersion"])
+    if pending_before != expected or expected != receipt_scope \
+            or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected):
+        raise UpgradeError("pending target paths do not match the reconstructed upgrade")
+    if git_head(target_repo) != authority_head or authority_branch_oid != authority_head \
+            or require_registered_task(target_repo, task_id) != (task_id, branch, worktree) \
+            or registered_worktrees(target_repo).get(worktree) != authority_registration:
+        raise UpgradeError("Task identity or HEAD changed during source recovery")
+    actual_fingerprints = {p: file_fingerprint(target_repo, p) for p in expected}
+    candidate = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": receipt["source"], "source_revision": receipt_revision,
+        "current_version": candidate_versions[0], "upstream_version": candidate_versions[1],
+        "changed_paths": receipt_scope, "authority_head": authority_head,
+        "authority_nonce": receipt["authority_nonce"], "path_fingerprints": actual_fingerprints,
+    }
+    if active.read_bytes() != raw_receipt or candidate != receipt:
+        raise UpgradeError("receipt or target changed during source recovery")
+    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+                            raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
+    proof_path = source_recovery_proof_path(target_repo)
+    created_proof: tuple[int, int] | None = None
+    try:
+        proof_admin = worktree_admin_dir(target_repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        if os.path.lexists(proof_path):
+            existing = _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof"))
+            if existing != proof:
+                raise UpgradeError("existing source-recovery proof does not match reconstruction")
+        else:
+            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+        current_source, current_implementation_revision = resolve_clean_source_worktree(source)
+        if current_source != source or current_implementation_revision != implementation_revision:
+            raise UpgradeError("source changed before source-recovery publication")
+        if active.read_bytes() != raw_receipt or authority_exists(target_repo):
+            raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
+        if (git_head(target_repo) != authority_head
+                or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip() != authority_branch_oid
+                or require_registered_task(target_repo, task_id) != (task_id, branch, worktree)
+                or registered_worktrees(target_repo).get(worktree) != authority_registration
+                or pending_paths(target_repo) != pending_before
+                or receipt_paths(target_repo, receipt) != receipt_scope
+                or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected)):
+            raise UpgradeError("target changed before source-recovery bridge publication")
+        if _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof")) != proof:
+            raise UpgradeError("source-recovery proof changed before bridge publication")
+        _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
+                            admin=worktree_admin_dir(target_repo))
+    except (OSError, UpgradeError):
+        if created_proof is not None:
+            try:
+                metadata = proof_path.lstat()
+                if (metadata.st_dev, metadata.st_ino) == created_proof:
+                    proof_path.unlink()
+            except OSError as exc:
+                raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
+        raise
+    return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
+            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+
+
 def validate_receipt_path(raw: object) -> str:
     if not isinstance(raw, str) or not raw or "\\" in raw:
         raise UpgradeError("receipt contains an unsafe path")
@@ -1468,7 +1771,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1478,7 +1781,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("no active successful automation upgrade receipt")
     try:
         receipt = json.loads(active.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise UpgradeError("invalid automation upgrade receipt") from exc
     receipt = validate_receipt_schema(receipt)
     if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
@@ -1493,7 +1796,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    authority = validate_authority(repo, receipt)
+    proof_path = source_recovery_proof_path(repo)
+    proof: dict | None = None
+    proof_raw: bytes | None = None
+    if mode == "standard":
+        authority = validate_authority(repo, receipt)
+    elif mode == "source_recovery":
+        proof_admin = worktree_admin_dir(repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        proof = _validate_recovery_proof(proof_record)
+        source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
+        if (proof["implementation_source"] != str(source)
+                or proof["implementation_revision"] != current_revision
+                or (source_root is not None and source_root != source)):
+            raise UpgradeError("source-recovery proof implementation is stale")
+        if not _source_is_compatible(receipt["source"], source):
+            raise UpgradeError("source-recovery receipt source is incompatible")
+        _validate_source_revision(source, receipt["source_revision"])
+        authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
+        if proof_path.read_bytes() != proof_raw:
+            raise UpgradeError("source-recovery proof changed before commit mutation")
+    else:  # pragma: no cover
+        raise UpgradeError("unsupported commit mode")
 
     consumed = consumed_receipt_path(repo)
     consumed_receipt = dict(receipt)
@@ -1504,6 +1829,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     commit_sha = ""
     active_moved = False
     authority_removed = False
+    proof_removed = False
     consumed_instances: set[tuple[int, int]] = set()
     try:
         if os.path.lexists(consumed):
@@ -1519,6 +1845,9 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
         authority.unlink(missing_ok=True)
         authority_removed = True
+        if mode == "source_recovery" and proof is not None:
+            proof_path.unlink()
+            proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
         index_environment = {"GIT_INDEX_FILE": str(private_index)}
@@ -1571,24 +1900,25 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
     except (UpgradeError, OSError) as failure:
         if committed:
-            if isinstance(failure, OSError):
-                raise UpgradeError("commit finalization failed") from failure
-            raise
+            raise UpgradeError(
+                f"commit {commit_sha} was published but finalization failed"
+            ) from failure
         rollback_errors: list[str] = []
         try:
+            if proof_removed and proof is not None:
+                if proof_raw is None:
+                    raise UpgradeError("source-recovery proof bytes were not captured")
+                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"proof restore failed: {rollback_error}")
+        try:
             if authority_removed:
-                _write_authority_at(
-                    authority,
-                    {
-                        "schema_version": 1,
-                        "task_id": receipt["task_id"],
-                        "branch": receipt["branch"],
-                        "worktree": receipt["worktree"],
-                        "authority_nonce": receipt["authority_nonce"],
-                        "receipt_sha256": receipt_digest(receipt),
-                    },
-                    admin=_rollback_authority_guard(repo, authority),
-                )
+                restored = _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()) if mode == "source_recovery" and proof is not None else {
+                    "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                    "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                    "receipt_sha256": receipt_digest(receipt),
+                }
+                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -1622,7 +1952,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
             private_index.unlink(missing_ok=True)
         except OSError as cleanup_error:
             raise UpgradeError("private index cleanup failed") from cleanup_error
-    return {"status": "COMMITTED", "commit_sha": commit_sha}
+    result: dict[str, str | bool | list[str]] = {
+        "status": "COMMITTED", "commit_sha": commit_sha,
+    }
+    if mode == "source_recovery":
+        result.update({
+            "commitCreated": True,
+            "changedPaths": paths,
+            "pushPerformed": False,
+            "mergePerformed": False,
+        })
+    return result
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, object]:
+    return _commit_mode(repo, task, message, "standard")
+
+
+def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+    """Commit only a proof-bound source recovery; no network or merge operation is performed."""
+    # The source argument is deliberately checked before the receipt is opened, and
+    # is not a target mutation/apply hook.
+    source, _ = resolve_clean_source_worktree(templates_source_root)
+    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -23,6 +23,7 @@ class UpgradeError(RuntimeError):
 
 RECEIPT_NAME = "automation-maintenance.json"
 CONSUMED_RECEIPT_NAME = "automation-maintenance.consumed.json"
+SOURCE_RECOVERY_PROOF_NAME = "source-recovery-proof.json"
 TASK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 RECEIPT_FIELDS = {
     "schema_version",
@@ -130,6 +131,12 @@ def authority_path(repo: Path) -> Path:
     return _authority_locations(repo)[0]
 
 
+def source_recovery_proof_path(repo: Path) -> Path:
+    """Return the proof path, using the same containment guard as authority."""
+    authority = authority_path(repo)
+    return authority.parent / SOURCE_RECOVERY_PROOF_NAME
+
+
 def canonical_json(value: dict) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
@@ -218,6 +225,48 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
     return path
 
 
+def _read_json_record(path: Path, error: str) -> dict:
+    _, value = _read_json_record_bytes(path, error)
+    return value
+
+
+def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
+    try:
+        metadata = path.lstat()
+        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+            raise UpgradeError(error)
+        raw = path.read_bytes()
+        value = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError(error) from exc
+    if not isinstance(value, dict):
+        raise UpgradeError(error)
+    return raw, value
+
+
+def _bridge_authority_path(repo: Path) -> Path:
+    return authority_path(repo)
+
+
+def _bridge_authority(receipt: dict, proof_digest: str) -> dict:
+    return {
+        "schema_version": 2,
+        "kind": "source-recovery-bridge",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "proof_sha256": proof_digest,
+    }
+
+
+def _validate_no_authority(repo: Path) -> None:
+    new_path, legacy_path = _authority_locations(repo)
+    if os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path)):
+        raise UpgradeError("cannot recover with an existing authority record")
+
+
 def authority_exists(repo: Path) -> bool:
     new_path, legacy_path = _authority_locations(repo)
     return os.path.lexists(new_path) or (legacy_path is not None and os.path.lexists(legacy_path))
@@ -303,6 +352,53 @@ def exclusive_json_write(path: Path, value: dict) -> tuple[int, int]:
             temporary.unlink(missing_ok=True)
         except OSError as exc:
             raise UpgradeError(f"cannot clean temporary JSON record: {temporary}") from exc
+
+
+def exclusive_bytes_write(path: Path, content: bytes) -> tuple[int, int]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            try:
+                os.fsync(stream.fileno())
+            except OSError:
+                pass
+        os.link(temporary, path, follow_symlinks=False)
+        metadata = path.lstat()
+        return metadata.st_dev, metadata.st_ino
+    except FileExistsError as exc:
+        raise UpgradeError(f"cannot publish record over an existing record: {path}") from exc
+    except OSError as exc:
+        raise UpgradeError(f"cannot publish record: {path}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _validate_admin_record_parent(path: Path, admin: Path) -> None:
+    try:
+        resolved_admin = admin.resolve()
+        parent = path.parent.resolve()
+    except (OSError, ValueError, RuntimeError) as exc:
+        raise UpgradeError("record path containment cannot be validated") from exc
+    if parent != resolved_admin and resolved_admin not in parent.parents:
+        raise UpgradeError("record path escapes the worktree administrative directory")
+
+
+def exclusive_json_write_contained(path: Path, value: dict, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_json_write(path, value)
+    _validate_admin_record_parent(path, admin)
+    return result
+
+
+def exclusive_bytes_write_contained(path: Path, content: bytes, *, admin: Path) -> tuple[int, int]:
+    _validate_admin_record_parent(path, admin)
+    result = exclusive_bytes_write(path, content)
+    _validate_admin_record_parent(path, admin)
+    return result
 
 
 def file_fingerprint(repo: Path, raw_path: str) -> dict[str, object]:
@@ -556,6 +652,41 @@ def resolve_pinned_source(path: Path) -> tuple[Path, str]:
     if status:
         raise UpgradeError("source components/agent-core must be clean")
     return source, head
+
+
+def resolve_clean_source_worktree(path: Path) -> tuple[Path, str]:
+    """Validate the whole Templates checkout for source-side recovery."""
+    source = resolve_source(path)
+    top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=source).stdout.strip()).resolve()
+    head = git_head(source)
+    if top != source or not re.fullmatch(r"[0-9a-f]{40,64}", head):
+        raise UpgradeError("source must be a Git worktree root with a full non-null HEAD")
+    if git_bytes(["git", "status", "--porcelain=v1", "-z"], cwd=source):
+        raise UpgradeError("Templates source worktree must be clean")
+    return source, head
+
+
+def _source_is_compatible(receipt_source: str, source: Path) -> bool:
+    candidate = Path(receipt_source)
+    if not candidate.is_absolute() or not candidate.exists() or not candidate.is_dir():
+        return False
+    try:
+        candidate = candidate.resolve()
+        top = Path(run(["git", "rev-parse", "--show-toplevel"], cwd=candidate).stdout.strip()).resolve()
+        return top == candidate and (
+            candidate == source or common_git_dir(candidate) == common_git_dir(source)
+        )
+    except (OSError, UpgradeError, ValueError, RuntimeError):
+        return False
+
+
+def _validate_source_revision(source: Path, revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError("receipt source_revision must be a full lowercase hexadecimal Git revision")
+    result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
+    if result.returncode != 0 or result.stdout.strip() != revision:
+        raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
 
 
 def load_ownership(repo: Path) -> dict[str, str]:
@@ -1358,6 +1489,178 @@ def bootstrap_receipt(repo: Path, source_path: Path) -> dict:
     return {"status": "RECEIPT_BOOTSTRAPPED", "changedPaths": expected, "authorityIssued": True}
 
 
+PROOF_FIELDS = {
+    "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+    "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+    "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+    "receipt_source", "receipt_source_revision",
+}
+
+
+def _recovery_proof(receipt: dict, *, implementation_source: Path, implementation_revision: str,
+                    raw_receipt: bytes, paths: list[str], fingerprints: dict) -> dict:
+    return {
+        "schema_version": 1,
+        "kind": "source-recovery-proof",
+        "task_id": receipt["task_id"],
+        "branch": receipt["branch"],
+        "worktree": receipt["worktree"],
+        "authority_head": receipt["authority_head"],
+        "authority_nonce": receipt["authority_nonce"],
+        "receipt_sha256": receipt_digest(receipt),
+        "receipt_bytes_sha256": hashlib.sha256(raw_receipt).hexdigest(),
+        "changed_paths_sha256": hashlib.sha256(canonical_json({"changed_paths": paths})).hexdigest(),
+        "path_fingerprints_sha256": hashlib.sha256(canonical_json(fingerprints)).hexdigest(),
+        "implementation_source": str(implementation_source),
+        "implementation_revision": implementation_revision,
+        "receipt_source": receipt["source"],
+        "receipt_source_revision": receipt["source_revision"],
+    }
+
+
+def _validate_recovery_proof(proof: object) -> dict:
+    if not isinstance(proof, dict) or set(proof) != PROOF_FIELDS or proof.get("schema_version") != 1 \
+            or proof.get("kind") != "source-recovery-proof":
+        raise UpgradeError("missing or invalid source-recovery proof")
+    for key in ("task_id", "branch", "worktree", "authority_head", "authority_nonce",
+                "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+                "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+                "receipt_source", "receipt_source_revision"):
+        if not isinstance(proof[key], str) or not proof[key]:
+            raise UpgradeError("missing or invalid source-recovery proof")
+    if not re.fullmatch(r"[0-9a-f]{40,64}", proof["implementation_revision"]):
+        raise UpgradeError("invalid source-recovery implementation revision")
+    for key in ("receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256"):
+        if not re.fullmatch(r"[0-9a-f]{64}", proof[key]):
+            raise UpgradeError("invalid source-recovery proof digest")
+    return proof
+
+
+def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, proof: dict) -> Path:
+    expected = _recovery_proof(
+        receipt,
+        implementation_source=Path(proof["implementation_source"]),
+        implementation_revision=proof["implementation_revision"],
+        raw_receipt=raw_receipt,
+        paths=receipt["changed_paths"],
+        fingerprints=receipt["path_fingerprints"],
+    )
+    if proof != expected:
+        raise UpgradeError("source-recovery proof does not match the reconstructed receipt")
+    authority = _read_json_record(_bridge_authority_path(repo), "missing or invalid source-recovery authority")
+    if authority != _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()):
+        raise UpgradeError("source-recovery authority does not match its proof")
+    return _bridge_authority_path(repo)
+
+
+def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+    """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    task_id, branch, worktree = require_maintenance(target_repo)
+    source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    active = receipt_path(target_repo)
+    if not active.is_file():
+        raise UpgradeError("no active automation upgrade receipt")
+    try:
+        raw_receipt = active.read_bytes()
+        receipt = validate_receipt_schema(json.loads(raw_receipt.decode("utf-8")))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise UpgradeError("invalid automation upgrade receipt") from exc
+    receipt_scope = receipt_paths(target_repo, receipt)
+    if receipt["source_revision"] is None or not _source_is_compatible(receipt["source"], source):
+        raise UpgradeError("receipt source is not compatible with the current Templates source")
+    receipt_revision = _validate_source_revision(source, receipt["source_revision"])
+    if (receipt["task_id"], receipt["branch"], receipt["worktree"]) != (task_id, branch, str(worktree)):
+        raise UpgradeError("automation receipt identity does not match the current Task worktree")
+    _validate_no_authority(target_repo)
+    authority_head = receipt["authority_head"]
+    authority_branch_oid = run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip()
+    authority_registration = registered_worktrees(target_repo).get(worktree)
+    pending_before = pending_paths(target_repo)
+    for pending in pending_before:
+        reject_bootstrap_path(target_repo, pending)
+    with tempfile.TemporaryDirectory(prefix="automation-source-recovery-", dir=task_state_dir(target_repo)) as temporary:
+        baseline = Path(temporary) / "baseline"
+        snapshot, source_core = materialize_source_snapshot(source, receipt_revision, Path(temporary))
+        materialize_tree(target_repo, authority_head, baseline, surface_only=True)
+        before = {
+            path.relative_to(baseline).as_posix(): bootstrap_fingerprint(baseline, path.relative_to(baseline).as_posix())
+            for path in baseline.rglob("*") if path.is_file()
+        }
+        plan = build_plan(baseline, snapshot)
+        if plan["blockers"]:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(plan["blockers"]))
+        selected = [migration for migration in load_migrations(source_core)
+                    if migration.to_version <= version_number(source_core)]
+        _, migration_blockers, _ = migration_actions(target_repo, selected)
+        if migration_blockers:
+            raise UpgradeError("reconstruction blocked:\n- " + "\n- ".join(migration_blockers))
+        returned = {item["path"] for item in plan["actions"] if item["action"] != "noop"}
+        apply_plan_to_tree(baseline, source_core, plan)
+        expected = sorted(path for path in returned
+                          if before.get(path, {"state": "absent", "mode": None, "content_sha256": None})
+                          != bootstrap_fingerprint(baseline, path))
+        expected_fingerprints = {path: bootstrap_fingerprint(baseline, path) for path in expected}
+        candidate_versions = (plan["currentVersion"], plan["upstreamVersion"])
+    if pending_before != expected or expected != receipt_scope \
+            or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected):
+        raise UpgradeError("pending target paths do not match the reconstructed upgrade")
+    if git_head(target_repo) != authority_head or authority_branch_oid != authority_head \
+            or require_registered_task(target_repo, task_id) != (task_id, branch, worktree) \
+            or registered_worktrees(target_repo).get(worktree) != authority_registration:
+        raise UpgradeError("Task identity or HEAD changed during source recovery")
+    actual_fingerprints = {p: file_fingerprint(target_repo, p) for p in expected}
+    candidate = {
+        "schema_version": 1, "status": "active", "task_id": task_id, "branch": branch,
+        "worktree": str(worktree), "source": receipt["source"], "source_revision": receipt_revision,
+        "current_version": candidate_versions[0], "upstream_version": candidate_versions[1],
+        "changed_paths": receipt_scope, "authority_head": authority_head,
+        "authority_nonce": receipt["authority_nonce"], "path_fingerprints": actual_fingerprints,
+    }
+    if active.read_bytes() != raw_receipt or candidate != receipt:
+        raise UpgradeError("receipt or target changed during source recovery")
+    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+                            raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
+    proof_path = source_recovery_proof_path(target_repo)
+    created_proof: tuple[int, int] | None = None
+    try:
+        proof_admin = worktree_admin_dir(target_repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        if os.path.lexists(proof_path):
+            existing = _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof"))
+            if existing != proof:
+                raise UpgradeError("existing source-recovery proof does not match reconstruction")
+        else:
+            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+        current_source, current_implementation_revision = resolve_clean_source_worktree(source)
+        if current_source != source or current_implementation_revision != implementation_revision:
+            raise UpgradeError("source changed before source-recovery publication")
+        if active.read_bytes() != raw_receipt or authority_exists(target_repo):
+            raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
+        if (git_head(target_repo) != authority_head
+                or run(["git", "rev-parse", f"refs/heads/{branch}"], cwd=target_repo).stdout.strip() != authority_branch_oid
+                or require_registered_task(target_repo, task_id) != (task_id, branch, worktree)
+                or registered_worktrees(target_repo).get(worktree) != authority_registration
+                or pending_paths(target_repo) != pending_before
+                or receipt_paths(target_repo, receipt) != receipt_scope
+                or any(file_fingerprint(target_repo, p) != expected_fingerprints[p] for p in expected)):
+            raise UpgradeError("target changed before source-recovery bridge publication")
+        if _validate_recovery_proof(_read_json_record(proof_path, "missing or invalid source-recovery proof")) != proof:
+            raise UpgradeError("source-recovery proof changed before bridge publication")
+        _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
+                            admin=worktree_admin_dir(target_repo))
+    except (OSError, UpgradeError):
+        if created_proof is not None:
+            try:
+                metadata = proof_path.lstat()
+                if (metadata.st_dev, metadata.st_ino) == created_proof:
+                    proof_path.unlink()
+            except OSError as exc:
+                raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
+        raise
+    return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
+            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+
+
 def validate_receipt_path(raw: object) -> str:
     if not isinstance(raw, str) or not raw or "\\" in raw:
         raise UpgradeError("receipt contains an unsafe path")
@@ -1468,7 +1771,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def commit(repo: Path, task: str, message: str) -> dict[str, str]:
+def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1478,7 +1781,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("no active successful automation upgrade receipt")
     try:
         receipt = json.loads(active.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise UpgradeError("invalid automation upgrade receipt") from exc
     receipt = validate_receipt_schema(receipt)
     if (receipt.get("task_id"), receipt.get("branch"), receipt.get("worktree")) != (task, branch, str(worktree)):
@@ -1493,7 +1796,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         raise UpgradeError("automation receipt path content/state fingerprint changed")
     if pending_paths(repo) != paths:
         raise UpgradeError("pending paths do not exactly match the automation receipt")
-    authority = validate_authority(repo, receipt)
+    proof_path = source_recovery_proof_path(repo)
+    proof: dict | None = None
+    proof_raw: bytes | None = None
+    if mode == "standard":
+        authority = validate_authority(repo, receipt)
+    elif mode == "source_recovery":
+        proof_admin = worktree_admin_dir(repo)
+        _validate_admin_record_parent(proof_path, proof_admin)
+        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        proof = _validate_recovery_proof(proof_record)
+        source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
+        if (proof["implementation_source"] != str(source)
+                or proof["implementation_revision"] != current_revision
+                or (source_root is not None and source_root != source)):
+            raise UpgradeError("source-recovery proof implementation is stale")
+        if not _source_is_compatible(receipt["source"], source):
+            raise UpgradeError("source-recovery receipt source is incompatible")
+        _validate_source_revision(source, receipt["source_revision"])
+        authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
+        if proof_path.read_bytes() != proof_raw:
+            raise UpgradeError("source-recovery proof changed before commit mutation")
+    else:  # pragma: no cover
+        raise UpgradeError("unsupported commit mode")
 
     consumed = consumed_receipt_path(repo)
     consumed_receipt = dict(receipt)
@@ -1504,6 +1829,7 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
     commit_sha = ""
     active_moved = False
     authority_removed = False
+    proof_removed = False
     consumed_instances: set[tuple[int, int]] = set()
     try:
         if os.path.lexists(consumed):
@@ -1519,6 +1845,9 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
         authority.unlink(missing_ok=True)
         authority_removed = True
+        if mode == "source_recovery" and proof is not None:
+            proof_path.unlink()
+            proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
         index_environment = {"GIT_INDEX_FILE": str(private_index)}
@@ -1571,24 +1900,25 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
     except (UpgradeError, OSError) as failure:
         if committed:
-            if isinstance(failure, OSError):
-                raise UpgradeError("commit finalization failed") from failure
-            raise
+            raise UpgradeError(
+                f"commit {commit_sha} was published but finalization failed"
+            ) from failure
         rollback_errors: list[str] = []
         try:
+            if proof_removed and proof is not None:
+                if proof_raw is None:
+                    raise UpgradeError("source-recovery proof bytes were not captured")
+                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
+        except (OSError, UpgradeError) as rollback_error:
+            rollback_errors.append(f"proof restore failed: {rollback_error}")
+        try:
             if authority_removed:
-                _write_authority_at(
-                    authority,
-                    {
-                        "schema_version": 1,
-                        "task_id": receipt["task_id"],
-                        "branch": receipt["branch"],
-                        "worktree": receipt["worktree"],
-                        "authority_nonce": receipt["authority_nonce"],
-                        "receipt_sha256": receipt_digest(receipt),
-                    },
-                    admin=_rollback_authority_guard(repo, authority),
-                )
+                restored = _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()) if mode == "source_recovery" and proof is not None else {
+                    "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                    "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                    "receipt_sha256": receipt_digest(receipt),
+                }
+                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -1622,7 +1952,29 @@ def commit(repo: Path, task: str, message: str) -> dict[str, str]:
             private_index.unlink(missing_ok=True)
         except OSError as cleanup_error:
             raise UpgradeError("private index cleanup failed") from cleanup_error
-    return {"status": "COMMITTED", "commit_sha": commit_sha}
+    result: dict[str, str | bool | list[str]] = {
+        "status": "COMMITTED", "commit_sha": commit_sha,
+    }
+    if mode == "source_recovery":
+        result.update({
+            "commitCreated": True,
+            "changedPaths": paths,
+            "pushPerformed": False,
+            "mergePerformed": False,
+        })
+    return result
+
+
+def commit(repo: Path, task: str, message: str) -> dict[str, object]:
+    return _commit_mode(repo, task, message, "standard")
+
+
+def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+    """Commit only a proof-bound source recovery; no network or merge operation is performed."""
+    # The source argument is deliberately checked before the receipt is opened, and
+    # is not a target mutation/apply hook.
+    source, _ = resolve_clean_source_worktree(templates_source_root)
+    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
 
 
 def parser() -> argparse.ArgumentParser:

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -8,6 +8,7 @@ import tempfile
 import unittest
 import os
 import shutil
+import shlex
 import subprocess
 import tarfile
 import threading
@@ -257,6 +258,73 @@ mod project 'just/project/mod.just'
         environment = os.environ.copy()
         environment["AUTOMATION_MAINTENANCE"] = "1"
         result = subprocess.run(["python3", ".automation/bin/automation_upgrade.py", *args], cwd=repo, env=environment, text=True, capture_output=True, check=False)
+        if check:
+            self.assertEqual(0, result.returncode, result.stderr)
+        return result
+
+    def _source_recovery_bridge_fixture(self, root: Path) -> tuple[Path, Path, Path, dict]:
+        """Build the two-generation, shared-object source-recovery topology."""
+        bridge = root / "templates-bridge"
+        self._git(["clone", "--shared", "--no-checkout", str(ROOT), str(bridge)], ROOT)
+        self._git(["switch", "--detach", "HEAD"], bridge)
+        implementation = (
+            "components/agent-core/.automation/bin/automation_upgrade.py",
+            "tools/automation_recovery_bridge.py",
+            "just/agent-core.just",
+        )
+        for relative in implementation:
+            destination = bridge / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / relative, destination)
+        self._git(["config", "user.name", "Test User"], bridge)
+        self._git(["config", "user.email", "test@example.invalid"], bridge)
+        self._git(["add", *implementation], bridge)
+        self._git(["commit", "--allow-empty", "-m", "source recovery bridge implementation"], bridge)
+        bridge_head = self._git(["rev-parse", "HEAD"], bridge)
+        source = root / "source-v3.0.1"
+        source_revision = "b61341feee36eaf16fc37c91323f1da9cb3d671f"
+        self.assertEqual(source_revision, self._git(["rev-parse", "v3.0.1^{commit}"], bridge))
+        self._git(["worktree", "add", "--detach", str(source), source_revision], bridge)
+        self.assertEqual(source_revision, self._git(["rev-parse", "HEAD"], source))
+        self.assertNotEqual(source_revision, bridge_head)
+        _, task, _ = self._separate_git_topology_fixture(root / "consumer")
+        self.assertTrue((task / ".git").is_file())
+        old_script = task / ".automation/bin/automation_upgrade.py"
+        old_result = json.loads(self._cli(task, ["upgrade", "--source", str(source)]).stdout)
+        self.assertEqual("APPLIED", old_result["status"])
+        old_script_bytes = old_script.read_bytes()
+        bootstrap_result = json.loads(self._cli(task, ["bootstrap-receipt", "--source", str(source)]).stdout)
+        self.assertEqual("RECEIPT_BOOTSTRAPPED", bootstrap_result["status"])
+        receipt = self._receipt(task)
+        receipt_bound = {
+            path: ((task / Path(*path.split("/"))).read_bytes(), (task / Path(*path.split("/"))).stat().st_mode & 0o777)
+            for path in receipt["changed_paths"]
+        }
+        new_authority, legacy_authority = upgrade._authority_locations(task)
+        self.assertFalse(new_authority.exists())
+        self.assertIsNotNone(legacy_authority)
+        assert legacy_authority is not None
+        self.assertTrue(legacy_authority.is_file())
+        legacy_authority.unlink()
+        metadata = {
+            "bridge_head": bridge_head,
+            "source_revision": source_revision,
+            "old_script": old_script_bytes,
+            "receipt_bound": receipt_bound,
+            "receipt": receipt,
+            "old_result": old_result,
+            "legacy_authority": legacy_authority,
+            "remote_refs": self._git(["for-each-ref", "--format=%(refname) %(objectname)", "refs/remotes"], task),
+        }
+        return bridge, source, task, metadata
+
+    def _bridge_cli(self, bridge: Path, command: str, target: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["AUTOMATION_MAINTENANCE"] = "1"
+        result = subprocess.run(
+            ["python3", "tools/automation_recovery_bridge.py", command, str(target), *args],
+            cwd=bridge, env=environment, text=True, capture_output=True, check=False,
+        )
         if check:
             self.assertEqual(0, result.returncode, result.stderr)
         return result
@@ -1734,6 +1802,350 @@ mod project 'just/project/mod.just'
             self.assertNotEqual(0, result.returncode)
             self.assertIn("non-empty pending paths", result.stderr)
             self.assertFalse(upgrade.authority_path(task).exists())
+
+    def test_issue_85_real_bridge_recovers_and_commits_only_the_old_upgrade(self) -> None:
+        repository_status = self._git(["status", "--porcelain=v1"], ROOT)
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, source, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
+            receipt_before = metadata["receipt"]
+            receipt_bytes = upgrade.receipt_path(task).read_bytes()
+            recovered = json.loads(self._bridge_cli(bridge, "recover-maintenance-authority", task).stdout)
+            self.assertEqual("AUTHORITY_RECOVERED", recovered["status"])
+            self.assertEqual(metadata["source_revision"], recovered["receiptSourceRevision"])
+            self.assertNotEqual(metadata["source_revision"], recovered["implementationRevision"])
+            self.assertEqual(metadata["source_revision"], receipt_before["source_revision"])
+            self.assertEqual(receipt_bytes, upgrade.receipt_path(task).read_bytes())
+            self.assertEqual(metadata["old_script"], (task / ".automation/bin/automation_upgrade.py").read_bytes())
+            for path, (content, mode) in metadata["receipt_bound"].items():
+                target = task / Path(*path.split("/"))
+                self.assertEqual(content, target.read_bytes(), path)
+                self.assertEqual(mode, target.stat().st_mode & 0o777, path)
+            proof = json.loads(upgrade.source_recovery_proof_path(task).read_text(encoding="utf-8"))
+            authority = json.loads(upgrade.authority_path(task).read_text(encoding="utf-8"))
+            self.assertEqual(1, proof["schema_version"])
+            self.assertEqual("source-recovery-proof", proof["kind"])
+            self.assertEqual(2, authority["schema_version"])
+            self.assertEqual("source-recovery-bridge", authority["kind"])
+            self.assertEqual(str(bridge.resolve()), proof["implementation_source"])
+            self.assertEqual(metadata["bridge_head"], proof["implementation_revision"])
+
+            old_head = self._git(["rev-parse", "HEAD"], task)
+            committed = json.loads(self._bridge_cli(
+                bridge, "commit-recovered-maintenance", task, "TASK-83", "source recovery"
+            ).stdout)
+            self.assertEqual("COMMITTED", committed["status"])
+            self.assertTrue(committed["commitCreated"])
+            self.assertFalse(committed["pushPerformed"])
+            self.assertFalse(committed["mergePerformed"])
+            self.assertEqual(receipt_before["changed_paths"], committed["changedPaths"])
+            self.assertEqual(committed["commit_sha"], self._git(["rev-parse", "HEAD"], task))
+            self.assertNotEqual(receipt_before["authority_head"], committed["commit_sha"])
+            self.assertEqual(receipt_before["authority_head"], old_head)
+            self.assertEqual(old_head, self._git(["show", "-s", "--format=%P", "HEAD"], task))
+            self.assertEqual(receipt_before["changed_paths"], sorted(self._git(
+                ["show", "--pretty=", "--name-only", "HEAD"], task
+            ).splitlines()))
+            self.assertFalse(upgrade.receipt_path(task).exists())
+            self.assertFalse(upgrade.authority_path(task).exists())
+            self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+            consumed = json.loads(upgrade.consumed_receipt_path(task).read_text(encoding="utf-8"))
+            self.assertEqual("consumed", consumed["status"])
+            self.assertEqual(committed["commit_sha"], consumed["commit_sha"])
+            self.assertNotIn(".automation/ADAPTER", receipt_before["changed_paths"])
+            self.assertFalse(any(path.startswith("just/project/") for path in receipt_before["changed_paths"]))
+            self.assertNotIn(".task-state/task.md", receipt_before["changed_paths"])
+            self.assertEqual(metadata["remote_refs"], self._git(
+                ["for-each-ref", "--format=%(refname) %(objectname)", "refs/remotes"], task
+            ))
+        self.assertEqual(repository_status, self._git(["status", "--porcelain=v1"], ROOT))
+
+    def test_issue_85_bridge_contract_and_rejection_matrix(self) -> None:
+        root_justfile = (ROOT / "Justfile").read_text(encoding="utf-8")
+        self.assertIn("mod agent-core 'just/agent-core.just'", root_justfile)
+        justfile = (ROOT / "just/agent-core.just").read_text(encoding="utf-8")
+        self.assertIn("root := justfile_directory()", justfile)
+        self.assertIn("tools/automation_recovery_bridge.py", justfile)
+        self.assertIn("recover-maintenance-authority", justfile)
+        self.assertIn("commit-recovered-maintenance", justfile)
+        for forbidden in ("git push", "git merge", "apply"):
+            self.assertNotIn(forbidden, justfile)
+        if shutil.which("just") is None:
+            self.skipTest("just is unavailable")
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "target with spaces"
+            for recipe, arguments in (
+                ("agent-core::recover-maintenance-authority", [str(target)]),
+                ("agent-core::commit-recovered-maintenance", [str(target), "TASK-83", "quoted message"]),
+            ):
+                result = subprocess.run(
+                    ["just", "--dry-run", recipe, *arguments],
+                    cwd=ROOT, text=True, capture_output=True, check=False,
+                )
+                self.assertEqual(0, result.returncode, result.stderr)
+                output = result.stdout + result.stderr
+                self.assertIn(str((ROOT / "tools/automation_recovery_bridge.py").resolve()), output)
+                self.assertIn(shlex.quote(str(target)), output)
+                self.assertNotIn(".automation/bin/automation_upgrade.py", output)
+                if recipe.endswith("commit-recovered-maintenance"):
+                    self.assertIn(shlex.quote("TASK-83"), output)
+                    self.assertIn(shlex.quote("quoted message"), output)
+
+        for kind in ("missing", "unrelated", "unknown-revision", "unclean-bridge"):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as directory:
+                bridge, source, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
+                if kind == "missing":
+                    missing = Path(directory) / "missing-source"
+                    receipt = metadata["receipt"] | {"source": str(missing.resolve())}
+                    upgrade.atomic_json_write(upgrade.receipt_path(task), receipt)
+                elif kind == "unrelated":
+                    unrelated = Path(directory) / "unrelated"
+                    self._task_repo(unrelated)
+                    receipt = metadata["receipt"] | {"source": str(unrelated.resolve())}
+                    upgrade.atomic_json_write(upgrade.receipt_path(task), receipt)
+                elif kind == "unknown-revision":
+                    receipt = metadata["receipt"] | {"source_revision": "0" * 40}
+                    upgrade.atomic_json_write(upgrade.receipt_path(task), receipt)
+                else:
+                    self._write_file(bridge / "dirty-bridge", "dirty\n")
+                result = self._bridge_cli(bridge, "recover-maintenance-authority", task, check=False)
+                self.assertNotEqual(0, result.returncode)
+                self.assertFalse(upgrade.authority_path(task).exists())
+
+    def test_issue_85_bridge_rolls_back_source_recovery_publication_and_retries(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, source, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            original = upgrade._write_authority_at
+            calls = 0
+
+            def fail_once(path: Path, value: dict, *, admin: Path | None = None) -> None:
+                nonlocal calls
+                calls += 1
+                if calls == 1:
+                    raise upgrade.UpgradeError("injected bridge publication failure")
+                original(path, value, admin=admin)
+
+            with mock.patch.object(upgrade, "_write_authority_at", side_effect=fail_once):
+                with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                    with self.assertRaisesRegex(upgrade.UpgradeError, "injected bridge publication failure"):
+                        upgrade.recover_maintenance_authority_from_source(task, bridge)
+            self.assertTrue(upgrade.receipt_path(task).exists())
+            self.assertFalse(upgrade.authority_path(task).exists())
+            self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+            retry = json.loads(self._bridge_cli(bridge, "recover-maintenance-authority", task).stdout)
+            self.assertEqual("AUTHORITY_RECOVERED", retry["status"])
+
+    def test_issue_85_recovery_rejects_authority_appearing_during_publication(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            with mock.patch.object(upgrade, "authority_exists", return_value=True):
+                with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                    with self.assertRaisesRegex(upgrade.UpgradeError, "changed before source-recovery bridge publication"):
+                        upgrade.recover_maintenance_authority_from_source(task, bridge)
+            self.assertTrue(upgrade.receipt_path(task).exists())
+            self.assertFalse(upgrade.authority_path(task).exists())
+            self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+
+    def test_issue_85_proof_only_interruption_retries_without_rewriting_receipt_or_proof(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            first = json.loads(self._bridge_cli(bridge, "recover-maintenance-authority", task).stdout)
+            self.assertEqual("AUTHORITY_RECOVERED", first["status"])
+            receipt_bytes = upgrade.receipt_path(task).read_bytes()
+            proof_bytes = upgrade.source_recovery_proof_path(task).read_bytes()
+            authority = upgrade.authority_path(task)
+            authority_record = json.loads(authority.read_text(encoding="utf-8"))
+            self.assertEqual(2, authority_record["schema_version"])
+            authority.unlink()
+            retry = json.loads(self._bridge_cli(bridge, "recover-maintenance-authority", task).stdout)
+            self.assertEqual("AUTHORITY_RECOVERED", retry["status"])
+            self.assertEqual(receipt_bytes, upgrade.receipt_path(task).read_bytes())
+            self.assertEqual(proof_bytes, upgrade.source_recovery_proof_path(task).read_bytes())
+            self.assertTrue(upgrade.authority_path(task).is_file())
+            committed = json.loads(self._bridge_cli(
+                bridge, "commit-recovered-maintenance", task, "TASK-83", "proof retry"
+            ).stdout)
+            self.assertEqual("COMMITTED", committed["status"])
+
+    def test_issue_85_cli_rejects_unregistered_outside_and_malformed_targets(self) -> None:
+        for kind in ("unregistered", "outside", "malformed"):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as directory:
+                bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+                target = task
+                if kind == "unregistered":
+                    state = task / ".task-state/task.md"
+                    state.write_text(state.read_text(encoding="utf-8").replace(
+                        "task/TASK-83-linked", "task/TASK-83-unregistered"
+                    ), encoding="utf-8")
+                elif kind == "outside":
+                    target = Path(directory) / "outside-target"
+                    self._task_repo(target, task="TASK-OUTSIDE")
+                else:
+                    upgrade.receipt_path(task).write_text("not-json\n", encoding="utf-8")
+                result = self._bridge_cli(bridge, "recover-maintenance-authority", target, check=False)
+                self.assertNotEqual(0, result.returncode)
+                self.assertIn("ERROR:", result.stderr)
+                self.assertNotIn("Traceback", result.stderr)
+                self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+                self.assertFalse(upgrade.authority_path(task).exists())
+                self.assertFalse(upgrade.source_recovery_proof_path(target).exists())
+                self.assertFalse(upgrade.authority_path(target).exists())
+
+    def test_issue_85_tampered_proof_cannot_commit_or_change_refs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            self._bridge_cli(bridge, "recover-maintenance-authority", task)
+            active = upgrade.receipt_path(task)
+            authority = upgrade.authority_path(task)
+            proof = upgrade.source_recovery_proof_path(task)
+            active_bytes = active.read_bytes()
+            authority_bytes = authority.read_bytes()
+            record = json.loads(proof.read_text(encoding="utf-8"))
+            record["proof_sha256"] = "0" * 64
+            proof.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+            head = self._git(["rev-parse", "HEAD"], task)
+            refs = self._git(["for-each-ref", "--format=%(refname) %(objectname)"], task)
+            result = self._bridge_cli(
+                bridge, "commit-recovered-maintenance", task, "TASK-83", "tampered proof", check=False
+            )
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("ERROR:", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertEqual(active_bytes, active.read_bytes())
+            self.assertEqual(authority_bytes, authority.read_bytes())
+            self.assertEqual(head, self._git(["rev-parse", "HEAD"], task))
+            self.assertEqual(refs, self._git(["for-each-ref", "--format=%(refname) %(objectname)"], task))
+
+    def test_issue_85_commit_cli_rejects_malformed_and_invalid_utf8_active_receipts(self) -> None:
+        for payload in (b"not-json\n", b"\xff\xfe\n"):
+            with self.subTest(payload=payload), tempfile.TemporaryDirectory() as directory:
+                bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+                self._bridge_cli(bridge, "recover-maintenance-authority", task)
+                upgrade.receipt_path(task).write_bytes(payload)
+                upgrade.source_recovery_proof_path(task).unlink()
+                upgrade.authority_path(task).unlink()
+                result = self._bridge_cli(
+                    bridge, "commit-recovered-maintenance", task, "TASK-83", "malformed receipt", check=False
+                )
+                self.assertEqual(2, result.returncode)
+                self.assertIn("ERROR:", result.stderr)
+                self.assertNotIn("Traceback", result.stderr)
+                self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+                self.assertFalse(upgrade.authority_path(task).exists())
+
+    def test_issue_85_published_commit_finalization_failure_is_not_retryable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            self._bridge_cli(bridge, "recover-maintenance-authority", task)
+            old_head = self._git(["rev-parse", "HEAD"], task)
+            remote_refs = self._git(["for-each-ref", "--format=%(refname) %(objectname)", "refs/remotes"], task)
+            original_run = upgrade.run
+
+            def fail_final_reset(command, *args, **kwargs):
+                if len(command) >= 3 and command[:3] == ["git", "reset", "-q"]:
+                    raise OSError("injected final reset failure")
+                return original_run(command, *args, **kwargs)
+
+            with mock.patch.object(upgrade, "run", side_effect=fail_final_reset):
+                with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                    with self.assertRaisesRegex(
+                        upgrade.UpgradeError,
+                        r"commit [0-9a-f]{40,64} was published but finalization failed",
+                    ):
+                        upgrade.commit_recovered_maintenance(task, bridge, "TASK-83", "published failure")
+            consumed = json.loads(upgrade.consumed_receipt_path(task).read_text(encoding="utf-8"))
+            commit_sha = consumed["commit_sha"]
+            self.assertEqual("consumed", consumed["status"])
+            self.assertEqual(commit_sha, self._git(["rev-parse", "HEAD"], task))
+            self.assertEqual(commit_sha, self._git(["rev-parse", "refs/heads/task/TASK-83-linked"], task))
+            self.assertEqual(old_head, self._git(["show", "-s", "--format=%P", "HEAD"], task))
+            self.assertEqual("1", self._git(["rev-list", "--count", f"{old_head}..{commit_sha}"], task))
+            self.assertNotEqual(old_head, commit_sha)
+            self.assertFalse(upgrade.receipt_path(task).exists())
+            self.assertFalse(upgrade.authority_path(task).exists())
+            self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+            self.assertEqual(remote_refs, self._git(
+                ["for-each-ref", "--format=%(refname) %(objectname)", "refs/remotes"], task
+            ))
+
+    def test_issue_85_source_commit_failure_restores_bridge_records_and_cli_retry_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            recovered = json.loads(self._bridge_cli(bridge, "recover-maintenance-authority", task).stdout)
+            self.assertEqual("AUTHORITY_RECOVERED", recovered["status"])
+            active = upgrade.receipt_path(task)
+            authority = upgrade.authority_path(task)
+            proof = upgrade.source_recovery_proof_path(task)
+            active_bytes, authority_bytes, proof_bytes = active.read_bytes(), authority.read_bytes(), proof.read_bytes()
+            original_run = upgrade.run
+
+            def fail_staging_check(command, *args, **kwargs):
+                if command == ["git", "diff", "--no-ext-diff", "--cached", "--check"]:
+                    raise upgrade.UpgradeError("injected source commit staging failure")
+                return original_run(command, *args, **kwargs)
+
+            with mock.patch.object(upgrade, "run", side_effect=fail_staging_check):
+                with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                    with self.assertRaisesRegex(upgrade.UpgradeError, "injected source commit staging failure"):
+                        upgrade.commit_recovered_maintenance(task, bridge, "TASK-83", "injected failure")
+            self.assertEqual(active_bytes, active.read_bytes())
+            self.assertEqual(authority_bytes, authority.read_bytes())
+            self.assertEqual(proof_bytes, proof.read_bytes())
+            self.assertFalse(upgrade.consumed_receipt_path(task).exists())
+            retry = json.loads(self._bridge_cli(
+                bridge, "commit-recovered-maintenance", task, "TASK-83", "retry"
+            ).stdout)
+            self.assertEqual("COMMITTED", retry["status"])
+
+    def test_issue_85_receipt_change_and_target_rejections_leave_no_bridge_records(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, _, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
+            active = upgrade.receipt_path(task)
+            original_read_bytes = Path.read_bytes
+            reads = 0
+
+            def changing_receipt(path: Path):
+                nonlocal reads
+                value = original_read_bytes(path)
+                if path == active:
+                    reads += 1
+                    if reads == 2:
+                        return value + b"changed during recovery"
+                return value
+
+            with mock.patch.object(Path, "read_bytes", autospec=True, side_effect=changing_receipt):
+                with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                    with self.assertRaisesRegex(upgrade.UpgradeError, "receipt or target changed"):
+                        upgrade.recover_maintenance_authority_from_source(task, bridge)
+            self.assertFalse(upgrade.authority_path(task).exists())
+            self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+
+        for kind in ("version", "fingerprint", "head", "pending", "content", "mode"):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as directory:
+                bridge, _, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
+                receipt = metadata["receipt"]
+                path = receipt["changed_paths"][0]
+                target = task / Path(*path.split("/"))
+                if kind == "version":
+                    upgrade.atomic_json_write(active := upgrade.receipt_path(task), receipt | {"current_version": "999"})
+                elif kind == "fingerprint":
+                    fingerprints = dict(receipt["path_fingerprints"])
+                    fingerprints[path] = dict(fingerprints[path], content_sha256="0" * 64)
+                    upgrade.atomic_json_write(upgrade.receipt_path(task), receipt | {"path_fingerprints": fingerprints})
+                elif kind == "head":
+                    self._write_file(task / "HEAD-tamper", "head\n")
+                    self._git(["add", "HEAD-tamper"], task)
+                    self._git(["commit", "-m", "head tamper"], task)
+                elif kind == "pending":
+                    self._write_file(task / ".automation/pending-extra", "pending\n")
+                elif kind == "content":
+                    target.write_bytes(target.read_bytes() + b"tampered")
+                else:
+                    target.chmod(target.stat().st_mode ^ 0o100)
+                with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                    with self.assertRaises(upgrade.UpgradeError):
+                        upgrade.recover_maintenance_authority_from_source(task, bridge)
+                self.assertFalse(upgrade.authority_path(task).exists())
+                self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
 
 
 if __name__ == "__main__":

--- a/tools/automation_recovery_bridge.py
+++ b/tools/automation_recovery_bridge.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Narrow Templates-root bridge for source-side maintenance recovery."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+
+
+ROOT = Path(__file__).resolve().parent.parent
+ENGINE_PATH = ROOT / "components" / "agent-core" / ".automation" / "bin" / "automation_upgrade.py"
+
+
+class BridgeError(RuntimeError):
+    pass
+
+
+def load_engine() -> ModuleType:
+    """Load the repository's supported recovery implementation, not a substitute."""
+    spec = None
+    try:
+        spec = importlib.util.spec_from_file_location("templates_automation_upgrade", ENGINE_PATH)
+        if spec is None or spec.loader is None:
+            raise BridgeError(f"cannot create import specification for supported engine: {ENGINE_PATH}")
+        engine = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = engine
+        spec.loader.exec_module(engine)
+        return engine
+    except BridgeError:
+        raise
+    except Exception as exc:
+        if spec is not None and spec.name in sys.modules:
+            del sys.modules[spec.name]
+        raise BridgeError(f"cannot load supported recovery engine {ENGINE_PATH}: {exc}") from exc
+
+
+def require_templates_root(engine: ModuleType) -> Path:
+    try:
+        top = Path(engine.run(["git", "rev-parse", "--show-toplevel"], cwd=ROOT).stdout.strip()).resolve()
+    except Exception as exc:
+        if isinstance(exc, engine.UpgradeError):
+            raise
+        raise BridgeError(f"cannot verify Templates Git root: {exc}") from exc
+    if top != ROOT:
+        raise BridgeError(f"recovery bridge must run from the Templates Git root: {top}")
+    return top
+
+
+@contextmanager
+def maintenance_environment():
+    previous = os.environ.get("AUTOMATION_MAINTENANCE")
+    os.environ["AUTOMATION_MAINTENANCE"] = "1"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("AUTOMATION_MAINTENANCE", None)
+        else:
+            os.environ["AUTOMATION_MAINTENANCE"] = previous
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description="Templates source-side maintenance recovery bridge")
+    sub = result.add_subparsers(dest="command", required=True)
+    recover = sub.add_parser("recover-maintenance-authority")
+    recover.add_argument("target", type=Path)
+    commit = sub.add_parser("commit-recovered-maintenance")
+    commit.add_argument("target", type=Path)
+    commit.add_argument("task")
+    commit.add_argument("message", nargs="?", default="")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        engine = load_engine()
+    except BridgeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    try:
+        root = require_templates_root(engine)
+        target = args.target.resolve()
+        with maintenance_environment():
+            if args.command == "recover-maintenance-authority":
+                result = engine.recover_maintenance_authority_from_source(target, root)
+            elif args.command == "commit-recovered-maintenance":
+                result = engine.commit_recovered_maintenance(target, root, args.task, args.message)
+            else:  # pragma: no cover
+                raise BridgeError(f"unsupported bridge command: {args.command}")
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+    except engine.UpgradeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    except BridgeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add supported Templates-root commands to recover pre-fix consumer authority without modifying receipt-bound Agent Core files
- reconstruct the historical receipt source revision from tracked Git objects while binding proof to the current clean implementation revision
- add schema-2 per-worktree bridge authority and proof records, including interrupted recovery and rollback handling
- publish through current guarded commit semantics with exact private-index staging and expected-HEAD branch update, without push or merge
- cover a real v3.0.1 linked/gitfile two-generation consumer through recovery and publication

## Authoritative amendment
This implements the issue comment requiring the source-side bridge to complete guarded publication when the old consumer commit implementation cannot consume the recovered authority.

## Verification
- `nix develop -c python3 -m unittest tests.test_automation_upgrade -v -k issue_85` (11 tests, 0 skipped)
- `nix develop -c python3 -m unittest discover -s tests -v` (273 tests, 0 skipped)
- `nix develop -c just template::check`
- `nix develop -c just template::distribution-verify`
- `git diff --check`
- `nix flake check --all-systems --no-build --no-update-lock-file`
- `nix build .#checks.x86_64-linux.opencode-policy --no-link --no-update-lock-file`

Closes #85