### PR TITLE
Verify recovery bridge before loading engine code

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,26 @@ uncommitted pair. There is no push or merge. The existing consumer script need n
 be replaced first. This is not a generic external apply/upgrade/commit
 primitive; normal consumer bootstrap and commit remain separate workflows.
 
+Both root bridge recipes use `python3 -I` for their small stdlib-only bootstrap:
+isolated mode excludes `PYTHONPATH`, the current directory, and user-site
+shadowing from bootstrap imports. The bootstrap resolves the root and trusted,
+root-owned, non-writable Git repository with scrubbed `GIT_*`, then verifies the
+full `HEAD` and the whole clean Templates worktree. It verifies the live
+bootstrap against the tracked `HEAD` blob, obtains the engine regular blob from
+the verified `HEAD` Git objects, materializes it privately, and executes the
+engine only afterward. The verified `HEAD` is passed to the engine; the engine
+independently repeats clean-source, root, and `HEAD` validation and requires
+equality before publishing authority. Thus `implementation_revision` is proven
+to be the blob-providing `HEAD`, and source races fail closed. Dirty bridge or
+engine files and module-shadow states are rejected before target authority or
+publication changes.
+
+The live bootstrap is the small initial trust anchor: its self-check detects
+accidental or concurrent divergence, but does not claim to defeat hostile
+replacement. That requires an external trusted launcher or signing mechanism.
+Hard-crash consistency remains out of scope; these safeguards do not change
+Issue #85 semantics or claim stronger durability.
+
 After a successful commit, the active receipt is consumed as `.task-state/automation-maintenance.consumed.json`. A later successful upgrade with changes replaces the active receipt and removes the prior consumed receipt; a no-change invocation returns `NO_CHANGES` and preserves existing receipt lifecycle evidence. There is no raw Git/GitHub bypass, and merge is excluded: the Main Orchestrator performs the separately gated integration/merge workflow.
 
 The upgrade system supports versioned removal migrations. Removals name explicit, exact Agent Core-managed paths; repository-owned and protected paths cannot be removed. Migration preconditions are checked before any mutation, and `.automation/VERSION` advances only after all deletion, creation, replacement, and merge actions succeed.

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -525,7 +525,10 @@ def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
         for key, value in os.environ.items()
-        if not key.startswith("GIT_") and key != "EMAIL"
+        if not key.startswith("GIT_")
+        and not key.startswith("LD_")
+        and not key.startswith("DYLD_")
+        and key != "EMAIL"
     }
     if overrides:
         environment.update(overrides)
@@ -554,6 +557,21 @@ def git_executable() -> Path:
     return executable
 
 
+def trusted_git_command(command: list[str]) -> list[str]:
+    if not command or command[0] != "git":
+        raise UpgradeError("trusted Git command must start with git")
+    return [
+        str(git_executable()),
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.pager=",
+        *command[1:],
+    ]
+
+
 def run(
     command: list[str],
     *,
@@ -564,7 +582,7 @@ def run(
 ) -> subprocess.CompletedProcess[str]:
     is_git = bool(command and command[0] == "git")
     environment = git_environment(env_overrides) if is_git else None
-    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    executable_command = trusted_git_command(command) if is_git else command
     result = subprocess.run(
         executable_command,
         cwd=cwd,
@@ -628,7 +646,7 @@ def git_bytes(command: list[str], *, cwd: Path) -> bytes:
     if not command or command[0] != "git":
         raise UpgradeError("byte helper only accepts Git commands")
     result = subprocess.run(
-        [str(git_executable()), *command[1:]],
+        trusted_git_command(command),
         cwd=cwd,
         capture_output=True,
         check=False,
@@ -686,6 +704,14 @@ def _validate_source_revision(source: Path, revision: object) -> str:
     result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
     if result.returncode != 0 or result.stdout.strip() != revision:
         raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
+
+
+def _validate_expected_implementation_revision(revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError(
+            "expected implementation revision must be a full lowercase hexadecimal Git revision"
+        )
     return revision
 
 
@@ -988,7 +1014,7 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 
 def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
     result = subprocess.run(
-        [str(git_executable()), "show", f"{revision}:{path}"],
+        trusted_git_command(["git", "show", f"{revision}:{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1553,10 +1579,20 @@ def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, pr
     return _bridge_authority_path(repo)
 
 
-def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+def recover_maintenance_authority_from_source(
+    target_repo: Path,
+    templates_source_root: Path,
+    *,
+    expected_implementation_revision: str,
+) -> dict:
     """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
     task_id, branch, worktree = require_maintenance(target_repo)
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    if implementation_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
     active = receipt_path(target_repo)
     if not active.is_file():
         raise UpgradeError("no active automation upgrade receipt")
@@ -1618,7 +1654,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
     }
     if active.read_bytes() != raw_receipt or candidate != receipt:
         raise UpgradeError("receipt or target changed during source recovery")
-    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+    proof = _recovery_proof(receipt, implementation_source=source,
+                            implementation_revision=expected_implementation_revision,
                             raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
     proof_path = source_recovery_proof_path(target_repo)
     created_proof: tuple[int, int] | None = None
@@ -1632,7 +1669,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
         else:
             created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
-        if current_source != source or current_implementation_revision != implementation_revision:
+        if (current_source != source
+                or current_implementation_revision != expected_implementation_revision):
             raise UpgradeError("source changed before source-recovery publication")
         if active.read_bytes() != raw_receipt or authority_exists(target_repo):
             raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
@@ -1658,7 +1696,7 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
-            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+            "implementationRevision": expected_implementation_revision, "receiptSourceRevision": receipt_revision}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1736,7 +1774,7 @@ def staged_fingerprint(
         raise UpgradeError(f"staged path has an unsupported index entry: {path}")
     mode = fields[0]
     result = subprocess.run(
-        [str(git_executable()), "show", f":{path}"],
+        trusted_git_command(["git", "show", f":{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1771,7 +1809,15 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1802,13 +1848,19 @@ def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root:
     if mode == "standard":
         authority = validate_authority(repo, receipt)
     elif mode == "source_recovery":
+        if expected_implementation_revision is None:
+            raise UpgradeError("source-recovery commit requires an expected implementation revision")
+        expected_implementation_revision = _validate_expected_implementation_revision(
+            expected_implementation_revision
+        )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
         proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
-                or proof["implementation_revision"] != current_revision
+                or proof["implementation_revision"] != expected_implementation_revision
+                or current_revision != expected_implementation_revision
                 or (source_root is not None and source_root != source)):
             raise UpgradeError("source-recovery proof implementation is stale")
         if not _source_is_compatible(receipt["source"], source):
@@ -1969,12 +2021,31 @@ def commit(repo: Path, task: str, message: str) -> dict[str, object]:
     return _commit_mode(repo, task, message, "standard")
 
 
-def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+def commit_recovered_maintenance(
+    target_repo: Path,
+    templates_source_root: Path,
+    task: str,
+    message: str,
+    *,
+    expected_implementation_revision: str,
+) -> dict[str, object]:
     """Commit only a proof-bound source recovery; no network or merge operation is performed."""
     # The source argument is deliberately checked before the receipt is opened, and
     # is not a target mutation/apply hook.
-    source, _ = resolve_clean_source_worktree(templates_source_root)
-    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
+    source, source_revision = resolve_clean_source_worktree(templates_source_root)
+    if source_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
+    return _commit_mode(
+        target_repo,
+        task,
+        message,
+        "source_recovery",
+        source_root=source,
+        expected_implementation_revision=expected_implementation_revision,
+    )
 
 
 def parser() -> argparse.ArgumentParser:

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -668,9 +668,29 @@ The canonical publication flows are:
    reported as already published and must not be retried as an uncommitted pair.
    It consumes receipt, authority, and proof. It does not push or merge. The existing consumer script need not and must not be
    replaced first. This is not a generic external apply/upgrade/commit
-   primitive; normal consumer bootstrap and commit remain distinct.
+    primitive; normal consumer bootstrap and commit remain distinct.
 
- Successful upgrade writes or replaces the ignored `.task-state/automation-maintenance.json` receipt. Its schema-1 content records Task identity (`task_id`, `branch`, `worktree`), source and source revision, current/upstream versions, sorted unique `changed_paths`, the authority `HEAD`, and per-path content/state fingerprints. Receipt and authority publication is a logical pair. Authority records live under the Git-resolved per-worktree administrative directory returned by `--absolute-git-dir`, not an assumed visible `.git` or shared Git directory; linked and special administrative topologies are supported, and worktrees do not share authority. Existing safe legacy shared-common-dir hashed records remain validation/commit compatible. `automation::commit <task> [message]` fails closed unless both records match the current Task/worktree identity and `HEAD`, fingerprints, and complete pending path set. Receipt paths must be Agent Core-managed; any mixed Adapter, repository, product, configured-secret, or `.task-state` scope is rejected. Ambient Git repository/index overrides are scrubbed; exact blobs and modes are staged and rechecked in a private index, committed as that verified tree without hooks, and published only by an expected-HEAD Task branch update. A handled authority-write failure removes the newly written receipt if it is unchanged; an interruption half-state is recoverable only through the strict source-side bridge above. No cross-filesystem atomicity is claimed. The receipt is moved to `.task-state/automation-maintenance.consumed.json` after successful commit; the next successful upgrade with changes replaces the active receipt and removes the prior consumed receipt. A no-change invocation returns `NO_CHANGES` and preserves existing lifecycle evidence.
+    Both root bridge recipes use `python3 -I` and a small stdlib-only bootstrap.
+    Isolated mode excludes `PYTHONPATH`, the current directory, and user-site
+    shadowing from bootstrap imports. The bootstrap resolves the root and a
+    trusted, root-owned, non-writable Git repository with scrubbed `GIT_*`, then
+    verifies the full `HEAD` and the whole clean Templates worktree. It verifies
+    the live bootstrap against the tracked `HEAD` blob, obtains the engine
+    regular blob from the verified `HEAD` Git objects, materializes it privately,
+    and executes the engine only afterward. The verified `HEAD` is passed into
+    the engine, which independently reruns clean-source, root, and `HEAD`
+    validation and requires equality before authority publication. Therefore
+    `implementation_revision` equals the blob-providing `HEAD`, and source races
+    fail closed. Dirty bridge or engine files and module-shadow states reject
+    before target authority or publication changes.
+
+    The live bootstrap is the small initial trust anchor. Its self-check detects
+    accidental or concurrent divergence; hostile replacement requires an
+    external trusted launcher or signing mechanism and is not claimed here.
+    Hard-crash consistency remains out of scope, and this does not change Issue
+    #85 semantics or imply stronger durability.
+
+  Successful upgrade writes or replaces the ignored `.task-state/automation-maintenance.json` receipt. Its schema-1 content records Task identity (`task_id`, `branch`, `worktree`), source and source revision, current/upstream versions, sorted unique `changed_paths`, the authority `HEAD`, and per-path content/state fingerprints. Receipt and authority publication is a logical pair. Authority records live under the Git-resolved per-worktree administrative directory returned by `--absolute-git-dir`, not an assumed visible `.git` or shared Git directory; linked and special administrative topologies are supported, and worktrees do not share authority. Existing safe legacy shared-common-dir hashed records remain validation/commit compatible. `automation::commit <task> [message]` fails closed unless both records match the current Task/worktree identity and `HEAD`, fingerprints, and complete pending path set. Receipt paths must be Agent Core-managed; any mixed Adapter, repository, product, configured-secret, or `.task-state` scope is rejected. Ambient Git repository/index overrides are scrubbed; exact blobs and modes are staged and rechecked in a private index, committed as that verified tree without hooks, and published only by an expected-HEAD Task branch update. A handled authority-write failure removes the newly written receipt if it is unchanged; an interruption half-state is recoverable only through the strict source-side bridge above. No cross-filesystem atomicity is claimed. The receipt is moved to `.task-state/automation-maintenance.consumed.json` after successful commit; the next successful upgrade with changes replaces the active receipt and removes the prior consumed receipt. A no-change invocation returns `NO_CHANGES` and preserves existing lifecycle evidence.
 
 The required sequence is `git diff --check`, `just agent::doctor`, `just project::check`, and the repository CI/smoke suite, followed by `just automation::commit <task> [message]`, existing `just agent::push <task>`, and `just agent::pr-create <task>` (Draft PR). Raw Git/GitHub bypass is not permitted. Merge is excluded from this workflow and remains a separately gated Main Orchestrator operation.
 

--- a/just/agent-core.just
+++ b/just/agent-core.just
@@ -3,8 +3,8 @@ tool := root / "tools/automation_recovery_bridge.py"
 
 [working-directory: root]
 recover-maintenance-authority target:
-    python3 {{quote(tool)}} recover-maintenance-authority {{quote(target)}}
+    python3 -I {{quote(tool)}} recover-maintenance-authority {{quote(target)}}
 
 [working-directory: root]
 commit-recovered-maintenance target task message="":
-    python3 {{quote(tool)}} commit-recovered-maintenance {{quote(target)}} {{quote(task)}} {{quote(message)}}
+    python3 -I {{quote(tool)}} commit-recovered-maintenance {{quote(target)}} {{quote(task)}} {{quote(message)}}

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -525,7 +525,10 @@ def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
         for key, value in os.environ.items()
-        if not key.startswith("GIT_") and key != "EMAIL"
+        if not key.startswith("GIT_")
+        and not key.startswith("LD_")
+        and not key.startswith("DYLD_")
+        and key != "EMAIL"
     }
     if overrides:
         environment.update(overrides)
@@ -554,6 +557,21 @@ def git_executable() -> Path:
     return executable
 
 
+def trusted_git_command(command: list[str]) -> list[str]:
+    if not command or command[0] != "git":
+        raise UpgradeError("trusted Git command must start with git")
+    return [
+        str(git_executable()),
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.pager=",
+        *command[1:],
+    ]
+
+
 def run(
     command: list[str],
     *,
@@ -564,7 +582,7 @@ def run(
 ) -> subprocess.CompletedProcess[str]:
     is_git = bool(command and command[0] == "git")
     environment = git_environment(env_overrides) if is_git else None
-    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    executable_command = trusted_git_command(command) if is_git else command
     result = subprocess.run(
         executable_command,
         cwd=cwd,
@@ -628,7 +646,7 @@ def git_bytes(command: list[str], *, cwd: Path) -> bytes:
     if not command or command[0] != "git":
         raise UpgradeError("byte helper only accepts Git commands")
     result = subprocess.run(
-        [str(git_executable()), *command[1:]],
+        trusted_git_command(command),
         cwd=cwd,
         capture_output=True,
         check=False,
@@ -686,6 +704,14 @@ def _validate_source_revision(source: Path, revision: object) -> str:
     result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
     if result.returncode != 0 or result.stdout.strip() != revision:
         raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
+
+
+def _validate_expected_implementation_revision(revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError(
+            "expected implementation revision must be a full lowercase hexadecimal Git revision"
+        )
     return revision
 
 
@@ -988,7 +1014,7 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 
 def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
     result = subprocess.run(
-        [str(git_executable()), "show", f"{revision}:{path}"],
+        trusted_git_command(["git", "show", f"{revision}:{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1553,10 +1579,20 @@ def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, pr
     return _bridge_authority_path(repo)
 
 
-def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+def recover_maintenance_authority_from_source(
+    target_repo: Path,
+    templates_source_root: Path,
+    *,
+    expected_implementation_revision: str,
+) -> dict:
     """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
     task_id, branch, worktree = require_maintenance(target_repo)
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    if implementation_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
     active = receipt_path(target_repo)
     if not active.is_file():
         raise UpgradeError("no active automation upgrade receipt")
@@ -1618,7 +1654,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
     }
     if active.read_bytes() != raw_receipt or candidate != receipt:
         raise UpgradeError("receipt or target changed during source recovery")
-    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+    proof = _recovery_proof(receipt, implementation_source=source,
+                            implementation_revision=expected_implementation_revision,
                             raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
     proof_path = source_recovery_proof_path(target_repo)
     created_proof: tuple[int, int] | None = None
@@ -1632,7 +1669,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
         else:
             created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
-        if current_source != source or current_implementation_revision != implementation_revision:
+        if (current_source != source
+                or current_implementation_revision != expected_implementation_revision):
             raise UpgradeError("source changed before source-recovery publication")
         if active.read_bytes() != raw_receipt or authority_exists(target_repo):
             raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
@@ -1658,7 +1696,7 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
-            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+            "implementationRevision": expected_implementation_revision, "receiptSourceRevision": receipt_revision}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1736,7 +1774,7 @@ def staged_fingerprint(
         raise UpgradeError(f"staged path has an unsupported index entry: {path}")
     mode = fields[0]
     result = subprocess.run(
-        [str(git_executable()), "show", f":{path}"],
+        trusted_git_command(["git", "show", f":{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1771,7 +1809,15 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1802,13 +1848,19 @@ def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root:
     if mode == "standard":
         authority = validate_authority(repo, receipt)
     elif mode == "source_recovery":
+        if expected_implementation_revision is None:
+            raise UpgradeError("source-recovery commit requires an expected implementation revision")
+        expected_implementation_revision = _validate_expected_implementation_revision(
+            expected_implementation_revision
+        )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
         proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
-                or proof["implementation_revision"] != current_revision
+                or proof["implementation_revision"] != expected_implementation_revision
+                or current_revision != expected_implementation_revision
                 or (source_root is not None and source_root != source)):
             raise UpgradeError("source-recovery proof implementation is stale")
         if not _source_is_compatible(receipt["source"], source):
@@ -1969,12 +2021,31 @@ def commit(repo: Path, task: str, message: str) -> dict[str, object]:
     return _commit_mode(repo, task, message, "standard")
 
 
-def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+def commit_recovered_maintenance(
+    target_repo: Path,
+    templates_source_root: Path,
+    task: str,
+    message: str,
+    *,
+    expected_implementation_revision: str,
+) -> dict[str, object]:
     """Commit only a proof-bound source recovery; no network or merge operation is performed."""
     # The source argument is deliberately checked before the receipt is opened, and
     # is not a target mutation/apply hook.
-    source, _ = resolve_clean_source_worktree(templates_source_root)
-    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
+    source, source_revision = resolve_clean_source_worktree(templates_source_root)
+    if source_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
+    return _commit_mode(
+        target_repo,
+        task,
+        message,
+        "source_recovery",
+        source_root=source,
+        expected_implementation_revision=expected_implementation_revision,
+    )
 
 
 def parser() -> argparse.ArgumentParser:

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -525,7 +525,10 @@ def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
         for key, value in os.environ.items()
-        if not key.startswith("GIT_") and key != "EMAIL"
+        if not key.startswith("GIT_")
+        and not key.startswith("LD_")
+        and not key.startswith("DYLD_")
+        and key != "EMAIL"
     }
     if overrides:
         environment.update(overrides)
@@ -554,6 +557,21 @@ def git_executable() -> Path:
     return executable
 
 
+def trusted_git_command(command: list[str]) -> list[str]:
+    if not command or command[0] != "git":
+        raise UpgradeError("trusted Git command must start with git")
+    return [
+        str(git_executable()),
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.pager=",
+        *command[1:],
+    ]
+
+
 def run(
     command: list[str],
     *,
@@ -564,7 +582,7 @@ def run(
 ) -> subprocess.CompletedProcess[str]:
     is_git = bool(command and command[0] == "git")
     environment = git_environment(env_overrides) if is_git else None
-    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    executable_command = trusted_git_command(command) if is_git else command
     result = subprocess.run(
         executable_command,
         cwd=cwd,
@@ -628,7 +646,7 @@ def git_bytes(command: list[str], *, cwd: Path) -> bytes:
     if not command or command[0] != "git":
         raise UpgradeError("byte helper only accepts Git commands")
     result = subprocess.run(
-        [str(git_executable()), *command[1:]],
+        trusted_git_command(command),
         cwd=cwd,
         capture_output=True,
         check=False,
@@ -686,6 +704,14 @@ def _validate_source_revision(source: Path, revision: object) -> str:
     result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
     if result.returncode != 0 or result.stdout.strip() != revision:
         raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
+
+
+def _validate_expected_implementation_revision(revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError(
+            "expected implementation revision must be a full lowercase hexadecimal Git revision"
+        )
     return revision
 
 
@@ -988,7 +1014,7 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 
 def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
     result = subprocess.run(
-        [str(git_executable()), "show", f"{revision}:{path}"],
+        trusted_git_command(["git", "show", f"{revision}:{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1553,10 +1579,20 @@ def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, pr
     return _bridge_authority_path(repo)
 
 
-def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+def recover_maintenance_authority_from_source(
+    target_repo: Path,
+    templates_source_root: Path,
+    *,
+    expected_implementation_revision: str,
+) -> dict:
     """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
     task_id, branch, worktree = require_maintenance(target_repo)
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    if implementation_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
     active = receipt_path(target_repo)
     if not active.is_file():
         raise UpgradeError("no active automation upgrade receipt")
@@ -1618,7 +1654,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
     }
     if active.read_bytes() != raw_receipt or candidate != receipt:
         raise UpgradeError("receipt or target changed during source recovery")
-    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+    proof = _recovery_proof(receipt, implementation_source=source,
+                            implementation_revision=expected_implementation_revision,
                             raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
     proof_path = source_recovery_proof_path(target_repo)
     created_proof: tuple[int, int] | None = None
@@ -1632,7 +1669,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
         else:
             created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
-        if current_source != source or current_implementation_revision != implementation_revision:
+        if (current_source != source
+                or current_implementation_revision != expected_implementation_revision):
             raise UpgradeError("source changed before source-recovery publication")
         if active.read_bytes() != raw_receipt or authority_exists(target_repo):
             raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
@@ -1658,7 +1696,7 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
-            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+            "implementationRevision": expected_implementation_revision, "receiptSourceRevision": receipt_revision}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1736,7 +1774,7 @@ def staged_fingerprint(
         raise UpgradeError(f"staged path has an unsupported index entry: {path}")
     mode = fields[0]
     result = subprocess.run(
-        [str(git_executable()), "show", f":{path}"],
+        trusted_git_command(["git", "show", f":{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1771,7 +1809,15 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1802,13 +1848,19 @@ def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root:
     if mode == "standard":
         authority = validate_authority(repo, receipt)
     elif mode == "source_recovery":
+        if expected_implementation_revision is None:
+            raise UpgradeError("source-recovery commit requires an expected implementation revision")
+        expected_implementation_revision = _validate_expected_implementation_revision(
+            expected_implementation_revision
+        )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
         proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
-                or proof["implementation_revision"] != current_revision
+                or proof["implementation_revision"] != expected_implementation_revision
+                or current_revision != expected_implementation_revision
                 or (source_root is not None and source_root != source)):
             raise UpgradeError("source-recovery proof implementation is stale")
         if not _source_is_compatible(receipt["source"], source):
@@ -1969,12 +2021,31 @@ def commit(repo: Path, task: str, message: str) -> dict[str, object]:
     return _commit_mode(repo, task, message, "standard")
 
 
-def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+def commit_recovered_maintenance(
+    target_repo: Path,
+    templates_source_root: Path,
+    task: str,
+    message: str,
+    *,
+    expected_implementation_revision: str,
+) -> dict[str, object]:
     """Commit only a proof-bound source recovery; no network or merge operation is performed."""
     # The source argument is deliberately checked before the receipt is opened, and
     # is not a target mutation/apply hook.
-    source, _ = resolve_clean_source_worktree(templates_source_root)
-    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
+    source, source_revision = resolve_clean_source_worktree(templates_source_root)
+    if source_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
+    return _commit_mode(
+        target_repo,
+        task,
+        message,
+        "source_recovery",
+        source_root=source,
+        expected_implementation_revision=expected_implementation_revision,
+    )
 
 
 def parser() -> argparse.ArgumentParser:

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -525,7 +525,10 @@ def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
         for key, value in os.environ.items()
-        if not key.startswith("GIT_") and key != "EMAIL"
+        if not key.startswith("GIT_")
+        and not key.startswith("LD_")
+        and not key.startswith("DYLD_")
+        and key != "EMAIL"
     }
     if overrides:
         environment.update(overrides)
@@ -554,6 +557,21 @@ def git_executable() -> Path:
     return executable
 
 
+def trusted_git_command(command: list[str]) -> list[str]:
+    if not command or command[0] != "git":
+        raise UpgradeError("trusted Git command must start with git")
+    return [
+        str(git_executable()),
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.pager=",
+        *command[1:],
+    ]
+
+
 def run(
     command: list[str],
     *,
@@ -564,7 +582,7 @@ def run(
 ) -> subprocess.CompletedProcess[str]:
     is_git = bool(command and command[0] == "git")
     environment = git_environment(env_overrides) if is_git else None
-    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    executable_command = trusted_git_command(command) if is_git else command
     result = subprocess.run(
         executable_command,
         cwd=cwd,
@@ -628,7 +646,7 @@ def git_bytes(command: list[str], *, cwd: Path) -> bytes:
     if not command or command[0] != "git":
         raise UpgradeError("byte helper only accepts Git commands")
     result = subprocess.run(
-        [str(git_executable()), *command[1:]],
+        trusted_git_command(command),
         cwd=cwd,
         capture_output=True,
         check=False,
@@ -686,6 +704,14 @@ def _validate_source_revision(source: Path, revision: object) -> str:
     result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
     if result.returncode != 0 or result.stdout.strip() != revision:
         raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
+
+
+def _validate_expected_implementation_revision(revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError(
+            "expected implementation revision must be a full lowercase hexadecimal Git revision"
+        )
     return revision
 
 
@@ -988,7 +1014,7 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 
 def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
     result = subprocess.run(
-        [str(git_executable()), "show", f"{revision}:{path}"],
+        trusted_git_command(["git", "show", f"{revision}:{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1553,10 +1579,20 @@ def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, pr
     return _bridge_authority_path(repo)
 
 
-def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+def recover_maintenance_authority_from_source(
+    target_repo: Path,
+    templates_source_root: Path,
+    *,
+    expected_implementation_revision: str,
+) -> dict:
     """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
     task_id, branch, worktree = require_maintenance(target_repo)
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    if implementation_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
     active = receipt_path(target_repo)
     if not active.is_file():
         raise UpgradeError("no active automation upgrade receipt")
@@ -1618,7 +1654,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
     }
     if active.read_bytes() != raw_receipt or candidate != receipt:
         raise UpgradeError("receipt or target changed during source recovery")
-    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+    proof = _recovery_proof(receipt, implementation_source=source,
+                            implementation_revision=expected_implementation_revision,
                             raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
     proof_path = source_recovery_proof_path(target_repo)
     created_proof: tuple[int, int] | None = None
@@ -1632,7 +1669,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
         else:
             created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
-        if current_source != source or current_implementation_revision != implementation_revision:
+        if (current_source != source
+                or current_implementation_revision != expected_implementation_revision):
             raise UpgradeError("source changed before source-recovery publication")
         if active.read_bytes() != raw_receipt or authority_exists(target_repo):
             raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
@@ -1658,7 +1696,7 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
-            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+            "implementationRevision": expected_implementation_revision, "receiptSourceRevision": receipt_revision}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1736,7 +1774,7 @@ def staged_fingerprint(
         raise UpgradeError(f"staged path has an unsupported index entry: {path}")
     mode = fields[0]
     result = subprocess.run(
-        [str(git_executable()), "show", f":{path}"],
+        trusted_git_command(["git", "show", f":{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1771,7 +1809,15 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1802,13 +1848,19 @@ def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root:
     if mode == "standard":
         authority = validate_authority(repo, receipt)
     elif mode == "source_recovery":
+        if expected_implementation_revision is None:
+            raise UpgradeError("source-recovery commit requires an expected implementation revision")
+        expected_implementation_revision = _validate_expected_implementation_revision(
+            expected_implementation_revision
+        )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
         proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
-                or proof["implementation_revision"] != current_revision
+                or proof["implementation_revision"] != expected_implementation_revision
+                or current_revision != expected_implementation_revision
                 or (source_root is not None and source_root != source)):
             raise UpgradeError("source-recovery proof implementation is stale")
         if not _source_is_compatible(receipt["source"], source):
@@ -1969,12 +2021,31 @@ def commit(repo: Path, task: str, message: str) -> dict[str, object]:
     return _commit_mode(repo, task, message, "standard")
 
 
-def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+def commit_recovered_maintenance(
+    target_repo: Path,
+    templates_source_root: Path,
+    task: str,
+    message: str,
+    *,
+    expected_implementation_revision: str,
+) -> dict[str, object]:
     """Commit only a proof-bound source recovery; no network or merge operation is performed."""
     # The source argument is deliberately checked before the receipt is opened, and
     # is not a target mutation/apply hook.
-    source, _ = resolve_clean_source_worktree(templates_source_root)
-    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
+    source, source_revision = resolve_clean_source_worktree(templates_source_root)
+    if source_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
+    return _commit_mode(
+        target_repo,
+        task,
+        message,
+        "source_recovery",
+        source_root=source,
+        expected_implementation_revision=expected_implementation_revision,
+    )
 
 
 def parser() -> argparse.ArgumentParser:

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -525,7 +525,10 @@ def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
         for key, value in os.environ.items()
-        if not key.startswith("GIT_") and key != "EMAIL"
+        if not key.startswith("GIT_")
+        and not key.startswith("LD_")
+        and not key.startswith("DYLD_")
+        and key != "EMAIL"
     }
     if overrides:
         environment.update(overrides)
@@ -554,6 +557,21 @@ def git_executable() -> Path:
     return executable
 
 
+def trusted_git_command(command: list[str]) -> list[str]:
+    if not command or command[0] != "git":
+        raise UpgradeError("trusted Git command must start with git")
+    return [
+        str(git_executable()),
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.pager=",
+        *command[1:],
+    ]
+
+
 def run(
     command: list[str],
     *,
@@ -564,7 +582,7 @@ def run(
 ) -> subprocess.CompletedProcess[str]:
     is_git = bool(command and command[0] == "git")
     environment = git_environment(env_overrides) if is_git else None
-    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    executable_command = trusted_git_command(command) if is_git else command
     result = subprocess.run(
         executable_command,
         cwd=cwd,
@@ -628,7 +646,7 @@ def git_bytes(command: list[str], *, cwd: Path) -> bytes:
     if not command or command[0] != "git":
         raise UpgradeError("byte helper only accepts Git commands")
     result = subprocess.run(
-        [str(git_executable()), *command[1:]],
+        trusted_git_command(command),
         cwd=cwd,
         capture_output=True,
         check=False,
@@ -686,6 +704,14 @@ def _validate_source_revision(source: Path, revision: object) -> str:
     result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
     if result.returncode != 0 or result.stdout.strip() != revision:
         raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
+
+
+def _validate_expected_implementation_revision(revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError(
+            "expected implementation revision must be a full lowercase hexadecimal Git revision"
+        )
     return revision
 
 
@@ -988,7 +1014,7 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 
 def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
     result = subprocess.run(
-        [str(git_executable()), "show", f"{revision}:{path}"],
+        trusted_git_command(["git", "show", f"{revision}:{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1553,10 +1579,20 @@ def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, pr
     return _bridge_authority_path(repo)
 
 
-def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+def recover_maintenance_authority_from_source(
+    target_repo: Path,
+    templates_source_root: Path,
+    *,
+    expected_implementation_revision: str,
+) -> dict:
     """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
     task_id, branch, worktree = require_maintenance(target_repo)
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    if implementation_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
     active = receipt_path(target_repo)
     if not active.is_file():
         raise UpgradeError("no active automation upgrade receipt")
@@ -1618,7 +1654,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
     }
     if active.read_bytes() != raw_receipt or candidate != receipt:
         raise UpgradeError("receipt or target changed during source recovery")
-    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+    proof = _recovery_proof(receipt, implementation_source=source,
+                            implementation_revision=expected_implementation_revision,
                             raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
     proof_path = source_recovery_proof_path(target_repo)
     created_proof: tuple[int, int] | None = None
@@ -1632,7 +1669,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
         else:
             created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
-        if current_source != source or current_implementation_revision != implementation_revision:
+        if (current_source != source
+                or current_implementation_revision != expected_implementation_revision):
             raise UpgradeError("source changed before source-recovery publication")
         if active.read_bytes() != raw_receipt or authority_exists(target_repo):
             raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
@@ -1658,7 +1696,7 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
-            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+            "implementationRevision": expected_implementation_revision, "receiptSourceRevision": receipt_revision}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1736,7 +1774,7 @@ def staged_fingerprint(
         raise UpgradeError(f"staged path has an unsupported index entry: {path}")
     mode = fields[0]
     result = subprocess.run(
-        [str(git_executable()), "show", f":{path}"],
+        trusted_git_command(["git", "show", f":{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1771,7 +1809,15 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1802,13 +1848,19 @@ def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root:
     if mode == "standard":
         authority = validate_authority(repo, receipt)
     elif mode == "source_recovery":
+        if expected_implementation_revision is None:
+            raise UpgradeError("source-recovery commit requires an expected implementation revision")
+        expected_implementation_revision = _validate_expected_implementation_revision(
+            expected_implementation_revision
+        )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
         proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
-                or proof["implementation_revision"] != current_revision
+                or proof["implementation_revision"] != expected_implementation_revision
+                or current_revision != expected_implementation_revision
                 or (source_root is not None and source_root != source)):
             raise UpgradeError("source-recovery proof implementation is stale")
         if not _source_is_compatible(receipt["source"], source):
@@ -1969,12 +2021,31 @@ def commit(repo: Path, task: str, message: str) -> dict[str, object]:
     return _commit_mode(repo, task, message, "standard")
 
 
-def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+def commit_recovered_maintenance(
+    target_repo: Path,
+    templates_source_root: Path,
+    task: str,
+    message: str,
+    *,
+    expected_implementation_revision: str,
+) -> dict[str, object]:
     """Commit only a proof-bound source recovery; no network or merge operation is performed."""
     # The source argument is deliberately checked before the receipt is opened, and
     # is not a target mutation/apply hook.
-    source, _ = resolve_clean_source_worktree(templates_source_root)
-    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
+    source, source_revision = resolve_clean_source_worktree(templates_source_root)
+    if source_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
+    return _commit_mode(
+        target_repo,
+        task,
+        message,
+        "source_recovery",
+        source_root=source,
+        expected_implementation_revision=expected_implementation_revision,
+    )
 
 
 def parser() -> argparse.ArgumentParser:

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -525,7 +525,10 @@ def git_environment(overrides: dict[str, str] | None = None) -> dict[str, str]:
     environment = {
         key: value
         for key, value in os.environ.items()
-        if not key.startswith("GIT_") and key != "EMAIL"
+        if not key.startswith("GIT_")
+        and not key.startswith("LD_")
+        and not key.startswith("DYLD_")
+        and key != "EMAIL"
     }
     if overrides:
         environment.update(overrides)
@@ -554,6 +557,21 @@ def git_executable() -> Path:
     return executable
 
 
+def trusted_git_command(command: list[str]) -> list[str]:
+    if not command or command[0] != "git":
+        raise UpgradeError("trusted Git command must start with git")
+    return [
+        str(git_executable()),
+        "-c",
+        "core.fsmonitor=false",
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "core.pager=",
+        *command[1:],
+    ]
+
+
 def run(
     command: list[str],
     *,
@@ -564,7 +582,7 @@ def run(
 ) -> subprocess.CompletedProcess[str]:
     is_git = bool(command and command[0] == "git")
     environment = git_environment(env_overrides) if is_git else None
-    executable_command = [str(git_executable()), *command[1:]] if is_git else command
+    executable_command = trusted_git_command(command) if is_git else command
     result = subprocess.run(
         executable_command,
         cwd=cwd,
@@ -628,7 +646,7 @@ def git_bytes(command: list[str], *, cwd: Path) -> bytes:
     if not command or command[0] != "git":
         raise UpgradeError("byte helper only accepts Git commands")
     result = subprocess.run(
-        [str(git_executable()), *command[1:]],
+        trusted_git_command(command),
         cwd=cwd,
         capture_output=True,
         check=False,
@@ -686,6 +704,14 @@ def _validate_source_revision(source: Path, revision: object) -> str:
     result = run(["git", "rev-parse", "--verify", f"{revision}^{{commit}}"], cwd=source, check=False)
     if result.returncode != 0 or result.stdout.strip() != revision:
         raise UpgradeError("receipt source_revision is not a commit in the current source object database")
+    return revision
+
+
+def _validate_expected_implementation_revision(revision: object) -> str:
+    if not isinstance(revision, str) or not re.fullmatch(r"[0-9a-f]{40,64}", revision):
+        raise UpgradeError(
+            "expected implementation revision must be a full lowercase hexadecimal Git revision"
+        )
     return revision
 
 
@@ -988,7 +1014,7 @@ def action_for(repo: Path, source_core: Path, relative: Path, ownership: dict[st
 
 def git_object_bytes(repo: Path, revision: str, path: str) -> bytes:
     result = subprocess.run(
-        [str(git_executable()), "show", f"{revision}:{path}"],
+        trusted_git_command(["git", "show", f"{revision}:{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1553,10 +1579,20 @@ def _validate_recovery_records(repo: Path, receipt: dict, raw_receipt: bytes, pr
     return _bridge_authority_path(repo)
 
 
-def recover_maintenance_authority_from_source(target_repo: Path, templates_source_root: Path) -> dict:
+def recover_maintenance_authority_from_source(
+    target_repo: Path,
+    templates_source_root: Path,
+    *,
+    expected_implementation_revision: str,
+) -> dict:
     """Reconstruct and publish the source-recovery proof/bridge without touching target files."""
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
     task_id, branch, worktree = require_maintenance(target_repo)
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
+    if implementation_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
     active = receipt_path(target_repo)
     if not active.is_file():
         raise UpgradeError("no active automation upgrade receipt")
@@ -1618,7 +1654,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
     }
     if active.read_bytes() != raw_receipt or candidate != receipt:
         raise UpgradeError("receipt or target changed during source recovery")
-    proof = _recovery_proof(receipt, implementation_source=source, implementation_revision=implementation_revision,
+    proof = _recovery_proof(receipt, implementation_source=source,
+                            implementation_revision=expected_implementation_revision,
                             raw_receipt=raw_receipt, paths=expected, fingerprints=actual_fingerprints)
     proof_path = source_recovery_proof_path(target_repo)
     created_proof: tuple[int, int] | None = None
@@ -1632,7 +1669,8 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
         else:
             created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
-        if current_source != source or current_implementation_revision != implementation_revision:
+        if (current_source != source
+                or current_implementation_revision != expected_implementation_revision):
             raise UpgradeError("source changed before source-recovery publication")
         if active.read_bytes() != raw_receipt or authority_exists(target_repo):
             raise UpgradeError("receipt or authority changed before source-recovery bridge publication")
@@ -1658,7 +1696,7 @@ def recover_maintenance_authority_from_source(target_repo: Path, templates_sourc
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
-            "implementationRevision": implementation_revision, "receiptSourceRevision": receipt_revision}
+            "implementationRevision": expected_implementation_revision, "receiptSourceRevision": receipt_revision}
 
 
 def validate_receipt_path(raw: object) -> str:
@@ -1736,7 +1774,7 @@ def staged_fingerprint(
         raise UpgradeError(f"staged path has an unsupported index entry: {path}")
     mode = fields[0]
     result = subprocess.run(
-        [str(git_executable()), "show", f":{path}"],
+        trusted_git_command(["git", "show", f":{path}"]),
         cwd=repo,
         capture_output=True,
         check=False,
@@ -1771,7 +1809,15 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root: Path | None = None) -> dict[str, object]:
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
     _, branch, worktree = require_registered_task(repo, task)
     active = receipt_path(repo)
     state_dir = task_state_dir(repo)
@@ -1802,13 +1848,19 @@ def _commit_mode(repo: Path, task: str, message: str, mode: str, *, source_root:
     if mode == "standard":
         authority = validate_authority(repo, receipt)
     elif mode == "source_recovery":
+        if expected_implementation_revision is None:
+            raise UpgradeError("source-recovery commit requires an expected implementation revision")
+        expected_implementation_revision = _validate_expected_implementation_revision(
+            expected_implementation_revision
+        )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
         proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
-                or proof["implementation_revision"] != current_revision
+                or proof["implementation_revision"] != expected_implementation_revision
+                or current_revision != expected_implementation_revision
                 or (source_root is not None and source_root != source)):
             raise UpgradeError("source-recovery proof implementation is stale")
         if not _source_is_compatible(receipt["source"], source):
@@ -1969,12 +2021,31 @@ def commit(repo: Path, task: str, message: str) -> dict[str, object]:
     return _commit_mode(repo, task, message, "standard")
 
 
-def commit_recovered_maintenance(target_repo: Path, templates_source_root: Path, task: str, message: str) -> dict[str, object]:
+def commit_recovered_maintenance(
+    target_repo: Path,
+    templates_source_root: Path,
+    task: str,
+    message: str,
+    *,
+    expected_implementation_revision: str,
+) -> dict[str, object]:
     """Commit only a proof-bound source recovery; no network or merge operation is performed."""
     # The source argument is deliberately checked before the receipt is opened, and
     # is not a target mutation/apply hook.
-    source, _ = resolve_clean_source_worktree(templates_source_root)
-    return _commit_mode(target_repo, task, message, "source_recovery", source_root=source)
+    expected_implementation_revision = _validate_expected_implementation_revision(
+        expected_implementation_revision
+    )
+    source, source_revision = resolve_clean_source_worktree(templates_source_root)
+    if source_revision != expected_implementation_revision:
+        raise UpgradeError("source HEAD does not match the expected implementation revision")
+    return _commit_mode(
+        target_repo,
+        task,
+        message,
+        "source_recovery",
+        source_root=source,
+        expected_implementation_revision=expected_implementation_revision,
+    )
 
 
 def parser() -> argparse.ArgumentParser:

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -24,6 +24,13 @@ upgrade = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = upgrade
 SPEC.loader.exec_module(upgrade)
 
+BRIDGE_SPEC = importlib.util.spec_from_file_location(
+    "automation_recovery_bridge_for_tests", ROOT / "tools" / "automation_recovery_bridge.py"
+)
+assert BRIDGE_SPEC and BRIDGE_SPEC.loader
+bridge_bootstrap = importlib.util.module_from_spec(BRIDGE_SPEC)
+BRIDGE_SPEC.loader.exec_module(bridge_bootstrap)
+
 AGENT_SPEC = importlib.util.spec_from_file_location(
     "agent_core_for_upgrade_tests", ROOT / "components" / "agent-core" / ".automation" / "bin" / "agent_core.py"
 )
@@ -322,7 +329,7 @@ mod project 'just/project/mod.just'
         environment = os.environ.copy()
         environment["AUTOMATION_MAINTENANCE"] = "1"
         result = subprocess.run(
-            ["python3", "tools/automation_recovery_bridge.py", command, str(target), *args],
+            ["python3", "-I", "tools/automation_recovery_bridge.py", command, str(target), *args],
             cwd=bridge, env=environment, text=True, capture_output=True, check=False,
         )
         if check:
@@ -410,6 +417,31 @@ mod project 'just/project/mod.just'
 
     def _receipt(self, repo: Path) -> dict:
         return json.loads(upgrade.receipt_path(repo).read_text(encoding="utf-8"))
+
+    def test_issue_87_bridge_tree_blob_binds_ls_tree_to_captured_revision(self) -> None:
+        revision_a = "a" * 40
+        relative = "tools/automation_recovery_bridge.py"
+        git_bytes = mock.Mock(
+            side_effect=[
+                f"100755 blob {'b' * 40}\t{relative}\0".encode("ascii"),
+            ]
+        )
+        with mock.patch.object(bridge_bootstrap, "git_bytes", git_bytes):
+            self.assertEqual(
+                ("b" * 40, 0o100755),
+                bridge_bootstrap._tree_blob(Path("/bridge"), revision_a, relative),
+            )
+        self.assertEqual(
+            ["git", "ls-tree", "-z", revision_a, "--", relative],
+            git_bytes.call_args.args[0],
+        )
+        self.assertNotIn("HEAD", git_bytes.call_args.args[0])
+
+    def test_issue_87_bridge_error_renderer_is_bounded_and_printable(self) -> None:
+        rendered = bridge_bootstrap._error_text(Exception("x" * 2000 + "\n\r\x00\x1b"))
+        self.assertLessEqual(len(rendered), 1600)
+        self.assertEqual(rendered, rendered.replace("\n", "").replace("\r", ""))
+        self.assertTrue(all(" " <= character <= "~" for character in rendered))
 
     def _bootstrap_receipt(self, repo: Path, source_root: Path) -> dict:
         with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
@@ -1806,7 +1838,7 @@ mod project 'just/project/mod.just'
     def test_issue_85_real_bridge_recovers_and_commits_only_the_old_upgrade(self) -> None:
         repository_status = self._git(["status", "--porcelain=v1"], ROOT)
         with tempfile.TemporaryDirectory() as directory:
-            bridge, source, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
+            bridge, _, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
             receipt_before = metadata["receipt"]
             receipt_bytes = upgrade.receipt_path(task).read_bytes()
             recovered = json.loads(self._bridge_cli(bridge, "recover-maintenance-authority", task).stdout)
@@ -1883,6 +1915,7 @@ mod project 'just/project/mod.just'
                 )
                 self.assertEqual(0, result.returncode, result.stderr)
                 output = result.stdout + result.stderr
+                self.assertIn("python3 -I", output)
                 self.assertIn(str((ROOT / "tools/automation_recovery_bridge.py").resolve()), output)
                 self.assertIn(shlex.quote(str(target)), output)
                 self.assertNotIn(".automation/bin/automation_upgrade.py", output)
@@ -1911,9 +1944,199 @@ mod project 'just/project/mod.just'
                 self.assertNotEqual(0, result.returncode)
                 self.assertFalse(upgrade.authority_path(task).exists())
 
+    def test_issue_87_dirty_live_engine_is_rejected_before_engine_execution(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bridge, _, task, metadata = self._source_recovery_bridge_fixture(root)
+            marker = root / "live-engine-executed"
+            engine = bridge / "components/agent-core/.automation/bin/automation_upgrade.py"
+            with engine.open("a", encoding="utf-8") as stream:
+                stream.write(f"\nPath({str(marker)!r}).write_text('executed')\n")
+            receipt_bytes = upgrade.receipt_path(task).read_bytes()
+            branch = self._git(["rev-parse", "HEAD"], task)
+            authority = upgrade.authority_path(task)
+            proof = upgrade.source_recovery_proof_path(task)
+            result = self._bridge_cli(bridge, "recover-maintenance-authority", task, check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("ERROR:", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertFalse(marker.exists())
+            self.assertEqual(receipt_bytes, upgrade.receipt_path(task).read_bytes())
+            self.assertEqual(branch, self._git(["rev-parse", "HEAD"], task))
+            self.assertFalse(authority.exists())
+            self.assertFalse(proof.exists())
+            self.assertEqual(metadata["bridge_head"], self._git(["rev-parse", "HEAD"], bridge))
+
+    def test_issue_87_dirty_tracked_bridge_file_is_rejected_before_target_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            self._write_file(
+                bridge / "tools/automation_recovery_bridge.py",
+                (bridge / "tools/automation_recovery_bridge.py").read_text(encoding="utf-8")
+                + "\n# harmless tracked checkout modification\n",
+            )
+            receipt_bytes = upgrade.receipt_path(task).read_bytes()
+            head = self._git(["rev-parse", "HEAD"], task)
+            result = self._bridge_cli(bridge, "recover-maintenance-authority", task, check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("ERROR:", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertEqual(receipt_bytes, upgrade.receipt_path(task).read_bytes())
+            self.assertEqual(head, self._git(["rev-parse", "HEAD"], task))
+            self.assertFalse(upgrade.authority_path(task).exists())
+            self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+
+    def test_issue_87_isolated_bridge_ignores_shadow_modules_and_rejects_dirty_checkout(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(root)
+            marker = root / "shadow-module-executed"
+            payload = f"from pathlib import Path\nPath({str(marker)!r}).write_text('executed')\n"
+            self._write_file(bridge / "json.py", payload)
+            self._write_file(bridge / "pathlib.py", payload)
+            result = self._bridge_cli(bridge, "recover-maintenance-authority", task, check=False)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("ERROR:", result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertFalse(marker.exists())
+            self.assertFalse(upgrade.authority_path(task).exists())
+            self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+
+    def test_issue_87_isolated_bridge_ignores_external_pythonpath_module(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(root)
+            fake_root = root / "fake-pythonpath"
+            marker = root / "external-module-executed"
+            self._write_file(
+                fake_root / "json.py",
+                f"from pathlib import Path\nPath({str(marker)!r}).write_text('executed')\n",
+            )
+            with mock.patch.dict(os.environ, {"PYTHONPATH": str(fake_root)}, clear=False):
+                recovered = json.loads(self._bridge_cli(bridge, "recover-maintenance-authority", task).stdout)
+            self.assertEqual("AUTHORITY_RECOVERED", recovered["status"])
+            self.assertFalse(marker.exists())
+
+    def test_issue_87_bridge_disables_local_and_ambient_git_fsmonitor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(root)
+            fsmonitor = root / "fsmonitor-marker.sh"
+            marker = root / "fsmonitor-executed"
+            fsmonitor.write_text(f"#!/bin/sh\ntouch {shlex.quote(str(marker))}\n", encoding="utf-8")
+            fsmonitor.chmod(0o755)
+            self._git(["config", "--local", "core.fsmonitor", str(fsmonitor)], bridge)
+
+            fake_home = root / "home"
+            fake_xdg = root / "xdg"
+            fake_home.mkdir()
+            (fake_xdg / "git").mkdir(parents=True)
+            (fake_xdg / "git" / "config").write_text(
+                f"[core]\n\tfsmonitor = {fsmonitor}\n", encoding="utf-8"
+            )
+            environment = {
+                "HOME": str(fake_home),
+                "XDG_CONFIG_HOME": str(fake_xdg),
+            }
+            with mock.patch.dict(os.environ, environment, clear=False):
+                recovered = json.loads(self._bridge_cli(
+                    bridge, "recover-maintenance-authority", task
+                ).stdout)
+            self.assertEqual("AUTHORITY_RECOVERED", recovered["status"])
+            self.assertFalse(marker.exists())
+
+    def test_issue_87_subprocess_error_output_is_bounded_and_normalized(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            bridge_status = self._git(["status", "--porcelain=v1"], bridge)
+            receipt = upgrade.receipt_path(task)
+            authority = upgrade.authority_path(task)
+            proof = upgrade.source_recovery_proof_path(task)
+            target_records = {
+                path: path.read_bytes() if path.exists() else None
+                for path in (receipt, authority, proof)
+            }
+            target_head = self._git(["rev-parse", "HEAD"], task)
+            oversized_subcommand = ("!\n\x01" * 1200) + "!"
+            result = self._bridge_cli(
+                bridge,
+                oversized_subcommand,
+                task,
+                check=False,
+            )
+            self.assertEqual(2, result.returncode)
+            self.assertTrue(result.stderr.startswith("ERROR:"), result.stderr[:80])
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertLessEqual(len(result.stderr), 1610)
+            self.assertTrue(result.stderr.endswith("\n"))
+            self.assertTrue(all(" " <= character <= "~" for character in result.stderr[:-1]))
+            self.assertEqual(bridge_status, self._git(["status", "--porcelain=v1"], bridge))
+            self.assertEqual(target_head, self._git(["rev-parse", "HEAD"], task))
+            self.assertEqual(target_records, {
+                path: path.read_bytes() if path.exists() else None
+                for path in target_records
+            })
+
+    def test_issue_87_wrong_binding_and_source_resolution_race_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bridge, _, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
+            receipt_bytes = upgrade.receipt_path(task).read_bytes()
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                with self.assertRaisesRegex(upgrade.UpgradeError, "expected implementation revision"):
+                    upgrade.recover_maintenance_authority_from_source(
+                        task, bridge, expected_implementation_revision="0" * 40
+                    )
+            self.assertEqual(receipt_bytes, upgrade.receipt_path(task).read_bytes())
+            self.assertFalse(upgrade.authority_path(task).exists())
+            self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+
+            self._bridge_cli(bridge, "recover-maintenance-authority", task)
+            record_bytes = {
+                path: path.read_bytes()
+                for path in (
+                    upgrade.receipt_path(task),
+                    upgrade.authority_path(task),
+                    upgrade.source_recovery_proof_path(task),
+                )
+            }
+            branch = self._git(["rev-parse", "HEAD"], task)
+            with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                with self.assertRaisesRegex(upgrade.UpgradeError, "expected implementation revision"):
+                    upgrade.commit_recovered_maintenance(
+                        task, bridge, "TASK-83", "wrong binding",
+                        expected_implementation_revision="0" * 40,
+                    )
+            self.assertEqual(branch, self._git(["rev-parse", "HEAD"], task))
+            self.assertEqual(record_bytes, {
+                path: path.read_bytes() for path in record_bytes
+            })
+            upgrade.authority_path(task).unlink()
+            upgrade.source_recovery_proof_path(task).unlink()
+
+            calls = 0
+            original_resolve = upgrade.resolve_clean_source_worktree
+
+            def race(path: Path):
+                nonlocal calls
+                calls += 1
+                if calls == 2:
+                    raise upgrade.UpgradeError("injected source resolution race")
+                return original_resolve(path)
+
+            with mock.patch.object(upgrade, "resolve_clean_source_worktree", side_effect=race):
+                with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
+                    with self.assertRaisesRegex(upgrade.UpgradeError, "source resolution race"):
+                        upgrade.recover_maintenance_authority_from_source(
+                            task, bridge, expected_implementation_revision=metadata["bridge_head"]
+                        )
+            self.assertEqual(2, calls)
+            self.assertEqual(receipt_bytes, upgrade.receipt_path(task).read_bytes())
+            self.assertFalse(upgrade.authority_path(task).exists())
+            self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
+
     def test_issue_85_bridge_rolls_back_source_recovery_publication_and_retries(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            bridge, source, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            bridge, source, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
             original = upgrade._write_authority_at
             calls = 0
 
@@ -1927,7 +2150,9 @@ mod project 'just/project/mod.just'
             with mock.patch.object(upgrade, "_write_authority_at", side_effect=fail_once):
                 with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
                     with self.assertRaisesRegex(upgrade.UpgradeError, "injected bridge publication failure"):
-                        upgrade.recover_maintenance_authority_from_source(task, bridge)
+                        upgrade.recover_maintenance_authority_from_source(
+                            task, bridge, expected_implementation_revision=metadata["bridge_head"]
+                        )
             self.assertTrue(upgrade.receipt_path(task).exists())
             self.assertFalse(upgrade.authority_path(task).exists())
             self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
@@ -1936,18 +2161,20 @@ mod project 'just/project/mod.just'
 
     def test_issue_85_recovery_rejects_authority_appearing_during_publication(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            bridge, _, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
             with mock.patch.object(upgrade, "authority_exists", return_value=True):
                 with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
                     with self.assertRaisesRegex(upgrade.UpgradeError, "changed before source-recovery bridge publication"):
-                        upgrade.recover_maintenance_authority_from_source(task, bridge)
+                        upgrade.recover_maintenance_authority_from_source(
+                            task, bridge, expected_implementation_revision=metadata["bridge_head"]
+                        )
             self.assertTrue(upgrade.receipt_path(task).exists())
             self.assertFalse(upgrade.authority_path(task).exists())
             self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
 
     def test_issue_85_proof_only_interruption_retries_without_rewriting_receipt_or_proof(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            bridge, _, task, _ = self._source_recovery_bridge_fixture(Path(directory))
+            bridge, _, task, metadata = self._source_recovery_bridge_fixture(Path(directory))
             first = json.loads(self._bridge_cli(bridge, "recover-maintenance-authority", task).stdout)
             self.assertEqual("AUTHORITY_RECOVERED", first["status"])
             receipt_bytes = upgrade.receipt_path(task).read_bytes()
@@ -2051,7 +2278,10 @@ mod project 'just/project/mod.just'
                         upgrade.UpgradeError,
                         r"commit [0-9a-f]{40,64} was published but finalization failed",
                     ):
-                        upgrade.commit_recovered_maintenance(task, bridge, "TASK-83", "published failure")
+                        upgrade.commit_recovered_maintenance(
+                            task, bridge, "TASK-83", "published failure",
+                            expected_implementation_revision=self._git(["rev-parse", "HEAD"], bridge),
+                        )
             consumed = json.loads(upgrade.consumed_receipt_path(task).read_text(encoding="utf-8"))
             commit_sha = consumed["commit_sha"]
             self.assertEqual("consumed", consumed["status"])
@@ -2086,7 +2316,10 @@ mod project 'just/project/mod.just'
             with mock.patch.object(upgrade, "run", side_effect=fail_staging_check):
                 with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
                     with self.assertRaisesRegex(upgrade.UpgradeError, "injected source commit staging failure"):
-                        upgrade.commit_recovered_maintenance(task, bridge, "TASK-83", "injected failure")
+                        upgrade.commit_recovered_maintenance(
+                            task, bridge, "TASK-83", "injected failure",
+                            expected_implementation_revision=self._git(["rev-parse", "HEAD"], bridge),
+                        )
             self.assertEqual(active_bytes, active.read_bytes())
             self.assertEqual(authority_bytes, authority.read_bytes())
             self.assertEqual(proof_bytes, proof.read_bytes())
@@ -2115,7 +2348,9 @@ mod project 'just/project/mod.just'
             with mock.patch.object(Path, "read_bytes", autospec=True, side_effect=changing_receipt):
                 with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
                     with self.assertRaisesRegex(upgrade.UpgradeError, "receipt or target changed"):
-                        upgrade.recover_maintenance_authority_from_source(task, bridge)
+                        upgrade.recover_maintenance_authority_from_source(
+                            task, bridge, expected_implementation_revision=metadata["bridge_head"]
+                        )
             self.assertFalse(upgrade.authority_path(task).exists())
             self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
 
@@ -2143,7 +2378,9 @@ mod project 'just/project/mod.just'
                     target.chmod(target.stat().st_mode ^ 0o100)
                 with mock.patch.dict(os.environ, {"AUTOMATION_MAINTENANCE": "1"}, clear=False):
                     with self.assertRaises(upgrade.UpgradeError):
-                        upgrade.recover_maintenance_authority_from_source(task, bridge)
+                        upgrade.recover_maintenance_authority_from_source(
+                            task, bridge, expected_implementation_revision=metadata["bridge_head"]
+                        )
                 self.assertFalse(upgrade.authority_path(task).exists())
                 self.assertFalse(upgrade.source_recovery_proof_path(task).exists())
 

--- a/tools/automation_recovery_bridge.py
+++ b/tools/automation_recovery_bridge.py
@@ -7,49 +7,172 @@ import argparse
 import importlib.util
 import json
 import os
+import re
+import shutil
+import stat
 import sys
+import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from types import ModuleType
+import secrets
+import subprocess
 
 
 ROOT = Path(__file__).resolve().parent.parent
+BOOTSTRAP_PATH = ROOT / "tools" / "automation_recovery_bridge.py"
 ENGINE_PATH = ROOT / "components" / "agent-core" / ".automation" / "bin" / "automation_upgrade.py"
+_TRUSTED_GIT: Path | None = None
+_REVISION_RE = re.compile(r"[0-9a-f]{40,64}")
 
 
 class BridgeError(RuntimeError):
     pass
 
 
-def load_engine() -> ModuleType:
-    """Load the repository's supported recovery implementation, not a substitute."""
-    spec = None
-    try:
-        spec = importlib.util.spec_from_file_location("templates_automation_upgrade", ENGINE_PATH)
-        if spec is None or spec.loader is None:
-            raise BridgeError(f"cannot create import specification for supported engine: {ENGINE_PATH}")
-        engine = importlib.util.module_from_spec(spec)
-        sys.modules[spec.name] = engine
-        spec.loader.exec_module(engine)
-        return engine
-    except BridgeError:
-        raise
-    except Exception as exc:
-        if spec is not None and spec.name in sys.modules:
-            del sys.modules[spec.name]
-        raise BridgeError(f"cannot load supported recovery engine {ENGINE_PATH}: {exc}") from exc
+class BoundedArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise BridgeError(message)
 
 
-def require_templates_root(engine: ModuleType) -> Path:
+def trusted_git() -> Path:
+    global _TRUSTED_GIT
+    if _TRUSTED_GIT is not None:
+        return _TRUSTED_GIT
+    candidate = shutil.which("git")
+    if not candidate:
+        raise BridgeError("trusted Git executable is unavailable")
+    executable = Path(candidate).resolve()
     try:
-        top = Path(engine.run(["git", "rev-parse", "--show-toplevel"], cwd=ROOT).stdout.strip()).resolve()
-    except Exception as exc:
-        if isinstance(exc, engine.UpgradeError):
-            raise
-        raise BridgeError(f"cannot verify Templates Git root: {exc}") from exc
-    if top != ROOT:
+        metadata = executable.stat()
+    except OSError as exc:
+        raise BridgeError("trusted Git executable is unavailable") from exc
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != 0 or stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise BridgeError(f"Git executable is not root-owned and immutable: {executable}")
+    _TRUSTED_GIT = executable
+    return executable
+
+
+def git_bytes(args: list[str], *, cwd: Path) -> bytes:
+    if not args or args[0] != "git":
+        raise BridgeError("bootstrap Git helper only accepts Git commands")
+    environment = {
+        "LC_ALL": "C",
+        "LANG": "C",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    }
+    command = [str(trusted_git()), "-c", "core.fsmonitor=false",
+               "-c", "core.hooksPath=/dev/null", "--no-pager", *args[1:]]
+    result = subprocess.run(command, cwd=cwd,
+                            capture_output=True, env=environment, check=False)
+    if result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
+        raise BridgeError(f"{' '.join(args)}: {detail}")
+    return result.stdout
+
+
+def _revision(root: Path) -> str:
+    value = git_bytes(["git", "rev-parse", "--verify", "HEAD^{commit}"], cwd=root)
+    revision = value.decode("ascii", "strict").strip()
+    if not _REVISION_RE.fullmatch(revision):
+        raise BridgeError("Git HEAD is not a full lowercase commit revision")
+    return revision
+
+
+def _clean_root(root: Path, expected_revision: str | None = None) -> str:
+    top = git_bytes(["git", "rev-parse", "--show-toplevel"], cwd=root).decode("utf-8", "strict").strip()
+    if Path(top).resolve() != root:
         raise BridgeError(f"recovery bridge must run from the Templates Git root: {top}")
-    return top
+    revision = _revision(root)
+    if expected_revision is not None and revision != expected_revision:
+        raise BridgeError("Templates HEAD changed during bootstrap")
+    if git_bytes(["git", "status", "--porcelain=v1", "-z"], cwd=root):
+        raise BridgeError("Templates source worktree must be clean")
+    return revision
+
+
+def _tree_blob(root: Path, revision: str, relative: str) -> tuple[str, int]:
+    if not _REVISION_RE.fullmatch(revision):
+        raise BridgeError("Git tree lookup requires a full lowercase commit revision")
+    raw = git_bytes(["git", "ls-tree", "-z", revision, "--", relative], cwd=root)
+    records = raw.split(b"\0")
+    records = [record for record in records if record]
+    matches: list[tuple[str, int]] = []
+    for record in records:
+        header, separator, path = record.partition(b"\t")
+        fields = header.split()
+        if not separator or len(fields) != 3 or path.decode("utf-8", "surrogateescape") != relative:
+            continue
+        mode, kind, oid = fields
+        if kind != b"blob" or not re.fullmatch(rb"[0-9a-f]{40,64}", oid) or mode not in (b"100644", b"100755"):
+            raise BridgeError(f"Git tree entry for {relative} is not a safe regular blob")
+        matches.append((oid.decode("ascii"), int(mode, 8)))
+    if len(matches) != 1:
+        raise BridgeError(f"Git revision must contain exactly one regular blob at {relative}")
+    return matches[0]
+
+
+def _blob(root: Path, oid: str) -> bytes:
+    return git_bytes(["git", "cat-file", "blob", oid], cwd=root)
+
+
+def _verify_bootstrap(root: Path, revision: str) -> None:
+    if BOOTSTRAP_PATH != Path(__file__).resolve():
+        raise BridgeError("bootstrap path is not exactly the expected Templates path")
+    oid, mode = _tree_blob(root, revision, "tools/automation_recovery_bridge.py")
+    try:
+        metadata = BOOTSTRAP_PATH.lstat()
+        live = BOOTSTRAP_PATH.read_bytes()
+    except OSError as exc:
+        raise BridgeError("cannot read the live recovery bootstrap") from exc
+    if not stat.S_ISREG(metadata.st_mode) or stat.S_IMODE(metadata.st_mode) & 0o111 != mode & 0o111:
+        raise BridgeError("live recovery bootstrap is not a regular file with the HEAD executable mode")
+    if live != _blob(root, oid):
+        raise BridgeError("live recovery bootstrap does not match its HEAD blob")
+
+
+@contextmanager
+def _verified_engine(root: Path, revision: str):
+    oid, mode = _tree_blob(root, revision, "components/agent-core/.automation/bin/automation_upgrade.py")
+    engine_bytes = _blob(root, oid)
+    _clean_root(root, revision)
+    with tempfile.TemporaryDirectory(prefix="automation-bridge-") as directory:
+        path = Path(directory) / "engine.py"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags, 0o600)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(engine_bytes)
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            raise
+        name = f"_templates_verified_engine_{secrets.token_hex(16)}"
+        previous = sys.dont_write_bytecode
+        sys.dont_write_bytecode = True
+        spec = None
+        try:
+            spec = importlib.util.spec_from_file_location(name, path)
+            if spec is None or spec.loader is None:
+                raise BridgeError("cannot create specification for verified recovery engine")
+            engine = importlib.util.module_from_spec(spec)
+            sys.modules[name] = engine
+            spec.loader.exec_module(engine)
+            yield engine
+        except BridgeError:
+            raise
+        except Exception as exc:
+            raise BridgeError(f"cannot load verified recovery engine: {exc}") from exc
+        finally:
+            sys.modules.pop(name, None)
+            sys.dont_write_bytecode = previous
 
 
 @contextmanager
@@ -66,8 +189,8 @@ def maintenance_environment():
 
 
 def parser() -> argparse.ArgumentParser:
-    result = argparse.ArgumentParser(description="Templates source-side maintenance recovery bridge")
-    sub = result.add_subparsers(dest="command", required=True)
+    result = BoundedArgumentParser(description="Templates source-side maintenance recovery bridge")
+    sub = result.add_subparsers(dest="command", required=True, parser_class=BoundedArgumentParser)
     recover = sub.add_parser("recover-maintenance-authority")
     recover.add_argument("target", type=Path)
     commit = sub.add_parser("commit-recovered-maintenance")
@@ -77,30 +200,37 @@ def parser() -> argparse.ArgumentParser:
     return result
 
 
+def _error_text(exc: BaseException) -> str:
+    detail = str(exc).replace("\r", "\\r").replace("\n", "\\n")
+    detail = re.sub(r"[^\x20-\x7e]", "?", detail)
+    return detail[:1600] or exc.__class__.__name__
+
+
 def main() -> int:
-    args = parser().parse_args()
     try:
-        engine = load_engine()
-    except BridgeError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        return 2
-    try:
-        root = require_templates_root(engine)
-        target = args.target.resolve()
-        with maintenance_environment():
-            if args.command == "recover-maintenance-authority":
-                result = engine.recover_maintenance_authority_from_source(target, root)
-            elif args.command == "commit-recovered-maintenance":
-                result = engine.commit_recovered_maintenance(target, root, args.task, args.message)
-            else:  # pragma: no cover
-                raise BridgeError(f"unsupported bridge command: {args.command}")
+        args = parser().parse_args()
+        if Path(__file__).resolve() != BOOTSTRAP_PATH:
+            raise BridgeError("bootstrap path is not exactly the expected Templates path")
+        revision = _clean_root(ROOT)
+        _verify_bootstrap(ROOT, revision)
+        with _verified_engine(ROOT, revision) as engine:
+            if engine.git_executable().resolve() != trusted_git():
+                raise BridgeError("recovery engine selected a different Git executable")
+            _clean_root(ROOT, revision)
+            target = args.target.resolve()
+            with maintenance_environment():
+                if args.command == "recover-maintenance-authority":
+                    result = engine.recover_maintenance_authority_from_source(
+                        target, ROOT, expected_implementation_revision=revision)
+                elif args.command == "commit-recovered-maintenance":
+                    result = engine.commit_recovered_maintenance(
+                        target, ROOT, args.task, args.message, expected_implementation_revision=revision)
+                else:  # pragma: no cover
+                    raise BridgeError(f"unsupported bridge command: {args.command}")
         print(json.dumps(result, indent=2, sort_keys=True))
         return 0
-    except engine.UpgradeError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        return 2
-    except BridgeError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
+    except Exception as exc:
+        print(f"ERROR: {_error_text(exc)}", file=sys.stderr)
         return 2
 
 


### PR DESCRIPTION
## Summary
- fix the previous trust-order defect where the live worktree engine executed before checkout verification
- perform pre-import root, trusted-Git, full-HEAD, whole-tree-clean, and tracked bootstrap validation in the stdlib-only bootstrap
- load the recovery engine from the verified HEAD Git blob in a private temporary module, never from the live engine path
- run both source-side bridge recipes with Python isolated mode (`python3 -I`)
- pass the verified implementation revision into the engine and independently revalidate it before recovery/publication

## Security regressions
- dirty live engine with a top-level side effect is rejected without executing the side effect
- dirty tracked bridge bootstrap is rejected before target mutation
- checkout-local and `PYTHONPATH` shadow modules cannot execute
- revision-specific blob lookup prevents mutable-HEAD/ABA attribution
- config-driven fsmonitor execution is disabled in bootstrap and engine Git calls

## #85 regression
The real v3.0.1 linked/gitfile two-generation fixture still reaches `AUTHORITY_RECOVERED` and the exact guarded maintenance commit with no push or merge.

## Verification
- `nix develop -c python3 -m unittest tests.test_automation_upgrade -v -k issue_87` (9 tests, 0 skipped)
- `nix develop -c python3 -m unittest tests.test_automation_upgrade -v -k issue_85` (11 tests, 0 skipped)
- `nix develop -c python3 -m unittest discover -s tests -v` (282 tests, 0 skipped)
- `nix develop -c just template::check`
- `nix develop -c just template::distribution-verify`
- `git diff --check`
- `nix flake check --all-systems --no-build --no-update-lock-file`
- `nix build .#checks.x86_64-linux.opencode-policy --no-link --no-update-lock-file`

Closes #87