### PR TITLE
chore: update OpenCodePolicy to e8236812f2ad

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -41,11 +41,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787237951,
-        "narHash": "sha256-VWJWPI7hz+u+DcbuO0QOsREjuRAwpnsBPv0pIfxQJi4=",
+        "lastModified": 1788012886,
+        "narHash": "sha256-xYmcUhcUPfb3224lUYDXfSJWxcV5r2rwcCjY3rGE/bA=",
         "owner": "upiscium",
         "repo": "OpenCodePolicy",
-        "rev": "103b47b67a7e650835ac277ed192dbc92d1639c4",
+        "rev": "e8236812f2ad384afa89b0ec9510a6990ea1bd9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## 概要
- OpenCodePolicyを`103b47b67a7e650835ac277ed192dbc92d1639c4`から`e8236812f2ad384afa89b0ec9510a6990ea1bd9a`へ更新

## Lock hygiene
- nixpkgs unchanged
- flake-utils unchanged
- root inputs unchanged
- only opencodePolicy-exclusive lock subtree changed

## Policy audit
- profile = agent-core
- strict audit: `SUMMARY PASS=24 INTENTIONAL_DIFFERENCE=2 DIFF=0 MISSING=0`
- DIFF=0
- MISSING=0

## Templates contract
- Python contract tests PASS
- generated drift PASS
- distribution verify PASS

## Verification
- `nix flake check --all-systems --no-build --no-update-lock-file`
- explicit policy check build
- `opencode-policy validate`
- strict agent-core audit

## Scope
- flake.lock only
- Agent Core source unchanged
- generated templates unchanged
- adapters unchanged

## Non-goals
- Agent Core behavior changes
- model assignment changes
- template regeneration
- automatic merge
