### PR TITLE
Fail closed on unfilled pull request publication metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,13 @@ and `.task-state/pr-body.md` from the resolved Task Contract, changed paths,
 the persisted successful project check, and completed reviewer/security
 reviewer Work Units. Publication rejects untouched placeholders, stale
 metadata, and a `NOT RUN` claim that contradicts persisted PASS evidence.
+The PR renders non-empty Task `Blockers` and `Unverified` values instead of
+claiming that no risks are recorded; missing Current-state evidence fails
+closed. Issue-backed acceptance criteria are labeled as authoritative
+requirements, while completion evidence remains in Validation and Reviews.
+Creation and repair rerun project verification, and publication requires a
+completed reviewer Work Unit; any present security-reviewer unit must also be
+completed before its evidence can be rendered.
 `pr-edit` repairs the same existing open Draft PR after preparation;
 `pr-ready` reruns verification and requires exact canonical/live metadata
 before marking Ready and entering `integration-pending`. Generic `state-set`

--- a/README.md
+++ b/README.md
@@ -417,6 +417,26 @@ its filtered content digest to remain identical to the stored snapshot. A
 coherently rewritten set of ignored Task State files therefore cannot
 self-authenticate. An unavailable or changed Issue fails closed.
 
+Issue #101 makes pull request publication metadata evidence-backed and
+fail-closed. After current-head `just agent::verify <task>` evidence exists and
+the Task is `publication-ready`, run:
+
+```sh
+just agent::pr-prepare <task>
+just agent::pr-create <task>
+```
+
+Preparation deterministically writes only ignored `.task-state/pr-title.txt`
+and `.task-state/pr-body.md` from the resolved Task Contract, changed paths,
+the persisted successful project check, and completed reviewer/security
+reviewer Work Units. Publication rejects untouched placeholders, stale
+metadata, and a `NOT RUN` claim that contradicts persisted PASS evidence.
+`pr-edit` repairs the same existing open Draft PR after preparation;
+`pr-ready` reruns verification and requires exact canonical/live metadata
+before marking Ready and entering `integration-pending`. Generic `state-set`
+cannot cross either publication boundary. Merge remains Main-owned and Agent
+Core VERSION remains 3.
+
 For a pre-fix consumer such as AgentKnowledgeVault Task #19, run the verified
 source-side bridge from a clean Templates checkout containing Issue #99's fix:
 

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -94,6 +94,12 @@ just agent::pr-edit <task>
 just agent::pr-ready <task>
 ```
 
+`pr-prepare` renders acceptance criteria as authoritative requirements and
+renders non-empty `Current state` Blockers/Unverified values in the PR risk
+section. Missing Current-state evidence, unresolved placeholders, stale
+verification, missing completed reviewer evidence, an incomplete declared
+security review, or contradictory validation claims block publication.
+
 The normal upgrade flow creates its receipt before verification. If a self-hosted
 pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
 normal verification and, before `automation::commit`, run the strict bootstrap

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -89,6 +89,9 @@ Before publication, execute `git diff --check`, `just agent::doctor`,
 just automation::commit <task> [message]
 just agent::push <task>
 just agent::pr-create <task>
+just agent::pr-prepare <task>
+just agent::pr-edit <task>
+just agent::pr-ready <task>
 ```
 
 The normal upgrade flow creates its receipt before verification. If a self-hosted

--- a/components/agent-core/.automation/bin/agent_core.py
+++ b/components/agent-core/.automation/bin/agent_core.py
@@ -406,6 +406,7 @@ def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> Non
 
 
 def pr_create(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] != "publication-ready":
         raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
@@ -429,6 +430,7 @@ def pr_create(root: Path, task: str) -> None:
 
 
 def pr_edit(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] not in {"publication-ready", "draft-pr-created"}:
         raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")

--- a/components/agent-core/.automation/bin/agent_core.py
+++ b/components/agent-core/.automation/bin/agent_core.py
@@ -8,12 +8,15 @@ import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 import task_lifecycle as lifecycle
+import publication_metadata as publication
+import task_contract
 
 try:
     import tomllib
@@ -101,7 +104,7 @@ def validate_slug(slug: str) -> None:
 def ensure_task_branch(root: Path, task: str) -> str:
     validate_task(task)
     branch = current_branch(root)
-    if task not in branch or not (branch.startswith("task/") or branch.startswith("fix/")):
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
         raise AutomationError(f"current branch {branch!r} is not the Task branch for {task}")
     if branch == default_branch(root):
         raise AutomationError("Task operation refused on the default branch")
@@ -238,7 +241,33 @@ def status(root: Path, task: str) -> None:
 
 def verify(root: Path, task: str) -> None:
     ensure_task_branch(root, task)
-    run(["just", "project::check"], cwd=root)
+    head = git("rev-parse", "HEAD", cwd=root)
+    status_before = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    result = run(["just", "project::check"], cwd=root, check=False)
+    status_after = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    receipt = {
+        "schema_version": 1,
+        "task_id": task,
+        "head": head,
+        "clean_tracked_worktree": not status_before and not status_after,
+        "worktree_stable": status_before == status_after,
+        "project_check": {
+            "command": ["just", "project::check"],
+            "returncode": result.returncode,
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    try:
+        task_contract.write_verification_receipt(
+            root, (json.dumps(receipt, sort_keys=True) + "\n").encode()
+        )
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise AutomationError(f"just project::check: {detail}")
+    if status_before != status_after:
+        raise AutomationError("project::check changed tracked or untracked product files")
     print("Project verification: PASS")
 
 
@@ -265,54 +294,192 @@ def push_task(root: Path, task: str) -> None:
     print(f"pushed origin/{branch}")
 
 
-def pr_for_branch(root: Path, branch: str) -> dict | None:
-    result = run(["gh", "pr", "view", branch, "--json", "number,title,body,headRefName,baseRefName,isDraft,state,headRefOid"], cwd=root, check=False)
+def canonical_repository(root: Path) -> str:
+    path = root / ".task-state" / "contract.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AutomationError(f"invalid canonical Task Contract metadata: {path}") from exc
+    repository = value.get("repository") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise AutomationError("canonical Task Contract repository is invalid")
+    try:
+        live = task_contract.repository_identity(root)
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if live.casefold() != repository.casefold():
+        raise AutomationError("live origin repository does not match the canonical Task Contract")
+    return repository
+
+
+def pr_for_branch(root: Path, branch: str, repository: str | None = None) -> dict | None:
+    command = ["gh", "pr", "view", branch]
+    if repository is not None:
+        command.extend(["--repo", repository])
+    command.extend(["--json", "number,title,body,headRefName,baseRefName,isDraft,isCrossRepository,state,headRefOid"])
+    result = run(command, cwd=root, check=False)
     if result.returncode != 0:
-        return None
-    return json.loads(result.stdout)
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        if "no pull requests found" in detail.lower():
+            return None
+        raise AutomationError(f"cannot resolve pull request for {branch}: {detail}")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AutomationError("invalid pull request data returned by GitHub") from exc
+    return value
 
 
-def pr_body(root: Path, task: str) -> Path:
-    state_dir = root / ".task-state"
-    state_dir.mkdir(parents=True, exist_ok=True)
-    path = state_dir / "pr-body.md"
-    if not path.exists():
-        template = root / ".automation" / "templates" / "pull-request.md"
-        text = template.read_text(encoding="utf-8").replace("@@TASK_ID@@", task)
-        path.write_text(text, encoding="utf-8")
-    return path
+def _publication_context(root: Path, task: str) -> tuple[str, dict, str]:
+    branch = ensure_task_branch(root, task)
+    head = git("rev-parse", "HEAD", cwd=root)
+    try:
+        record = lifecycle.require_local_task(root, task)
+        lifecycle.require_resolved_contract(record, task)
+        status = lifecycle.state_status(lifecycle.state_path(root))
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    repository = canonical_repository(root)
+    return branch, {"record": record, "status": status, "repository": repository}, head
+
+
+def pr_prepare(root: Path, task: str) -> None:
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"publication metadata preparation requires publication-ready or draft-pr-created; found {context['status']}")
+    state = lifecycle.state_path(root).read_text(encoding="utf-8")
+    base_revision = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", state)
+    if base_revision is None:
+        raise AutomationError("Task State has no valid Base revision")
+    paths = git("diff", "--name-only", f"{base_revision.group(1)}...{head}", cwd=root).splitlines()
+    try:
+        title, body = publication.canonical_metadata(root, task, head=head, changed_paths=paths)
+        publication.write_metadata(root, title, body)
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps({"task": task, "branch": branch, "title": title, "body": str(root / '.task-state' / 'pr-body.md')}))
+
+
+def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Path, str]:
+    try:
+        receipt = publication.verification_evidence(root, task, head)
+        title, body = publication.read_and_validate_metadata(root, receipt=receipt)
+        expected_title, expected_body = publication.canonical_metadata(
+            root,
+            task,
+            head=head,
+            changed_paths=git("diff", "--name-only", f"{_base_revision(root)}...{head}", cwd=root).splitlines(),
+        )
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    if title != expected_title or body.rstrip() != expected_body.rstrip():
+        raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
+    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+
+
+def _base_revision(root: Path) -> str:
+    text = lifecycle.state_path(root).read_text(encoding="utf-8")
+    match = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", text)
+    if match is None:
+        raise AutomationError("Task State has no valid Base revision")
+    return match.group(1)
+
+
+def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches:
+        raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
+
+
+def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "isDraft": True, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches or not isinstance(pr.get("number"), int):
+        raise AutomationError("pull request repair target identity is invalid: " + ", ".join(mismatches or ["number"]))
 
 
 def pr_create(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    if pr_for_branch(root, branch):
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "publication-ready":
+        raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
+    repository = context["repository"]
+    if pr_for_branch(root, branch, repository):
         raise AutomationError(f"pull request already exists for {branch}")
     base = default_branch(root)
-    title = f"{task}: {branch.split('/', 1)[1]}"
-    body = pr_body(root, task)
-    gh("pr", "create", "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
-    print(json.dumps(pr_for_branch(root, branch)))
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "create", "--repo", repository, "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request creation")
+    pr = pr_for_branch(root, branch, repository)
+    if not pr:
+        raise AutomationError("created pull request cannot be re-read")
+    _validate_live_pr(pr, branch=branch, base=base, head=head, title=title, body=body_text, draft=True)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps(pr))
 
 
 def pr_edit(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    title_file = root / ".task-state" / "pr-title.txt"
-    title = title_file.read_text(encoding="utf-8").strip() if title_file.exists() else pr["title"]
-    body = pr_body(root, task)
-    gh("pr", "edit", str(pr["number"]), "--title", title, "--body-file", str(body), cwd=root)
+    _validate_edit_target(pr, branch=branch, base=default_branch(root), head=head)
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "edit", str(pr["number"]), "--repo", repository, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request repair")
+    updated = pr_for_branch(root, branch, repository)
+    if not updated or updated.get("number") != pr.get("number"):
+        raise AutomationError("pull request identity changed during guarded repair")
+    _validate_live_pr(updated, branch=branch, base=default_branch(root), head=head, title=title, body=body_text, draft=True)
+    if context["status"] == "publication-ready":
+        try:
+            lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+        except lifecycle.LifecycleError as exc:
+            raise AutomationError(str(exc)) from exc
     print(f"updated PR #{pr['number']}")
 
 
 def pr_ready(root: Path, task: str) -> None:
     verify(root, task)
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "draft-pr-created":
+        raise AutomationError(f"pr-ready requires draft-pr-created; found {context['status']}")
+    title, _, body = _validated_local_metadata(root, task, head)
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    gh("pr", "ready", str(pr["number"]), cwd=root)
+    if pr.get("isDraft"):
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=True)
+        gh("pr", "ready", str(pr["number"]), "--repo", repository, cwd=root)
+        if canonical_repository(root).casefold() != repository.casefold():
+            raise AutomationError("repository identity changed while marking pull request ready")
+        ready = pr_for_branch(root, branch, repository)
+        if not ready or ready.get("number") != pr.get("number"):
+            raise AutomationError("pull request identity changed while marking ready")
+        _validate_live_pr(ready, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    else:
+        # Reconcile an earlier successful GitHub readiness write whose local
+        # lifecycle transition was interrupted.
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "draft-pr-created", "integration-pending")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
     print(f"PR #{pr['number']} marked ready")
 
 
@@ -514,7 +681,7 @@ def build_parser() -> argparse.ArgumentParser:
     for name in ("doctor", "context"):
         agent_cmd.add_parser(name)
     start = agent_cmd.add_parser("task-start"); start.add_argument("task"); start.add_argument("slug")
-    for name in ("status", "verify", "push", "pr-create", "pr-edit", "pr-ready", "cleanup"):
+    for name in ("status", "verify", "push", "pr-prepare", "pr-create", "pr-edit", "pr-ready", "cleanup"):
         p = agent_cmd.add_parser(name); p.add_argument("task")
     commit = agent_cmd.add_parser("commit"); commit.add_argument("task"); commit.add_argument("message", nargs="?", default="")
     integrate = scope.add_parser("integrate")
@@ -540,6 +707,7 @@ def main() -> int:
                 "verify": lambda: verify(root, args.task),
                 "commit": lambda: commit_task(root, args.task, args.message),
                 "push": lambda: push_task(root, args.task),
+                "pr-prepare": lambda: pr_prepare(root, args.task),
                 "pr-create": lambda: pr_create(root, args.task),
                 "pr-edit": lambda: pr_edit(root, args.task),
                 "pr-ready": lambda: pr_ready(root, args.task),

--- a/components/agent-core/.automation/bin/publication_metadata.py
+++ b/components/agent-core/.automation/bin/publication_metadata.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Prepare and validate evidence-backed pull request metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import task_contract
+
+
+class PublicationMetadataError(RuntimeError):
+    pass
+
+
+PLACEHOLDER_PATTERNS = (
+    r"@@[A-Z0-9_]+@@",
+    r"\bTBD\b",
+    r"Describe the implemented Task outcome\.",
+    r"Task-specific criteria copied from `?\.task-state/task\.md`?",
+    r"Define Task-specific acceptance criteria",
+)
+NOT_RUN_RE = re.compile(r"(?im)^.*(?:NOT[ _-]?RUN|not run).*$")
+
+
+def _sections(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"(?m)^## (.+?)\s*$", text))
+    return {
+        match.group(1): text[match.end() : matches[index + 1].start() if index + 1 < len(matches) else len(text)].strip()
+        for index, match in enumerate(matches)
+    }
+
+
+def _content_lines(value: str) -> list[str]:
+    ignored = {"none yet.", "none yet", "none recorded", "none recorded yet."}
+    return [line for line in value.splitlines() if line.strip() and line.strip().lower().lstrip("- ") not in ignored]
+
+
+def _identity(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing {name}")
+    return match.group(1).strip()
+
+
+def _read_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}") from exc
+    if not isinstance(value, dict):
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}")
+    return value
+
+
+def verification_evidence(root: Path, task: str, head: str) -> dict:
+    receipt = _read_json(root / ".task-state" / "verification.json")
+    if receipt is None:
+        raise PublicationMetadataError("missing persisted project verification evidence")
+    if set(receipt) != {"schema_version", "task_id", "head", "clean_tracked_worktree", "worktree_stable", "project_check"} or receipt["schema_version"] != 1:
+        raise PublicationMetadataError("invalid project verification evidence schema")
+    check = receipt.get("project_check")
+    if receipt.get("task_id") != task:
+        raise PublicationMetadataError("project verification evidence belongs to another Task")
+    if receipt.get("head") != head or not isinstance(check, dict):
+        raise PublicationMetadataError("project verification evidence is stale")
+    if check.get("command") != ["just", "project::check"] or check.get("returncode") != 0:
+        raise PublicationMetadataError("project::check has no persisted PASS evidence")
+    if receipt.get("clean_tracked_worktree") is not True or receipt.get("worktree_stable") is not True:
+        raise PublicationMetadataError("project verification is not bound to a clean stable worktree")
+    if not isinstance(check.get("executed_at"), str) or not check["executed_at"]:
+        raise PublicationMetadataError("project verification evidence has no execution time")
+    return receipt
+
+
+def completed_reviews(root: Path, task: str) -> list[str]:
+    value = _read_json(root / ".task-state" / "work-units.json")
+    if value is None:
+        return []
+    if value.get("task_id") != task or not isinstance(value.get("units"), dict):
+        raise PublicationMetadataError("Work Unit evidence does not match the Task")
+    reviews = []
+    for identifier, unit in value["units"].items():
+        if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
+            continue
+        if unit.get("state") != "completed":
+            raise PublicationMetadataError(
+                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+            )
+        transitions = unit.get("transitions")
+        digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
+        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+    return reviews
+
+
+def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[str]) -> tuple[str, str]:
+    state_path = root / ".task-state" / "task.md"
+    try:
+        text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError(f"missing Task State: {state_path}") from exc
+    if _identity(text, "Task ID") != task:
+        raise PublicationMetadataError("Task State identity does not match requested Task")
+    sections = _sections(text)
+    purpose = _content_lines(sections.get("Purpose", ""))
+    criteria = _content_lines(sections.get("Acceptance criteria", ""))
+    if not purpose or not criteria:
+        raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    summary = purpose[0].lstrip("- ").strip()
+    verification = verification_evidence(root, task, head)
+    title = f"{task}: {summary}"
+    changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
+    reviews = completed_reviews(root, task)
+    followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
+    body = "\n".join(
+        [
+            "## Summary", "", f"Task: {task}", "", *purpose,
+            "", "## Changed paths", "", *changes,
+            "", "## Acceptance criteria", "", *criteria,
+            "", "## Validation", "",
+            f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
+            "", "## Reviews", "", *(reviews or ["- None recorded."]),
+            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Follow-up Tasks", "", *followups, "",
+        ]
+    )
+    validate_metadata(title, body, receipt=verification)
+    return title, body
+
+
+def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> None:
+    if not title.strip() or not body.strip():
+        raise PublicationMetadataError("pull request title and body must be non-empty")
+    combined = title + "\n" + body
+    for pattern in PLACEHOLDER_PATTERNS:
+        if re.search(pattern, combined, re.IGNORECASE):
+            raise PublicationMetadataError("unresolved pull request publication placeholder")
+    not_run = NOT_RUN_RE.findall(body)
+    if not_run:
+        if receipt and receipt.get("project_check", {}).get("returncode") == 0:
+            raise PublicationMetadataError("pull request metadata contradicts persisted PASS evidence with NOT RUN")
+        raise PublicationMetadataError("unresolved NOT RUN publication metadata")
+    required = ("## Summary", "## Acceptance criteria", "## Validation", "## Risks and unverified areas", "## Follow-up Tasks")
+    if any(heading not in body for heading in required):
+        raise PublicationMetadataError("pull request body is missing required sections")
+
+
+def write_metadata(root: Path, title: str, body: str) -> None:
+    try:
+        task_contract.write_publication_metadata(
+            root,
+            (title.strip() + "\n").encode(),
+            (body.rstrip() + "\n").encode(),
+        )
+    except task_contract.ContractError as exc:
+        raise PublicationMetadataError(str(exc)) from exc
+
+
+def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tuple[str, str]:
+    title_path = root / ".task-state" / "pr-title.txt"
+    body_path = root / ".task-state" / "pr-body.md"
+    try:
+        title = title_path.read_text(encoding="utf-8").strip()
+        body = body_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError("run agent::pr-prepare before publication") from exc
+    validate_metadata(title, body, receipt=receipt)
+    return title, body

--- a/components/agent-core/.automation/bin/publication_metadata.py
+++ b/components/agent-core/.automation/bin/publication_metadata.py
@@ -44,6 +44,27 @@ def _identity(text: str, name: str) -> str:
     return match.group(1).strip()
 
 
+def _current_state_value(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing Current state {name}")
+    return match.group(1).strip()
+
+
+def _is_none_value(value: str) -> bool:
+    return value.casefold().rstrip(".") in {"none", "none recorded"}
+
+
+def _requirements(lines: list[str]) -> list[str]:
+    requirements = []
+    for line in lines:
+        value = re.sub(r"^-\s*\[[ xX]\]\s*", "", line.strip())
+        value = value.removeprefix("- ").strip()
+        if value:
+            requirements.append(f"- Requirement: {value}")
+    return requirements
+
+
 def _read_json(path: Path) -> dict | None:
     if not path.exists():
         return None
@@ -110,21 +131,39 @@ def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[
     criteria = _content_lines(sections.get("Acceptance criteria", ""))
     if not purpose or not criteria:
         raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    requirements = _requirements(criteria)
+    if not requirements:
+        raise PublicationMetadataError("Task acceptance criteria contain no authoritative requirements")
+    blockers = _current_state_value(sections.get("Current state", ""), "Blockers")
+    unverified = _current_state_value(sections.get("Current state", ""), "Unverified")
+    risks = []
+    if not _is_none_value(blockers):
+        risks.append(f"- Blockers: {blockers}")
+    if not _is_none_value(unverified):
+        risks.append(f"- Unverified: {unverified}")
+    if not risks:
+        risks = ["- None recorded."]
     summary = purpose[0].lstrip("- ").strip()
     verification = verification_evidence(root, task, head)
     title = f"{task}: {summary}"
     changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
     reviews = completed_reviews(root, task)
+    if not any("— `reviewer` — completed" in review for review in reviews):
+        raise PublicationMetadataError(
+            "publication requires a completed reviewer Work Unit"
+        )
     followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
     body = "\n".join(
         [
             "## Summary", "", f"Task: {task}", "", *purpose,
             "", "## Changed paths", "", *changes,
-            "", "## Acceptance criteria", "", *criteria,
+            "", "## Acceptance criteria", "",
+            "The following are authoritative Task requirements; completion evidence is reported separately under Validation and Reviews.",
+            "", *requirements,
             "", "## Validation", "",
             f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
             "", "## Reviews", "", *(reviews or ["- None recorded."]),
-            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Risks and unverified areas", "", *risks,
             "", "## Follow-up Tasks", "", *followups, "",
         ]
     )

--- a/components/agent-core/.automation/bin/task_contract.py
+++ b/components/agent-core/.automation/bin/task_contract.py
@@ -139,6 +139,30 @@ def _restore_state_file(directory_fd: int, name: str, content: bytes | None) -> 
         _write_state_file(directory_fd, name, content)
 
 
+def write_publication_metadata(root: Path, title: bytes, body: bytes) -> None:
+    """Atomically replace the two publication files in pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        previous = {
+            name: _read_state_file(directory_fd, name)
+            for name in ("pr-title.txt", "pr-body.md")
+        }
+        try:
+            _write_state_file(directory_fd, "pr-title.txt", title)
+            _write_state_file(directory_fd, "pr-body.md", body)
+            _assert_state_dir_binding(root, directory_fd)
+        except Exception:
+            for name, content in previous.items():
+                _restore_state_file(directory_fd, name, content)
+            raise
+
+
+def write_verification_receipt(root: Path, content: bytes) -> None:
+    """Replace the verification receipt through pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        _write_state_file(directory_fd, "verification.json", content)
+        _assert_state_dir_binding(root, directory_fd)
+
+
 def validate_issue_number(value: str) -> int:
     if not ISSUE_RE.fullmatch(value):
         raise ContractError("Issue number must be an exact positive decimal integer")

--- a/components/agent-core/.automation/bin/task_lifecycle.py
+++ b/components/agent-core/.automation/bin/task_lifecycle.py
@@ -919,10 +919,40 @@ def task_status(root: Path, task: str) -> None:
 def task_state_set(root: Path, task: str, status: str) -> None:
     record = require_local_task(root, task)
     require_resolved_contract(record, task)
+    if status in {"draft-pr-created", "integration-pending"}:
+        raise LifecycleError(
+            f"{status} is reserved for the guarded pull request publication boundary"
+        )
     with work_units_lock(record):
         assert_task_identity(record, task)
         set_state_status(state_path(record.path), status)
     print(json.dumps({"task": task, "status": status}))
+
+
+def mark_task_publication_state(
+    record: WorktreeRecord, task: str, expected: str, target: str
+) -> str:
+    """Narrow transition authority for validated PR creation/readiness."""
+    allowed = {
+        ("publication-ready", "draft-pr-created"),
+        ("draft-pr-created", "integration-pending"),
+    }
+    if (expected, target) not in allowed:
+        raise LifecycleError("invalid guarded publication transition")
+    validate_task(task)
+    require_resolved_contract(record, task)
+    with work_units_lock(record):
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        previous = state_status(path)
+        if previous == target:
+            return "already-transitioned"
+        if previous != expected:
+            raise LifecycleError(
+                f"guarded publication transition requires {expected}; found {previous}"
+            )
+        set_state_status(path, target)
+    return "transitioned"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/components/agent-core/.automation/just/agent.just
+++ b/components/agent-core/.automation/just/agent.just
@@ -84,6 +84,10 @@ pr-create task:
     python3 {{quote(script)}} agent pr-create {{quote(task)}}
 
 [working-directory: root]
+pr-prepare task:
+    python3 {{quote(script)}} agent pr-prepare {{quote(task)}}
+
+[working-directory: root]
 pr-edit task:
     python3 {{quote(script)}} agent pr-edit {{quote(task)}}
 

--- a/components/agent-core/.opencode/agents/build.md
+++ b/components/agent-core/.opencode/agents/build.md
@@ -25,6 +25,7 @@ permission:
     "just agent::batch-plan *": allow
     "just agent::commit *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just integrate::finalize *": allow

--- a/components/agent-core/.opencode/agents/general.md
+++ b/components/agent-core/.opencode/agents/general.md
@@ -38,6 +38,7 @@ permission:
     "just agent::commit *": deny
     "just agent::push *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just agent::cleanup *": deny

--- a/components/agent-core/.opencode/agents/task-orchestrator.md
+++ b/components/agent-core/.opencode/agents/task-orchestrator.md
@@ -30,6 +30,7 @@ permission:
     "just agent::work-unit-dispatch-check *": allow
     "just agent::work-unit-status *": allow
     "just agent::work-unit-state-set *": allow
+    "just agent::pr-prepare *": allow
     "just integrate::check *": deny
     "just integrate::finalize *": deny
     "just integrate::merge *": deny
@@ -77,6 +78,6 @@ Before advancing Task State to `publication-ready`, and again before guarded com
 - a reviewer Work Unit for non-trivial changes;
 - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 
-No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, and prepare a Draft PR. Never merge.
+No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, run `just agent::pr-prepare <task>`, and create or repair the same Draft PR through the guarded publication API. Metadata with placeholders or false `NOT RUN` claims is forbidden. Never merge.
 
 Never invoke another Task Orchestrator. Never merge. Never operate on sibling Task worktrees. Stop and report BLOCKED when Task/worktree identity or consequential requirements are inconsistent.

--- a/components/agent-core/.opencode/skills/task-orchestration/SKILL.md
+++ b/components/agent-core/.opencode/skills/task-orchestration/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when the Main Orchestrator is asked to run a specific Task that a
     - a reviewer Work Unit for non-trivial changes;
     - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 12. No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop.
-13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, and create or edit only a Draft PR.
+13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, run `just agent::pr-prepare <task>`, and create or edit only the same Draft PR. Publication metadata must be regenerated from persisted evidence and must contain no unresolved placeholder or false `NOT RUN` claim.
 14. Persist every transition and continue the loop until integration-pending. Stop for `NEEDS_APPROVAL` or `NEEDS_DECISION` human handling, and otherwise stop at integration-pending. Do not merge from this skill. Never merge.
 
 Do not silently select another Issue or Task. Do not weaken permissions to work around a blocked approval or missing tool/model.

--- a/components/agent-core/opencode.json
+++ b/components/agent-core/opencode.json
@@ -91,6 +91,7 @@
       "just agent::status *": "allow",
       "just agent::verify *": "allow",
       "just agent::commit *": "allow",
+      "just agent::pr-prepare *": "allow",
       "just agent::pr-create *": "allow",
       "just agent::pr-edit *": "allow",
       "just agent::pr-ready *": "allow",

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -94,6 +94,12 @@ just agent::pr-edit <task>
 just agent::pr-ready <task>
 ```
 
+`pr-prepare` renders acceptance criteria as authoritative requirements and
+renders non-empty `Current state` Blockers/Unverified values in the PR risk
+section. Missing Current-state evidence, unresolved placeholders, stale
+verification, missing completed reviewer evidence, an incomplete declared
+security review, or contradictory validation claims block publication.
+
 The normal upgrade flow creates its receipt before verification. If a self-hosted
 pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
 normal verification and, before `automation::commit`, run the strict bootstrap

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -89,6 +89,9 @@ Before publication, execute `git diff --check`, `just agent::doctor`,
 just automation::commit <task> [message]
 just agent::push <task>
 just agent::pr-create <task>
+just agent::pr-prepare <task>
+just agent::pr-edit <task>
+just agent::pr-ready <task>
 ```
 
 The normal upgrade flow creates its receipt before verification. If a self-hosted

--- a/templates/agent-base/.automation/bin/agent_core.py
+++ b/templates/agent-base/.automation/bin/agent_core.py
@@ -406,6 +406,7 @@ def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> Non
 
 
 def pr_create(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] != "publication-ready":
         raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
@@ -429,6 +430,7 @@ def pr_create(root: Path, task: str) -> None:
 
 
 def pr_edit(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] not in {"publication-ready", "draft-pr-created"}:
         raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")

--- a/templates/agent-base/.automation/bin/agent_core.py
+++ b/templates/agent-base/.automation/bin/agent_core.py
@@ -8,12 +8,15 @@ import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 import task_lifecycle as lifecycle
+import publication_metadata as publication
+import task_contract
 
 try:
     import tomllib
@@ -101,7 +104,7 @@ def validate_slug(slug: str) -> None:
 def ensure_task_branch(root: Path, task: str) -> str:
     validate_task(task)
     branch = current_branch(root)
-    if task not in branch or not (branch.startswith("task/") or branch.startswith("fix/")):
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
         raise AutomationError(f"current branch {branch!r} is not the Task branch for {task}")
     if branch == default_branch(root):
         raise AutomationError("Task operation refused on the default branch")
@@ -238,7 +241,33 @@ def status(root: Path, task: str) -> None:
 
 def verify(root: Path, task: str) -> None:
     ensure_task_branch(root, task)
-    run(["just", "project::check"], cwd=root)
+    head = git("rev-parse", "HEAD", cwd=root)
+    status_before = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    result = run(["just", "project::check"], cwd=root, check=False)
+    status_after = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    receipt = {
+        "schema_version": 1,
+        "task_id": task,
+        "head": head,
+        "clean_tracked_worktree": not status_before and not status_after,
+        "worktree_stable": status_before == status_after,
+        "project_check": {
+            "command": ["just", "project::check"],
+            "returncode": result.returncode,
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    try:
+        task_contract.write_verification_receipt(
+            root, (json.dumps(receipt, sort_keys=True) + "\n").encode()
+        )
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise AutomationError(f"just project::check: {detail}")
+    if status_before != status_after:
+        raise AutomationError("project::check changed tracked or untracked product files")
     print("Project verification: PASS")
 
 
@@ -265,54 +294,192 @@ def push_task(root: Path, task: str) -> None:
     print(f"pushed origin/{branch}")
 
 
-def pr_for_branch(root: Path, branch: str) -> dict | None:
-    result = run(["gh", "pr", "view", branch, "--json", "number,title,body,headRefName,baseRefName,isDraft,state,headRefOid"], cwd=root, check=False)
+def canonical_repository(root: Path) -> str:
+    path = root / ".task-state" / "contract.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AutomationError(f"invalid canonical Task Contract metadata: {path}") from exc
+    repository = value.get("repository") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise AutomationError("canonical Task Contract repository is invalid")
+    try:
+        live = task_contract.repository_identity(root)
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if live.casefold() != repository.casefold():
+        raise AutomationError("live origin repository does not match the canonical Task Contract")
+    return repository
+
+
+def pr_for_branch(root: Path, branch: str, repository: str | None = None) -> dict | None:
+    command = ["gh", "pr", "view", branch]
+    if repository is not None:
+        command.extend(["--repo", repository])
+    command.extend(["--json", "number,title,body,headRefName,baseRefName,isDraft,isCrossRepository,state,headRefOid"])
+    result = run(command, cwd=root, check=False)
     if result.returncode != 0:
-        return None
-    return json.loads(result.stdout)
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        if "no pull requests found" in detail.lower():
+            return None
+        raise AutomationError(f"cannot resolve pull request for {branch}: {detail}")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AutomationError("invalid pull request data returned by GitHub") from exc
+    return value
 
 
-def pr_body(root: Path, task: str) -> Path:
-    state_dir = root / ".task-state"
-    state_dir.mkdir(parents=True, exist_ok=True)
-    path = state_dir / "pr-body.md"
-    if not path.exists():
-        template = root / ".automation" / "templates" / "pull-request.md"
-        text = template.read_text(encoding="utf-8").replace("@@TASK_ID@@", task)
-        path.write_text(text, encoding="utf-8")
-    return path
+def _publication_context(root: Path, task: str) -> tuple[str, dict, str]:
+    branch = ensure_task_branch(root, task)
+    head = git("rev-parse", "HEAD", cwd=root)
+    try:
+        record = lifecycle.require_local_task(root, task)
+        lifecycle.require_resolved_contract(record, task)
+        status = lifecycle.state_status(lifecycle.state_path(root))
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    repository = canonical_repository(root)
+    return branch, {"record": record, "status": status, "repository": repository}, head
+
+
+def pr_prepare(root: Path, task: str) -> None:
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"publication metadata preparation requires publication-ready or draft-pr-created; found {context['status']}")
+    state = lifecycle.state_path(root).read_text(encoding="utf-8")
+    base_revision = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", state)
+    if base_revision is None:
+        raise AutomationError("Task State has no valid Base revision")
+    paths = git("diff", "--name-only", f"{base_revision.group(1)}...{head}", cwd=root).splitlines()
+    try:
+        title, body = publication.canonical_metadata(root, task, head=head, changed_paths=paths)
+        publication.write_metadata(root, title, body)
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps({"task": task, "branch": branch, "title": title, "body": str(root / '.task-state' / 'pr-body.md')}))
+
+
+def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Path, str]:
+    try:
+        receipt = publication.verification_evidence(root, task, head)
+        title, body = publication.read_and_validate_metadata(root, receipt=receipt)
+        expected_title, expected_body = publication.canonical_metadata(
+            root,
+            task,
+            head=head,
+            changed_paths=git("diff", "--name-only", f"{_base_revision(root)}...{head}", cwd=root).splitlines(),
+        )
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    if title != expected_title or body.rstrip() != expected_body.rstrip():
+        raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
+    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+
+
+def _base_revision(root: Path) -> str:
+    text = lifecycle.state_path(root).read_text(encoding="utf-8")
+    match = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", text)
+    if match is None:
+        raise AutomationError("Task State has no valid Base revision")
+    return match.group(1)
+
+
+def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches:
+        raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
+
+
+def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "isDraft": True, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches or not isinstance(pr.get("number"), int):
+        raise AutomationError("pull request repair target identity is invalid: " + ", ".join(mismatches or ["number"]))
 
 
 def pr_create(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    if pr_for_branch(root, branch):
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "publication-ready":
+        raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
+    repository = context["repository"]
+    if pr_for_branch(root, branch, repository):
         raise AutomationError(f"pull request already exists for {branch}")
     base = default_branch(root)
-    title = f"{task}: {branch.split('/', 1)[1]}"
-    body = pr_body(root, task)
-    gh("pr", "create", "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
-    print(json.dumps(pr_for_branch(root, branch)))
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "create", "--repo", repository, "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request creation")
+    pr = pr_for_branch(root, branch, repository)
+    if not pr:
+        raise AutomationError("created pull request cannot be re-read")
+    _validate_live_pr(pr, branch=branch, base=base, head=head, title=title, body=body_text, draft=True)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps(pr))
 
 
 def pr_edit(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    title_file = root / ".task-state" / "pr-title.txt"
-    title = title_file.read_text(encoding="utf-8").strip() if title_file.exists() else pr["title"]
-    body = pr_body(root, task)
-    gh("pr", "edit", str(pr["number"]), "--title", title, "--body-file", str(body), cwd=root)
+    _validate_edit_target(pr, branch=branch, base=default_branch(root), head=head)
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "edit", str(pr["number"]), "--repo", repository, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request repair")
+    updated = pr_for_branch(root, branch, repository)
+    if not updated or updated.get("number") != pr.get("number"):
+        raise AutomationError("pull request identity changed during guarded repair")
+    _validate_live_pr(updated, branch=branch, base=default_branch(root), head=head, title=title, body=body_text, draft=True)
+    if context["status"] == "publication-ready":
+        try:
+            lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+        except lifecycle.LifecycleError as exc:
+            raise AutomationError(str(exc)) from exc
     print(f"updated PR #{pr['number']}")
 
 
 def pr_ready(root: Path, task: str) -> None:
     verify(root, task)
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "draft-pr-created":
+        raise AutomationError(f"pr-ready requires draft-pr-created; found {context['status']}")
+    title, _, body = _validated_local_metadata(root, task, head)
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    gh("pr", "ready", str(pr["number"]), cwd=root)
+    if pr.get("isDraft"):
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=True)
+        gh("pr", "ready", str(pr["number"]), "--repo", repository, cwd=root)
+        if canonical_repository(root).casefold() != repository.casefold():
+            raise AutomationError("repository identity changed while marking pull request ready")
+        ready = pr_for_branch(root, branch, repository)
+        if not ready or ready.get("number") != pr.get("number"):
+            raise AutomationError("pull request identity changed while marking ready")
+        _validate_live_pr(ready, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    else:
+        # Reconcile an earlier successful GitHub readiness write whose local
+        # lifecycle transition was interrupted.
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "draft-pr-created", "integration-pending")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
     print(f"PR #{pr['number']} marked ready")
 
 
@@ -514,7 +681,7 @@ def build_parser() -> argparse.ArgumentParser:
     for name in ("doctor", "context"):
         agent_cmd.add_parser(name)
     start = agent_cmd.add_parser("task-start"); start.add_argument("task"); start.add_argument("slug")
-    for name in ("status", "verify", "push", "pr-create", "pr-edit", "pr-ready", "cleanup"):
+    for name in ("status", "verify", "push", "pr-prepare", "pr-create", "pr-edit", "pr-ready", "cleanup"):
         p = agent_cmd.add_parser(name); p.add_argument("task")
     commit = agent_cmd.add_parser("commit"); commit.add_argument("task"); commit.add_argument("message", nargs="?", default="")
     integrate = scope.add_parser("integrate")
@@ -540,6 +707,7 @@ def main() -> int:
                 "verify": lambda: verify(root, args.task),
                 "commit": lambda: commit_task(root, args.task, args.message),
                 "push": lambda: push_task(root, args.task),
+                "pr-prepare": lambda: pr_prepare(root, args.task),
                 "pr-create": lambda: pr_create(root, args.task),
                 "pr-edit": lambda: pr_edit(root, args.task),
                 "pr-ready": lambda: pr_ready(root, args.task),

--- a/templates/agent-base/.automation/bin/publication_metadata.py
+++ b/templates/agent-base/.automation/bin/publication_metadata.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Prepare and validate evidence-backed pull request metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import task_contract
+
+
+class PublicationMetadataError(RuntimeError):
+    pass
+
+
+PLACEHOLDER_PATTERNS = (
+    r"@@[A-Z0-9_]+@@",
+    r"\bTBD\b",
+    r"Describe the implemented Task outcome\.",
+    r"Task-specific criteria copied from `?\.task-state/task\.md`?",
+    r"Define Task-specific acceptance criteria",
+)
+NOT_RUN_RE = re.compile(r"(?im)^.*(?:NOT[ _-]?RUN|not run).*$")
+
+
+def _sections(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"(?m)^## (.+?)\s*$", text))
+    return {
+        match.group(1): text[match.end() : matches[index + 1].start() if index + 1 < len(matches) else len(text)].strip()
+        for index, match in enumerate(matches)
+    }
+
+
+def _content_lines(value: str) -> list[str]:
+    ignored = {"none yet.", "none yet", "none recorded", "none recorded yet."}
+    return [line for line in value.splitlines() if line.strip() and line.strip().lower().lstrip("- ") not in ignored]
+
+
+def _identity(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing {name}")
+    return match.group(1).strip()
+
+
+def _read_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}") from exc
+    if not isinstance(value, dict):
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}")
+    return value
+
+
+def verification_evidence(root: Path, task: str, head: str) -> dict:
+    receipt = _read_json(root / ".task-state" / "verification.json")
+    if receipt is None:
+        raise PublicationMetadataError("missing persisted project verification evidence")
+    if set(receipt) != {"schema_version", "task_id", "head", "clean_tracked_worktree", "worktree_stable", "project_check"} or receipt["schema_version"] != 1:
+        raise PublicationMetadataError("invalid project verification evidence schema")
+    check = receipt.get("project_check")
+    if receipt.get("task_id") != task:
+        raise PublicationMetadataError("project verification evidence belongs to another Task")
+    if receipt.get("head") != head or not isinstance(check, dict):
+        raise PublicationMetadataError("project verification evidence is stale")
+    if check.get("command") != ["just", "project::check"] or check.get("returncode") != 0:
+        raise PublicationMetadataError("project::check has no persisted PASS evidence")
+    if receipt.get("clean_tracked_worktree") is not True or receipt.get("worktree_stable") is not True:
+        raise PublicationMetadataError("project verification is not bound to a clean stable worktree")
+    if not isinstance(check.get("executed_at"), str) or not check["executed_at"]:
+        raise PublicationMetadataError("project verification evidence has no execution time")
+    return receipt
+
+
+def completed_reviews(root: Path, task: str) -> list[str]:
+    value = _read_json(root / ".task-state" / "work-units.json")
+    if value is None:
+        return []
+    if value.get("task_id") != task or not isinstance(value.get("units"), dict):
+        raise PublicationMetadataError("Work Unit evidence does not match the Task")
+    reviews = []
+    for identifier, unit in value["units"].items():
+        if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
+            continue
+        if unit.get("state") != "completed":
+            raise PublicationMetadataError(
+                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+            )
+        transitions = unit.get("transitions")
+        digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
+        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+    return reviews
+
+
+def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[str]) -> tuple[str, str]:
+    state_path = root / ".task-state" / "task.md"
+    try:
+        text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError(f"missing Task State: {state_path}") from exc
+    if _identity(text, "Task ID") != task:
+        raise PublicationMetadataError("Task State identity does not match requested Task")
+    sections = _sections(text)
+    purpose = _content_lines(sections.get("Purpose", ""))
+    criteria = _content_lines(sections.get("Acceptance criteria", ""))
+    if not purpose or not criteria:
+        raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    summary = purpose[0].lstrip("- ").strip()
+    verification = verification_evidence(root, task, head)
+    title = f"{task}: {summary}"
+    changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
+    reviews = completed_reviews(root, task)
+    followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
+    body = "\n".join(
+        [
+            "## Summary", "", f"Task: {task}", "", *purpose,
+            "", "## Changed paths", "", *changes,
+            "", "## Acceptance criteria", "", *criteria,
+            "", "## Validation", "",
+            f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
+            "", "## Reviews", "", *(reviews or ["- None recorded."]),
+            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Follow-up Tasks", "", *followups, "",
+        ]
+    )
+    validate_metadata(title, body, receipt=verification)
+    return title, body
+
+
+def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> None:
+    if not title.strip() or not body.strip():
+        raise PublicationMetadataError("pull request title and body must be non-empty")
+    combined = title + "\n" + body
+    for pattern in PLACEHOLDER_PATTERNS:
+        if re.search(pattern, combined, re.IGNORECASE):
+            raise PublicationMetadataError("unresolved pull request publication placeholder")
+    not_run = NOT_RUN_RE.findall(body)
+    if not_run:
+        if receipt and receipt.get("project_check", {}).get("returncode") == 0:
+            raise PublicationMetadataError("pull request metadata contradicts persisted PASS evidence with NOT RUN")
+        raise PublicationMetadataError("unresolved NOT RUN publication metadata")
+    required = ("## Summary", "## Acceptance criteria", "## Validation", "## Risks and unverified areas", "## Follow-up Tasks")
+    if any(heading not in body for heading in required):
+        raise PublicationMetadataError("pull request body is missing required sections")
+
+
+def write_metadata(root: Path, title: str, body: str) -> None:
+    try:
+        task_contract.write_publication_metadata(
+            root,
+            (title.strip() + "\n").encode(),
+            (body.rstrip() + "\n").encode(),
+        )
+    except task_contract.ContractError as exc:
+        raise PublicationMetadataError(str(exc)) from exc
+
+
+def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tuple[str, str]:
+    title_path = root / ".task-state" / "pr-title.txt"
+    body_path = root / ".task-state" / "pr-body.md"
+    try:
+        title = title_path.read_text(encoding="utf-8").strip()
+        body = body_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError("run agent::pr-prepare before publication") from exc
+    validate_metadata(title, body, receipt=receipt)
+    return title, body

--- a/templates/agent-base/.automation/bin/publication_metadata.py
+++ b/templates/agent-base/.automation/bin/publication_metadata.py
@@ -44,6 +44,27 @@ def _identity(text: str, name: str) -> str:
     return match.group(1).strip()
 
 
+def _current_state_value(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing Current state {name}")
+    return match.group(1).strip()
+
+
+def _is_none_value(value: str) -> bool:
+    return value.casefold().rstrip(".") in {"none", "none recorded"}
+
+
+def _requirements(lines: list[str]) -> list[str]:
+    requirements = []
+    for line in lines:
+        value = re.sub(r"^-\s*\[[ xX]\]\s*", "", line.strip())
+        value = value.removeprefix("- ").strip()
+        if value:
+            requirements.append(f"- Requirement: {value}")
+    return requirements
+
+
 def _read_json(path: Path) -> dict | None:
     if not path.exists():
         return None
@@ -110,21 +131,39 @@ def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[
     criteria = _content_lines(sections.get("Acceptance criteria", ""))
     if not purpose or not criteria:
         raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    requirements = _requirements(criteria)
+    if not requirements:
+        raise PublicationMetadataError("Task acceptance criteria contain no authoritative requirements")
+    blockers = _current_state_value(sections.get("Current state", ""), "Blockers")
+    unverified = _current_state_value(sections.get("Current state", ""), "Unverified")
+    risks = []
+    if not _is_none_value(blockers):
+        risks.append(f"- Blockers: {blockers}")
+    if not _is_none_value(unverified):
+        risks.append(f"- Unverified: {unverified}")
+    if not risks:
+        risks = ["- None recorded."]
     summary = purpose[0].lstrip("- ").strip()
     verification = verification_evidence(root, task, head)
     title = f"{task}: {summary}"
     changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
     reviews = completed_reviews(root, task)
+    if not any("— `reviewer` — completed" in review for review in reviews):
+        raise PublicationMetadataError(
+            "publication requires a completed reviewer Work Unit"
+        )
     followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
     body = "\n".join(
         [
             "## Summary", "", f"Task: {task}", "", *purpose,
             "", "## Changed paths", "", *changes,
-            "", "## Acceptance criteria", "", *criteria,
+            "", "## Acceptance criteria", "",
+            "The following are authoritative Task requirements; completion evidence is reported separately under Validation and Reviews.",
+            "", *requirements,
             "", "## Validation", "",
             f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
             "", "## Reviews", "", *(reviews or ["- None recorded."]),
-            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Risks and unverified areas", "", *risks,
             "", "## Follow-up Tasks", "", *followups, "",
         ]
     )

--- a/templates/agent-base/.automation/bin/task_contract.py
+++ b/templates/agent-base/.automation/bin/task_contract.py
@@ -139,6 +139,30 @@ def _restore_state_file(directory_fd: int, name: str, content: bytes | None) -> 
         _write_state_file(directory_fd, name, content)
 
 
+def write_publication_metadata(root: Path, title: bytes, body: bytes) -> None:
+    """Atomically replace the two publication files in pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        previous = {
+            name: _read_state_file(directory_fd, name)
+            for name in ("pr-title.txt", "pr-body.md")
+        }
+        try:
+            _write_state_file(directory_fd, "pr-title.txt", title)
+            _write_state_file(directory_fd, "pr-body.md", body)
+            _assert_state_dir_binding(root, directory_fd)
+        except Exception:
+            for name, content in previous.items():
+                _restore_state_file(directory_fd, name, content)
+            raise
+
+
+def write_verification_receipt(root: Path, content: bytes) -> None:
+    """Replace the verification receipt through pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        _write_state_file(directory_fd, "verification.json", content)
+        _assert_state_dir_binding(root, directory_fd)
+
+
 def validate_issue_number(value: str) -> int:
     if not ISSUE_RE.fullmatch(value):
         raise ContractError("Issue number must be an exact positive decimal integer")

--- a/templates/agent-base/.automation/bin/task_lifecycle.py
+++ b/templates/agent-base/.automation/bin/task_lifecycle.py
@@ -919,10 +919,40 @@ def task_status(root: Path, task: str) -> None:
 def task_state_set(root: Path, task: str, status: str) -> None:
     record = require_local_task(root, task)
     require_resolved_contract(record, task)
+    if status in {"draft-pr-created", "integration-pending"}:
+        raise LifecycleError(
+            f"{status} is reserved for the guarded pull request publication boundary"
+        )
     with work_units_lock(record):
         assert_task_identity(record, task)
         set_state_status(state_path(record.path), status)
     print(json.dumps({"task": task, "status": status}))
+
+
+def mark_task_publication_state(
+    record: WorktreeRecord, task: str, expected: str, target: str
+) -> str:
+    """Narrow transition authority for validated PR creation/readiness."""
+    allowed = {
+        ("publication-ready", "draft-pr-created"),
+        ("draft-pr-created", "integration-pending"),
+    }
+    if (expected, target) not in allowed:
+        raise LifecycleError("invalid guarded publication transition")
+    validate_task(task)
+    require_resolved_contract(record, task)
+    with work_units_lock(record):
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        previous = state_status(path)
+        if previous == target:
+            return "already-transitioned"
+        if previous != expected:
+            raise LifecycleError(
+                f"guarded publication transition requires {expected}; found {previous}"
+            )
+        set_state_status(path, target)
+    return "transitioned"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/templates/agent-base/.automation/just/agent.just
+++ b/templates/agent-base/.automation/just/agent.just
@@ -84,6 +84,10 @@ pr-create task:
     python3 {{quote(script)}} agent pr-create {{quote(task)}}
 
 [working-directory: root]
+pr-prepare task:
+    python3 {{quote(script)}} agent pr-prepare {{quote(task)}}
+
+[working-directory: root]
 pr-edit task:
     python3 {{quote(script)}} agent pr-edit {{quote(task)}}
 

--- a/templates/agent-base/.opencode/agents/build.md
+++ b/templates/agent-base/.opencode/agents/build.md
@@ -25,6 +25,7 @@ permission:
     "just agent::batch-plan *": allow
     "just agent::commit *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just integrate::finalize *": allow

--- a/templates/agent-base/.opencode/agents/general.md
+++ b/templates/agent-base/.opencode/agents/general.md
@@ -38,6 +38,7 @@ permission:
     "just agent::commit *": deny
     "just agent::push *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just agent::cleanup *": deny

--- a/templates/agent-base/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-base/.opencode/agents/task-orchestrator.md
@@ -30,6 +30,7 @@ permission:
     "just agent::work-unit-dispatch-check *": allow
     "just agent::work-unit-status *": allow
     "just agent::work-unit-state-set *": allow
+    "just agent::pr-prepare *": allow
     "just integrate::check *": deny
     "just integrate::finalize *": deny
     "just integrate::merge *": deny
@@ -77,6 +78,6 @@ Before advancing Task State to `publication-ready`, and again before guarded com
 - a reviewer Work Unit for non-trivial changes;
 - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 
-No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, and prepare a Draft PR. Never merge.
+No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, run `just agent::pr-prepare <task>`, and create or repair the same Draft PR through the guarded publication API. Metadata with placeholders or false `NOT RUN` claims is forbidden. Never merge.
 
 Never invoke another Task Orchestrator. Never merge. Never operate on sibling Task worktrees. Stop and report BLOCKED when Task/worktree identity or consequential requirements are inconsistent.

--- a/templates/agent-base/.opencode/skills/task-orchestration/SKILL.md
+++ b/templates/agent-base/.opencode/skills/task-orchestration/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when the Main Orchestrator is asked to run a specific Task that a
     - a reviewer Work Unit for non-trivial changes;
     - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 12. No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop.
-13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, and create or edit only a Draft PR.
+13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, run `just agent::pr-prepare <task>`, and create or edit only the same Draft PR. Publication metadata must be regenerated from persisted evidence and must contain no unresolved placeholder or false `NOT RUN` claim.
 14. Persist every transition and continue the loop until integration-pending. Stop for `NEEDS_APPROVAL` or `NEEDS_DECISION` human handling, and otherwise stop at integration-pending. Do not merge from this skill. Never merge.
 
 Do not silently select another Issue or Task. Do not weaken permissions to work around a blocked approval or missing tool/model.

--- a/templates/agent-base/opencode.json
+++ b/templates/agent-base/opencode.json
@@ -91,6 +91,7 @@
       "just agent::status *": "allow",
       "just agent::verify *": "allow",
       "just agent::commit *": "allow",
+      "just agent::pr-prepare *": "allow",
       "just agent::pr-create *": "allow",
       "just agent::pr-edit *": "allow",
       "just agent::pr-ready *": "allow",

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -94,6 +94,12 @@ just agent::pr-edit <task>
 just agent::pr-ready <task>
 ```
 
+`pr-prepare` renders acceptance criteria as authoritative requirements and
+renders non-empty `Current state` Blockers/Unverified values in the PR risk
+section. Missing Current-state evidence, unresolved placeholders, stale
+verification, missing completed reviewer evidence, an incomplete declared
+security review, or contradictory validation claims block publication.
+
 The normal upgrade flow creates its receipt before verification. If a self-hosted
 pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
 normal verification and, before `automation::commit`, run the strict bootstrap

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -89,6 +89,9 @@ Before publication, execute `git diff --check`, `just agent::doctor`,
 just automation::commit <task> [message]
 just agent::push <task>
 just agent::pr-create <task>
+just agent::pr-prepare <task>
+just agent::pr-edit <task>
+just agent::pr-ready <task>
 ```
 
 The normal upgrade flow creates its receipt before verification. If a self-hosted

--- a/templates/agent-cpp-cmake/.automation/bin/agent_core.py
+++ b/templates/agent-cpp-cmake/.automation/bin/agent_core.py
@@ -406,6 +406,7 @@ def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> Non
 
 
 def pr_create(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] != "publication-ready":
         raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
@@ -429,6 +430,7 @@ def pr_create(root: Path, task: str) -> None:
 
 
 def pr_edit(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] not in {"publication-ready", "draft-pr-created"}:
         raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")

--- a/templates/agent-cpp-cmake/.automation/bin/agent_core.py
+++ b/templates/agent-cpp-cmake/.automation/bin/agent_core.py
@@ -8,12 +8,15 @@ import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 import task_lifecycle as lifecycle
+import publication_metadata as publication
+import task_contract
 
 try:
     import tomllib
@@ -101,7 +104,7 @@ def validate_slug(slug: str) -> None:
 def ensure_task_branch(root: Path, task: str) -> str:
     validate_task(task)
     branch = current_branch(root)
-    if task not in branch or not (branch.startswith("task/") or branch.startswith("fix/")):
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
         raise AutomationError(f"current branch {branch!r} is not the Task branch for {task}")
     if branch == default_branch(root):
         raise AutomationError("Task operation refused on the default branch")
@@ -238,7 +241,33 @@ def status(root: Path, task: str) -> None:
 
 def verify(root: Path, task: str) -> None:
     ensure_task_branch(root, task)
-    run(["just", "project::check"], cwd=root)
+    head = git("rev-parse", "HEAD", cwd=root)
+    status_before = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    result = run(["just", "project::check"], cwd=root, check=False)
+    status_after = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    receipt = {
+        "schema_version": 1,
+        "task_id": task,
+        "head": head,
+        "clean_tracked_worktree": not status_before and not status_after,
+        "worktree_stable": status_before == status_after,
+        "project_check": {
+            "command": ["just", "project::check"],
+            "returncode": result.returncode,
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    try:
+        task_contract.write_verification_receipt(
+            root, (json.dumps(receipt, sort_keys=True) + "\n").encode()
+        )
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise AutomationError(f"just project::check: {detail}")
+    if status_before != status_after:
+        raise AutomationError("project::check changed tracked or untracked product files")
     print("Project verification: PASS")
 
 
@@ -265,54 +294,192 @@ def push_task(root: Path, task: str) -> None:
     print(f"pushed origin/{branch}")
 
 
-def pr_for_branch(root: Path, branch: str) -> dict | None:
-    result = run(["gh", "pr", "view", branch, "--json", "number,title,body,headRefName,baseRefName,isDraft,state,headRefOid"], cwd=root, check=False)
+def canonical_repository(root: Path) -> str:
+    path = root / ".task-state" / "contract.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AutomationError(f"invalid canonical Task Contract metadata: {path}") from exc
+    repository = value.get("repository") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise AutomationError("canonical Task Contract repository is invalid")
+    try:
+        live = task_contract.repository_identity(root)
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if live.casefold() != repository.casefold():
+        raise AutomationError("live origin repository does not match the canonical Task Contract")
+    return repository
+
+
+def pr_for_branch(root: Path, branch: str, repository: str | None = None) -> dict | None:
+    command = ["gh", "pr", "view", branch]
+    if repository is not None:
+        command.extend(["--repo", repository])
+    command.extend(["--json", "number,title,body,headRefName,baseRefName,isDraft,isCrossRepository,state,headRefOid"])
+    result = run(command, cwd=root, check=False)
     if result.returncode != 0:
-        return None
-    return json.loads(result.stdout)
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        if "no pull requests found" in detail.lower():
+            return None
+        raise AutomationError(f"cannot resolve pull request for {branch}: {detail}")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AutomationError("invalid pull request data returned by GitHub") from exc
+    return value
 
 
-def pr_body(root: Path, task: str) -> Path:
-    state_dir = root / ".task-state"
-    state_dir.mkdir(parents=True, exist_ok=True)
-    path = state_dir / "pr-body.md"
-    if not path.exists():
-        template = root / ".automation" / "templates" / "pull-request.md"
-        text = template.read_text(encoding="utf-8").replace("@@TASK_ID@@", task)
-        path.write_text(text, encoding="utf-8")
-    return path
+def _publication_context(root: Path, task: str) -> tuple[str, dict, str]:
+    branch = ensure_task_branch(root, task)
+    head = git("rev-parse", "HEAD", cwd=root)
+    try:
+        record = lifecycle.require_local_task(root, task)
+        lifecycle.require_resolved_contract(record, task)
+        status = lifecycle.state_status(lifecycle.state_path(root))
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    repository = canonical_repository(root)
+    return branch, {"record": record, "status": status, "repository": repository}, head
+
+
+def pr_prepare(root: Path, task: str) -> None:
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"publication metadata preparation requires publication-ready or draft-pr-created; found {context['status']}")
+    state = lifecycle.state_path(root).read_text(encoding="utf-8")
+    base_revision = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", state)
+    if base_revision is None:
+        raise AutomationError("Task State has no valid Base revision")
+    paths = git("diff", "--name-only", f"{base_revision.group(1)}...{head}", cwd=root).splitlines()
+    try:
+        title, body = publication.canonical_metadata(root, task, head=head, changed_paths=paths)
+        publication.write_metadata(root, title, body)
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps({"task": task, "branch": branch, "title": title, "body": str(root / '.task-state' / 'pr-body.md')}))
+
+
+def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Path, str]:
+    try:
+        receipt = publication.verification_evidence(root, task, head)
+        title, body = publication.read_and_validate_metadata(root, receipt=receipt)
+        expected_title, expected_body = publication.canonical_metadata(
+            root,
+            task,
+            head=head,
+            changed_paths=git("diff", "--name-only", f"{_base_revision(root)}...{head}", cwd=root).splitlines(),
+        )
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    if title != expected_title or body.rstrip() != expected_body.rstrip():
+        raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
+    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+
+
+def _base_revision(root: Path) -> str:
+    text = lifecycle.state_path(root).read_text(encoding="utf-8")
+    match = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", text)
+    if match is None:
+        raise AutomationError("Task State has no valid Base revision")
+    return match.group(1)
+
+
+def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches:
+        raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
+
+
+def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "isDraft": True, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches or not isinstance(pr.get("number"), int):
+        raise AutomationError("pull request repair target identity is invalid: " + ", ".join(mismatches or ["number"]))
 
 
 def pr_create(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    if pr_for_branch(root, branch):
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "publication-ready":
+        raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
+    repository = context["repository"]
+    if pr_for_branch(root, branch, repository):
         raise AutomationError(f"pull request already exists for {branch}")
     base = default_branch(root)
-    title = f"{task}: {branch.split('/', 1)[1]}"
-    body = pr_body(root, task)
-    gh("pr", "create", "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
-    print(json.dumps(pr_for_branch(root, branch)))
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "create", "--repo", repository, "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request creation")
+    pr = pr_for_branch(root, branch, repository)
+    if not pr:
+        raise AutomationError("created pull request cannot be re-read")
+    _validate_live_pr(pr, branch=branch, base=base, head=head, title=title, body=body_text, draft=True)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps(pr))
 
 
 def pr_edit(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    title_file = root / ".task-state" / "pr-title.txt"
-    title = title_file.read_text(encoding="utf-8").strip() if title_file.exists() else pr["title"]
-    body = pr_body(root, task)
-    gh("pr", "edit", str(pr["number"]), "--title", title, "--body-file", str(body), cwd=root)
+    _validate_edit_target(pr, branch=branch, base=default_branch(root), head=head)
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "edit", str(pr["number"]), "--repo", repository, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request repair")
+    updated = pr_for_branch(root, branch, repository)
+    if not updated or updated.get("number") != pr.get("number"):
+        raise AutomationError("pull request identity changed during guarded repair")
+    _validate_live_pr(updated, branch=branch, base=default_branch(root), head=head, title=title, body=body_text, draft=True)
+    if context["status"] == "publication-ready":
+        try:
+            lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+        except lifecycle.LifecycleError as exc:
+            raise AutomationError(str(exc)) from exc
     print(f"updated PR #{pr['number']}")
 
 
 def pr_ready(root: Path, task: str) -> None:
     verify(root, task)
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "draft-pr-created":
+        raise AutomationError(f"pr-ready requires draft-pr-created; found {context['status']}")
+    title, _, body = _validated_local_metadata(root, task, head)
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    gh("pr", "ready", str(pr["number"]), cwd=root)
+    if pr.get("isDraft"):
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=True)
+        gh("pr", "ready", str(pr["number"]), "--repo", repository, cwd=root)
+        if canonical_repository(root).casefold() != repository.casefold():
+            raise AutomationError("repository identity changed while marking pull request ready")
+        ready = pr_for_branch(root, branch, repository)
+        if not ready or ready.get("number") != pr.get("number"):
+            raise AutomationError("pull request identity changed while marking ready")
+        _validate_live_pr(ready, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    else:
+        # Reconcile an earlier successful GitHub readiness write whose local
+        # lifecycle transition was interrupted.
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "draft-pr-created", "integration-pending")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
     print(f"PR #{pr['number']} marked ready")
 
 
@@ -514,7 +681,7 @@ def build_parser() -> argparse.ArgumentParser:
     for name in ("doctor", "context"):
         agent_cmd.add_parser(name)
     start = agent_cmd.add_parser("task-start"); start.add_argument("task"); start.add_argument("slug")
-    for name in ("status", "verify", "push", "pr-create", "pr-edit", "pr-ready", "cleanup"):
+    for name in ("status", "verify", "push", "pr-prepare", "pr-create", "pr-edit", "pr-ready", "cleanup"):
         p = agent_cmd.add_parser(name); p.add_argument("task")
     commit = agent_cmd.add_parser("commit"); commit.add_argument("task"); commit.add_argument("message", nargs="?", default="")
     integrate = scope.add_parser("integrate")
@@ -540,6 +707,7 @@ def main() -> int:
                 "verify": lambda: verify(root, args.task),
                 "commit": lambda: commit_task(root, args.task, args.message),
                 "push": lambda: push_task(root, args.task),
+                "pr-prepare": lambda: pr_prepare(root, args.task),
                 "pr-create": lambda: pr_create(root, args.task),
                 "pr-edit": lambda: pr_edit(root, args.task),
                 "pr-ready": lambda: pr_ready(root, args.task),

--- a/templates/agent-cpp-cmake/.automation/bin/publication_metadata.py
+++ b/templates/agent-cpp-cmake/.automation/bin/publication_metadata.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Prepare and validate evidence-backed pull request metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import task_contract
+
+
+class PublicationMetadataError(RuntimeError):
+    pass
+
+
+PLACEHOLDER_PATTERNS = (
+    r"@@[A-Z0-9_]+@@",
+    r"\bTBD\b",
+    r"Describe the implemented Task outcome\.",
+    r"Task-specific criteria copied from `?\.task-state/task\.md`?",
+    r"Define Task-specific acceptance criteria",
+)
+NOT_RUN_RE = re.compile(r"(?im)^.*(?:NOT[ _-]?RUN|not run).*$")
+
+
+def _sections(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"(?m)^## (.+?)\s*$", text))
+    return {
+        match.group(1): text[match.end() : matches[index + 1].start() if index + 1 < len(matches) else len(text)].strip()
+        for index, match in enumerate(matches)
+    }
+
+
+def _content_lines(value: str) -> list[str]:
+    ignored = {"none yet.", "none yet", "none recorded", "none recorded yet."}
+    return [line for line in value.splitlines() if line.strip() and line.strip().lower().lstrip("- ") not in ignored]
+
+
+def _identity(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing {name}")
+    return match.group(1).strip()
+
+
+def _read_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}") from exc
+    if not isinstance(value, dict):
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}")
+    return value
+
+
+def verification_evidence(root: Path, task: str, head: str) -> dict:
+    receipt = _read_json(root / ".task-state" / "verification.json")
+    if receipt is None:
+        raise PublicationMetadataError("missing persisted project verification evidence")
+    if set(receipt) != {"schema_version", "task_id", "head", "clean_tracked_worktree", "worktree_stable", "project_check"} or receipt["schema_version"] != 1:
+        raise PublicationMetadataError("invalid project verification evidence schema")
+    check = receipt.get("project_check")
+    if receipt.get("task_id") != task:
+        raise PublicationMetadataError("project verification evidence belongs to another Task")
+    if receipt.get("head") != head or not isinstance(check, dict):
+        raise PublicationMetadataError("project verification evidence is stale")
+    if check.get("command") != ["just", "project::check"] or check.get("returncode") != 0:
+        raise PublicationMetadataError("project::check has no persisted PASS evidence")
+    if receipt.get("clean_tracked_worktree") is not True or receipt.get("worktree_stable") is not True:
+        raise PublicationMetadataError("project verification is not bound to a clean stable worktree")
+    if not isinstance(check.get("executed_at"), str) or not check["executed_at"]:
+        raise PublicationMetadataError("project verification evidence has no execution time")
+    return receipt
+
+
+def completed_reviews(root: Path, task: str) -> list[str]:
+    value = _read_json(root / ".task-state" / "work-units.json")
+    if value is None:
+        return []
+    if value.get("task_id") != task or not isinstance(value.get("units"), dict):
+        raise PublicationMetadataError("Work Unit evidence does not match the Task")
+    reviews = []
+    for identifier, unit in value["units"].items():
+        if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
+            continue
+        if unit.get("state") != "completed":
+            raise PublicationMetadataError(
+                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+            )
+        transitions = unit.get("transitions")
+        digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
+        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+    return reviews
+
+
+def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[str]) -> tuple[str, str]:
+    state_path = root / ".task-state" / "task.md"
+    try:
+        text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError(f"missing Task State: {state_path}") from exc
+    if _identity(text, "Task ID") != task:
+        raise PublicationMetadataError("Task State identity does not match requested Task")
+    sections = _sections(text)
+    purpose = _content_lines(sections.get("Purpose", ""))
+    criteria = _content_lines(sections.get("Acceptance criteria", ""))
+    if not purpose or not criteria:
+        raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    summary = purpose[0].lstrip("- ").strip()
+    verification = verification_evidence(root, task, head)
+    title = f"{task}: {summary}"
+    changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
+    reviews = completed_reviews(root, task)
+    followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
+    body = "\n".join(
+        [
+            "## Summary", "", f"Task: {task}", "", *purpose,
+            "", "## Changed paths", "", *changes,
+            "", "## Acceptance criteria", "", *criteria,
+            "", "## Validation", "",
+            f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
+            "", "## Reviews", "", *(reviews or ["- None recorded."]),
+            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Follow-up Tasks", "", *followups, "",
+        ]
+    )
+    validate_metadata(title, body, receipt=verification)
+    return title, body
+
+
+def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> None:
+    if not title.strip() or not body.strip():
+        raise PublicationMetadataError("pull request title and body must be non-empty")
+    combined = title + "\n" + body
+    for pattern in PLACEHOLDER_PATTERNS:
+        if re.search(pattern, combined, re.IGNORECASE):
+            raise PublicationMetadataError("unresolved pull request publication placeholder")
+    not_run = NOT_RUN_RE.findall(body)
+    if not_run:
+        if receipt and receipt.get("project_check", {}).get("returncode") == 0:
+            raise PublicationMetadataError("pull request metadata contradicts persisted PASS evidence with NOT RUN")
+        raise PublicationMetadataError("unresolved NOT RUN publication metadata")
+    required = ("## Summary", "## Acceptance criteria", "## Validation", "## Risks and unverified areas", "## Follow-up Tasks")
+    if any(heading not in body for heading in required):
+        raise PublicationMetadataError("pull request body is missing required sections")
+
+
+def write_metadata(root: Path, title: str, body: str) -> None:
+    try:
+        task_contract.write_publication_metadata(
+            root,
+            (title.strip() + "\n").encode(),
+            (body.rstrip() + "\n").encode(),
+        )
+    except task_contract.ContractError as exc:
+        raise PublicationMetadataError(str(exc)) from exc
+
+
+def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tuple[str, str]:
+    title_path = root / ".task-state" / "pr-title.txt"
+    body_path = root / ".task-state" / "pr-body.md"
+    try:
+        title = title_path.read_text(encoding="utf-8").strip()
+        body = body_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError("run agent::pr-prepare before publication") from exc
+    validate_metadata(title, body, receipt=receipt)
+    return title, body

--- a/templates/agent-cpp-cmake/.automation/bin/publication_metadata.py
+++ b/templates/agent-cpp-cmake/.automation/bin/publication_metadata.py
@@ -44,6 +44,27 @@ def _identity(text: str, name: str) -> str:
     return match.group(1).strip()
 
 
+def _current_state_value(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing Current state {name}")
+    return match.group(1).strip()
+
+
+def _is_none_value(value: str) -> bool:
+    return value.casefold().rstrip(".") in {"none", "none recorded"}
+
+
+def _requirements(lines: list[str]) -> list[str]:
+    requirements = []
+    for line in lines:
+        value = re.sub(r"^-\s*\[[ xX]\]\s*", "", line.strip())
+        value = value.removeprefix("- ").strip()
+        if value:
+            requirements.append(f"- Requirement: {value}")
+    return requirements
+
+
 def _read_json(path: Path) -> dict | None:
     if not path.exists():
         return None
@@ -110,21 +131,39 @@ def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[
     criteria = _content_lines(sections.get("Acceptance criteria", ""))
     if not purpose or not criteria:
         raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    requirements = _requirements(criteria)
+    if not requirements:
+        raise PublicationMetadataError("Task acceptance criteria contain no authoritative requirements")
+    blockers = _current_state_value(sections.get("Current state", ""), "Blockers")
+    unverified = _current_state_value(sections.get("Current state", ""), "Unverified")
+    risks = []
+    if not _is_none_value(blockers):
+        risks.append(f"- Blockers: {blockers}")
+    if not _is_none_value(unverified):
+        risks.append(f"- Unverified: {unverified}")
+    if not risks:
+        risks = ["- None recorded."]
     summary = purpose[0].lstrip("- ").strip()
     verification = verification_evidence(root, task, head)
     title = f"{task}: {summary}"
     changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
     reviews = completed_reviews(root, task)
+    if not any("— `reviewer` — completed" in review for review in reviews):
+        raise PublicationMetadataError(
+            "publication requires a completed reviewer Work Unit"
+        )
     followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
     body = "\n".join(
         [
             "## Summary", "", f"Task: {task}", "", *purpose,
             "", "## Changed paths", "", *changes,
-            "", "## Acceptance criteria", "", *criteria,
+            "", "## Acceptance criteria", "",
+            "The following are authoritative Task requirements; completion evidence is reported separately under Validation and Reviews.",
+            "", *requirements,
             "", "## Validation", "",
             f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
             "", "## Reviews", "", *(reviews or ["- None recorded."]),
-            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Risks and unverified areas", "", *risks,
             "", "## Follow-up Tasks", "", *followups, "",
         ]
     )

--- a/templates/agent-cpp-cmake/.automation/bin/task_contract.py
+++ b/templates/agent-cpp-cmake/.automation/bin/task_contract.py
@@ -139,6 +139,30 @@ def _restore_state_file(directory_fd: int, name: str, content: bytes | None) -> 
         _write_state_file(directory_fd, name, content)
 
 
+def write_publication_metadata(root: Path, title: bytes, body: bytes) -> None:
+    """Atomically replace the two publication files in pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        previous = {
+            name: _read_state_file(directory_fd, name)
+            for name in ("pr-title.txt", "pr-body.md")
+        }
+        try:
+            _write_state_file(directory_fd, "pr-title.txt", title)
+            _write_state_file(directory_fd, "pr-body.md", body)
+            _assert_state_dir_binding(root, directory_fd)
+        except Exception:
+            for name, content in previous.items():
+                _restore_state_file(directory_fd, name, content)
+            raise
+
+
+def write_verification_receipt(root: Path, content: bytes) -> None:
+    """Replace the verification receipt through pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        _write_state_file(directory_fd, "verification.json", content)
+        _assert_state_dir_binding(root, directory_fd)
+
+
 def validate_issue_number(value: str) -> int:
     if not ISSUE_RE.fullmatch(value):
         raise ContractError("Issue number must be an exact positive decimal integer")

--- a/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
+++ b/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
@@ -919,10 +919,40 @@ def task_status(root: Path, task: str) -> None:
 def task_state_set(root: Path, task: str, status: str) -> None:
     record = require_local_task(root, task)
     require_resolved_contract(record, task)
+    if status in {"draft-pr-created", "integration-pending"}:
+        raise LifecycleError(
+            f"{status} is reserved for the guarded pull request publication boundary"
+        )
     with work_units_lock(record):
         assert_task_identity(record, task)
         set_state_status(state_path(record.path), status)
     print(json.dumps({"task": task, "status": status}))
+
+
+def mark_task_publication_state(
+    record: WorktreeRecord, task: str, expected: str, target: str
+) -> str:
+    """Narrow transition authority for validated PR creation/readiness."""
+    allowed = {
+        ("publication-ready", "draft-pr-created"),
+        ("draft-pr-created", "integration-pending"),
+    }
+    if (expected, target) not in allowed:
+        raise LifecycleError("invalid guarded publication transition")
+    validate_task(task)
+    require_resolved_contract(record, task)
+    with work_units_lock(record):
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        previous = state_status(path)
+        if previous == target:
+            return "already-transitioned"
+        if previous != expected:
+            raise LifecycleError(
+                f"guarded publication transition requires {expected}; found {previous}"
+            )
+        set_state_status(path, target)
+    return "transitioned"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/templates/agent-cpp-cmake/.automation/just/agent.just
+++ b/templates/agent-cpp-cmake/.automation/just/agent.just
@@ -84,6 +84,10 @@ pr-create task:
     python3 {{quote(script)}} agent pr-create {{quote(task)}}
 
 [working-directory: root]
+pr-prepare task:
+    python3 {{quote(script)}} agent pr-prepare {{quote(task)}}
+
+[working-directory: root]
 pr-edit task:
     python3 {{quote(script)}} agent pr-edit {{quote(task)}}
 

--- a/templates/agent-cpp-cmake/.opencode/agents/build.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/build.md
@@ -25,6 +25,7 @@ permission:
     "just agent::batch-plan *": allow
     "just agent::commit *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just integrate::finalize *": allow

--- a/templates/agent-cpp-cmake/.opencode/agents/general.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/general.md
@@ -38,6 +38,7 @@ permission:
     "just agent::commit *": deny
     "just agent::push *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just agent::cleanup *": deny

--- a/templates/agent-cpp-cmake/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-cpp-cmake/.opencode/agents/task-orchestrator.md
@@ -30,6 +30,7 @@ permission:
     "just agent::work-unit-dispatch-check *": allow
     "just agent::work-unit-status *": allow
     "just agent::work-unit-state-set *": allow
+    "just agent::pr-prepare *": allow
     "just integrate::check *": deny
     "just integrate::finalize *": deny
     "just integrate::merge *": deny
@@ -77,6 +78,6 @@ Before advancing Task State to `publication-ready`, and again before guarded com
 - a reviewer Work Unit for non-trivial changes;
 - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 
-No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, and prepare a Draft PR. Never merge.
+No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, run `just agent::pr-prepare <task>`, and create or repair the same Draft PR through the guarded publication API. Metadata with placeholders or false `NOT RUN` claims is forbidden. Never merge.
 
 Never invoke another Task Orchestrator. Never merge. Never operate on sibling Task worktrees. Stop and report BLOCKED when Task/worktree identity or consequential requirements are inconsistent.

--- a/templates/agent-cpp-cmake/.opencode/skills/task-orchestration/SKILL.md
+++ b/templates/agent-cpp-cmake/.opencode/skills/task-orchestration/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when the Main Orchestrator is asked to run a specific Task that a
     - a reviewer Work Unit for non-trivial changes;
     - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 12. No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop.
-13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, and create or edit only a Draft PR.
+13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, run `just agent::pr-prepare <task>`, and create or edit only the same Draft PR. Publication metadata must be regenerated from persisted evidence and must contain no unresolved placeholder or false `NOT RUN` claim.
 14. Persist every transition and continue the loop until integration-pending. Stop for `NEEDS_APPROVAL` or `NEEDS_DECISION` human handling, and otherwise stop at integration-pending. Do not merge from this skill. Never merge.
 
 Do not silently select another Issue or Task. Do not weaken permissions to work around a blocked approval or missing tool/model.

--- a/templates/agent-cpp-cmake/opencode.json
+++ b/templates/agent-cpp-cmake/opencode.json
@@ -91,6 +91,7 @@
       "just agent::status *": "allow",
       "just agent::verify *": "allow",
       "just agent::commit *": "allow",
+      "just agent::pr-prepare *": "allow",
       "just agent::pr-create *": "allow",
       "just agent::pr-edit *": "allow",
       "just agent::pr-ready *": "allow",

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -94,6 +94,12 @@ just agent::pr-edit <task>
 just agent::pr-ready <task>
 ```
 
+`pr-prepare` renders acceptance criteria as authoritative requirements and
+renders non-empty `Current state` Blockers/Unverified values in the PR risk
+section. Missing Current-state evidence, unresolved placeholders, stale
+verification, missing completed reviewer evidence, an incomplete declared
+security review, or contradictory validation claims block publication.
+
 The normal upgrade flow creates its receipt before verification. If a self-hosted
 pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
 normal verification and, before `automation::commit`, run the strict bootstrap

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -89,6 +89,9 @@ Before publication, execute `git diff --check`, `just agent::doctor`,
 just automation::commit <task> [message]
 just agent::push <task>
 just agent::pr-create <task>
+just agent::pr-prepare <task>
+just agent::pr-edit <task>
+just agent::pr-ready <task>
 ```
 
 The normal upgrade flow creates its receipt before verification. If a self-hosted

--- a/templates/agent-nix/.automation/bin/agent_core.py
+++ b/templates/agent-nix/.automation/bin/agent_core.py
@@ -406,6 +406,7 @@ def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> Non
 
 
 def pr_create(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] != "publication-ready":
         raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
@@ -429,6 +430,7 @@ def pr_create(root: Path, task: str) -> None:
 
 
 def pr_edit(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] not in {"publication-ready", "draft-pr-created"}:
         raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")

--- a/templates/agent-nix/.automation/bin/agent_core.py
+++ b/templates/agent-nix/.automation/bin/agent_core.py
@@ -8,12 +8,15 @@ import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 import task_lifecycle as lifecycle
+import publication_metadata as publication
+import task_contract
 
 try:
     import tomllib
@@ -101,7 +104,7 @@ def validate_slug(slug: str) -> None:
 def ensure_task_branch(root: Path, task: str) -> str:
     validate_task(task)
     branch = current_branch(root)
-    if task not in branch or not (branch.startswith("task/") or branch.startswith("fix/")):
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
         raise AutomationError(f"current branch {branch!r} is not the Task branch for {task}")
     if branch == default_branch(root):
         raise AutomationError("Task operation refused on the default branch")
@@ -238,7 +241,33 @@ def status(root: Path, task: str) -> None:
 
 def verify(root: Path, task: str) -> None:
     ensure_task_branch(root, task)
-    run(["just", "project::check"], cwd=root)
+    head = git("rev-parse", "HEAD", cwd=root)
+    status_before = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    result = run(["just", "project::check"], cwd=root, check=False)
+    status_after = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    receipt = {
+        "schema_version": 1,
+        "task_id": task,
+        "head": head,
+        "clean_tracked_worktree": not status_before and not status_after,
+        "worktree_stable": status_before == status_after,
+        "project_check": {
+            "command": ["just", "project::check"],
+            "returncode": result.returncode,
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    try:
+        task_contract.write_verification_receipt(
+            root, (json.dumps(receipt, sort_keys=True) + "\n").encode()
+        )
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise AutomationError(f"just project::check: {detail}")
+    if status_before != status_after:
+        raise AutomationError("project::check changed tracked or untracked product files")
     print("Project verification: PASS")
 
 
@@ -265,54 +294,192 @@ def push_task(root: Path, task: str) -> None:
     print(f"pushed origin/{branch}")
 
 
-def pr_for_branch(root: Path, branch: str) -> dict | None:
-    result = run(["gh", "pr", "view", branch, "--json", "number,title,body,headRefName,baseRefName,isDraft,state,headRefOid"], cwd=root, check=False)
+def canonical_repository(root: Path) -> str:
+    path = root / ".task-state" / "contract.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AutomationError(f"invalid canonical Task Contract metadata: {path}") from exc
+    repository = value.get("repository") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise AutomationError("canonical Task Contract repository is invalid")
+    try:
+        live = task_contract.repository_identity(root)
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if live.casefold() != repository.casefold():
+        raise AutomationError("live origin repository does not match the canonical Task Contract")
+    return repository
+
+
+def pr_for_branch(root: Path, branch: str, repository: str | None = None) -> dict | None:
+    command = ["gh", "pr", "view", branch]
+    if repository is not None:
+        command.extend(["--repo", repository])
+    command.extend(["--json", "number,title,body,headRefName,baseRefName,isDraft,isCrossRepository,state,headRefOid"])
+    result = run(command, cwd=root, check=False)
     if result.returncode != 0:
-        return None
-    return json.loads(result.stdout)
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        if "no pull requests found" in detail.lower():
+            return None
+        raise AutomationError(f"cannot resolve pull request for {branch}: {detail}")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AutomationError("invalid pull request data returned by GitHub") from exc
+    return value
 
 
-def pr_body(root: Path, task: str) -> Path:
-    state_dir = root / ".task-state"
-    state_dir.mkdir(parents=True, exist_ok=True)
-    path = state_dir / "pr-body.md"
-    if not path.exists():
-        template = root / ".automation" / "templates" / "pull-request.md"
-        text = template.read_text(encoding="utf-8").replace("@@TASK_ID@@", task)
-        path.write_text(text, encoding="utf-8")
-    return path
+def _publication_context(root: Path, task: str) -> tuple[str, dict, str]:
+    branch = ensure_task_branch(root, task)
+    head = git("rev-parse", "HEAD", cwd=root)
+    try:
+        record = lifecycle.require_local_task(root, task)
+        lifecycle.require_resolved_contract(record, task)
+        status = lifecycle.state_status(lifecycle.state_path(root))
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    repository = canonical_repository(root)
+    return branch, {"record": record, "status": status, "repository": repository}, head
+
+
+def pr_prepare(root: Path, task: str) -> None:
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"publication metadata preparation requires publication-ready or draft-pr-created; found {context['status']}")
+    state = lifecycle.state_path(root).read_text(encoding="utf-8")
+    base_revision = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", state)
+    if base_revision is None:
+        raise AutomationError("Task State has no valid Base revision")
+    paths = git("diff", "--name-only", f"{base_revision.group(1)}...{head}", cwd=root).splitlines()
+    try:
+        title, body = publication.canonical_metadata(root, task, head=head, changed_paths=paths)
+        publication.write_metadata(root, title, body)
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps({"task": task, "branch": branch, "title": title, "body": str(root / '.task-state' / 'pr-body.md')}))
+
+
+def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Path, str]:
+    try:
+        receipt = publication.verification_evidence(root, task, head)
+        title, body = publication.read_and_validate_metadata(root, receipt=receipt)
+        expected_title, expected_body = publication.canonical_metadata(
+            root,
+            task,
+            head=head,
+            changed_paths=git("diff", "--name-only", f"{_base_revision(root)}...{head}", cwd=root).splitlines(),
+        )
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    if title != expected_title or body.rstrip() != expected_body.rstrip():
+        raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
+    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+
+
+def _base_revision(root: Path) -> str:
+    text = lifecycle.state_path(root).read_text(encoding="utf-8")
+    match = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", text)
+    if match is None:
+        raise AutomationError("Task State has no valid Base revision")
+    return match.group(1)
+
+
+def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches:
+        raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
+
+
+def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "isDraft": True, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches or not isinstance(pr.get("number"), int):
+        raise AutomationError("pull request repair target identity is invalid: " + ", ".join(mismatches or ["number"]))
 
 
 def pr_create(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    if pr_for_branch(root, branch):
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "publication-ready":
+        raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
+    repository = context["repository"]
+    if pr_for_branch(root, branch, repository):
         raise AutomationError(f"pull request already exists for {branch}")
     base = default_branch(root)
-    title = f"{task}: {branch.split('/', 1)[1]}"
-    body = pr_body(root, task)
-    gh("pr", "create", "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
-    print(json.dumps(pr_for_branch(root, branch)))
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "create", "--repo", repository, "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request creation")
+    pr = pr_for_branch(root, branch, repository)
+    if not pr:
+        raise AutomationError("created pull request cannot be re-read")
+    _validate_live_pr(pr, branch=branch, base=base, head=head, title=title, body=body_text, draft=True)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps(pr))
 
 
 def pr_edit(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    title_file = root / ".task-state" / "pr-title.txt"
-    title = title_file.read_text(encoding="utf-8").strip() if title_file.exists() else pr["title"]
-    body = pr_body(root, task)
-    gh("pr", "edit", str(pr["number"]), "--title", title, "--body-file", str(body), cwd=root)
+    _validate_edit_target(pr, branch=branch, base=default_branch(root), head=head)
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "edit", str(pr["number"]), "--repo", repository, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request repair")
+    updated = pr_for_branch(root, branch, repository)
+    if not updated or updated.get("number") != pr.get("number"):
+        raise AutomationError("pull request identity changed during guarded repair")
+    _validate_live_pr(updated, branch=branch, base=default_branch(root), head=head, title=title, body=body_text, draft=True)
+    if context["status"] == "publication-ready":
+        try:
+            lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+        except lifecycle.LifecycleError as exc:
+            raise AutomationError(str(exc)) from exc
     print(f"updated PR #{pr['number']}")
 
 
 def pr_ready(root: Path, task: str) -> None:
     verify(root, task)
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "draft-pr-created":
+        raise AutomationError(f"pr-ready requires draft-pr-created; found {context['status']}")
+    title, _, body = _validated_local_metadata(root, task, head)
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    gh("pr", "ready", str(pr["number"]), cwd=root)
+    if pr.get("isDraft"):
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=True)
+        gh("pr", "ready", str(pr["number"]), "--repo", repository, cwd=root)
+        if canonical_repository(root).casefold() != repository.casefold():
+            raise AutomationError("repository identity changed while marking pull request ready")
+        ready = pr_for_branch(root, branch, repository)
+        if not ready or ready.get("number") != pr.get("number"):
+            raise AutomationError("pull request identity changed while marking ready")
+        _validate_live_pr(ready, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    else:
+        # Reconcile an earlier successful GitHub readiness write whose local
+        # lifecycle transition was interrupted.
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "draft-pr-created", "integration-pending")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
     print(f"PR #{pr['number']} marked ready")
 
 
@@ -514,7 +681,7 @@ def build_parser() -> argparse.ArgumentParser:
     for name in ("doctor", "context"):
         agent_cmd.add_parser(name)
     start = agent_cmd.add_parser("task-start"); start.add_argument("task"); start.add_argument("slug")
-    for name in ("status", "verify", "push", "pr-create", "pr-edit", "pr-ready", "cleanup"):
+    for name in ("status", "verify", "push", "pr-prepare", "pr-create", "pr-edit", "pr-ready", "cleanup"):
         p = agent_cmd.add_parser(name); p.add_argument("task")
     commit = agent_cmd.add_parser("commit"); commit.add_argument("task"); commit.add_argument("message", nargs="?", default="")
     integrate = scope.add_parser("integrate")
@@ -540,6 +707,7 @@ def main() -> int:
                 "verify": lambda: verify(root, args.task),
                 "commit": lambda: commit_task(root, args.task, args.message),
                 "push": lambda: push_task(root, args.task),
+                "pr-prepare": lambda: pr_prepare(root, args.task),
                 "pr-create": lambda: pr_create(root, args.task),
                 "pr-edit": lambda: pr_edit(root, args.task),
                 "pr-ready": lambda: pr_ready(root, args.task),

--- a/templates/agent-nix/.automation/bin/publication_metadata.py
+++ b/templates/agent-nix/.automation/bin/publication_metadata.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Prepare and validate evidence-backed pull request metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import task_contract
+
+
+class PublicationMetadataError(RuntimeError):
+    pass
+
+
+PLACEHOLDER_PATTERNS = (
+    r"@@[A-Z0-9_]+@@",
+    r"\bTBD\b",
+    r"Describe the implemented Task outcome\.",
+    r"Task-specific criteria copied from `?\.task-state/task\.md`?",
+    r"Define Task-specific acceptance criteria",
+)
+NOT_RUN_RE = re.compile(r"(?im)^.*(?:NOT[ _-]?RUN|not run).*$")
+
+
+def _sections(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"(?m)^## (.+?)\s*$", text))
+    return {
+        match.group(1): text[match.end() : matches[index + 1].start() if index + 1 < len(matches) else len(text)].strip()
+        for index, match in enumerate(matches)
+    }
+
+
+def _content_lines(value: str) -> list[str]:
+    ignored = {"none yet.", "none yet", "none recorded", "none recorded yet."}
+    return [line for line in value.splitlines() if line.strip() and line.strip().lower().lstrip("- ") not in ignored]
+
+
+def _identity(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing {name}")
+    return match.group(1).strip()
+
+
+def _read_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}") from exc
+    if not isinstance(value, dict):
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}")
+    return value
+
+
+def verification_evidence(root: Path, task: str, head: str) -> dict:
+    receipt = _read_json(root / ".task-state" / "verification.json")
+    if receipt is None:
+        raise PublicationMetadataError("missing persisted project verification evidence")
+    if set(receipt) != {"schema_version", "task_id", "head", "clean_tracked_worktree", "worktree_stable", "project_check"} or receipt["schema_version"] != 1:
+        raise PublicationMetadataError("invalid project verification evidence schema")
+    check = receipt.get("project_check")
+    if receipt.get("task_id") != task:
+        raise PublicationMetadataError("project verification evidence belongs to another Task")
+    if receipt.get("head") != head or not isinstance(check, dict):
+        raise PublicationMetadataError("project verification evidence is stale")
+    if check.get("command") != ["just", "project::check"] or check.get("returncode") != 0:
+        raise PublicationMetadataError("project::check has no persisted PASS evidence")
+    if receipt.get("clean_tracked_worktree") is not True or receipt.get("worktree_stable") is not True:
+        raise PublicationMetadataError("project verification is not bound to a clean stable worktree")
+    if not isinstance(check.get("executed_at"), str) or not check["executed_at"]:
+        raise PublicationMetadataError("project verification evidence has no execution time")
+    return receipt
+
+
+def completed_reviews(root: Path, task: str) -> list[str]:
+    value = _read_json(root / ".task-state" / "work-units.json")
+    if value is None:
+        return []
+    if value.get("task_id") != task or not isinstance(value.get("units"), dict):
+        raise PublicationMetadataError("Work Unit evidence does not match the Task")
+    reviews = []
+    for identifier, unit in value["units"].items():
+        if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
+            continue
+        if unit.get("state") != "completed":
+            raise PublicationMetadataError(
+                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+            )
+        transitions = unit.get("transitions")
+        digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
+        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+    return reviews
+
+
+def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[str]) -> tuple[str, str]:
+    state_path = root / ".task-state" / "task.md"
+    try:
+        text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError(f"missing Task State: {state_path}") from exc
+    if _identity(text, "Task ID") != task:
+        raise PublicationMetadataError("Task State identity does not match requested Task")
+    sections = _sections(text)
+    purpose = _content_lines(sections.get("Purpose", ""))
+    criteria = _content_lines(sections.get("Acceptance criteria", ""))
+    if not purpose or not criteria:
+        raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    summary = purpose[0].lstrip("- ").strip()
+    verification = verification_evidence(root, task, head)
+    title = f"{task}: {summary}"
+    changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
+    reviews = completed_reviews(root, task)
+    followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
+    body = "\n".join(
+        [
+            "## Summary", "", f"Task: {task}", "", *purpose,
+            "", "## Changed paths", "", *changes,
+            "", "## Acceptance criteria", "", *criteria,
+            "", "## Validation", "",
+            f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
+            "", "## Reviews", "", *(reviews or ["- None recorded."]),
+            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Follow-up Tasks", "", *followups, "",
+        ]
+    )
+    validate_metadata(title, body, receipt=verification)
+    return title, body
+
+
+def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> None:
+    if not title.strip() or not body.strip():
+        raise PublicationMetadataError("pull request title and body must be non-empty")
+    combined = title + "\n" + body
+    for pattern in PLACEHOLDER_PATTERNS:
+        if re.search(pattern, combined, re.IGNORECASE):
+            raise PublicationMetadataError("unresolved pull request publication placeholder")
+    not_run = NOT_RUN_RE.findall(body)
+    if not_run:
+        if receipt and receipt.get("project_check", {}).get("returncode") == 0:
+            raise PublicationMetadataError("pull request metadata contradicts persisted PASS evidence with NOT RUN")
+        raise PublicationMetadataError("unresolved NOT RUN publication metadata")
+    required = ("## Summary", "## Acceptance criteria", "## Validation", "## Risks and unverified areas", "## Follow-up Tasks")
+    if any(heading not in body for heading in required):
+        raise PublicationMetadataError("pull request body is missing required sections")
+
+
+def write_metadata(root: Path, title: str, body: str) -> None:
+    try:
+        task_contract.write_publication_metadata(
+            root,
+            (title.strip() + "\n").encode(),
+            (body.rstrip() + "\n").encode(),
+        )
+    except task_contract.ContractError as exc:
+        raise PublicationMetadataError(str(exc)) from exc
+
+
+def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tuple[str, str]:
+    title_path = root / ".task-state" / "pr-title.txt"
+    body_path = root / ".task-state" / "pr-body.md"
+    try:
+        title = title_path.read_text(encoding="utf-8").strip()
+        body = body_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError("run agent::pr-prepare before publication") from exc
+    validate_metadata(title, body, receipt=receipt)
+    return title, body

--- a/templates/agent-nix/.automation/bin/publication_metadata.py
+++ b/templates/agent-nix/.automation/bin/publication_metadata.py
@@ -44,6 +44,27 @@ def _identity(text: str, name: str) -> str:
     return match.group(1).strip()
 
 
+def _current_state_value(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing Current state {name}")
+    return match.group(1).strip()
+
+
+def _is_none_value(value: str) -> bool:
+    return value.casefold().rstrip(".") in {"none", "none recorded"}
+
+
+def _requirements(lines: list[str]) -> list[str]:
+    requirements = []
+    for line in lines:
+        value = re.sub(r"^-\s*\[[ xX]\]\s*", "", line.strip())
+        value = value.removeprefix("- ").strip()
+        if value:
+            requirements.append(f"- Requirement: {value}")
+    return requirements
+
+
 def _read_json(path: Path) -> dict | None:
     if not path.exists():
         return None
@@ -110,21 +131,39 @@ def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[
     criteria = _content_lines(sections.get("Acceptance criteria", ""))
     if not purpose or not criteria:
         raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    requirements = _requirements(criteria)
+    if not requirements:
+        raise PublicationMetadataError("Task acceptance criteria contain no authoritative requirements")
+    blockers = _current_state_value(sections.get("Current state", ""), "Blockers")
+    unverified = _current_state_value(sections.get("Current state", ""), "Unverified")
+    risks = []
+    if not _is_none_value(blockers):
+        risks.append(f"- Blockers: {blockers}")
+    if not _is_none_value(unverified):
+        risks.append(f"- Unverified: {unverified}")
+    if not risks:
+        risks = ["- None recorded."]
     summary = purpose[0].lstrip("- ").strip()
     verification = verification_evidence(root, task, head)
     title = f"{task}: {summary}"
     changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
     reviews = completed_reviews(root, task)
+    if not any("— `reviewer` — completed" in review for review in reviews):
+        raise PublicationMetadataError(
+            "publication requires a completed reviewer Work Unit"
+        )
     followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
     body = "\n".join(
         [
             "## Summary", "", f"Task: {task}", "", *purpose,
             "", "## Changed paths", "", *changes,
-            "", "## Acceptance criteria", "", *criteria,
+            "", "## Acceptance criteria", "",
+            "The following are authoritative Task requirements; completion evidence is reported separately under Validation and Reviews.",
+            "", *requirements,
             "", "## Validation", "",
             f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
             "", "## Reviews", "", *(reviews or ["- None recorded."]),
-            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Risks and unverified areas", "", *risks,
             "", "## Follow-up Tasks", "", *followups, "",
         ]
     )

--- a/templates/agent-nix/.automation/bin/task_contract.py
+++ b/templates/agent-nix/.automation/bin/task_contract.py
@@ -139,6 +139,30 @@ def _restore_state_file(directory_fd: int, name: str, content: bytes | None) -> 
         _write_state_file(directory_fd, name, content)
 
 
+def write_publication_metadata(root: Path, title: bytes, body: bytes) -> None:
+    """Atomically replace the two publication files in pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        previous = {
+            name: _read_state_file(directory_fd, name)
+            for name in ("pr-title.txt", "pr-body.md")
+        }
+        try:
+            _write_state_file(directory_fd, "pr-title.txt", title)
+            _write_state_file(directory_fd, "pr-body.md", body)
+            _assert_state_dir_binding(root, directory_fd)
+        except Exception:
+            for name, content in previous.items():
+                _restore_state_file(directory_fd, name, content)
+            raise
+
+
+def write_verification_receipt(root: Path, content: bytes) -> None:
+    """Replace the verification receipt through pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        _write_state_file(directory_fd, "verification.json", content)
+        _assert_state_dir_binding(root, directory_fd)
+
+
 def validate_issue_number(value: str) -> int:
     if not ISSUE_RE.fullmatch(value):
         raise ContractError("Issue number must be an exact positive decimal integer")

--- a/templates/agent-nix/.automation/bin/task_lifecycle.py
+++ b/templates/agent-nix/.automation/bin/task_lifecycle.py
@@ -919,10 +919,40 @@ def task_status(root: Path, task: str) -> None:
 def task_state_set(root: Path, task: str, status: str) -> None:
     record = require_local_task(root, task)
     require_resolved_contract(record, task)
+    if status in {"draft-pr-created", "integration-pending"}:
+        raise LifecycleError(
+            f"{status} is reserved for the guarded pull request publication boundary"
+        )
     with work_units_lock(record):
         assert_task_identity(record, task)
         set_state_status(state_path(record.path), status)
     print(json.dumps({"task": task, "status": status}))
+
+
+def mark_task_publication_state(
+    record: WorktreeRecord, task: str, expected: str, target: str
+) -> str:
+    """Narrow transition authority for validated PR creation/readiness."""
+    allowed = {
+        ("publication-ready", "draft-pr-created"),
+        ("draft-pr-created", "integration-pending"),
+    }
+    if (expected, target) not in allowed:
+        raise LifecycleError("invalid guarded publication transition")
+    validate_task(task)
+    require_resolved_contract(record, task)
+    with work_units_lock(record):
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        previous = state_status(path)
+        if previous == target:
+            return "already-transitioned"
+        if previous != expected:
+            raise LifecycleError(
+                f"guarded publication transition requires {expected}; found {previous}"
+            )
+        set_state_status(path, target)
+    return "transitioned"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/templates/agent-nix/.automation/just/agent.just
+++ b/templates/agent-nix/.automation/just/agent.just
@@ -84,6 +84,10 @@ pr-create task:
     python3 {{quote(script)}} agent pr-create {{quote(task)}}
 
 [working-directory: root]
+pr-prepare task:
+    python3 {{quote(script)}} agent pr-prepare {{quote(task)}}
+
+[working-directory: root]
 pr-edit task:
     python3 {{quote(script)}} agent pr-edit {{quote(task)}}
 

--- a/templates/agent-nix/.opencode/agents/build.md
+++ b/templates/agent-nix/.opencode/agents/build.md
@@ -25,6 +25,7 @@ permission:
     "just agent::batch-plan *": allow
     "just agent::commit *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just integrate::finalize *": allow

--- a/templates/agent-nix/.opencode/agents/general.md
+++ b/templates/agent-nix/.opencode/agents/general.md
@@ -38,6 +38,7 @@ permission:
     "just agent::commit *": deny
     "just agent::push *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just agent::cleanup *": deny

--- a/templates/agent-nix/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-nix/.opencode/agents/task-orchestrator.md
@@ -30,6 +30,7 @@ permission:
     "just agent::work-unit-dispatch-check *": allow
     "just agent::work-unit-status *": allow
     "just agent::work-unit-state-set *": allow
+    "just agent::pr-prepare *": allow
     "just integrate::check *": deny
     "just integrate::finalize *": deny
     "just integrate::merge *": deny
@@ -77,6 +78,6 @@ Before advancing Task State to `publication-ready`, and again before guarded com
 - a reviewer Work Unit for non-trivial changes;
 - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 
-No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, and prepare a Draft PR. Never merge.
+No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, run `just agent::pr-prepare <task>`, and create or repair the same Draft PR through the guarded publication API. Metadata with placeholders or false `NOT RUN` claims is forbidden. Never merge.
 
 Never invoke another Task Orchestrator. Never merge. Never operate on sibling Task worktrees. Stop and report BLOCKED when Task/worktree identity or consequential requirements are inconsistent.

--- a/templates/agent-nix/.opencode/skills/task-orchestration/SKILL.md
+++ b/templates/agent-nix/.opencode/skills/task-orchestration/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when the Main Orchestrator is asked to run a specific Task that a
     - a reviewer Work Unit for non-trivial changes;
     - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 12. No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop.
-13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, and create or edit only a Draft PR.
+13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, run `just agent::pr-prepare <task>`, and create or edit only the same Draft PR. Publication metadata must be regenerated from persisted evidence and must contain no unresolved placeholder or false `NOT RUN` claim.
 14. Persist every transition and continue the loop until integration-pending. Stop for `NEEDS_APPROVAL` or `NEEDS_DECISION` human handling, and otherwise stop at integration-pending. Do not merge from this skill. Never merge.
 
 Do not silently select another Issue or Task. Do not weaken permissions to work around a blocked approval or missing tool/model.

--- a/templates/agent-nix/opencode.json
+++ b/templates/agent-nix/opencode.json
@@ -91,6 +91,7 @@
       "just agent::status *": "allow",
       "just agent::verify *": "allow",
       "just agent::commit *": "allow",
+      "just agent::pr-prepare *": "allow",
       "just agent::pr-create *": "allow",
       "just agent::pr-edit *": "allow",
       "just agent::pr-ready *": "allow",

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -94,6 +94,12 @@ just agent::pr-edit <task>
 just agent::pr-ready <task>
 ```
 
+`pr-prepare` renders acceptance criteria as authoritative requirements and
+renders non-empty `Current state` Blockers/Unverified values in the PR risk
+section. Missing Current-state evidence, unresolved placeholders, stale
+verification, missing completed reviewer evidence, an incomplete declared
+security review, or contradictory validation claims block publication.
+
 The normal upgrade flow creates its receipt before verification. If a self-hosted
 pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
 normal verification and, before `automation::commit`, run the strict bootstrap

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -89,6 +89,9 @@ Before publication, execute `git diff --check`, `just agent::doctor`,
 just automation::commit <task> [message]
 just agent::push <task>
 just agent::pr-create <task>
+just agent::pr-prepare <task>
+just agent::pr-edit <task>
+just agent::pr-ready <task>
 ```
 
 The normal upgrade flow creates its receipt before verification. If a self-hosted

--- a/templates/agent-python/.automation/bin/agent_core.py
+++ b/templates/agent-python/.automation/bin/agent_core.py
@@ -406,6 +406,7 @@ def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> Non
 
 
 def pr_create(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] != "publication-ready":
         raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
@@ -429,6 +430,7 @@ def pr_create(root: Path, task: str) -> None:
 
 
 def pr_edit(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] not in {"publication-ready", "draft-pr-created"}:
         raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")

--- a/templates/agent-python/.automation/bin/agent_core.py
+++ b/templates/agent-python/.automation/bin/agent_core.py
@@ -8,12 +8,15 @@ import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 import task_lifecycle as lifecycle
+import publication_metadata as publication
+import task_contract
 
 try:
     import tomllib
@@ -101,7 +104,7 @@ def validate_slug(slug: str) -> None:
 def ensure_task_branch(root: Path, task: str) -> str:
     validate_task(task)
     branch = current_branch(root)
-    if task not in branch or not (branch.startswith("task/") or branch.startswith("fix/")):
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
         raise AutomationError(f"current branch {branch!r} is not the Task branch for {task}")
     if branch == default_branch(root):
         raise AutomationError("Task operation refused on the default branch")
@@ -238,7 +241,33 @@ def status(root: Path, task: str) -> None:
 
 def verify(root: Path, task: str) -> None:
     ensure_task_branch(root, task)
-    run(["just", "project::check"], cwd=root)
+    head = git("rev-parse", "HEAD", cwd=root)
+    status_before = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    result = run(["just", "project::check"], cwd=root, check=False)
+    status_after = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    receipt = {
+        "schema_version": 1,
+        "task_id": task,
+        "head": head,
+        "clean_tracked_worktree": not status_before and not status_after,
+        "worktree_stable": status_before == status_after,
+        "project_check": {
+            "command": ["just", "project::check"],
+            "returncode": result.returncode,
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    try:
+        task_contract.write_verification_receipt(
+            root, (json.dumps(receipt, sort_keys=True) + "\n").encode()
+        )
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise AutomationError(f"just project::check: {detail}")
+    if status_before != status_after:
+        raise AutomationError("project::check changed tracked or untracked product files")
     print("Project verification: PASS")
 
 
@@ -265,54 +294,192 @@ def push_task(root: Path, task: str) -> None:
     print(f"pushed origin/{branch}")
 
 
-def pr_for_branch(root: Path, branch: str) -> dict | None:
-    result = run(["gh", "pr", "view", branch, "--json", "number,title,body,headRefName,baseRefName,isDraft,state,headRefOid"], cwd=root, check=False)
+def canonical_repository(root: Path) -> str:
+    path = root / ".task-state" / "contract.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AutomationError(f"invalid canonical Task Contract metadata: {path}") from exc
+    repository = value.get("repository") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise AutomationError("canonical Task Contract repository is invalid")
+    try:
+        live = task_contract.repository_identity(root)
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if live.casefold() != repository.casefold():
+        raise AutomationError("live origin repository does not match the canonical Task Contract")
+    return repository
+
+
+def pr_for_branch(root: Path, branch: str, repository: str | None = None) -> dict | None:
+    command = ["gh", "pr", "view", branch]
+    if repository is not None:
+        command.extend(["--repo", repository])
+    command.extend(["--json", "number,title,body,headRefName,baseRefName,isDraft,isCrossRepository,state,headRefOid"])
+    result = run(command, cwd=root, check=False)
     if result.returncode != 0:
-        return None
-    return json.loads(result.stdout)
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        if "no pull requests found" in detail.lower():
+            return None
+        raise AutomationError(f"cannot resolve pull request for {branch}: {detail}")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AutomationError("invalid pull request data returned by GitHub") from exc
+    return value
 
 
-def pr_body(root: Path, task: str) -> Path:
-    state_dir = root / ".task-state"
-    state_dir.mkdir(parents=True, exist_ok=True)
-    path = state_dir / "pr-body.md"
-    if not path.exists():
-        template = root / ".automation" / "templates" / "pull-request.md"
-        text = template.read_text(encoding="utf-8").replace("@@TASK_ID@@", task)
-        path.write_text(text, encoding="utf-8")
-    return path
+def _publication_context(root: Path, task: str) -> tuple[str, dict, str]:
+    branch = ensure_task_branch(root, task)
+    head = git("rev-parse", "HEAD", cwd=root)
+    try:
+        record = lifecycle.require_local_task(root, task)
+        lifecycle.require_resolved_contract(record, task)
+        status = lifecycle.state_status(lifecycle.state_path(root))
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    repository = canonical_repository(root)
+    return branch, {"record": record, "status": status, "repository": repository}, head
+
+
+def pr_prepare(root: Path, task: str) -> None:
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"publication metadata preparation requires publication-ready or draft-pr-created; found {context['status']}")
+    state = lifecycle.state_path(root).read_text(encoding="utf-8")
+    base_revision = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", state)
+    if base_revision is None:
+        raise AutomationError("Task State has no valid Base revision")
+    paths = git("diff", "--name-only", f"{base_revision.group(1)}...{head}", cwd=root).splitlines()
+    try:
+        title, body = publication.canonical_metadata(root, task, head=head, changed_paths=paths)
+        publication.write_metadata(root, title, body)
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps({"task": task, "branch": branch, "title": title, "body": str(root / '.task-state' / 'pr-body.md')}))
+
+
+def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Path, str]:
+    try:
+        receipt = publication.verification_evidence(root, task, head)
+        title, body = publication.read_and_validate_metadata(root, receipt=receipt)
+        expected_title, expected_body = publication.canonical_metadata(
+            root,
+            task,
+            head=head,
+            changed_paths=git("diff", "--name-only", f"{_base_revision(root)}...{head}", cwd=root).splitlines(),
+        )
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    if title != expected_title or body.rstrip() != expected_body.rstrip():
+        raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
+    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+
+
+def _base_revision(root: Path) -> str:
+    text = lifecycle.state_path(root).read_text(encoding="utf-8")
+    match = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", text)
+    if match is None:
+        raise AutomationError("Task State has no valid Base revision")
+    return match.group(1)
+
+
+def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches:
+        raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
+
+
+def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "isDraft": True, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches or not isinstance(pr.get("number"), int):
+        raise AutomationError("pull request repair target identity is invalid: " + ", ".join(mismatches or ["number"]))
 
 
 def pr_create(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    if pr_for_branch(root, branch):
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "publication-ready":
+        raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
+    repository = context["repository"]
+    if pr_for_branch(root, branch, repository):
         raise AutomationError(f"pull request already exists for {branch}")
     base = default_branch(root)
-    title = f"{task}: {branch.split('/', 1)[1]}"
-    body = pr_body(root, task)
-    gh("pr", "create", "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
-    print(json.dumps(pr_for_branch(root, branch)))
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "create", "--repo", repository, "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request creation")
+    pr = pr_for_branch(root, branch, repository)
+    if not pr:
+        raise AutomationError("created pull request cannot be re-read")
+    _validate_live_pr(pr, branch=branch, base=base, head=head, title=title, body=body_text, draft=True)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps(pr))
 
 
 def pr_edit(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    title_file = root / ".task-state" / "pr-title.txt"
-    title = title_file.read_text(encoding="utf-8").strip() if title_file.exists() else pr["title"]
-    body = pr_body(root, task)
-    gh("pr", "edit", str(pr["number"]), "--title", title, "--body-file", str(body), cwd=root)
+    _validate_edit_target(pr, branch=branch, base=default_branch(root), head=head)
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "edit", str(pr["number"]), "--repo", repository, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request repair")
+    updated = pr_for_branch(root, branch, repository)
+    if not updated or updated.get("number") != pr.get("number"):
+        raise AutomationError("pull request identity changed during guarded repair")
+    _validate_live_pr(updated, branch=branch, base=default_branch(root), head=head, title=title, body=body_text, draft=True)
+    if context["status"] == "publication-ready":
+        try:
+            lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+        except lifecycle.LifecycleError as exc:
+            raise AutomationError(str(exc)) from exc
     print(f"updated PR #{pr['number']}")
 
 
 def pr_ready(root: Path, task: str) -> None:
     verify(root, task)
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "draft-pr-created":
+        raise AutomationError(f"pr-ready requires draft-pr-created; found {context['status']}")
+    title, _, body = _validated_local_metadata(root, task, head)
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    gh("pr", "ready", str(pr["number"]), cwd=root)
+    if pr.get("isDraft"):
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=True)
+        gh("pr", "ready", str(pr["number"]), "--repo", repository, cwd=root)
+        if canonical_repository(root).casefold() != repository.casefold():
+            raise AutomationError("repository identity changed while marking pull request ready")
+        ready = pr_for_branch(root, branch, repository)
+        if not ready or ready.get("number") != pr.get("number"):
+            raise AutomationError("pull request identity changed while marking ready")
+        _validate_live_pr(ready, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    else:
+        # Reconcile an earlier successful GitHub readiness write whose local
+        # lifecycle transition was interrupted.
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "draft-pr-created", "integration-pending")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
     print(f"PR #{pr['number']} marked ready")
 
 
@@ -514,7 +681,7 @@ def build_parser() -> argparse.ArgumentParser:
     for name in ("doctor", "context"):
         agent_cmd.add_parser(name)
     start = agent_cmd.add_parser("task-start"); start.add_argument("task"); start.add_argument("slug")
-    for name in ("status", "verify", "push", "pr-create", "pr-edit", "pr-ready", "cleanup"):
+    for name in ("status", "verify", "push", "pr-prepare", "pr-create", "pr-edit", "pr-ready", "cleanup"):
         p = agent_cmd.add_parser(name); p.add_argument("task")
     commit = agent_cmd.add_parser("commit"); commit.add_argument("task"); commit.add_argument("message", nargs="?", default="")
     integrate = scope.add_parser("integrate")
@@ -540,6 +707,7 @@ def main() -> int:
                 "verify": lambda: verify(root, args.task),
                 "commit": lambda: commit_task(root, args.task, args.message),
                 "push": lambda: push_task(root, args.task),
+                "pr-prepare": lambda: pr_prepare(root, args.task),
                 "pr-create": lambda: pr_create(root, args.task),
                 "pr-edit": lambda: pr_edit(root, args.task),
                 "pr-ready": lambda: pr_ready(root, args.task),

--- a/templates/agent-python/.automation/bin/publication_metadata.py
+++ b/templates/agent-python/.automation/bin/publication_metadata.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Prepare and validate evidence-backed pull request metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import task_contract
+
+
+class PublicationMetadataError(RuntimeError):
+    pass
+
+
+PLACEHOLDER_PATTERNS = (
+    r"@@[A-Z0-9_]+@@",
+    r"\bTBD\b",
+    r"Describe the implemented Task outcome\.",
+    r"Task-specific criteria copied from `?\.task-state/task\.md`?",
+    r"Define Task-specific acceptance criteria",
+)
+NOT_RUN_RE = re.compile(r"(?im)^.*(?:NOT[ _-]?RUN|not run).*$")
+
+
+def _sections(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"(?m)^## (.+?)\s*$", text))
+    return {
+        match.group(1): text[match.end() : matches[index + 1].start() if index + 1 < len(matches) else len(text)].strip()
+        for index, match in enumerate(matches)
+    }
+
+
+def _content_lines(value: str) -> list[str]:
+    ignored = {"none yet.", "none yet", "none recorded", "none recorded yet."}
+    return [line for line in value.splitlines() if line.strip() and line.strip().lower().lstrip("- ") not in ignored]
+
+
+def _identity(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing {name}")
+    return match.group(1).strip()
+
+
+def _read_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}") from exc
+    if not isinstance(value, dict):
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}")
+    return value
+
+
+def verification_evidence(root: Path, task: str, head: str) -> dict:
+    receipt = _read_json(root / ".task-state" / "verification.json")
+    if receipt is None:
+        raise PublicationMetadataError("missing persisted project verification evidence")
+    if set(receipt) != {"schema_version", "task_id", "head", "clean_tracked_worktree", "worktree_stable", "project_check"} or receipt["schema_version"] != 1:
+        raise PublicationMetadataError("invalid project verification evidence schema")
+    check = receipt.get("project_check")
+    if receipt.get("task_id") != task:
+        raise PublicationMetadataError("project verification evidence belongs to another Task")
+    if receipt.get("head") != head or not isinstance(check, dict):
+        raise PublicationMetadataError("project verification evidence is stale")
+    if check.get("command") != ["just", "project::check"] or check.get("returncode") != 0:
+        raise PublicationMetadataError("project::check has no persisted PASS evidence")
+    if receipt.get("clean_tracked_worktree") is not True or receipt.get("worktree_stable") is not True:
+        raise PublicationMetadataError("project verification is not bound to a clean stable worktree")
+    if not isinstance(check.get("executed_at"), str) or not check["executed_at"]:
+        raise PublicationMetadataError("project verification evidence has no execution time")
+    return receipt
+
+
+def completed_reviews(root: Path, task: str) -> list[str]:
+    value = _read_json(root / ".task-state" / "work-units.json")
+    if value is None:
+        return []
+    if value.get("task_id") != task or not isinstance(value.get("units"), dict):
+        raise PublicationMetadataError("Work Unit evidence does not match the Task")
+    reviews = []
+    for identifier, unit in value["units"].items():
+        if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
+            continue
+        if unit.get("state") != "completed":
+            raise PublicationMetadataError(
+                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+            )
+        transitions = unit.get("transitions")
+        digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
+        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+    return reviews
+
+
+def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[str]) -> tuple[str, str]:
+    state_path = root / ".task-state" / "task.md"
+    try:
+        text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError(f"missing Task State: {state_path}") from exc
+    if _identity(text, "Task ID") != task:
+        raise PublicationMetadataError("Task State identity does not match requested Task")
+    sections = _sections(text)
+    purpose = _content_lines(sections.get("Purpose", ""))
+    criteria = _content_lines(sections.get("Acceptance criteria", ""))
+    if not purpose or not criteria:
+        raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    summary = purpose[0].lstrip("- ").strip()
+    verification = verification_evidence(root, task, head)
+    title = f"{task}: {summary}"
+    changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
+    reviews = completed_reviews(root, task)
+    followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
+    body = "\n".join(
+        [
+            "## Summary", "", f"Task: {task}", "", *purpose,
+            "", "## Changed paths", "", *changes,
+            "", "## Acceptance criteria", "", *criteria,
+            "", "## Validation", "",
+            f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
+            "", "## Reviews", "", *(reviews or ["- None recorded."]),
+            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Follow-up Tasks", "", *followups, "",
+        ]
+    )
+    validate_metadata(title, body, receipt=verification)
+    return title, body
+
+
+def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> None:
+    if not title.strip() or not body.strip():
+        raise PublicationMetadataError("pull request title and body must be non-empty")
+    combined = title + "\n" + body
+    for pattern in PLACEHOLDER_PATTERNS:
+        if re.search(pattern, combined, re.IGNORECASE):
+            raise PublicationMetadataError("unresolved pull request publication placeholder")
+    not_run = NOT_RUN_RE.findall(body)
+    if not_run:
+        if receipt and receipt.get("project_check", {}).get("returncode") == 0:
+            raise PublicationMetadataError("pull request metadata contradicts persisted PASS evidence with NOT RUN")
+        raise PublicationMetadataError("unresolved NOT RUN publication metadata")
+    required = ("## Summary", "## Acceptance criteria", "## Validation", "## Risks and unverified areas", "## Follow-up Tasks")
+    if any(heading not in body for heading in required):
+        raise PublicationMetadataError("pull request body is missing required sections")
+
+
+def write_metadata(root: Path, title: str, body: str) -> None:
+    try:
+        task_contract.write_publication_metadata(
+            root,
+            (title.strip() + "\n").encode(),
+            (body.rstrip() + "\n").encode(),
+        )
+    except task_contract.ContractError as exc:
+        raise PublicationMetadataError(str(exc)) from exc
+
+
+def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tuple[str, str]:
+    title_path = root / ".task-state" / "pr-title.txt"
+    body_path = root / ".task-state" / "pr-body.md"
+    try:
+        title = title_path.read_text(encoding="utf-8").strip()
+        body = body_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError("run agent::pr-prepare before publication") from exc
+    validate_metadata(title, body, receipt=receipt)
+    return title, body

--- a/templates/agent-python/.automation/bin/publication_metadata.py
+++ b/templates/agent-python/.automation/bin/publication_metadata.py
@@ -44,6 +44,27 @@ def _identity(text: str, name: str) -> str:
     return match.group(1).strip()
 
 
+def _current_state_value(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing Current state {name}")
+    return match.group(1).strip()
+
+
+def _is_none_value(value: str) -> bool:
+    return value.casefold().rstrip(".") in {"none", "none recorded"}
+
+
+def _requirements(lines: list[str]) -> list[str]:
+    requirements = []
+    for line in lines:
+        value = re.sub(r"^-\s*\[[ xX]\]\s*", "", line.strip())
+        value = value.removeprefix("- ").strip()
+        if value:
+            requirements.append(f"- Requirement: {value}")
+    return requirements
+
+
 def _read_json(path: Path) -> dict | None:
     if not path.exists():
         return None
@@ -110,21 +131,39 @@ def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[
     criteria = _content_lines(sections.get("Acceptance criteria", ""))
     if not purpose or not criteria:
         raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    requirements = _requirements(criteria)
+    if not requirements:
+        raise PublicationMetadataError("Task acceptance criteria contain no authoritative requirements")
+    blockers = _current_state_value(sections.get("Current state", ""), "Blockers")
+    unverified = _current_state_value(sections.get("Current state", ""), "Unverified")
+    risks = []
+    if not _is_none_value(blockers):
+        risks.append(f"- Blockers: {blockers}")
+    if not _is_none_value(unverified):
+        risks.append(f"- Unverified: {unverified}")
+    if not risks:
+        risks = ["- None recorded."]
     summary = purpose[0].lstrip("- ").strip()
     verification = verification_evidence(root, task, head)
     title = f"{task}: {summary}"
     changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
     reviews = completed_reviews(root, task)
+    if not any("— `reviewer` — completed" in review for review in reviews):
+        raise PublicationMetadataError(
+            "publication requires a completed reviewer Work Unit"
+        )
     followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
     body = "\n".join(
         [
             "## Summary", "", f"Task: {task}", "", *purpose,
             "", "## Changed paths", "", *changes,
-            "", "## Acceptance criteria", "", *criteria,
+            "", "## Acceptance criteria", "",
+            "The following are authoritative Task requirements; completion evidence is reported separately under Validation and Reviews.",
+            "", *requirements,
             "", "## Validation", "",
             f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
             "", "## Reviews", "", *(reviews or ["- None recorded."]),
-            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Risks and unverified areas", "", *risks,
             "", "## Follow-up Tasks", "", *followups, "",
         ]
     )

--- a/templates/agent-python/.automation/bin/task_contract.py
+++ b/templates/agent-python/.automation/bin/task_contract.py
@@ -139,6 +139,30 @@ def _restore_state_file(directory_fd: int, name: str, content: bytes | None) -> 
         _write_state_file(directory_fd, name, content)
 
 
+def write_publication_metadata(root: Path, title: bytes, body: bytes) -> None:
+    """Atomically replace the two publication files in pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        previous = {
+            name: _read_state_file(directory_fd, name)
+            for name in ("pr-title.txt", "pr-body.md")
+        }
+        try:
+            _write_state_file(directory_fd, "pr-title.txt", title)
+            _write_state_file(directory_fd, "pr-body.md", body)
+            _assert_state_dir_binding(root, directory_fd)
+        except Exception:
+            for name, content in previous.items():
+                _restore_state_file(directory_fd, name, content)
+            raise
+
+
+def write_verification_receipt(root: Path, content: bytes) -> None:
+    """Replace the verification receipt through pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        _write_state_file(directory_fd, "verification.json", content)
+        _assert_state_dir_binding(root, directory_fd)
+
+
 def validate_issue_number(value: str) -> int:
     if not ISSUE_RE.fullmatch(value):
         raise ContractError("Issue number must be an exact positive decimal integer")

--- a/templates/agent-python/.automation/bin/task_lifecycle.py
+++ b/templates/agent-python/.automation/bin/task_lifecycle.py
@@ -919,10 +919,40 @@ def task_status(root: Path, task: str) -> None:
 def task_state_set(root: Path, task: str, status: str) -> None:
     record = require_local_task(root, task)
     require_resolved_contract(record, task)
+    if status in {"draft-pr-created", "integration-pending"}:
+        raise LifecycleError(
+            f"{status} is reserved for the guarded pull request publication boundary"
+        )
     with work_units_lock(record):
         assert_task_identity(record, task)
         set_state_status(state_path(record.path), status)
     print(json.dumps({"task": task, "status": status}))
+
+
+def mark_task_publication_state(
+    record: WorktreeRecord, task: str, expected: str, target: str
+) -> str:
+    """Narrow transition authority for validated PR creation/readiness."""
+    allowed = {
+        ("publication-ready", "draft-pr-created"),
+        ("draft-pr-created", "integration-pending"),
+    }
+    if (expected, target) not in allowed:
+        raise LifecycleError("invalid guarded publication transition")
+    validate_task(task)
+    require_resolved_contract(record, task)
+    with work_units_lock(record):
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        previous = state_status(path)
+        if previous == target:
+            return "already-transitioned"
+        if previous != expected:
+            raise LifecycleError(
+                f"guarded publication transition requires {expected}; found {previous}"
+            )
+        set_state_status(path, target)
+    return "transitioned"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/templates/agent-python/.automation/just/agent.just
+++ b/templates/agent-python/.automation/just/agent.just
@@ -84,6 +84,10 @@ pr-create task:
     python3 {{quote(script)}} agent pr-create {{quote(task)}}
 
 [working-directory: root]
+pr-prepare task:
+    python3 {{quote(script)}} agent pr-prepare {{quote(task)}}
+
+[working-directory: root]
 pr-edit task:
     python3 {{quote(script)}} agent pr-edit {{quote(task)}}
 

--- a/templates/agent-python/.opencode/agents/build.md
+++ b/templates/agent-python/.opencode/agents/build.md
@@ -25,6 +25,7 @@ permission:
     "just agent::batch-plan *": allow
     "just agent::commit *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just integrate::finalize *": allow

--- a/templates/agent-python/.opencode/agents/general.md
+++ b/templates/agent-python/.opencode/agents/general.md
@@ -38,6 +38,7 @@ permission:
     "just agent::commit *": deny
     "just agent::push *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just agent::cleanup *": deny

--- a/templates/agent-python/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-python/.opencode/agents/task-orchestrator.md
@@ -30,6 +30,7 @@ permission:
     "just agent::work-unit-dispatch-check *": allow
     "just agent::work-unit-status *": allow
     "just agent::work-unit-state-set *": allow
+    "just agent::pr-prepare *": allow
     "just integrate::check *": deny
     "just integrate::finalize *": deny
     "just integrate::merge *": deny
@@ -77,6 +78,6 @@ Before advancing Task State to `publication-ready`, and again before guarded com
 - a reviewer Work Unit for non-trivial changes;
 - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 
-No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, and prepare a Draft PR. Never merge.
+No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, run `just agent::pr-prepare <task>`, and create or repair the same Draft PR through the guarded publication API. Metadata with placeholders or false `NOT RUN` claims is forbidden. Never merge.
 
 Never invoke another Task Orchestrator. Never merge. Never operate on sibling Task worktrees. Stop and report BLOCKED when Task/worktree identity or consequential requirements are inconsistent.

--- a/templates/agent-python/.opencode/skills/task-orchestration/SKILL.md
+++ b/templates/agent-python/.opencode/skills/task-orchestration/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when the Main Orchestrator is asked to run a specific Task that a
     - a reviewer Work Unit for non-trivial changes;
     - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 12. No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop.
-13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, and create or edit only a Draft PR.
+13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, run `just agent::pr-prepare <task>`, and create or edit only the same Draft PR. Publication metadata must be regenerated from persisted evidence and must contain no unresolved placeholder or false `NOT RUN` claim.
 14. Persist every transition and continue the loop until integration-pending. Stop for `NEEDS_APPROVAL` or `NEEDS_DECISION` human handling, and otherwise stop at integration-pending. Do not merge from this skill. Never merge.
 
 Do not silently select another Issue or Task. Do not weaken permissions to work around a blocked approval or missing tool/model.

--- a/templates/agent-python/opencode.json
+++ b/templates/agent-python/opencode.json
@@ -91,6 +91,7 @@
       "just agent::status *": "allow",
       "just agent::verify *": "allow",
       "just agent::commit *": "allow",
+      "just agent::pr-prepare *": "allow",
       "just agent::pr-create *": "allow",
       "just agent::pr-edit *": "allow",
       "just agent::pr-ready *": "allow",

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -94,6 +94,12 @@ just agent::pr-edit <task>
 just agent::pr-ready <task>
 ```
 
+`pr-prepare` renders acceptance criteria as authoritative requirements and
+renders non-empty `Current state` Blockers/Unverified values in the PR risk
+section. Missing Current-state evidence, unresolved placeholders, stale
+verification, missing completed reviewer evidence, an incomplete declared
+security review, or contradictory validation claims block publication.
+
 The normal upgrade flow creates its receipt before verification. If a self-hosted
 pre-receipt upgrade leaves the exact upgraded diff without that receipt, perform
 normal verification and, before `automation::commit`, run the strict bootstrap

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -89,6 +89,9 @@ Before publication, execute `git diff --check`, `just agent::doctor`,
 just automation::commit <task> [message]
 just agent::push <task>
 just agent::pr-create <task>
+just agent::pr-prepare <task>
+just agent::pr-edit <task>
+just agent::pr-ready <task>
 ```
 
 The normal upgrade flow creates its receipt before verification. If a self-hosted

--- a/templates/agent-rust/.automation/bin/agent_core.py
+++ b/templates/agent-rust/.automation/bin/agent_core.py
@@ -406,6 +406,7 @@ def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> Non
 
 
 def pr_create(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] != "publication-ready":
         raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
@@ -429,6 +430,7 @@ def pr_create(root: Path, task: str) -> None:
 
 
 def pr_edit(root: Path, task: str) -> None:
+    verify(root, task)
     branch, context, head = _publication_context(root, task)
     if context["status"] not in {"publication-ready", "draft-pr-created"}:
         raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")

--- a/templates/agent-rust/.automation/bin/agent_core.py
+++ b/templates/agent-rust/.automation/bin/agent_core.py
@@ -8,12 +8,15 @@ import re
 import shutil
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR))
 import task_lifecycle as lifecycle
+import publication_metadata as publication
+import task_contract
 
 try:
     import tomllib
@@ -101,7 +104,7 @@ def validate_slug(slug: str) -> None:
 def ensure_task_branch(root: Path, task: str) -> str:
     validate_task(task)
     branch = current_branch(root)
-    if task not in branch or not (branch.startswith("task/") or branch.startswith("fix/")):
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
         raise AutomationError(f"current branch {branch!r} is not the Task branch for {task}")
     if branch == default_branch(root):
         raise AutomationError("Task operation refused on the default branch")
@@ -238,7 +241,33 @@ def status(root: Path, task: str) -> None:
 
 def verify(root: Path, task: str) -> None:
     ensure_task_branch(root, task)
-    run(["just", "project::check"], cwd=root)
+    head = git("rev-parse", "HEAD", cwd=root)
+    status_before = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    result = run(["just", "project::check"], cwd=root, check=False)
+    status_after = git("status", "--porcelain", "--untracked-files=all", cwd=root)
+    receipt = {
+        "schema_version": 1,
+        "task_id": task,
+        "head": head,
+        "clean_tracked_worktree": not status_before and not status_after,
+        "worktree_stable": status_before == status_after,
+        "project_check": {
+            "command": ["just", "project::check"],
+            "returncode": result.returncode,
+            "executed_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+    try:
+        task_contract.write_verification_receipt(
+            root, (json.dumps(receipt, sort_keys=True) + "\n").encode()
+        )
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise AutomationError(f"just project::check: {detail}")
+    if status_before != status_after:
+        raise AutomationError("project::check changed tracked or untracked product files")
     print("Project verification: PASS")
 
 
@@ -265,54 +294,192 @@ def push_task(root: Path, task: str) -> None:
     print(f"pushed origin/{branch}")
 
 
-def pr_for_branch(root: Path, branch: str) -> dict | None:
-    result = run(["gh", "pr", "view", branch, "--json", "number,title,body,headRefName,baseRefName,isDraft,state,headRefOid"], cwd=root, check=False)
+def canonical_repository(root: Path) -> str:
+    path = root / ".task-state" / "contract.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AutomationError(f"invalid canonical Task Contract metadata: {path}") from exc
+    repository = value.get("repository") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+        raise AutomationError("canonical Task Contract repository is invalid")
+    try:
+        live = task_contract.repository_identity(root)
+    except task_contract.ContractError as exc:
+        raise AutomationError(str(exc)) from exc
+    if live.casefold() != repository.casefold():
+        raise AutomationError("live origin repository does not match the canonical Task Contract")
+    return repository
+
+
+def pr_for_branch(root: Path, branch: str, repository: str | None = None) -> dict | None:
+    command = ["gh", "pr", "view", branch]
+    if repository is not None:
+        command.extend(["--repo", repository])
+    command.extend(["--json", "number,title,body,headRefName,baseRefName,isDraft,isCrossRepository,state,headRefOid"])
+    result = run(command, cwd=root, check=False)
     if result.returncode != 0:
-        return None
-    return json.loads(result.stdout)
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        if "no pull requests found" in detail.lower():
+            return None
+        raise AutomationError(f"cannot resolve pull request for {branch}: {detail}")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AutomationError("invalid pull request data returned by GitHub") from exc
+    return value
 
 
-def pr_body(root: Path, task: str) -> Path:
-    state_dir = root / ".task-state"
-    state_dir.mkdir(parents=True, exist_ok=True)
-    path = state_dir / "pr-body.md"
-    if not path.exists():
-        template = root / ".automation" / "templates" / "pull-request.md"
-        text = template.read_text(encoding="utf-8").replace("@@TASK_ID@@", task)
-        path.write_text(text, encoding="utf-8")
-    return path
+def _publication_context(root: Path, task: str) -> tuple[str, dict, str]:
+    branch = ensure_task_branch(root, task)
+    head = git("rev-parse", "HEAD", cwd=root)
+    try:
+        record = lifecycle.require_local_task(root, task)
+        lifecycle.require_resolved_contract(record, task)
+        status = lifecycle.state_status(lifecycle.state_path(root))
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    repository = canonical_repository(root)
+    return branch, {"record": record, "status": status, "repository": repository}, head
+
+
+def pr_prepare(root: Path, task: str) -> None:
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"publication metadata preparation requires publication-ready or draft-pr-created; found {context['status']}")
+    state = lifecycle.state_path(root).read_text(encoding="utf-8")
+    base_revision = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", state)
+    if base_revision is None:
+        raise AutomationError("Task State has no valid Base revision")
+    paths = git("diff", "--name-only", f"{base_revision.group(1)}...{head}", cwd=root).splitlines()
+    try:
+        title, body = publication.canonical_metadata(root, task, head=head, changed_paths=paths)
+        publication.write_metadata(root, title, body)
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps({"task": task, "branch": branch, "title": title, "body": str(root / '.task-state' / 'pr-body.md')}))
+
+
+def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Path, str]:
+    try:
+        receipt = publication.verification_evidence(root, task, head)
+        title, body = publication.read_and_validate_metadata(root, receipt=receipt)
+        expected_title, expected_body = publication.canonical_metadata(
+            root,
+            task,
+            head=head,
+            changed_paths=git("diff", "--name-only", f"{_base_revision(root)}...{head}", cwd=root).splitlines(),
+        )
+    except publication.PublicationMetadataError as exc:
+        raise AutomationError(str(exc)) from exc
+    if title != expected_title or body.rstrip() != expected_body.rstrip():
+        raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
+    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+
+
+def _base_revision(root: Path) -> str:
+    text = lifecycle.state_path(root).read_text(encoding="utf-8")
+    match = re.search(r"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", text)
+    if match is None:
+        raise AutomationError("Task State has no valid Base revision")
+    return match.group(1)
+
+
+def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches:
+        raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
+
+
+def _validate_edit_target(pr: dict, *, branch: str, base: str, head: str) -> None:
+    expected = {
+        "headRefName": branch, "baseRefName": base, "headRefOid": head,
+        "isDraft": True, "isCrossRepository": False, "state": "OPEN",
+    }
+    mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if mismatches or not isinstance(pr.get("number"), int):
+        raise AutomationError("pull request repair target identity is invalid: " + ", ".join(mismatches or ["number"]))
 
 
 def pr_create(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    if pr_for_branch(root, branch):
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "publication-ready":
+        raise AutomationError(f"pr-create requires publication-ready; found {context['status']}")
+    repository = context["repository"]
+    if pr_for_branch(root, branch, repository):
         raise AutomationError(f"pull request already exists for {branch}")
     base = default_branch(root)
-    title = f"{task}: {branch.split('/', 1)[1]}"
-    body = pr_body(root, task)
-    gh("pr", "create", "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
-    print(json.dumps(pr_for_branch(root, branch)))
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "create", "--repo", repository, "--draft", "--base", base, "--head", branch, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request creation")
+    pr = pr_for_branch(root, branch, repository)
+    if not pr:
+        raise AutomationError("created pull request cannot be re-read")
+    _validate_live_pr(pr, branch=branch, base=base, head=head, title=title, body=body_text, draft=True)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
+    print(json.dumps(pr))
 
 
 def pr_edit(root: Path, task: str) -> None:
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] not in {"publication-ready", "draft-pr-created"}:
+        raise AutomationError(f"pr-edit requires publication-ready or draft-pr-created; found {context['status']}")
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    title_file = root / ".task-state" / "pr-title.txt"
-    title = title_file.read_text(encoding="utf-8").strip() if title_file.exists() else pr["title"]
-    body = pr_body(root, task)
-    gh("pr", "edit", str(pr["number"]), "--title", title, "--body-file", str(body), cwd=root)
+    _validate_edit_target(pr, branch=branch, base=default_branch(root), head=head)
+    title, body, body_text = _validated_local_metadata(root, task, head)
+    gh("pr", "edit", str(pr["number"]), "--repo", repository, "--title", title, "--body-file", str(body), cwd=root)
+    if canonical_repository(root).casefold() != repository.casefold():
+        raise AutomationError("repository identity changed during pull request repair")
+    updated = pr_for_branch(root, branch, repository)
+    if not updated or updated.get("number") != pr.get("number"):
+        raise AutomationError("pull request identity changed during guarded repair")
+    _validate_live_pr(updated, branch=branch, base=default_branch(root), head=head, title=title, body=body_text, draft=True)
+    if context["status"] == "publication-ready":
+        try:
+            lifecycle.mark_task_publication_state(context["record"], task, "publication-ready", "draft-pr-created")
+        except lifecycle.LifecycleError as exc:
+            raise AutomationError(str(exc)) from exc
     print(f"updated PR #{pr['number']}")
 
 
 def pr_ready(root: Path, task: str) -> None:
     verify(root, task)
-    branch = ensure_task_branch(root, task)
-    pr = pr_for_branch(root, branch)
+    branch, context, head = _publication_context(root, task)
+    if context["status"] != "draft-pr-created":
+        raise AutomationError(f"pr-ready requires draft-pr-created; found {context['status']}")
+    title, _, body = _validated_local_metadata(root, task, head)
+    repository = context["repository"]
+    pr = pr_for_branch(root, branch, repository)
     if not pr:
         raise AutomationError(f"no pull request for {branch}")
-    gh("pr", "ready", str(pr["number"]), cwd=root)
+    if pr.get("isDraft"):
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=True)
+        gh("pr", "ready", str(pr["number"]), "--repo", repository, cwd=root)
+        if canonical_repository(root).casefold() != repository.casefold():
+            raise AutomationError("repository identity changed while marking pull request ready")
+        ready = pr_for_branch(root, branch, repository)
+        if not ready or ready.get("number") != pr.get("number"):
+            raise AutomationError("pull request identity changed while marking ready")
+        _validate_live_pr(ready, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    else:
+        # Reconcile an earlier successful GitHub readiness write whose local
+        # lifecycle transition was interrupted.
+        _validate_live_pr(pr, branch=branch, base=default_branch(root), head=head, title=title, body=body, draft=False)
+    try:
+        lifecycle.mark_task_publication_state(context["record"], task, "draft-pr-created", "integration-pending")
+    except lifecycle.LifecycleError as exc:
+        raise AutomationError(str(exc)) from exc
     print(f"PR #{pr['number']} marked ready")
 
 
@@ -514,7 +681,7 @@ def build_parser() -> argparse.ArgumentParser:
     for name in ("doctor", "context"):
         agent_cmd.add_parser(name)
     start = agent_cmd.add_parser("task-start"); start.add_argument("task"); start.add_argument("slug")
-    for name in ("status", "verify", "push", "pr-create", "pr-edit", "pr-ready", "cleanup"):
+    for name in ("status", "verify", "push", "pr-prepare", "pr-create", "pr-edit", "pr-ready", "cleanup"):
         p = agent_cmd.add_parser(name); p.add_argument("task")
     commit = agent_cmd.add_parser("commit"); commit.add_argument("task"); commit.add_argument("message", nargs="?", default="")
     integrate = scope.add_parser("integrate")
@@ -540,6 +707,7 @@ def main() -> int:
                 "verify": lambda: verify(root, args.task),
                 "commit": lambda: commit_task(root, args.task, args.message),
                 "push": lambda: push_task(root, args.task),
+                "pr-prepare": lambda: pr_prepare(root, args.task),
                 "pr-create": lambda: pr_create(root, args.task),
                 "pr-edit": lambda: pr_edit(root, args.task),
                 "pr-ready": lambda: pr_ready(root, args.task),

--- a/templates/agent-rust/.automation/bin/publication_metadata.py
+++ b/templates/agent-rust/.automation/bin/publication_metadata.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Prepare and validate evidence-backed pull request metadata."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import task_contract
+
+
+class PublicationMetadataError(RuntimeError):
+    pass
+
+
+PLACEHOLDER_PATTERNS = (
+    r"@@[A-Z0-9_]+@@",
+    r"\bTBD\b",
+    r"Describe the implemented Task outcome\.",
+    r"Task-specific criteria copied from `?\.task-state/task\.md`?",
+    r"Define Task-specific acceptance criteria",
+)
+NOT_RUN_RE = re.compile(r"(?im)^.*(?:NOT[ _-]?RUN|not run).*$")
+
+
+def _sections(text: str) -> dict[str, str]:
+    matches = list(re.finditer(r"(?m)^## (.+?)\s*$", text))
+    return {
+        match.group(1): text[match.end() : matches[index + 1].start() if index + 1 < len(matches) else len(text)].strip()
+        for index, match in enumerate(matches)
+    }
+
+
+def _content_lines(value: str) -> list[str]:
+    ignored = {"none yet.", "none yet", "none recorded", "none recorded yet."}
+    return [line for line in value.splitlines() if line.strip() and line.strip().lower().lstrip("- ") not in ignored]
+
+
+def _identity(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing {name}")
+    return match.group(1).strip()
+
+
+def _read_json(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}") from exc
+    if not isinstance(value, dict):
+        raise PublicationMetadataError(f"invalid persisted evidence: {path}")
+    return value
+
+
+def verification_evidence(root: Path, task: str, head: str) -> dict:
+    receipt = _read_json(root / ".task-state" / "verification.json")
+    if receipt is None:
+        raise PublicationMetadataError("missing persisted project verification evidence")
+    if set(receipt) != {"schema_version", "task_id", "head", "clean_tracked_worktree", "worktree_stable", "project_check"} or receipt["schema_version"] != 1:
+        raise PublicationMetadataError("invalid project verification evidence schema")
+    check = receipt.get("project_check")
+    if receipt.get("task_id") != task:
+        raise PublicationMetadataError("project verification evidence belongs to another Task")
+    if receipt.get("head") != head or not isinstance(check, dict):
+        raise PublicationMetadataError("project verification evidence is stale")
+    if check.get("command") != ["just", "project::check"] or check.get("returncode") != 0:
+        raise PublicationMetadataError("project::check has no persisted PASS evidence")
+    if receipt.get("clean_tracked_worktree") is not True or receipt.get("worktree_stable") is not True:
+        raise PublicationMetadataError("project verification is not bound to a clean stable worktree")
+    if not isinstance(check.get("executed_at"), str) or not check["executed_at"]:
+        raise PublicationMetadataError("project verification evidence has no execution time")
+    return receipt
+
+
+def completed_reviews(root: Path, task: str) -> list[str]:
+    value = _read_json(root / ".task-state" / "work-units.json")
+    if value is None:
+        return []
+    if value.get("task_id") != task or not isinstance(value.get("units"), dict):
+        raise PublicationMetadataError("Work Unit evidence does not match the Task")
+    reviews = []
+    for identifier, unit in value["units"].items():
+        if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
+            continue
+        if unit.get("state") != "completed":
+            raise PublicationMetadataError(
+                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+            )
+        transitions = unit.get("transitions")
+        digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
+        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+    return reviews
+
+
+def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[str]) -> tuple[str, str]:
+    state_path = root / ".task-state" / "task.md"
+    try:
+        text = state_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError(f"missing Task State: {state_path}") from exc
+    if _identity(text, "Task ID") != task:
+        raise PublicationMetadataError("Task State identity does not match requested Task")
+    sections = _sections(text)
+    purpose = _content_lines(sections.get("Purpose", ""))
+    criteria = _content_lines(sections.get("Acceptance criteria", ""))
+    if not purpose or not criteria:
+        raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    summary = purpose[0].lstrip("- ").strip()
+    verification = verification_evidence(root, task, head)
+    title = f"{task}: {summary}"
+    changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
+    reviews = completed_reviews(root, task)
+    followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
+    body = "\n".join(
+        [
+            "## Summary", "", f"Task: {task}", "", *purpose,
+            "", "## Changed paths", "", *changes,
+            "", "## Acceptance criteria", "", *criteria,
+            "", "## Validation", "",
+            f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
+            "", "## Reviews", "", *(reviews or ["- None recorded."]),
+            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Follow-up Tasks", "", *followups, "",
+        ]
+    )
+    validate_metadata(title, body, receipt=verification)
+    return title, body
+
+
+def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> None:
+    if not title.strip() or not body.strip():
+        raise PublicationMetadataError("pull request title and body must be non-empty")
+    combined = title + "\n" + body
+    for pattern in PLACEHOLDER_PATTERNS:
+        if re.search(pattern, combined, re.IGNORECASE):
+            raise PublicationMetadataError("unresolved pull request publication placeholder")
+    not_run = NOT_RUN_RE.findall(body)
+    if not_run:
+        if receipt and receipt.get("project_check", {}).get("returncode") == 0:
+            raise PublicationMetadataError("pull request metadata contradicts persisted PASS evidence with NOT RUN")
+        raise PublicationMetadataError("unresolved NOT RUN publication metadata")
+    required = ("## Summary", "## Acceptance criteria", "## Validation", "## Risks and unverified areas", "## Follow-up Tasks")
+    if any(heading not in body for heading in required):
+        raise PublicationMetadataError("pull request body is missing required sections")
+
+
+def write_metadata(root: Path, title: str, body: str) -> None:
+    try:
+        task_contract.write_publication_metadata(
+            root,
+            (title.strip() + "\n").encode(),
+            (body.rstrip() + "\n").encode(),
+        )
+    except task_contract.ContractError as exc:
+        raise PublicationMetadataError(str(exc)) from exc
+
+
+def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tuple[str, str]:
+    title_path = root / ".task-state" / "pr-title.txt"
+    body_path = root / ".task-state" / "pr-body.md"
+    try:
+        title = title_path.read_text(encoding="utf-8").strip()
+        body = body_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PublicationMetadataError("run agent::pr-prepare before publication") from exc
+    validate_metadata(title, body, receipt=receipt)
+    return title, body

--- a/templates/agent-rust/.automation/bin/publication_metadata.py
+++ b/templates/agent-rust/.automation/bin/publication_metadata.py
@@ -44,6 +44,27 @@ def _identity(text: str, name: str) -> str:
     return match.group(1).strip()
 
 
+def _current_state_value(text: str, name: str) -> str:
+    match = re.search(rf"(?m)^- {re.escape(name)}: (.+)$", text)
+    if match is None or not match.group(1).strip():
+        raise PublicationMetadataError(f"Task State is missing Current state {name}")
+    return match.group(1).strip()
+
+
+def _is_none_value(value: str) -> bool:
+    return value.casefold().rstrip(".") in {"none", "none recorded"}
+
+
+def _requirements(lines: list[str]) -> list[str]:
+    requirements = []
+    for line in lines:
+        value = re.sub(r"^-\s*\[[ xX]\]\s*", "", line.strip())
+        value = value.removeprefix("- ").strip()
+        if value:
+            requirements.append(f"- Requirement: {value}")
+    return requirements
+
+
 def _read_json(path: Path) -> dict | None:
     if not path.exists():
         return None
@@ -110,21 +131,39 @@ def canonical_metadata(root: Path, task: str, *, head: str, changed_paths: list[
     criteria = _content_lines(sections.get("Acceptance criteria", ""))
     if not purpose or not criteria:
         raise PublicationMetadataError("Task purpose and acceptance criteria must be resolved")
+    requirements = _requirements(criteria)
+    if not requirements:
+        raise PublicationMetadataError("Task acceptance criteria contain no authoritative requirements")
+    blockers = _current_state_value(sections.get("Current state", ""), "Blockers")
+    unverified = _current_state_value(sections.get("Current state", ""), "Unverified")
+    risks = []
+    if not _is_none_value(blockers):
+        risks.append(f"- Blockers: {blockers}")
+    if not _is_none_value(unverified):
+        risks.append(f"- Unverified: {unverified}")
+    if not risks:
+        risks = ["- None recorded."]
     summary = purpose[0].lstrip("- ").strip()
     verification = verification_evidence(root, task, head)
     title = f"{task}: {summary}"
     changes = [f"- `{path.replace('`', '')}`" for path in changed_paths] or ["- No tracked changes recorded."]
     reviews = completed_reviews(root, task)
+    if not any("— `reviewer` — completed" in review for review in reviews):
+        raise PublicationMetadataError(
+            "publication requires a completed reviewer Work Unit"
+        )
     followups = _content_lines(sections.get("Follow-up Task candidates", "")) or ["- None recorded."]
     body = "\n".join(
         [
             "## Summary", "", f"Task: {task}", "", *purpose,
             "", "## Changed paths", "", *changes,
-            "", "## Acceptance criteria", "", *criteria,
+            "", "## Acceptance criteria", "",
+            "The following are authoritative Task requirements; completion evidence is reported separately under Validation and Reviews.",
+            "", *requirements,
             "", "## Validation", "",
             f"- `just project::check`: PASS at `{head}` (persisted executed evidence)",
             "", "## Reviews", "", *(reviews or ["- None recorded."]),
-            "", "## Risks and unverified areas", "", "- None recorded.",
+            "", "## Risks and unverified areas", "", *risks,
             "", "## Follow-up Tasks", "", *followups, "",
         ]
     )

--- a/templates/agent-rust/.automation/bin/task_contract.py
+++ b/templates/agent-rust/.automation/bin/task_contract.py
@@ -139,6 +139,30 @@ def _restore_state_file(directory_fd: int, name: str, content: bytes | None) -> 
         _write_state_file(directory_fd, name, content)
 
 
+def write_publication_metadata(root: Path, title: bytes, body: bytes) -> None:
+    """Atomically replace the two publication files in pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        previous = {
+            name: _read_state_file(directory_fd, name)
+            for name in ("pr-title.txt", "pr-body.md")
+        }
+        try:
+            _write_state_file(directory_fd, "pr-title.txt", title)
+            _write_state_file(directory_fd, "pr-body.md", body)
+            _assert_state_dir_binding(root, directory_fd)
+        except Exception:
+            for name, content in previous.items():
+                _restore_state_file(directory_fd, name, content)
+            raise
+
+
+def write_verification_receipt(root: Path, content: bytes) -> None:
+    """Replace the verification receipt through pinned Task State."""
+    with contract_state_lock(root) as directory_fd:
+        _write_state_file(directory_fd, "verification.json", content)
+        _assert_state_dir_binding(root, directory_fd)
+
+
 def validate_issue_number(value: str) -> int:
     if not ISSUE_RE.fullmatch(value):
         raise ContractError("Issue number must be an exact positive decimal integer")

--- a/templates/agent-rust/.automation/bin/task_lifecycle.py
+++ b/templates/agent-rust/.automation/bin/task_lifecycle.py
@@ -919,10 +919,40 @@ def task_status(root: Path, task: str) -> None:
 def task_state_set(root: Path, task: str, status: str) -> None:
     record = require_local_task(root, task)
     require_resolved_contract(record, task)
+    if status in {"draft-pr-created", "integration-pending"}:
+        raise LifecycleError(
+            f"{status} is reserved for the guarded pull request publication boundary"
+        )
     with work_units_lock(record):
         assert_task_identity(record, task)
         set_state_status(state_path(record.path), status)
     print(json.dumps({"task": task, "status": status}))
+
+
+def mark_task_publication_state(
+    record: WorktreeRecord, task: str, expected: str, target: str
+) -> str:
+    """Narrow transition authority for validated PR creation/readiness."""
+    allowed = {
+        ("publication-ready", "draft-pr-created"),
+        ("draft-pr-created", "integration-pending"),
+    }
+    if (expected, target) not in allowed:
+        raise LifecycleError("invalid guarded publication transition")
+    validate_task(task)
+    require_resolved_contract(record, task)
+    with work_units_lock(record):
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        previous = state_status(path)
+        if previous == target:
+            return "already-transitioned"
+        if previous != expected:
+            raise LifecycleError(
+                f"guarded publication transition requires {expected}; found {previous}"
+            )
+        set_state_status(path, target)
+    return "transitioned"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/templates/agent-rust/.automation/just/agent.just
+++ b/templates/agent-rust/.automation/just/agent.just
@@ -84,6 +84,10 @@ pr-create task:
     python3 {{quote(script)}} agent pr-create {{quote(task)}}
 
 [working-directory: root]
+pr-prepare task:
+    python3 {{quote(script)}} agent pr-prepare {{quote(task)}}
+
+[working-directory: root]
 pr-edit task:
     python3 {{quote(script)}} agent pr-edit {{quote(task)}}
 

--- a/templates/agent-rust/.opencode/agents/build.md
+++ b/templates/agent-rust/.opencode/agents/build.md
@@ -25,6 +25,7 @@ permission:
     "just agent::batch-plan *": allow
     "just agent::commit *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just integrate::finalize *": allow

--- a/templates/agent-rust/.opencode/agents/general.md
+++ b/templates/agent-rust/.opencode/agents/general.md
@@ -38,6 +38,7 @@ permission:
     "just agent::commit *": deny
     "just agent::push *": deny
     "just agent::pr-create *": deny
+    "just agent::pr-prepare *": deny
     "just agent::pr-edit *": deny
     "just agent::pr-ready *": deny
     "just agent::cleanup *": deny

--- a/templates/agent-rust/.opencode/agents/task-orchestrator.md
+++ b/templates/agent-rust/.opencode/agents/task-orchestrator.md
@@ -30,6 +30,7 @@ permission:
     "just agent::work-unit-dispatch-check *": allow
     "just agent::work-unit-status *": allow
     "just agent::work-unit-state-set *": allow
+    "just agent::pr-prepare *": allow
     "just integrate::check *": deny
     "just integrate::finalize *": deny
     "just integrate::merge *": deny
@@ -77,6 +78,6 @@ Before advancing Task State to `publication-ready`, and again before guarded com
 - a reviewer Work Unit for non-trivial changes;
 - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 
-No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, and prepare a Draft PR. Never merge.
+No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop. Only after this evidence gate passes may Task State become `publication-ready`; then commit only through the guarded Just API, request approval before pushing, run `just agent::pr-prepare <task>`, and create or repair the same Draft PR through the guarded publication API. Metadata with placeholders or false `NOT RUN` claims is forbidden. Never merge.
 
 Never invoke another Task Orchestrator. Never merge. Never operate on sibling Task worktrees. Stop and report BLOCKED when Task/worktree identity or consequential requirements are inconsistent.

--- a/templates/agent-rust/.opencode/skills/task-orchestration/SKILL.md
+++ b/templates/agent-rust/.opencode/skills/task-orchestration/SKILL.md
@@ -34,7 +34,7 @@ Use this skill when the Main Orchestrator is asked to run a specific Task that a
     - a reviewer Work Unit for non-trivial changes;
     - a security-reviewer Work Unit when trust- or security-sensitive surfaces changed.
 12. No unexecuted check or Work Unit may count as PASS. If any required review, verifier, or check fails and a bounded correction is possible, create a fresh corrective Work Unit and return to verification. Otherwise set the Task `blocked`, surface the evidence, and stop.
-13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, and create or edit only a Draft PR.
+13. Only after the verification evidence gate passes may Task State become `publication-ready`; then use guarded `commit`, request approval for `push`, run `just agent::pr-prepare <task>`, and create or edit only the same Draft PR. Publication metadata must be regenerated from persisted evidence and must contain no unresolved placeholder or false `NOT RUN` claim.
 14. Persist every transition and continue the loop until integration-pending. Stop for `NEEDS_APPROVAL` or `NEEDS_DECISION` human handling, and otherwise stop at integration-pending. Do not merge from this skill. Never merge.
 
 Do not silently select another Issue or Task. Do not weaken permissions to work around a blocked approval or missing tool/model.

--- a/templates/agent-rust/opencode.json
+++ b/templates/agent-rust/opencode.json
@@ -91,6 +91,7 @@
       "just agent::status *": "allow",
       "just agent::verify *": "allow",
       "just agent::commit *": "allow",
+      "just agent::pr-prepare *": "allow",
       "just agent::pr-create *": "allow",
       "just agent::pr-edit *": "allow",
       "just agent::pr-ready *": "allow",

--- a/tests/test_agent_core_automation.py
+++ b/tests/test_agent_core_automation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -70,6 +71,209 @@ class AgentCoreSafetyTest(unittest.TestCase):
                 self.assertRaisesRegex(agent_core.AutomationError, "head moved"),
             ):
                 agent_core.integrate_merge(root, "10")
+
+
+class PublicationMetadataTest(unittest.TestCase):
+    HEAD = "a" * 40
+
+    def fixture(self, root: Path, *, reviews: bool = False) -> None:
+        state = root / ".task-state"
+        state.mkdir()
+        (state / "task.md").write_text(
+            """# 19
+
+## Identity
+
+- Task ID: 19
+- Branch: task/19-agent-core-v3-1-1
+- Worktree: /fixture
+- Base branch: main
+- Base revision: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+
+## Purpose
+
+Repair AgentKnowledgeVault publication metadata without replacing PR #20.
+
+## Acceptance criteria
+
+- [x] Guard publication metadata.
+
+## Follow-up Task candidates
+
+None yet.
+""",
+            encoding="utf-8",
+        )
+        (state / "verification.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "task_id": "19",
+                    "head": self.HEAD,
+                    "clean_tracked_worktree": True,
+                    "worktree_stable": True,
+                    "project_check": {
+                        "command": ["just", "project::check"],
+                        "returncode": 0,
+                        "executed_at": "2026-08-30T00:00:00+00:00",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        if reviews:
+            digest = "c" * 64
+            (state / "work-units.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "task_id": "19",
+                        "units": {
+                            "WU-19-04": {
+                                "requested_role": "reviewer",
+                                "state": "completed",
+                                "transitions": [{"evidence_sha256": digest}],
+                            },
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+    def test_untouched_default_template_is_rejected(self) -> None:
+        body = (MODULE_PATH.parents[1] / "templates" / "pull-request.md").read_text(encoding="utf-8")
+        with self.assertRaisesRegex(agent_core.publication.PublicationMetadataError, "placeholder"):
+            agent_core.publication.validate_metadata("19: repair", body)
+
+    def test_unresolved_title_placeholder_is_rejected(self) -> None:
+        with self.assertRaisesRegex(agent_core.publication.PublicationMetadataError, "placeholder"):
+            agent_core.publication.validate_metadata("@@TITLE@@", "## Summary\n\nDone\n\n## Acceptance criteria\n\n- done\n\n## Validation\n\n- PASS\n\n## Risks and unverified areas\n\n- none\n\n## Follow-up Tasks\n\n- none")
+
+    def test_pass_evidence_contradicting_not_run_is_rejected(self) -> None:
+        receipt = {"project_check": {"returncode": 0}}
+        body = "## Summary\n\nDone\n\n## Acceptance criteria\n\n- done\n\n## Validation\n\n- `just project::check`: NOT RUN\n\n## Risks and unverified areas\n\n- none\n\n## Follow-up Tasks\n\n- none"
+        with self.assertRaisesRegex(agent_core.publication.PublicationMetadataError, "contradicts"):
+            agent_core.publication.validate_metadata("19: repair", body, receipt=receipt)
+
+    def test_verification_receipt_for_another_task_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            receipt_path = root / ".task-state" / "verification.json"
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            receipt["task_id"] = "20"
+            receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+            with self.assertRaisesRegex(agent_core.publication.PublicationMetadataError, "another Task"):
+                agent_core.publication.verification_evidence(root, "19", self.HEAD)
+
+    def test_dirty_worktree_verification_cannot_authorize_publication(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            receipt_path = root / ".task-state" / "verification.json"
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            receipt["clean_tracked_worktree"] = False
+            receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+            with self.assertRaisesRegex(agent_core.publication.PublicationMetadataError, "clean stable"):
+                agent_core.publication.verification_evidence(root, "19", self.HEAD)
+
+    def test_dogfood_fixture_prepares_complete_metadata_without_product_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root, reviews=True)
+            product = root / "product.txt"
+            product.write_text("unchanged\n", encoding="utf-8")
+            title, body = agent_core.publication.canonical_metadata(
+                root, "19", head=self.HEAD, changed_paths=[".automation/bin/agent_core.py"]
+            )
+            agent_core.publication.write_metadata(root, title, body)
+            self.assertEqual(product.read_text(encoding="utf-8"), "unchanged\n")
+            self.assertIn("`just project::check`: PASS", body)
+            self.assertIn("`WU-19-04` — `reviewer`", body)
+            self.assertNotIn("security-reviewer", body)
+            self.assertNotIn("NOT RUN", body)
+            self.assertNotIn("Describe the implemented", body)
+
+    def test_complete_metadata_allows_draft_creation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            title, body_text = agent_core.publication.canonical_metadata(root, "19", head=self.HEAD, changed_paths=["one"])
+            agent_core.publication.write_metadata(root, title, body_text)
+            context = {"record": mock.sentinel.record, "status": "publication-ready", "repository": "example/repo"}
+            live = {"number": 20, "title": title, "body": body_text.rstrip(), "headRefName": "task/19-agent-core-v3-1-1", "baseRefName": "main", "isDraft": True, "isCrossRepository": False, "state": "OPEN", "headRefOid": self.HEAD}
+            with (
+                mock.patch.object(agent_core, "_publication_context", return_value=(live["headRefName"], context, self.HEAD)),
+                mock.patch.object(agent_core, "_validated_local_metadata", return_value=(title, root / ".task-state/pr-body.md", body_text.rstrip())),
+                mock.patch.object(agent_core, "default_branch", return_value="main"),
+                mock.patch.object(agent_core, "canonical_repository", return_value="example/repo"),
+                mock.patch.object(agent_core, "pr_for_branch", side_effect=[None, live]),
+                mock.patch.object(agent_core, "gh") as gh,
+                mock.patch.object(agent_core.lifecycle, "mark_task_publication_state") as transition,
+            ):
+                agent_core.pr_create(root, "19")
+            self.assertIn("--draft", gh.call_args.args)
+            transition.assert_called_once()
+
+    def test_existing_stale_draft_is_repaired_in_place(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            body_file = root / ".task-state/pr-body.md"
+            body_file.parent.mkdir()
+            body_file.write_text("canonical", encoding="utf-8")
+            stale = {"number": 20, "headRefName": "task/19-fix", "baseRefName": "main", "headRefOid": self.HEAD, "isDraft": True, "isCrossRepository": False, "state": "OPEN"}
+            updated = {"number": 20, "title": "title", "body": "canonical", "headRefName": "task/19-fix", "baseRefName": "main", "isDraft": True, "isCrossRepository": False, "state": "OPEN", "headRefOid": self.HEAD}
+            with (
+                mock.patch.object(agent_core, "_publication_context", return_value=("task/19-fix", {"record": mock.sentinel.record, "status": "draft-pr-created", "repository": "example/repo"}, self.HEAD)),
+                mock.patch.object(agent_core, "_validated_local_metadata", return_value=("title", body_file, "canonical")),
+                mock.patch.object(agent_core, "default_branch", return_value="main"),
+                mock.patch.object(agent_core, "canonical_repository", return_value="example/repo"),
+                mock.patch.object(agent_core, "pr_for_branch", side_effect=[stale, updated]),
+                mock.patch.object(agent_core, "gh") as gh,
+            ):
+                agent_core.pr_edit(root, "19")
+            self.assertEqual(gh.call_args.args[:3], ("pr", "edit", "20"))
+
+    def test_pr_edit_rejects_wrong_identity_before_write(self) -> None:
+        wrong = {"number": 20, "headRefName": "task/19-fix", "baseRefName": "other", "headRefOid": self.HEAD, "isDraft": True, "isCrossRepository": False, "state": "OPEN"}
+        with (
+            mock.patch.object(agent_core, "_publication_context", return_value=("task/19-fix", {"record": mock.sentinel.record, "status": "draft-pr-created", "repository": "example/repo"}, self.HEAD)),
+            mock.patch.object(agent_core, "default_branch", return_value="main"),
+            mock.patch.object(agent_core, "pr_for_branch", return_value=wrong),
+            mock.patch.object(agent_core, "gh") as gh,
+            self.assertRaisesRegex(agent_core.AutomationError, "repair target identity"),
+        ):
+            agent_core.pr_edit(Path("."), "19")
+        gh.assert_not_called()
+
+    def test_pr_ready_reconciles_already_ready_pr(self) -> None:
+        ready = {"number": 20, "title": "title", "body": "canonical", "headRefName": "task/19-fix", "baseRefName": "main", "isDraft": False, "isCrossRepository": False, "state": "OPEN", "headRefOid": self.HEAD}
+        with (
+            mock.patch.object(agent_core, "verify"),
+            mock.patch.object(agent_core, "_publication_context", return_value=("task/19-fix", {"record": mock.sentinel.record, "status": "draft-pr-created", "repository": "example/repo"}, self.HEAD)),
+            mock.patch.object(agent_core, "_validated_local_metadata", return_value=("title", Path("body"), "canonical")),
+            mock.patch.object(agent_core, "default_branch", return_value="main"),
+            mock.patch.object(agent_core, "pr_for_branch", return_value=ready),
+            mock.patch.object(agent_core, "gh") as gh,
+            mock.patch.object(agent_core.lifecycle, "mark_task_publication_state") as transition,
+        ):
+            agent_core.pr_ready(Path("."), "19")
+        gh.assert_not_called()
+        transition.assert_called_once()
+
+    def test_pr_ready_rejects_stale_live_body_before_write(self) -> None:
+        live = {"number": 20, "title": "title", "body": "stale", "headRefName": "task/19-fix", "baseRefName": "main", "isDraft": True, "isCrossRepository": False, "state": "OPEN", "headRefOid": self.HEAD}
+        with (
+            mock.patch.object(agent_core, "verify"),
+            mock.patch.object(agent_core, "_publication_context", return_value=("task/19-fix", {"record": mock.sentinel.record, "status": "draft-pr-created", "repository": "example/repo"}, self.HEAD)),
+            mock.patch.object(agent_core, "_validated_local_metadata", return_value=("title", Path("body"), "canonical")),
+            mock.patch.object(agent_core, "default_branch", return_value="main"),
+            mock.patch.object(agent_core, "pr_for_branch", return_value=live),
+            mock.patch.object(agent_core, "gh") as gh,
+            self.assertRaisesRegex(agent_core.AutomationError, "stale or inconsistent"),
+        ):
+            agent_core.pr_ready(Path("."), "19")
+        gh.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_core_automation.py
+++ b/tests/test_agent_core_automation.py
@@ -76,7 +76,7 @@ class AgentCoreSafetyTest(unittest.TestCase):
 class PublicationMetadataTest(unittest.TestCase):
     HEAD = "a" * 40
 
-    def fixture(self, root: Path, *, reviews: bool = False) -> None:
+    def fixture(self, root: Path, *, reviews: bool = True) -> None:
         state = root / ".task-state"
         state.mkdir()
         (state / "task.md").write_text(
@@ -97,6 +97,12 @@ Repair AgentKnowledgeVault publication metadata without replacing PR #20.
 ## Acceptance criteria
 
 - [x] Guard publication metadata.
+
+## Current state
+
+- Status: publication-ready
+- Blockers: none
+- Unverified: none
 
 ## Follow-up Task candidates
 
@@ -189,10 +195,53 @@ None yet.
             agent_core.publication.write_metadata(root, title, body)
             self.assertEqual(product.read_text(encoding="utf-8"), "unchanged\n")
             self.assertIn("`just project::check`: PASS", body)
+            self.assertIn("authoritative Task requirements", body)
+            self.assertIn("- Requirement: Guard publication metadata.", body)
+            self.assertNotIn("- [x]", body)
             self.assertIn("`WU-19-04` — `reviewer`", body)
             self.assertNotIn("security-reviewer", body)
             self.assertNotIn("NOT RUN", body)
             self.assertNotIn("Describe the implemented", body)
+
+    def test_known_blockers_and_unverified_state_are_rendered_truthfully(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            task = root / ".task-state" / "task.md"
+            text = task.read_text(encoding="utf-8")
+            text = text.replace("- Blockers: none", "- Blockers: release approval pending")
+            text = text.replace("- Unverified: none", "- Unverified: generated C++ smoke")
+            task.write_text(text, encoding="utf-8")
+            _, body = agent_core.publication.canonical_metadata(
+                root, "19", head=self.HEAD, changed_paths=["one"]
+            )
+            risks = body.split("## Risks and unverified areas", 1)[1].split("## Follow-up Tasks", 1)[0]
+            self.assertIn("- Blockers: release approval pending", risks)
+            self.assertIn("- Unverified: generated C++ smoke", risks)
+            self.assertNotIn("None recorded", risks)
+
+    def test_missing_current_state_evidence_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            task = root / ".task-state" / "task.md"
+            task.write_text(
+                task.read_text(encoding="utf-8").replace("- Unverified: none\n", ""),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(agent_core.publication.PublicationMetadataError, "Current state Unverified"):
+                agent_core.publication.canonical_metadata(
+                    root, "19", head=self.HEAD, changed_paths=["one"]
+                )
+
+    def test_missing_reviewer_evidence_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root, reviews=False)
+            with self.assertRaisesRegex(agent_core.publication.PublicationMetadataError, "completed reviewer"):
+                agent_core.publication.canonical_metadata(
+                    root, "19", head=self.HEAD, changed_paths=["one"]
+                )
 
     def test_complete_metadata_allows_draft_creation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -203,6 +252,7 @@ None yet.
             context = {"record": mock.sentinel.record, "status": "publication-ready", "repository": "example/repo"}
             live = {"number": 20, "title": title, "body": body_text.rstrip(), "headRefName": "task/19-agent-core-v3-1-1", "baseRefName": "main", "isDraft": True, "isCrossRepository": False, "state": "OPEN", "headRefOid": self.HEAD}
             with (
+                mock.patch.object(agent_core, "verify") as verify_mock,
                 mock.patch.object(agent_core, "_publication_context", return_value=(live["headRefName"], context, self.HEAD)),
                 mock.patch.object(agent_core, "_validated_local_metadata", return_value=(title, root / ".task-state/pr-body.md", body_text.rstrip())),
                 mock.patch.object(agent_core, "default_branch", return_value="main"),
@@ -213,6 +263,7 @@ None yet.
             ):
                 agent_core.pr_create(root, "19")
             self.assertIn("--draft", gh.call_args.args)
+            verify_mock.assert_called_once_with(root, "19")
             transition.assert_called_once()
 
     def test_existing_stale_draft_is_repaired_in_place(self) -> None:
@@ -224,6 +275,7 @@ None yet.
             stale = {"number": 20, "headRefName": "task/19-fix", "baseRefName": "main", "headRefOid": self.HEAD, "isDraft": True, "isCrossRepository": False, "state": "OPEN"}
             updated = {"number": 20, "title": "title", "body": "canonical", "headRefName": "task/19-fix", "baseRefName": "main", "isDraft": True, "isCrossRepository": False, "state": "OPEN", "headRefOid": self.HEAD}
             with (
+                mock.patch.object(agent_core, "verify") as verify_mock,
                 mock.patch.object(agent_core, "_publication_context", return_value=("task/19-fix", {"record": mock.sentinel.record, "status": "draft-pr-created", "repository": "example/repo"}, self.HEAD)),
                 mock.patch.object(agent_core, "_validated_local_metadata", return_value=("title", body_file, "canonical")),
                 mock.patch.object(agent_core, "default_branch", return_value="main"),
@@ -233,10 +285,26 @@ None yet.
             ):
                 agent_core.pr_edit(root, "19")
             self.assertEqual(gh.call_args.args[:3], ("pr", "edit", "20"))
+            verify_mock.assert_called_once_with(root, "19")
+
+    def test_create_and_edit_do_not_write_when_verification_fails(self) -> None:
+        for action in (agent_core.pr_create, agent_core.pr_edit):
+            with (
+                mock.patch.object(
+                    agent_core,
+                    "verify",
+                    side_effect=agent_core.AutomationError("verification failed"),
+                ),
+                mock.patch.object(agent_core, "gh") as gh,
+                self.assertRaisesRegex(agent_core.AutomationError, "verification failed"),
+            ):
+                action(Path("."), "19")
+            gh.assert_not_called()
 
     def test_pr_edit_rejects_wrong_identity_before_write(self) -> None:
         wrong = {"number": 20, "headRefName": "task/19-fix", "baseRefName": "other", "headRefOid": self.HEAD, "isDraft": True, "isCrossRepository": False, "state": "OPEN"}
         with (
+            mock.patch.object(agent_core, "verify"),
             mock.patch.object(agent_core, "_publication_context", return_value=("task/19-fix", {"record": mock.sentinel.record, "status": "draft-pr-created", "repository": "example/repo"}, self.HEAD)),
             mock.patch.object(agent_core, "default_branch", return_value="main"),
             mock.patch.object(agent_core, "pr_for_branch", return_value=wrong),

--- a/tests/test_opencode_contract.py
+++ b/tests/test_opencode_contract.py
@@ -304,11 +304,15 @@ class OpenCodeContractTest(unittest.TestCase):
         self.assertEqual(bash["gh pr ready *"], "deny")
         self.assertEqual(bash["gh pr merge *"], "deny")
         self.assertEqual(bash["just agent::commit *"], "allow")
+        self.assertEqual(bash["just agent::pr-prepare *"], "allow")
         self.assertEqual(bash["just agent::pr-create *"], "allow")
         self.assertEqual(bash["just agent::pr-edit *"], "allow")
         self.assertEqual(bash["just agent::pr-ready *"], "allow")
         self.assertEqual(bash["just agent::push *"], "ask")
         self.assertEqual(bash["just integrate::merge *"], "ask")
+        self.assertEqual(permission_for("task-orchestrator")["bash"]["just agent::pr-prepare *"], "allow")
+        self.assertEqual(permission_for("build")["bash"]["just agent::pr-prepare *"], "deny")
+        self.assertEqual(permission_for("general")["bash"]["just agent::pr-prepare *"], "deny")
 
     def test_guarded_finalize_permission_boundaries(self) -> None:
         bash = self.config["permission"]["bash"]

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -17,6 +17,16 @@ spec.loader.exec_module(lifecycle)
 
 
 class TaskLifecycleTest(unittest.TestCase):
+    def test_generic_state_set_cannot_cross_publication_boundaries(self) -> None:
+        record = lifecycle.WorktreeRecord(Path("/task"), "task/101-metadata", "a" * 40)
+        for status in ("draft-pr-created", "integration-pending"):
+            with (
+                mock.patch.object(lifecycle, "require_local_task", return_value=record),
+                mock.patch.object(lifecycle, "require_resolved_contract"),
+                self.assertRaisesRegex(lifecycle.LifecycleError, "guarded pull request publication"),
+            ):
+                lifecycle.task_state_set(Path("/task"), "101", status)
+
     def test_task_branch_matching_is_not_substring_based(self) -> None:
         self.assertTrue(lifecycle.branch_matches_task("task/TASK-1-example", "TASK-1"))
         self.assertFalse(lifecycle.branch_matches_task("task/TASK-10-example", "TASK-1"))


### PR DESCRIPTION
## Summary

- add evidence-backed `pr-prepare` rendering for canonical PR title/body metadata
- fail closed on placeholders, stale metadata, cross-Task evidence, repository/head drift, and PASS/validation contradictions
- render Task State Blockers/Unverified values truthfully and fail closed when Current-state evidence is missing
- render acceptance criteria as authoritative requirements, separate from completion evidence
- validate and repair the same Draft PR through guarded `pr-create`, `pr-edit`, and `pr-ready` boundaries
- rerun actual project verification at every PR write boundary and require completed reviewer evidence
- preserve Draft-first/human-merge authority and keep Agent Core VERSION at 3

Closes #101

## Validation

- `python3 -m unittest discover -s tests -v`: PASS (377 tests)
- `just template::render-all`: PASS
- `just template::check`: PASS
- `just template::distribution-verify`: PASS
- `nix flake check --all-systems --no-build --no-update-lock-file`: PASS
- `nix build .#checks.x86_64-linux.opencode-policy --no-link --no-update-lock-file`: PASS
- `git diff --check`: PASS
- Template CI contracts: PASS
- generated-template smoke: PASS for Python, Rust, Nix, and C++/CMake
- GitGuardian Security Checks: PASS

## Reviews

- reviewer: PASS after blocker correction and verification failure-path coverage
- security-reviewer: PASS with no unresolved High/Medium findings

## Risks and unverified areas

- None recorded.

## Follow-up Tasks

- None.
