### PR TITLE
fix: allow cleanup after merged branch deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ Main
 
 Raw Git/GitHub writes are denied. Stable Just APIs provide the guarded write path. After merge, Main uses `just integrate::finalize <task> <pr>` to bind actual GitHub merge evidence to a narrow fast-forward-only default-branch synchronization and the dedicated `integration-pending -> merged` transition. `task-start` repeats that synchronization at execution time. Push, merge, cleanup, unknown Bash, and designated external paths require Ask; finalization is non-destructive and cleanup remains separate.
 
+Issue #103 permits that separate guarded cleanup to recover when GitHub has
+already deleted a merged Task's remote branch. A configured upstream is not
+treated as a live revision: cleanup queries origin directly, requires status
+`merged`, a clean registered worktree, one matching merged PR, and exact
+equality among the PR `headRefOid`, recorded published head when present, and
+the local Task branch. Any local-only commit, PR identity mismatch, remote
+head mismatch, or unavailable evidence fails closed. Cancelled Tasks do not
+receive this exception. A private cleanup receipt and expected-OID ref deletion
+make the worktree-removal/branch-removal tail retryable. The operation remains
+Main-owned, human-approved, and Agent Core VERSION 3.
+
 Each role uses one fixed GPT-5.6 model. Agent Core does not substitute models or retry an objective under another model. If the configured provider/model is unavailable, preserve Task and Work Unit evidence, report the exact failure, and return `BLOCKED`.
 
 Task Orchestrators autonomously drive the persisted Work Unit loop through the

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -51,6 +51,19 @@ integration-pending -> PR merge -> guarded finalize -> merged
   -> approval-gated cleanup -> dependency re-evaluation -> next Task
 ```
 
+For a merged Task, cleanup reconstructs safety from the unique same-repository
+merged PR: its branch and `headRefOid` must match the registered clean local
+Task branch exactly, and the local branch must contain no later commit. A live
+origin Task branch must have that same OID. A deleted origin branch is accepted
+only after those merged-PR checks, which allows a finalized Task such as
+AgentKnowledgeVault #12 to retry normal cleanup without recreating a remote
+branch. Cancelled Tasks retain the conservative unpublished-commit check and
+never use the merged-PR exception. Cleanup records a private administrative
+receipt before worktree removal and deletes the local branch with an
+expected-head compare-and-swap, so a partial failure remains retryable.
+Cleanup remains Main-owned and approval-gated; no raw cleanup authority is
+added.
+
 `agent::task-start` uses the same guarded default-branch synchronization at
 execution time before creating a branch/worktree, so it does not trust a stale
 remote-tracking ref even if the default branch advanced after finalization.

--- a/components/agent-core/.automation/bin/task_lifecycle.py
+++ b/components/agent-core/.automation/bin/task_lifecycle.py
@@ -1013,7 +1013,7 @@ def remote_branch_head(record: WorktreeRecord) -> str | None:
     return lines[0][0].lower()
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def unpushed_commits_from_base(record: WorktreeRecord, base_revision: str) -> int:
     assert record.branch is not None
     remote_head = remote_branch_head(record)
     if remote_head is not None:
@@ -1021,10 +1021,6 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
             "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
-
-    base_revision = extract_identity_value(state, "Base revision")
-    if not base_revision:
-        raise LifecycleError("Task State is missing Base revision")
     count = git(
         "rev-list",
         "--count",
@@ -1032,6 +1028,27 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
         cwd=record.path,
     )
     return int(count or "0")
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    base_revision = extract_identity_value(state, "Base revision")
+    if not base_revision:
+        raise LifecycleError("Task State is missing Base revision")
+    return unpushed_commits_from_base(record, base_revision)
+
+
+def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
+    if not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision):
+        raise LifecycleError("cleanup refused: Task Base revision is missing or invalid")
+    result = run(
+        ["git", "merge-base", "--is-ancestor", base_revision, default_branch(root)],
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError(
+            "cleanup refused: Task Base revision is not trusted default-branch history"
+        )
 
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
@@ -1182,13 +1199,22 @@ def cleanup_plan(root: Path, task: str) -> dict:
     if status == "merged":
         evidence = merged_cleanup_evidence(root, record, state, local_head)
     else:
-        ahead = unpushed_commits(record, state)
+        base_revision = extract_identity_value(state, "Base revision")
+        if not base_revision:
+            raise LifecycleError("Task State Base revision is missing or invalid")
+        base_revision = base_revision.lower()
+        require_cleanup_base_revision(root, base_revision)
+        ahead = unpushed_commits_from_base(record, base_revision)
         if ahead:
             raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
         repository = cleanup_repository(root)
         if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
-        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+        evidence = {
+            "repository": repository,
+            "upstream": "cancelled-safe",
+            "base_revision": base_revision,
+        }
     return {
         "schema_version": 1,
         "task": task,
@@ -1219,6 +1245,15 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
         or not isinstance(value.get("local_head"), str)
         or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
         or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    evidence = value["evidence"]
+    if value["status"] == "cancelled" and (
+        set(evidence) != {"repository", "upstream", "base_revision"}
+        or not isinstance(evidence.get("repository"), str)
+        or evidence.get("upstream") != "cancelled-safe"
+        or not isinstance(evidence.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", evidence["base_revision"])
     ):
         raise LifecycleError("cleanup receipt is invalid")
     return value
@@ -1266,6 +1301,19 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
             remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
             if remote_head is not None and remote_head != expected_head:
                 raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        else:
+            require_cleanup_base_revision(root, plan["evidence"]["base_revision"])
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
+                raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+            record = WorktreeRecord(root, branch, expected_head)
+            ahead = unpushed_commits_from_base(record, plan["evidence"]["base_revision"])
+            if ahead:
+                raise LifecycleError(
+                    f"cleanup refused: cancelled Task branch has {ahead} unpublished commit(s)"
+                )
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")

--- a/components/agent-core/.automation/bin/task_lifecycle.py
+++ b/components/agent-core/.automation/bin/task_lifecycle.py
@@ -981,21 +981,44 @@ def extract_identity_value(path: Path, label: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def remote_branch_head(record: WorktreeRecord) -> str | None:
+    """Resolve the live origin branch, distinguishing deletion from failures."""
     assert record.branch is not None
-    upstream = git(
-        "rev-parse",
-        "--abbrev-ref",
-        f"{record.branch}@{{upstream}}",
+    result = run(
+        [
+            "git",
+            "ls-remote",
+            "--exit-code",
+            "--heads",
+            "origin",
+            f"refs/heads/{record.branch}",
+        ],
         cwd=record.path,
         check=False,
     )
-    if upstream:
+    if result.returncode == 2 and not result.stdout.strip():
+        return None
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise LifecycleError(f"cleanup refused: cannot inspect live Task branch: {detail}")
+    lines = [line.split() for line in result.stdout.splitlines() if line.strip()]
+    expected_ref = f"refs/heads/{record.branch}"
+    if (
+        len(lines) != 1
+        or len(lines[0]) != 2
+        or lines[0][1] != expected_ref
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", lines[0][0])
+    ):
+        raise LifecycleError("cleanup refused: live Task branch response is invalid or ambiguous")
+    return lines[0][0].lower()
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    assert record.branch is not None
+    remote_head = remote_branch_head(record)
+    if remote_head is not None:
         count = git(
-            "rev-list",
-            "--count",
-            f"{upstream}..{record.branch}",
-            cwd=record.path,
+            "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
 
@@ -1011,8 +1034,135 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
     return int(count or "0")
 
 
-def task_cleanup(root: Path, task: str) -> None:
-    require_main_worktree(root)
+def cleanup_receipt_path(root: Path, task: str) -> Path:
+    validate_task(task)
+    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    path = common_git_dir(root) / "opencode" / "cleanup.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def cleanup_repository(root: Path) -> str:
+    result = gh("repo", "view", "--json", "nameWithOwner", cwd=root, check=False)
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot resolve GitHub repository identity")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid") from exc
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
+    ):
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid")
+    return repository
+
+
+def cleanup_prs(root: Path, branch: str, repository: str) -> list[dict]:
+    owner = repository.split("/", 1)[0]
+    result = gh(
+        "api",
+        "--method",
+        "GET",
+        "--paginate",
+        "--slurp",
+        f"repos/{repository}/pulls",
+        "-f",
+        "state=all",
+        "-f",
+        f"head={owner}:{branch}",
+        "-f",
+        "per_page=100",
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot reconstruct GitHub pull request evidence")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid") from exc
+    if not isinstance(value, list) or any(not isinstance(page, list) for page in value):
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+    matches = []
+    for item in (entry for page in value for entry in page):
+        if not isinstance(item, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        head = item.get("head")
+        base = item.get("base")
+        head_repo = head.get("repo") if isinstance(head, dict) else None
+        if not isinstance(head, dict) or not isinstance(base, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        if head.get("ref") != branch:
+            continue
+        matches.append(
+            {
+                "number": item.get("number"),
+                "state": "MERGED" if item.get("merged_at") else str(item.get("state", "")).upper(),
+                "headRefName": head.get("ref"),
+                "headRefOid": head.get("sha"),
+                "baseRefName": base.get("ref"),
+                "isCrossRepository": not isinstance(head_repo, dict)
+                or str(head_repo.get("full_name", "")).casefold() != repository.casefold(),
+                "mergeCommit": {"oid": item.get("merge_commit_sha")},
+            }
+        )
+    return matches
+
+
+def merged_cleanup_evidence(
+    root: Path, record: WorktreeRecord, state: Path, local_head: str
+) -> dict:
+    assert record.branch is not None
+    repository = cleanup_repository(root)
+    matches = cleanup_prs(root, record.branch, repository)
+    if len(matches) != 1:
+        raise LifecycleError("cleanup refused: merged Task pull request identity is missing or ambiguous")
+    pr = matches[0]
+    published_head = pr.get("headRefOid")
+    if (
+        pr.get("state") != "MERGED"
+        or pr.get("headRefName") != record.branch
+        or pr.get("baseRefName") != default_branch(root)
+        or pr.get("isCrossRepository") is not False
+        or not isinstance(pr.get("number"), int)
+        or not isinstance(published_head, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", published_head)
+    ):
+        raise LifecycleError("cleanup refused: merged pull request evidence does not match the Task")
+    published_head = published_head.lower()
+    if local_head.lower() != published_head:
+        raise LifecycleError("cleanup refused: local Task head does not match published PR head")
+    ahead = git(
+        "rev-list", "--count", f"{published_head}..{record.branch}", cwd=record.path
+    )
+    if int(ahead or "0") != 0:
+        raise LifecycleError("cleanup refused: local Task branch is ahead of published PR head")
+    recorded = extract_identity_value(state, "Published head SHA")
+    if recorded and recorded.casefold() != "none":
+        if not re.fullmatch(r"[0-9a-fA-F]{40,64}", recorded) or recorded.lower() != published_head:
+            raise LifecycleError("cleanup refused: Task State published head does not match GitHub")
+    remote_head = remote_branch_head(record)
+    if remote_head is not None and remote_head != published_head:
+        raise LifecycleError("cleanup refused: live remote Task branch does not match published PR head")
+    return {
+        "repository": repository,
+        "pr": pr["number"],
+        "published_head": published_head,
+        "upstream": "deleted" if remote_head is None else "live",
+    }
+
+
+def cleanup_plan(root: Path, task: str) -> dict:
     record = worktree_for_task(root, task)
     assert_task_identity(record, task)
     state = state_path(record.path)
@@ -1021,45 +1171,127 @@ def task_cleanup(root: Path, task: str) -> None:
         raise LifecycleError(
             f"cleanup refused while Task status is {status}; expected one of {sorted(TERMINAL_STATES)}"
         )
-    if git("status", "--porcelain", cwd=record.path):
+    if git("status", "--porcelain", "--untracked-files=all", cwd=record.path):
         raise LifecycleError("cleanup refused: Task worktree has uncommitted changes")
-    ahead = unpushed_commits(record, state)
-    if ahead:
-        raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
-
     branch = record.branch
     assert branch is not None
-    pr_result = run(
-        ["gh", "pr", "view", branch, "--json", "state,headRefName,headRefOid"],
-        cwd=record.path,
-        check=False,
-    )
+    local_head = git("rev-parse", "--verify", f"refs/heads/{branch}", cwd=record.path).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise LifecycleError("cleanup refused: registered Task head changed")
+    evidence: dict = {}
     if status == "merged":
-        if pr_result.returncode != 0:
-            raise LifecycleError("cleanup refused: merged Task has no resolvable pull request")
-        data = json.loads(pr_result.stdout)
-        if data.get("state") != "MERGED" or data.get("headRefName") != branch:
-            raise LifecycleError(
-                "cleanup refused: Task pull request is not merged for the expected branch"
-            )
-    elif pr_result.returncode == 0:
-        data = json.loads(pr_result.stdout)
-        if data.get("state") == "OPEN":
+        evidence = merged_cleanup_evidence(root, record, state, local_head)
+    else:
+        ahead = unpushed_commits(record, state)
+        if ahead:
+            raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
+        repository = cleanup_repository(root)
+        if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+    return {
+        "schema_version": 1,
+        "task": task,
+        "status": status,
+        "worktree": str(record.path),
+        "branch": branch,
+        "local_head": local_head,
+        "evidence": evidence,
+    }
 
-    removed_path = str(record.path)
-    run(["git", "worktree", "remove", str(record.path)], cwd=root)
-    run(["git", "branch", "-D", branch], cwd=root)
+
+def read_cleanup_receipt(path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise LifecycleError("cleanup receipt is not a regular local file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LifecycleError("cleanup receipt is invalid") from exc
+    required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != 1
+        or value.get("task") != task
+        or value.get("status") not in TERMINAL_STATES
+        or not isinstance(value.get("worktree"), str)
+        or not branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    return value
+
+
+def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+    records = parse_worktrees(root)
+    registered = [r for r in records if r.path == expected_path or r.branch == branch]
+    if registered:
+        if len(registered) != 1 or registered[0].path != expected_path or registered[0].branch != branch:
+            raise LifecycleError("cleanup receipt conflicts with current worktree registration")
+        current = cleanup_plan(root, task)
+        if current != plan:
+            raise LifecycleError("cleanup evidence changed before worktree removal")
+        run(["git", "worktree", "remove", str(expected_path)], cwd=root)
+    if any(r.path == expected_path or r.branch == branch for r in parse_worktrees(root)):
+        raise LifecycleError("cleanup failed to remove the expected worktree registration")
+
+    branch_ref = f"refs/heads/{branch}"
+    actual = git("rev-parse", "--verify", branch_ref, cwd=root, check=False).lower()
+    if actual:
+        if actual != expected_head:
+            raise LifecycleError("cleanup refused: local Task branch moved after validation")
+        if plan["status"] == "merged":
+            # Reconstruct the externally authoritative evidence again after
+            # Task State/worktree removal, using the receipt-bound identity.
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            matches = cleanup_prs(root, branch, repository)
+            if (
+                len(matches) != 1
+                or matches[0].get("state") != "MERGED"
+                or matches[0].get("headRefOid", "").lower() != expected_head
+                or matches[0].get("headRefName") != branch
+                or matches[0].get("baseRefName") != default_branch(root)
+                or matches[0].get("isCrossRepository") is not False
+                or matches[0].get("number") != plan["evidence"].get("pr")
+            ):
+                raise LifecycleError("cleanup merged PR evidence changed after worktree removal")
+            remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
+            if remote_head is not None and remote_head != expected_head:
+                raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
+    if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
+        raise LifecycleError("cleanup failed to delete the expected local Task branch")
+    receipt.unlink(missing_ok=True)
     print(
         json.dumps(
             {
                 "task": task,
-                "removedWorktree": removed_path,
+                "removedWorktree": str(expected_path),
                 "removedBranch": branch,
                 "taskStateDiscarded": True,
             }
         )
     )
+
+
+def task_cleanup(root: Path, task: str) -> None:
+    require_main_worktree(root)
+    receipt = cleanup_receipt_path(root, task)
+    with cleanup_lock(root):
+        if receipt.exists():
+            finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
+            return
+        plan = cleanup_plan(root, task)
+        atomic_json(receipt, plan)
+        finish_cleanup(root, plan, receipt)
 
 
 def extract_list(path: Path, heading: str) -> list[str]:

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -51,6 +51,19 @@ integration-pending -> PR merge -> guarded finalize -> merged
   -> approval-gated cleanup -> dependency re-evaluation -> next Task
 ```
 
+For a merged Task, cleanup reconstructs safety from the unique same-repository
+merged PR: its branch and `headRefOid` must match the registered clean local
+Task branch exactly, and the local branch must contain no later commit. A live
+origin Task branch must have that same OID. A deleted origin branch is accepted
+only after those merged-PR checks, which allows a finalized Task such as
+AgentKnowledgeVault #12 to retry normal cleanup without recreating a remote
+branch. Cancelled Tasks retain the conservative unpublished-commit check and
+never use the merged-PR exception. Cleanup records a private administrative
+receipt before worktree removal and deletes the local branch with an
+expected-head compare-and-swap, so a partial failure remains retryable.
+Cleanup remains Main-owned and approval-gated; no raw cleanup authority is
+added.
+
 `agent::task-start` uses the same guarded default-branch synchronization at
 execution time before creating a branch/worktree, so it does not trust a stale
 remote-tracking ref even if the default branch advanced after finalization.

--- a/templates/agent-base/.automation/bin/task_lifecycle.py
+++ b/templates/agent-base/.automation/bin/task_lifecycle.py
@@ -1013,7 +1013,7 @@ def remote_branch_head(record: WorktreeRecord) -> str | None:
     return lines[0][0].lower()
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def unpushed_commits_from_base(record: WorktreeRecord, base_revision: str) -> int:
     assert record.branch is not None
     remote_head = remote_branch_head(record)
     if remote_head is not None:
@@ -1021,10 +1021,6 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
             "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
-
-    base_revision = extract_identity_value(state, "Base revision")
-    if not base_revision:
-        raise LifecycleError("Task State is missing Base revision")
     count = git(
         "rev-list",
         "--count",
@@ -1032,6 +1028,27 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
         cwd=record.path,
     )
     return int(count or "0")
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    base_revision = extract_identity_value(state, "Base revision")
+    if not base_revision:
+        raise LifecycleError("Task State is missing Base revision")
+    return unpushed_commits_from_base(record, base_revision)
+
+
+def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
+    if not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision):
+        raise LifecycleError("cleanup refused: Task Base revision is missing or invalid")
+    result = run(
+        ["git", "merge-base", "--is-ancestor", base_revision, default_branch(root)],
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError(
+            "cleanup refused: Task Base revision is not trusted default-branch history"
+        )
 
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
@@ -1182,13 +1199,22 @@ def cleanup_plan(root: Path, task: str) -> dict:
     if status == "merged":
         evidence = merged_cleanup_evidence(root, record, state, local_head)
     else:
-        ahead = unpushed_commits(record, state)
+        base_revision = extract_identity_value(state, "Base revision")
+        if not base_revision:
+            raise LifecycleError("Task State Base revision is missing or invalid")
+        base_revision = base_revision.lower()
+        require_cleanup_base_revision(root, base_revision)
+        ahead = unpushed_commits_from_base(record, base_revision)
         if ahead:
             raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
         repository = cleanup_repository(root)
         if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
-        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+        evidence = {
+            "repository": repository,
+            "upstream": "cancelled-safe",
+            "base_revision": base_revision,
+        }
     return {
         "schema_version": 1,
         "task": task,
@@ -1219,6 +1245,15 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
         or not isinstance(value.get("local_head"), str)
         or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
         or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    evidence = value["evidence"]
+    if value["status"] == "cancelled" and (
+        set(evidence) != {"repository", "upstream", "base_revision"}
+        or not isinstance(evidence.get("repository"), str)
+        or evidence.get("upstream") != "cancelled-safe"
+        or not isinstance(evidence.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", evidence["base_revision"])
     ):
         raise LifecycleError("cleanup receipt is invalid")
     return value
@@ -1266,6 +1301,19 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
             remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
             if remote_head is not None and remote_head != expected_head:
                 raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        else:
+            require_cleanup_base_revision(root, plan["evidence"]["base_revision"])
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
+                raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+            record = WorktreeRecord(root, branch, expected_head)
+            ahead = unpushed_commits_from_base(record, plan["evidence"]["base_revision"])
+            if ahead:
+                raise LifecycleError(
+                    f"cleanup refused: cancelled Task branch has {ahead} unpublished commit(s)"
+                )
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")

--- a/templates/agent-base/.automation/bin/task_lifecycle.py
+++ b/templates/agent-base/.automation/bin/task_lifecycle.py
@@ -981,21 +981,44 @@ def extract_identity_value(path: Path, label: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def remote_branch_head(record: WorktreeRecord) -> str | None:
+    """Resolve the live origin branch, distinguishing deletion from failures."""
     assert record.branch is not None
-    upstream = git(
-        "rev-parse",
-        "--abbrev-ref",
-        f"{record.branch}@{{upstream}}",
+    result = run(
+        [
+            "git",
+            "ls-remote",
+            "--exit-code",
+            "--heads",
+            "origin",
+            f"refs/heads/{record.branch}",
+        ],
         cwd=record.path,
         check=False,
     )
-    if upstream:
+    if result.returncode == 2 and not result.stdout.strip():
+        return None
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise LifecycleError(f"cleanup refused: cannot inspect live Task branch: {detail}")
+    lines = [line.split() for line in result.stdout.splitlines() if line.strip()]
+    expected_ref = f"refs/heads/{record.branch}"
+    if (
+        len(lines) != 1
+        or len(lines[0]) != 2
+        or lines[0][1] != expected_ref
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", lines[0][0])
+    ):
+        raise LifecycleError("cleanup refused: live Task branch response is invalid or ambiguous")
+    return lines[0][0].lower()
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    assert record.branch is not None
+    remote_head = remote_branch_head(record)
+    if remote_head is not None:
         count = git(
-            "rev-list",
-            "--count",
-            f"{upstream}..{record.branch}",
-            cwd=record.path,
+            "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
 
@@ -1011,8 +1034,135 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
     return int(count or "0")
 
 
-def task_cleanup(root: Path, task: str) -> None:
-    require_main_worktree(root)
+def cleanup_receipt_path(root: Path, task: str) -> Path:
+    validate_task(task)
+    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    path = common_git_dir(root) / "opencode" / "cleanup.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def cleanup_repository(root: Path) -> str:
+    result = gh("repo", "view", "--json", "nameWithOwner", cwd=root, check=False)
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot resolve GitHub repository identity")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid") from exc
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
+    ):
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid")
+    return repository
+
+
+def cleanup_prs(root: Path, branch: str, repository: str) -> list[dict]:
+    owner = repository.split("/", 1)[0]
+    result = gh(
+        "api",
+        "--method",
+        "GET",
+        "--paginate",
+        "--slurp",
+        f"repos/{repository}/pulls",
+        "-f",
+        "state=all",
+        "-f",
+        f"head={owner}:{branch}",
+        "-f",
+        "per_page=100",
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot reconstruct GitHub pull request evidence")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid") from exc
+    if not isinstance(value, list) or any(not isinstance(page, list) for page in value):
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+    matches = []
+    for item in (entry for page in value for entry in page):
+        if not isinstance(item, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        head = item.get("head")
+        base = item.get("base")
+        head_repo = head.get("repo") if isinstance(head, dict) else None
+        if not isinstance(head, dict) or not isinstance(base, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        if head.get("ref") != branch:
+            continue
+        matches.append(
+            {
+                "number": item.get("number"),
+                "state": "MERGED" if item.get("merged_at") else str(item.get("state", "")).upper(),
+                "headRefName": head.get("ref"),
+                "headRefOid": head.get("sha"),
+                "baseRefName": base.get("ref"),
+                "isCrossRepository": not isinstance(head_repo, dict)
+                or str(head_repo.get("full_name", "")).casefold() != repository.casefold(),
+                "mergeCommit": {"oid": item.get("merge_commit_sha")},
+            }
+        )
+    return matches
+
+
+def merged_cleanup_evidence(
+    root: Path, record: WorktreeRecord, state: Path, local_head: str
+) -> dict:
+    assert record.branch is not None
+    repository = cleanup_repository(root)
+    matches = cleanup_prs(root, record.branch, repository)
+    if len(matches) != 1:
+        raise LifecycleError("cleanup refused: merged Task pull request identity is missing or ambiguous")
+    pr = matches[0]
+    published_head = pr.get("headRefOid")
+    if (
+        pr.get("state") != "MERGED"
+        or pr.get("headRefName") != record.branch
+        or pr.get("baseRefName") != default_branch(root)
+        or pr.get("isCrossRepository") is not False
+        or not isinstance(pr.get("number"), int)
+        or not isinstance(published_head, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", published_head)
+    ):
+        raise LifecycleError("cleanup refused: merged pull request evidence does not match the Task")
+    published_head = published_head.lower()
+    if local_head.lower() != published_head:
+        raise LifecycleError("cleanup refused: local Task head does not match published PR head")
+    ahead = git(
+        "rev-list", "--count", f"{published_head}..{record.branch}", cwd=record.path
+    )
+    if int(ahead or "0") != 0:
+        raise LifecycleError("cleanup refused: local Task branch is ahead of published PR head")
+    recorded = extract_identity_value(state, "Published head SHA")
+    if recorded and recorded.casefold() != "none":
+        if not re.fullmatch(r"[0-9a-fA-F]{40,64}", recorded) or recorded.lower() != published_head:
+            raise LifecycleError("cleanup refused: Task State published head does not match GitHub")
+    remote_head = remote_branch_head(record)
+    if remote_head is not None and remote_head != published_head:
+        raise LifecycleError("cleanup refused: live remote Task branch does not match published PR head")
+    return {
+        "repository": repository,
+        "pr": pr["number"],
+        "published_head": published_head,
+        "upstream": "deleted" if remote_head is None else "live",
+    }
+
+
+def cleanup_plan(root: Path, task: str) -> dict:
     record = worktree_for_task(root, task)
     assert_task_identity(record, task)
     state = state_path(record.path)
@@ -1021,45 +1171,127 @@ def task_cleanup(root: Path, task: str) -> None:
         raise LifecycleError(
             f"cleanup refused while Task status is {status}; expected one of {sorted(TERMINAL_STATES)}"
         )
-    if git("status", "--porcelain", cwd=record.path):
+    if git("status", "--porcelain", "--untracked-files=all", cwd=record.path):
         raise LifecycleError("cleanup refused: Task worktree has uncommitted changes")
-    ahead = unpushed_commits(record, state)
-    if ahead:
-        raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
-
     branch = record.branch
     assert branch is not None
-    pr_result = run(
-        ["gh", "pr", "view", branch, "--json", "state,headRefName,headRefOid"],
-        cwd=record.path,
-        check=False,
-    )
+    local_head = git("rev-parse", "--verify", f"refs/heads/{branch}", cwd=record.path).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise LifecycleError("cleanup refused: registered Task head changed")
+    evidence: dict = {}
     if status == "merged":
-        if pr_result.returncode != 0:
-            raise LifecycleError("cleanup refused: merged Task has no resolvable pull request")
-        data = json.loads(pr_result.stdout)
-        if data.get("state") != "MERGED" or data.get("headRefName") != branch:
-            raise LifecycleError(
-                "cleanup refused: Task pull request is not merged for the expected branch"
-            )
-    elif pr_result.returncode == 0:
-        data = json.loads(pr_result.stdout)
-        if data.get("state") == "OPEN":
+        evidence = merged_cleanup_evidence(root, record, state, local_head)
+    else:
+        ahead = unpushed_commits(record, state)
+        if ahead:
+            raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
+        repository = cleanup_repository(root)
+        if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+    return {
+        "schema_version": 1,
+        "task": task,
+        "status": status,
+        "worktree": str(record.path),
+        "branch": branch,
+        "local_head": local_head,
+        "evidence": evidence,
+    }
 
-    removed_path = str(record.path)
-    run(["git", "worktree", "remove", str(record.path)], cwd=root)
-    run(["git", "branch", "-D", branch], cwd=root)
+
+def read_cleanup_receipt(path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise LifecycleError("cleanup receipt is not a regular local file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LifecycleError("cleanup receipt is invalid") from exc
+    required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != 1
+        or value.get("task") != task
+        or value.get("status") not in TERMINAL_STATES
+        or not isinstance(value.get("worktree"), str)
+        or not branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    return value
+
+
+def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+    records = parse_worktrees(root)
+    registered = [r for r in records if r.path == expected_path or r.branch == branch]
+    if registered:
+        if len(registered) != 1 or registered[0].path != expected_path or registered[0].branch != branch:
+            raise LifecycleError("cleanup receipt conflicts with current worktree registration")
+        current = cleanup_plan(root, task)
+        if current != plan:
+            raise LifecycleError("cleanup evidence changed before worktree removal")
+        run(["git", "worktree", "remove", str(expected_path)], cwd=root)
+    if any(r.path == expected_path or r.branch == branch for r in parse_worktrees(root)):
+        raise LifecycleError("cleanup failed to remove the expected worktree registration")
+
+    branch_ref = f"refs/heads/{branch}"
+    actual = git("rev-parse", "--verify", branch_ref, cwd=root, check=False).lower()
+    if actual:
+        if actual != expected_head:
+            raise LifecycleError("cleanup refused: local Task branch moved after validation")
+        if plan["status"] == "merged":
+            # Reconstruct the externally authoritative evidence again after
+            # Task State/worktree removal, using the receipt-bound identity.
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            matches = cleanup_prs(root, branch, repository)
+            if (
+                len(matches) != 1
+                or matches[0].get("state") != "MERGED"
+                or matches[0].get("headRefOid", "").lower() != expected_head
+                or matches[0].get("headRefName") != branch
+                or matches[0].get("baseRefName") != default_branch(root)
+                or matches[0].get("isCrossRepository") is not False
+                or matches[0].get("number") != plan["evidence"].get("pr")
+            ):
+                raise LifecycleError("cleanup merged PR evidence changed after worktree removal")
+            remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
+            if remote_head is not None and remote_head != expected_head:
+                raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
+    if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
+        raise LifecycleError("cleanup failed to delete the expected local Task branch")
+    receipt.unlink(missing_ok=True)
     print(
         json.dumps(
             {
                 "task": task,
-                "removedWorktree": removed_path,
+                "removedWorktree": str(expected_path),
                 "removedBranch": branch,
                 "taskStateDiscarded": True,
             }
         )
     )
+
+
+def task_cleanup(root: Path, task: str) -> None:
+    require_main_worktree(root)
+    receipt = cleanup_receipt_path(root, task)
+    with cleanup_lock(root):
+        if receipt.exists():
+            finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
+            return
+        plan = cleanup_plan(root, task)
+        atomic_json(receipt, plan)
+        finish_cleanup(root, plan, receipt)
 
 
 def extract_list(path: Path, heading: str) -> list[str]:

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -51,6 +51,19 @@ integration-pending -> PR merge -> guarded finalize -> merged
   -> approval-gated cleanup -> dependency re-evaluation -> next Task
 ```
 
+For a merged Task, cleanup reconstructs safety from the unique same-repository
+merged PR: its branch and `headRefOid` must match the registered clean local
+Task branch exactly, and the local branch must contain no later commit. A live
+origin Task branch must have that same OID. A deleted origin branch is accepted
+only after those merged-PR checks, which allows a finalized Task such as
+AgentKnowledgeVault #12 to retry normal cleanup without recreating a remote
+branch. Cancelled Tasks retain the conservative unpublished-commit check and
+never use the merged-PR exception. Cleanup records a private administrative
+receipt before worktree removal and deletes the local branch with an
+expected-head compare-and-swap, so a partial failure remains retryable.
+Cleanup remains Main-owned and approval-gated; no raw cleanup authority is
+added.
+
 `agent::task-start` uses the same guarded default-branch synchronization at
 execution time before creating a branch/worktree, so it does not trust a stale
 remote-tracking ref even if the default branch advanced after finalization.

--- a/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
+++ b/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
@@ -1013,7 +1013,7 @@ def remote_branch_head(record: WorktreeRecord) -> str | None:
     return lines[0][0].lower()
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def unpushed_commits_from_base(record: WorktreeRecord, base_revision: str) -> int:
     assert record.branch is not None
     remote_head = remote_branch_head(record)
     if remote_head is not None:
@@ -1021,10 +1021,6 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
             "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
-
-    base_revision = extract_identity_value(state, "Base revision")
-    if not base_revision:
-        raise LifecycleError("Task State is missing Base revision")
     count = git(
         "rev-list",
         "--count",
@@ -1032,6 +1028,27 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
         cwd=record.path,
     )
     return int(count or "0")
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    base_revision = extract_identity_value(state, "Base revision")
+    if not base_revision:
+        raise LifecycleError("Task State is missing Base revision")
+    return unpushed_commits_from_base(record, base_revision)
+
+
+def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
+    if not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision):
+        raise LifecycleError("cleanup refused: Task Base revision is missing or invalid")
+    result = run(
+        ["git", "merge-base", "--is-ancestor", base_revision, default_branch(root)],
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError(
+            "cleanup refused: Task Base revision is not trusted default-branch history"
+        )
 
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
@@ -1182,13 +1199,22 @@ def cleanup_plan(root: Path, task: str) -> dict:
     if status == "merged":
         evidence = merged_cleanup_evidence(root, record, state, local_head)
     else:
-        ahead = unpushed_commits(record, state)
+        base_revision = extract_identity_value(state, "Base revision")
+        if not base_revision:
+            raise LifecycleError("Task State Base revision is missing or invalid")
+        base_revision = base_revision.lower()
+        require_cleanup_base_revision(root, base_revision)
+        ahead = unpushed_commits_from_base(record, base_revision)
         if ahead:
             raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
         repository = cleanup_repository(root)
         if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
-        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+        evidence = {
+            "repository": repository,
+            "upstream": "cancelled-safe",
+            "base_revision": base_revision,
+        }
     return {
         "schema_version": 1,
         "task": task,
@@ -1219,6 +1245,15 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
         or not isinstance(value.get("local_head"), str)
         or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
         or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    evidence = value["evidence"]
+    if value["status"] == "cancelled" and (
+        set(evidence) != {"repository", "upstream", "base_revision"}
+        or not isinstance(evidence.get("repository"), str)
+        or evidence.get("upstream") != "cancelled-safe"
+        or not isinstance(evidence.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", evidence["base_revision"])
     ):
         raise LifecycleError("cleanup receipt is invalid")
     return value
@@ -1266,6 +1301,19 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
             remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
             if remote_head is not None and remote_head != expected_head:
                 raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        else:
+            require_cleanup_base_revision(root, plan["evidence"]["base_revision"])
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
+                raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+            record = WorktreeRecord(root, branch, expected_head)
+            ahead = unpushed_commits_from_base(record, plan["evidence"]["base_revision"])
+            if ahead:
+                raise LifecycleError(
+                    f"cleanup refused: cancelled Task branch has {ahead} unpublished commit(s)"
+                )
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")

--- a/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
+++ b/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
@@ -981,21 +981,44 @@ def extract_identity_value(path: Path, label: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def remote_branch_head(record: WorktreeRecord) -> str | None:
+    """Resolve the live origin branch, distinguishing deletion from failures."""
     assert record.branch is not None
-    upstream = git(
-        "rev-parse",
-        "--abbrev-ref",
-        f"{record.branch}@{{upstream}}",
+    result = run(
+        [
+            "git",
+            "ls-remote",
+            "--exit-code",
+            "--heads",
+            "origin",
+            f"refs/heads/{record.branch}",
+        ],
         cwd=record.path,
         check=False,
     )
-    if upstream:
+    if result.returncode == 2 and not result.stdout.strip():
+        return None
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise LifecycleError(f"cleanup refused: cannot inspect live Task branch: {detail}")
+    lines = [line.split() for line in result.stdout.splitlines() if line.strip()]
+    expected_ref = f"refs/heads/{record.branch}"
+    if (
+        len(lines) != 1
+        or len(lines[0]) != 2
+        or lines[0][1] != expected_ref
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", lines[0][0])
+    ):
+        raise LifecycleError("cleanup refused: live Task branch response is invalid or ambiguous")
+    return lines[0][0].lower()
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    assert record.branch is not None
+    remote_head = remote_branch_head(record)
+    if remote_head is not None:
         count = git(
-            "rev-list",
-            "--count",
-            f"{upstream}..{record.branch}",
-            cwd=record.path,
+            "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
 
@@ -1011,8 +1034,135 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
     return int(count or "0")
 
 
-def task_cleanup(root: Path, task: str) -> None:
-    require_main_worktree(root)
+def cleanup_receipt_path(root: Path, task: str) -> Path:
+    validate_task(task)
+    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    path = common_git_dir(root) / "opencode" / "cleanup.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def cleanup_repository(root: Path) -> str:
+    result = gh("repo", "view", "--json", "nameWithOwner", cwd=root, check=False)
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot resolve GitHub repository identity")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid") from exc
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
+    ):
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid")
+    return repository
+
+
+def cleanup_prs(root: Path, branch: str, repository: str) -> list[dict]:
+    owner = repository.split("/", 1)[0]
+    result = gh(
+        "api",
+        "--method",
+        "GET",
+        "--paginate",
+        "--slurp",
+        f"repos/{repository}/pulls",
+        "-f",
+        "state=all",
+        "-f",
+        f"head={owner}:{branch}",
+        "-f",
+        "per_page=100",
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot reconstruct GitHub pull request evidence")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid") from exc
+    if not isinstance(value, list) or any(not isinstance(page, list) for page in value):
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+    matches = []
+    for item in (entry for page in value for entry in page):
+        if not isinstance(item, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        head = item.get("head")
+        base = item.get("base")
+        head_repo = head.get("repo") if isinstance(head, dict) else None
+        if not isinstance(head, dict) or not isinstance(base, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        if head.get("ref") != branch:
+            continue
+        matches.append(
+            {
+                "number": item.get("number"),
+                "state": "MERGED" if item.get("merged_at") else str(item.get("state", "")).upper(),
+                "headRefName": head.get("ref"),
+                "headRefOid": head.get("sha"),
+                "baseRefName": base.get("ref"),
+                "isCrossRepository": not isinstance(head_repo, dict)
+                or str(head_repo.get("full_name", "")).casefold() != repository.casefold(),
+                "mergeCommit": {"oid": item.get("merge_commit_sha")},
+            }
+        )
+    return matches
+
+
+def merged_cleanup_evidence(
+    root: Path, record: WorktreeRecord, state: Path, local_head: str
+) -> dict:
+    assert record.branch is not None
+    repository = cleanup_repository(root)
+    matches = cleanup_prs(root, record.branch, repository)
+    if len(matches) != 1:
+        raise LifecycleError("cleanup refused: merged Task pull request identity is missing or ambiguous")
+    pr = matches[0]
+    published_head = pr.get("headRefOid")
+    if (
+        pr.get("state") != "MERGED"
+        or pr.get("headRefName") != record.branch
+        or pr.get("baseRefName") != default_branch(root)
+        or pr.get("isCrossRepository") is not False
+        or not isinstance(pr.get("number"), int)
+        or not isinstance(published_head, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", published_head)
+    ):
+        raise LifecycleError("cleanup refused: merged pull request evidence does not match the Task")
+    published_head = published_head.lower()
+    if local_head.lower() != published_head:
+        raise LifecycleError("cleanup refused: local Task head does not match published PR head")
+    ahead = git(
+        "rev-list", "--count", f"{published_head}..{record.branch}", cwd=record.path
+    )
+    if int(ahead or "0") != 0:
+        raise LifecycleError("cleanup refused: local Task branch is ahead of published PR head")
+    recorded = extract_identity_value(state, "Published head SHA")
+    if recorded and recorded.casefold() != "none":
+        if not re.fullmatch(r"[0-9a-fA-F]{40,64}", recorded) or recorded.lower() != published_head:
+            raise LifecycleError("cleanup refused: Task State published head does not match GitHub")
+    remote_head = remote_branch_head(record)
+    if remote_head is not None and remote_head != published_head:
+        raise LifecycleError("cleanup refused: live remote Task branch does not match published PR head")
+    return {
+        "repository": repository,
+        "pr": pr["number"],
+        "published_head": published_head,
+        "upstream": "deleted" if remote_head is None else "live",
+    }
+
+
+def cleanup_plan(root: Path, task: str) -> dict:
     record = worktree_for_task(root, task)
     assert_task_identity(record, task)
     state = state_path(record.path)
@@ -1021,45 +1171,127 @@ def task_cleanup(root: Path, task: str) -> None:
         raise LifecycleError(
             f"cleanup refused while Task status is {status}; expected one of {sorted(TERMINAL_STATES)}"
         )
-    if git("status", "--porcelain", cwd=record.path):
+    if git("status", "--porcelain", "--untracked-files=all", cwd=record.path):
         raise LifecycleError("cleanup refused: Task worktree has uncommitted changes")
-    ahead = unpushed_commits(record, state)
-    if ahead:
-        raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
-
     branch = record.branch
     assert branch is not None
-    pr_result = run(
-        ["gh", "pr", "view", branch, "--json", "state,headRefName,headRefOid"],
-        cwd=record.path,
-        check=False,
-    )
+    local_head = git("rev-parse", "--verify", f"refs/heads/{branch}", cwd=record.path).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise LifecycleError("cleanup refused: registered Task head changed")
+    evidence: dict = {}
     if status == "merged":
-        if pr_result.returncode != 0:
-            raise LifecycleError("cleanup refused: merged Task has no resolvable pull request")
-        data = json.loads(pr_result.stdout)
-        if data.get("state") != "MERGED" or data.get("headRefName") != branch:
-            raise LifecycleError(
-                "cleanup refused: Task pull request is not merged for the expected branch"
-            )
-    elif pr_result.returncode == 0:
-        data = json.loads(pr_result.stdout)
-        if data.get("state") == "OPEN":
+        evidence = merged_cleanup_evidence(root, record, state, local_head)
+    else:
+        ahead = unpushed_commits(record, state)
+        if ahead:
+            raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
+        repository = cleanup_repository(root)
+        if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+    return {
+        "schema_version": 1,
+        "task": task,
+        "status": status,
+        "worktree": str(record.path),
+        "branch": branch,
+        "local_head": local_head,
+        "evidence": evidence,
+    }
 
-    removed_path = str(record.path)
-    run(["git", "worktree", "remove", str(record.path)], cwd=root)
-    run(["git", "branch", "-D", branch], cwd=root)
+
+def read_cleanup_receipt(path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise LifecycleError("cleanup receipt is not a regular local file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LifecycleError("cleanup receipt is invalid") from exc
+    required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != 1
+        or value.get("task") != task
+        or value.get("status") not in TERMINAL_STATES
+        or not isinstance(value.get("worktree"), str)
+        or not branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    return value
+
+
+def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+    records = parse_worktrees(root)
+    registered = [r for r in records if r.path == expected_path or r.branch == branch]
+    if registered:
+        if len(registered) != 1 or registered[0].path != expected_path or registered[0].branch != branch:
+            raise LifecycleError("cleanup receipt conflicts with current worktree registration")
+        current = cleanup_plan(root, task)
+        if current != plan:
+            raise LifecycleError("cleanup evidence changed before worktree removal")
+        run(["git", "worktree", "remove", str(expected_path)], cwd=root)
+    if any(r.path == expected_path or r.branch == branch for r in parse_worktrees(root)):
+        raise LifecycleError("cleanup failed to remove the expected worktree registration")
+
+    branch_ref = f"refs/heads/{branch}"
+    actual = git("rev-parse", "--verify", branch_ref, cwd=root, check=False).lower()
+    if actual:
+        if actual != expected_head:
+            raise LifecycleError("cleanup refused: local Task branch moved after validation")
+        if plan["status"] == "merged":
+            # Reconstruct the externally authoritative evidence again after
+            # Task State/worktree removal, using the receipt-bound identity.
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            matches = cleanup_prs(root, branch, repository)
+            if (
+                len(matches) != 1
+                or matches[0].get("state") != "MERGED"
+                or matches[0].get("headRefOid", "").lower() != expected_head
+                or matches[0].get("headRefName") != branch
+                or matches[0].get("baseRefName") != default_branch(root)
+                or matches[0].get("isCrossRepository") is not False
+                or matches[0].get("number") != plan["evidence"].get("pr")
+            ):
+                raise LifecycleError("cleanup merged PR evidence changed after worktree removal")
+            remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
+            if remote_head is not None and remote_head != expected_head:
+                raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
+    if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
+        raise LifecycleError("cleanup failed to delete the expected local Task branch")
+    receipt.unlink(missing_ok=True)
     print(
         json.dumps(
             {
                 "task": task,
-                "removedWorktree": removed_path,
+                "removedWorktree": str(expected_path),
                 "removedBranch": branch,
                 "taskStateDiscarded": True,
             }
         )
     )
+
+
+def task_cleanup(root: Path, task: str) -> None:
+    require_main_worktree(root)
+    receipt = cleanup_receipt_path(root, task)
+    with cleanup_lock(root):
+        if receipt.exists():
+            finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
+            return
+        plan = cleanup_plan(root, task)
+        atomic_json(receipt, plan)
+        finish_cleanup(root, plan, receipt)
 
 
 def extract_list(path: Path, heading: str) -> list[str]:

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -51,6 +51,19 @@ integration-pending -> PR merge -> guarded finalize -> merged
   -> approval-gated cleanup -> dependency re-evaluation -> next Task
 ```
 
+For a merged Task, cleanup reconstructs safety from the unique same-repository
+merged PR: its branch and `headRefOid` must match the registered clean local
+Task branch exactly, and the local branch must contain no later commit. A live
+origin Task branch must have that same OID. A deleted origin branch is accepted
+only after those merged-PR checks, which allows a finalized Task such as
+AgentKnowledgeVault #12 to retry normal cleanup without recreating a remote
+branch. Cancelled Tasks retain the conservative unpublished-commit check and
+never use the merged-PR exception. Cleanup records a private administrative
+receipt before worktree removal and deletes the local branch with an
+expected-head compare-and-swap, so a partial failure remains retryable.
+Cleanup remains Main-owned and approval-gated; no raw cleanup authority is
+added.
+
 `agent::task-start` uses the same guarded default-branch synchronization at
 execution time before creating a branch/worktree, so it does not trust a stale
 remote-tracking ref even if the default branch advanced after finalization.

--- a/templates/agent-nix/.automation/bin/task_lifecycle.py
+++ b/templates/agent-nix/.automation/bin/task_lifecycle.py
@@ -1013,7 +1013,7 @@ def remote_branch_head(record: WorktreeRecord) -> str | None:
     return lines[0][0].lower()
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def unpushed_commits_from_base(record: WorktreeRecord, base_revision: str) -> int:
     assert record.branch is not None
     remote_head = remote_branch_head(record)
     if remote_head is not None:
@@ -1021,10 +1021,6 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
             "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
-
-    base_revision = extract_identity_value(state, "Base revision")
-    if not base_revision:
-        raise LifecycleError("Task State is missing Base revision")
     count = git(
         "rev-list",
         "--count",
@@ -1032,6 +1028,27 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
         cwd=record.path,
     )
     return int(count or "0")
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    base_revision = extract_identity_value(state, "Base revision")
+    if not base_revision:
+        raise LifecycleError("Task State is missing Base revision")
+    return unpushed_commits_from_base(record, base_revision)
+
+
+def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
+    if not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision):
+        raise LifecycleError("cleanup refused: Task Base revision is missing or invalid")
+    result = run(
+        ["git", "merge-base", "--is-ancestor", base_revision, default_branch(root)],
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError(
+            "cleanup refused: Task Base revision is not trusted default-branch history"
+        )
 
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
@@ -1182,13 +1199,22 @@ def cleanup_plan(root: Path, task: str) -> dict:
     if status == "merged":
         evidence = merged_cleanup_evidence(root, record, state, local_head)
     else:
-        ahead = unpushed_commits(record, state)
+        base_revision = extract_identity_value(state, "Base revision")
+        if not base_revision:
+            raise LifecycleError("Task State Base revision is missing or invalid")
+        base_revision = base_revision.lower()
+        require_cleanup_base_revision(root, base_revision)
+        ahead = unpushed_commits_from_base(record, base_revision)
         if ahead:
             raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
         repository = cleanup_repository(root)
         if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
-        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+        evidence = {
+            "repository": repository,
+            "upstream": "cancelled-safe",
+            "base_revision": base_revision,
+        }
     return {
         "schema_version": 1,
         "task": task,
@@ -1219,6 +1245,15 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
         or not isinstance(value.get("local_head"), str)
         or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
         or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    evidence = value["evidence"]
+    if value["status"] == "cancelled" and (
+        set(evidence) != {"repository", "upstream", "base_revision"}
+        or not isinstance(evidence.get("repository"), str)
+        or evidence.get("upstream") != "cancelled-safe"
+        or not isinstance(evidence.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", evidence["base_revision"])
     ):
         raise LifecycleError("cleanup receipt is invalid")
     return value
@@ -1266,6 +1301,19 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
             remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
             if remote_head is not None and remote_head != expected_head:
                 raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        else:
+            require_cleanup_base_revision(root, plan["evidence"]["base_revision"])
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
+                raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+            record = WorktreeRecord(root, branch, expected_head)
+            ahead = unpushed_commits_from_base(record, plan["evidence"]["base_revision"])
+            if ahead:
+                raise LifecycleError(
+                    f"cleanup refused: cancelled Task branch has {ahead} unpublished commit(s)"
+                )
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")

--- a/templates/agent-nix/.automation/bin/task_lifecycle.py
+++ b/templates/agent-nix/.automation/bin/task_lifecycle.py
@@ -981,21 +981,44 @@ def extract_identity_value(path: Path, label: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def remote_branch_head(record: WorktreeRecord) -> str | None:
+    """Resolve the live origin branch, distinguishing deletion from failures."""
     assert record.branch is not None
-    upstream = git(
-        "rev-parse",
-        "--abbrev-ref",
-        f"{record.branch}@{{upstream}}",
+    result = run(
+        [
+            "git",
+            "ls-remote",
+            "--exit-code",
+            "--heads",
+            "origin",
+            f"refs/heads/{record.branch}",
+        ],
         cwd=record.path,
         check=False,
     )
-    if upstream:
+    if result.returncode == 2 and not result.stdout.strip():
+        return None
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise LifecycleError(f"cleanup refused: cannot inspect live Task branch: {detail}")
+    lines = [line.split() for line in result.stdout.splitlines() if line.strip()]
+    expected_ref = f"refs/heads/{record.branch}"
+    if (
+        len(lines) != 1
+        or len(lines[0]) != 2
+        or lines[0][1] != expected_ref
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", lines[0][0])
+    ):
+        raise LifecycleError("cleanup refused: live Task branch response is invalid or ambiguous")
+    return lines[0][0].lower()
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    assert record.branch is not None
+    remote_head = remote_branch_head(record)
+    if remote_head is not None:
         count = git(
-            "rev-list",
-            "--count",
-            f"{upstream}..{record.branch}",
-            cwd=record.path,
+            "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
 
@@ -1011,8 +1034,135 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
     return int(count or "0")
 
 
-def task_cleanup(root: Path, task: str) -> None:
-    require_main_worktree(root)
+def cleanup_receipt_path(root: Path, task: str) -> Path:
+    validate_task(task)
+    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    path = common_git_dir(root) / "opencode" / "cleanup.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def cleanup_repository(root: Path) -> str:
+    result = gh("repo", "view", "--json", "nameWithOwner", cwd=root, check=False)
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot resolve GitHub repository identity")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid") from exc
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
+    ):
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid")
+    return repository
+
+
+def cleanup_prs(root: Path, branch: str, repository: str) -> list[dict]:
+    owner = repository.split("/", 1)[0]
+    result = gh(
+        "api",
+        "--method",
+        "GET",
+        "--paginate",
+        "--slurp",
+        f"repos/{repository}/pulls",
+        "-f",
+        "state=all",
+        "-f",
+        f"head={owner}:{branch}",
+        "-f",
+        "per_page=100",
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot reconstruct GitHub pull request evidence")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid") from exc
+    if not isinstance(value, list) or any(not isinstance(page, list) for page in value):
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+    matches = []
+    for item in (entry for page in value for entry in page):
+        if not isinstance(item, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        head = item.get("head")
+        base = item.get("base")
+        head_repo = head.get("repo") if isinstance(head, dict) else None
+        if not isinstance(head, dict) or not isinstance(base, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        if head.get("ref") != branch:
+            continue
+        matches.append(
+            {
+                "number": item.get("number"),
+                "state": "MERGED" if item.get("merged_at") else str(item.get("state", "")).upper(),
+                "headRefName": head.get("ref"),
+                "headRefOid": head.get("sha"),
+                "baseRefName": base.get("ref"),
+                "isCrossRepository": not isinstance(head_repo, dict)
+                or str(head_repo.get("full_name", "")).casefold() != repository.casefold(),
+                "mergeCommit": {"oid": item.get("merge_commit_sha")},
+            }
+        )
+    return matches
+
+
+def merged_cleanup_evidence(
+    root: Path, record: WorktreeRecord, state: Path, local_head: str
+) -> dict:
+    assert record.branch is not None
+    repository = cleanup_repository(root)
+    matches = cleanup_prs(root, record.branch, repository)
+    if len(matches) != 1:
+        raise LifecycleError("cleanup refused: merged Task pull request identity is missing or ambiguous")
+    pr = matches[0]
+    published_head = pr.get("headRefOid")
+    if (
+        pr.get("state") != "MERGED"
+        or pr.get("headRefName") != record.branch
+        or pr.get("baseRefName") != default_branch(root)
+        or pr.get("isCrossRepository") is not False
+        or not isinstance(pr.get("number"), int)
+        or not isinstance(published_head, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", published_head)
+    ):
+        raise LifecycleError("cleanup refused: merged pull request evidence does not match the Task")
+    published_head = published_head.lower()
+    if local_head.lower() != published_head:
+        raise LifecycleError("cleanup refused: local Task head does not match published PR head")
+    ahead = git(
+        "rev-list", "--count", f"{published_head}..{record.branch}", cwd=record.path
+    )
+    if int(ahead or "0") != 0:
+        raise LifecycleError("cleanup refused: local Task branch is ahead of published PR head")
+    recorded = extract_identity_value(state, "Published head SHA")
+    if recorded and recorded.casefold() != "none":
+        if not re.fullmatch(r"[0-9a-fA-F]{40,64}", recorded) or recorded.lower() != published_head:
+            raise LifecycleError("cleanup refused: Task State published head does not match GitHub")
+    remote_head = remote_branch_head(record)
+    if remote_head is not None and remote_head != published_head:
+        raise LifecycleError("cleanup refused: live remote Task branch does not match published PR head")
+    return {
+        "repository": repository,
+        "pr": pr["number"],
+        "published_head": published_head,
+        "upstream": "deleted" if remote_head is None else "live",
+    }
+
+
+def cleanup_plan(root: Path, task: str) -> dict:
     record = worktree_for_task(root, task)
     assert_task_identity(record, task)
     state = state_path(record.path)
@@ -1021,45 +1171,127 @@ def task_cleanup(root: Path, task: str) -> None:
         raise LifecycleError(
             f"cleanup refused while Task status is {status}; expected one of {sorted(TERMINAL_STATES)}"
         )
-    if git("status", "--porcelain", cwd=record.path):
+    if git("status", "--porcelain", "--untracked-files=all", cwd=record.path):
         raise LifecycleError("cleanup refused: Task worktree has uncommitted changes")
-    ahead = unpushed_commits(record, state)
-    if ahead:
-        raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
-
     branch = record.branch
     assert branch is not None
-    pr_result = run(
-        ["gh", "pr", "view", branch, "--json", "state,headRefName,headRefOid"],
-        cwd=record.path,
-        check=False,
-    )
+    local_head = git("rev-parse", "--verify", f"refs/heads/{branch}", cwd=record.path).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise LifecycleError("cleanup refused: registered Task head changed")
+    evidence: dict = {}
     if status == "merged":
-        if pr_result.returncode != 0:
-            raise LifecycleError("cleanup refused: merged Task has no resolvable pull request")
-        data = json.loads(pr_result.stdout)
-        if data.get("state") != "MERGED" or data.get("headRefName") != branch:
-            raise LifecycleError(
-                "cleanup refused: Task pull request is not merged for the expected branch"
-            )
-    elif pr_result.returncode == 0:
-        data = json.loads(pr_result.stdout)
-        if data.get("state") == "OPEN":
+        evidence = merged_cleanup_evidence(root, record, state, local_head)
+    else:
+        ahead = unpushed_commits(record, state)
+        if ahead:
+            raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
+        repository = cleanup_repository(root)
+        if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+    return {
+        "schema_version": 1,
+        "task": task,
+        "status": status,
+        "worktree": str(record.path),
+        "branch": branch,
+        "local_head": local_head,
+        "evidence": evidence,
+    }
 
-    removed_path = str(record.path)
-    run(["git", "worktree", "remove", str(record.path)], cwd=root)
-    run(["git", "branch", "-D", branch], cwd=root)
+
+def read_cleanup_receipt(path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise LifecycleError("cleanup receipt is not a regular local file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LifecycleError("cleanup receipt is invalid") from exc
+    required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != 1
+        or value.get("task") != task
+        or value.get("status") not in TERMINAL_STATES
+        or not isinstance(value.get("worktree"), str)
+        or not branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    return value
+
+
+def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+    records = parse_worktrees(root)
+    registered = [r for r in records if r.path == expected_path or r.branch == branch]
+    if registered:
+        if len(registered) != 1 or registered[0].path != expected_path or registered[0].branch != branch:
+            raise LifecycleError("cleanup receipt conflicts with current worktree registration")
+        current = cleanup_plan(root, task)
+        if current != plan:
+            raise LifecycleError("cleanup evidence changed before worktree removal")
+        run(["git", "worktree", "remove", str(expected_path)], cwd=root)
+    if any(r.path == expected_path or r.branch == branch for r in parse_worktrees(root)):
+        raise LifecycleError("cleanup failed to remove the expected worktree registration")
+
+    branch_ref = f"refs/heads/{branch}"
+    actual = git("rev-parse", "--verify", branch_ref, cwd=root, check=False).lower()
+    if actual:
+        if actual != expected_head:
+            raise LifecycleError("cleanup refused: local Task branch moved after validation")
+        if plan["status"] == "merged":
+            # Reconstruct the externally authoritative evidence again after
+            # Task State/worktree removal, using the receipt-bound identity.
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            matches = cleanup_prs(root, branch, repository)
+            if (
+                len(matches) != 1
+                or matches[0].get("state") != "MERGED"
+                or matches[0].get("headRefOid", "").lower() != expected_head
+                or matches[0].get("headRefName") != branch
+                or matches[0].get("baseRefName") != default_branch(root)
+                or matches[0].get("isCrossRepository") is not False
+                or matches[0].get("number") != plan["evidence"].get("pr")
+            ):
+                raise LifecycleError("cleanup merged PR evidence changed after worktree removal")
+            remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
+            if remote_head is not None and remote_head != expected_head:
+                raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
+    if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
+        raise LifecycleError("cleanup failed to delete the expected local Task branch")
+    receipt.unlink(missing_ok=True)
     print(
         json.dumps(
             {
                 "task": task,
-                "removedWorktree": removed_path,
+                "removedWorktree": str(expected_path),
                 "removedBranch": branch,
                 "taskStateDiscarded": True,
             }
         )
     )
+
+
+def task_cleanup(root: Path, task: str) -> None:
+    require_main_worktree(root)
+    receipt = cleanup_receipt_path(root, task)
+    with cleanup_lock(root):
+        if receipt.exists():
+            finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
+            return
+        plan = cleanup_plan(root, task)
+        atomic_json(receipt, plan)
+        finish_cleanup(root, plan, receipt)
 
 
 def extract_list(path: Path, heading: str) -> list[str]:

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -51,6 +51,19 @@ integration-pending -> PR merge -> guarded finalize -> merged
   -> approval-gated cleanup -> dependency re-evaluation -> next Task
 ```
 
+For a merged Task, cleanup reconstructs safety from the unique same-repository
+merged PR: its branch and `headRefOid` must match the registered clean local
+Task branch exactly, and the local branch must contain no later commit. A live
+origin Task branch must have that same OID. A deleted origin branch is accepted
+only after those merged-PR checks, which allows a finalized Task such as
+AgentKnowledgeVault #12 to retry normal cleanup without recreating a remote
+branch. Cancelled Tasks retain the conservative unpublished-commit check and
+never use the merged-PR exception. Cleanup records a private administrative
+receipt before worktree removal and deletes the local branch with an
+expected-head compare-and-swap, so a partial failure remains retryable.
+Cleanup remains Main-owned and approval-gated; no raw cleanup authority is
+added.
+
 `agent::task-start` uses the same guarded default-branch synchronization at
 execution time before creating a branch/worktree, so it does not trust a stale
 remote-tracking ref even if the default branch advanced after finalization.

--- a/templates/agent-python/.automation/bin/task_lifecycle.py
+++ b/templates/agent-python/.automation/bin/task_lifecycle.py
@@ -1013,7 +1013,7 @@ def remote_branch_head(record: WorktreeRecord) -> str | None:
     return lines[0][0].lower()
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def unpushed_commits_from_base(record: WorktreeRecord, base_revision: str) -> int:
     assert record.branch is not None
     remote_head = remote_branch_head(record)
     if remote_head is not None:
@@ -1021,10 +1021,6 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
             "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
-
-    base_revision = extract_identity_value(state, "Base revision")
-    if not base_revision:
-        raise LifecycleError("Task State is missing Base revision")
     count = git(
         "rev-list",
         "--count",
@@ -1032,6 +1028,27 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
         cwd=record.path,
     )
     return int(count or "0")
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    base_revision = extract_identity_value(state, "Base revision")
+    if not base_revision:
+        raise LifecycleError("Task State is missing Base revision")
+    return unpushed_commits_from_base(record, base_revision)
+
+
+def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
+    if not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision):
+        raise LifecycleError("cleanup refused: Task Base revision is missing or invalid")
+    result = run(
+        ["git", "merge-base", "--is-ancestor", base_revision, default_branch(root)],
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError(
+            "cleanup refused: Task Base revision is not trusted default-branch history"
+        )
 
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
@@ -1182,13 +1199,22 @@ def cleanup_plan(root: Path, task: str) -> dict:
     if status == "merged":
         evidence = merged_cleanup_evidence(root, record, state, local_head)
     else:
-        ahead = unpushed_commits(record, state)
+        base_revision = extract_identity_value(state, "Base revision")
+        if not base_revision:
+            raise LifecycleError("Task State Base revision is missing or invalid")
+        base_revision = base_revision.lower()
+        require_cleanup_base_revision(root, base_revision)
+        ahead = unpushed_commits_from_base(record, base_revision)
         if ahead:
             raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
         repository = cleanup_repository(root)
         if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
-        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+        evidence = {
+            "repository": repository,
+            "upstream": "cancelled-safe",
+            "base_revision": base_revision,
+        }
     return {
         "schema_version": 1,
         "task": task,
@@ -1219,6 +1245,15 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
         or not isinstance(value.get("local_head"), str)
         or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
         or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    evidence = value["evidence"]
+    if value["status"] == "cancelled" and (
+        set(evidence) != {"repository", "upstream", "base_revision"}
+        or not isinstance(evidence.get("repository"), str)
+        or evidence.get("upstream") != "cancelled-safe"
+        or not isinstance(evidence.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", evidence["base_revision"])
     ):
         raise LifecycleError("cleanup receipt is invalid")
     return value
@@ -1266,6 +1301,19 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
             remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
             if remote_head is not None and remote_head != expected_head:
                 raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        else:
+            require_cleanup_base_revision(root, plan["evidence"]["base_revision"])
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
+                raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+            record = WorktreeRecord(root, branch, expected_head)
+            ahead = unpushed_commits_from_base(record, plan["evidence"]["base_revision"])
+            if ahead:
+                raise LifecycleError(
+                    f"cleanup refused: cancelled Task branch has {ahead} unpublished commit(s)"
+                )
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")

--- a/templates/agent-python/.automation/bin/task_lifecycle.py
+++ b/templates/agent-python/.automation/bin/task_lifecycle.py
@@ -981,21 +981,44 @@ def extract_identity_value(path: Path, label: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def remote_branch_head(record: WorktreeRecord) -> str | None:
+    """Resolve the live origin branch, distinguishing deletion from failures."""
     assert record.branch is not None
-    upstream = git(
-        "rev-parse",
-        "--abbrev-ref",
-        f"{record.branch}@{{upstream}}",
+    result = run(
+        [
+            "git",
+            "ls-remote",
+            "--exit-code",
+            "--heads",
+            "origin",
+            f"refs/heads/{record.branch}",
+        ],
         cwd=record.path,
         check=False,
     )
-    if upstream:
+    if result.returncode == 2 and not result.stdout.strip():
+        return None
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise LifecycleError(f"cleanup refused: cannot inspect live Task branch: {detail}")
+    lines = [line.split() for line in result.stdout.splitlines() if line.strip()]
+    expected_ref = f"refs/heads/{record.branch}"
+    if (
+        len(lines) != 1
+        or len(lines[0]) != 2
+        or lines[0][1] != expected_ref
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", lines[0][0])
+    ):
+        raise LifecycleError("cleanup refused: live Task branch response is invalid or ambiguous")
+    return lines[0][0].lower()
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    assert record.branch is not None
+    remote_head = remote_branch_head(record)
+    if remote_head is not None:
         count = git(
-            "rev-list",
-            "--count",
-            f"{upstream}..{record.branch}",
-            cwd=record.path,
+            "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
 
@@ -1011,8 +1034,135 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
     return int(count or "0")
 
 
-def task_cleanup(root: Path, task: str) -> None:
-    require_main_worktree(root)
+def cleanup_receipt_path(root: Path, task: str) -> Path:
+    validate_task(task)
+    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    path = common_git_dir(root) / "opencode" / "cleanup.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def cleanup_repository(root: Path) -> str:
+    result = gh("repo", "view", "--json", "nameWithOwner", cwd=root, check=False)
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot resolve GitHub repository identity")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid") from exc
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
+    ):
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid")
+    return repository
+
+
+def cleanup_prs(root: Path, branch: str, repository: str) -> list[dict]:
+    owner = repository.split("/", 1)[0]
+    result = gh(
+        "api",
+        "--method",
+        "GET",
+        "--paginate",
+        "--slurp",
+        f"repos/{repository}/pulls",
+        "-f",
+        "state=all",
+        "-f",
+        f"head={owner}:{branch}",
+        "-f",
+        "per_page=100",
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot reconstruct GitHub pull request evidence")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid") from exc
+    if not isinstance(value, list) or any(not isinstance(page, list) for page in value):
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+    matches = []
+    for item in (entry for page in value for entry in page):
+        if not isinstance(item, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        head = item.get("head")
+        base = item.get("base")
+        head_repo = head.get("repo") if isinstance(head, dict) else None
+        if not isinstance(head, dict) or not isinstance(base, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        if head.get("ref") != branch:
+            continue
+        matches.append(
+            {
+                "number": item.get("number"),
+                "state": "MERGED" if item.get("merged_at") else str(item.get("state", "")).upper(),
+                "headRefName": head.get("ref"),
+                "headRefOid": head.get("sha"),
+                "baseRefName": base.get("ref"),
+                "isCrossRepository": not isinstance(head_repo, dict)
+                or str(head_repo.get("full_name", "")).casefold() != repository.casefold(),
+                "mergeCommit": {"oid": item.get("merge_commit_sha")},
+            }
+        )
+    return matches
+
+
+def merged_cleanup_evidence(
+    root: Path, record: WorktreeRecord, state: Path, local_head: str
+) -> dict:
+    assert record.branch is not None
+    repository = cleanup_repository(root)
+    matches = cleanup_prs(root, record.branch, repository)
+    if len(matches) != 1:
+        raise LifecycleError("cleanup refused: merged Task pull request identity is missing or ambiguous")
+    pr = matches[0]
+    published_head = pr.get("headRefOid")
+    if (
+        pr.get("state") != "MERGED"
+        or pr.get("headRefName") != record.branch
+        or pr.get("baseRefName") != default_branch(root)
+        or pr.get("isCrossRepository") is not False
+        or not isinstance(pr.get("number"), int)
+        or not isinstance(published_head, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", published_head)
+    ):
+        raise LifecycleError("cleanup refused: merged pull request evidence does not match the Task")
+    published_head = published_head.lower()
+    if local_head.lower() != published_head:
+        raise LifecycleError("cleanup refused: local Task head does not match published PR head")
+    ahead = git(
+        "rev-list", "--count", f"{published_head}..{record.branch}", cwd=record.path
+    )
+    if int(ahead or "0") != 0:
+        raise LifecycleError("cleanup refused: local Task branch is ahead of published PR head")
+    recorded = extract_identity_value(state, "Published head SHA")
+    if recorded and recorded.casefold() != "none":
+        if not re.fullmatch(r"[0-9a-fA-F]{40,64}", recorded) or recorded.lower() != published_head:
+            raise LifecycleError("cleanup refused: Task State published head does not match GitHub")
+    remote_head = remote_branch_head(record)
+    if remote_head is not None and remote_head != published_head:
+        raise LifecycleError("cleanup refused: live remote Task branch does not match published PR head")
+    return {
+        "repository": repository,
+        "pr": pr["number"],
+        "published_head": published_head,
+        "upstream": "deleted" if remote_head is None else "live",
+    }
+
+
+def cleanup_plan(root: Path, task: str) -> dict:
     record = worktree_for_task(root, task)
     assert_task_identity(record, task)
     state = state_path(record.path)
@@ -1021,45 +1171,127 @@ def task_cleanup(root: Path, task: str) -> None:
         raise LifecycleError(
             f"cleanup refused while Task status is {status}; expected one of {sorted(TERMINAL_STATES)}"
         )
-    if git("status", "--porcelain", cwd=record.path):
+    if git("status", "--porcelain", "--untracked-files=all", cwd=record.path):
         raise LifecycleError("cleanup refused: Task worktree has uncommitted changes")
-    ahead = unpushed_commits(record, state)
-    if ahead:
-        raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
-
     branch = record.branch
     assert branch is not None
-    pr_result = run(
-        ["gh", "pr", "view", branch, "--json", "state,headRefName,headRefOid"],
-        cwd=record.path,
-        check=False,
-    )
+    local_head = git("rev-parse", "--verify", f"refs/heads/{branch}", cwd=record.path).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise LifecycleError("cleanup refused: registered Task head changed")
+    evidence: dict = {}
     if status == "merged":
-        if pr_result.returncode != 0:
-            raise LifecycleError("cleanup refused: merged Task has no resolvable pull request")
-        data = json.loads(pr_result.stdout)
-        if data.get("state") != "MERGED" or data.get("headRefName") != branch:
-            raise LifecycleError(
-                "cleanup refused: Task pull request is not merged for the expected branch"
-            )
-    elif pr_result.returncode == 0:
-        data = json.loads(pr_result.stdout)
-        if data.get("state") == "OPEN":
+        evidence = merged_cleanup_evidence(root, record, state, local_head)
+    else:
+        ahead = unpushed_commits(record, state)
+        if ahead:
+            raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
+        repository = cleanup_repository(root)
+        if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+    return {
+        "schema_version": 1,
+        "task": task,
+        "status": status,
+        "worktree": str(record.path),
+        "branch": branch,
+        "local_head": local_head,
+        "evidence": evidence,
+    }
 
-    removed_path = str(record.path)
-    run(["git", "worktree", "remove", str(record.path)], cwd=root)
-    run(["git", "branch", "-D", branch], cwd=root)
+
+def read_cleanup_receipt(path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise LifecycleError("cleanup receipt is not a regular local file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LifecycleError("cleanup receipt is invalid") from exc
+    required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != 1
+        or value.get("task") != task
+        or value.get("status") not in TERMINAL_STATES
+        or not isinstance(value.get("worktree"), str)
+        or not branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    return value
+
+
+def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+    records = parse_worktrees(root)
+    registered = [r for r in records if r.path == expected_path or r.branch == branch]
+    if registered:
+        if len(registered) != 1 or registered[0].path != expected_path or registered[0].branch != branch:
+            raise LifecycleError("cleanup receipt conflicts with current worktree registration")
+        current = cleanup_plan(root, task)
+        if current != plan:
+            raise LifecycleError("cleanup evidence changed before worktree removal")
+        run(["git", "worktree", "remove", str(expected_path)], cwd=root)
+    if any(r.path == expected_path or r.branch == branch for r in parse_worktrees(root)):
+        raise LifecycleError("cleanup failed to remove the expected worktree registration")
+
+    branch_ref = f"refs/heads/{branch}"
+    actual = git("rev-parse", "--verify", branch_ref, cwd=root, check=False).lower()
+    if actual:
+        if actual != expected_head:
+            raise LifecycleError("cleanup refused: local Task branch moved after validation")
+        if plan["status"] == "merged":
+            # Reconstruct the externally authoritative evidence again after
+            # Task State/worktree removal, using the receipt-bound identity.
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            matches = cleanup_prs(root, branch, repository)
+            if (
+                len(matches) != 1
+                or matches[0].get("state") != "MERGED"
+                or matches[0].get("headRefOid", "").lower() != expected_head
+                or matches[0].get("headRefName") != branch
+                or matches[0].get("baseRefName") != default_branch(root)
+                or matches[0].get("isCrossRepository") is not False
+                or matches[0].get("number") != plan["evidence"].get("pr")
+            ):
+                raise LifecycleError("cleanup merged PR evidence changed after worktree removal")
+            remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
+            if remote_head is not None and remote_head != expected_head:
+                raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
+    if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
+        raise LifecycleError("cleanup failed to delete the expected local Task branch")
+    receipt.unlink(missing_ok=True)
     print(
         json.dumps(
             {
                 "task": task,
-                "removedWorktree": removed_path,
+                "removedWorktree": str(expected_path),
                 "removedBranch": branch,
                 "taskStateDiscarded": True,
             }
         )
     )
+
+
+def task_cleanup(root: Path, task: str) -> None:
+    require_main_worktree(root)
+    receipt = cleanup_receipt_path(root, task)
+    with cleanup_lock(root):
+        if receipt.exists():
+            finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
+            return
+        plan = cleanup_plan(root, task)
+        atomic_json(receipt, plan)
+        finish_cleanup(root, plan, receipt)
 
 
 def extract_list(path: Path, heading: str) -> list[str]:

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -51,6 +51,19 @@ integration-pending -> PR merge -> guarded finalize -> merged
   -> approval-gated cleanup -> dependency re-evaluation -> next Task
 ```
 
+For a merged Task, cleanup reconstructs safety from the unique same-repository
+merged PR: its branch and `headRefOid` must match the registered clean local
+Task branch exactly, and the local branch must contain no later commit. A live
+origin Task branch must have that same OID. A deleted origin branch is accepted
+only after those merged-PR checks, which allows a finalized Task such as
+AgentKnowledgeVault #12 to retry normal cleanup without recreating a remote
+branch. Cancelled Tasks retain the conservative unpublished-commit check and
+never use the merged-PR exception. Cleanup records a private administrative
+receipt before worktree removal and deletes the local branch with an
+expected-head compare-and-swap, so a partial failure remains retryable.
+Cleanup remains Main-owned and approval-gated; no raw cleanup authority is
+added.
+
 `agent::task-start` uses the same guarded default-branch synchronization at
 execution time before creating a branch/worktree, so it does not trust a stale
 remote-tracking ref even if the default branch advanced after finalization.

--- a/templates/agent-rust/.automation/bin/task_lifecycle.py
+++ b/templates/agent-rust/.automation/bin/task_lifecycle.py
@@ -1013,7 +1013,7 @@ def remote_branch_head(record: WorktreeRecord) -> str | None:
     return lines[0][0].lower()
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def unpushed_commits_from_base(record: WorktreeRecord, base_revision: str) -> int:
     assert record.branch is not None
     remote_head = remote_branch_head(record)
     if remote_head is not None:
@@ -1021,10 +1021,6 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
             "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
-
-    base_revision = extract_identity_value(state, "Base revision")
-    if not base_revision:
-        raise LifecycleError("Task State is missing Base revision")
     count = git(
         "rev-list",
         "--count",
@@ -1032,6 +1028,27 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
         cwd=record.path,
     )
     return int(count or "0")
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    base_revision = extract_identity_value(state, "Base revision")
+    if not base_revision:
+        raise LifecycleError("Task State is missing Base revision")
+    return unpushed_commits_from_base(record, base_revision)
+
+
+def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
+    if not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision):
+        raise LifecycleError("cleanup refused: Task Base revision is missing or invalid")
+    result = run(
+        ["git", "merge-base", "--is-ancestor", base_revision, default_branch(root)],
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError(
+            "cleanup refused: Task Base revision is not trusted default-branch history"
+        )
 
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
@@ -1182,13 +1199,22 @@ def cleanup_plan(root: Path, task: str) -> dict:
     if status == "merged":
         evidence = merged_cleanup_evidence(root, record, state, local_head)
     else:
-        ahead = unpushed_commits(record, state)
+        base_revision = extract_identity_value(state, "Base revision")
+        if not base_revision:
+            raise LifecycleError("Task State Base revision is missing or invalid")
+        base_revision = base_revision.lower()
+        require_cleanup_base_revision(root, base_revision)
+        ahead = unpushed_commits_from_base(record, base_revision)
         if ahead:
             raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
         repository = cleanup_repository(root)
         if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
-        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+        evidence = {
+            "repository": repository,
+            "upstream": "cancelled-safe",
+            "base_revision": base_revision,
+        }
     return {
         "schema_version": 1,
         "task": task,
@@ -1219,6 +1245,15 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
         or not isinstance(value.get("local_head"), str)
         or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
         or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    evidence = value["evidence"]
+    if value["status"] == "cancelled" and (
+        set(evidence) != {"repository", "upstream", "base_revision"}
+        or not isinstance(evidence.get("repository"), str)
+        or evidence.get("upstream") != "cancelled-safe"
+        or not isinstance(evidence.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", evidence["base_revision"])
     ):
         raise LifecycleError("cleanup receipt is invalid")
     return value
@@ -1266,6 +1301,19 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
             remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
             if remote_head is not None and remote_head != expected_head:
                 raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        else:
+            require_cleanup_base_revision(root, plan["evidence"]["base_revision"])
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
+                raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+            record = WorktreeRecord(root, branch, expected_head)
+            ahead = unpushed_commits_from_base(record, plan["evidence"]["base_revision"])
+            if ahead:
+                raise LifecycleError(
+                    f"cleanup refused: cancelled Task branch has {ahead} unpublished commit(s)"
+                )
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")

--- a/templates/agent-rust/.automation/bin/task_lifecycle.py
+++ b/templates/agent-rust/.automation/bin/task_lifecycle.py
@@ -981,21 +981,44 @@ def extract_identity_value(path: Path, label: str) -> str | None:
     return match.group(1).strip() if match else None
 
 
-def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+def remote_branch_head(record: WorktreeRecord) -> str | None:
+    """Resolve the live origin branch, distinguishing deletion from failures."""
     assert record.branch is not None
-    upstream = git(
-        "rev-parse",
-        "--abbrev-ref",
-        f"{record.branch}@{{upstream}}",
+    result = run(
+        [
+            "git",
+            "ls-remote",
+            "--exit-code",
+            "--heads",
+            "origin",
+            f"refs/heads/{record.branch}",
+        ],
         cwd=record.path,
         check=False,
     )
-    if upstream:
+    if result.returncode == 2 and not result.stdout.strip():
+        return None
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise LifecycleError(f"cleanup refused: cannot inspect live Task branch: {detail}")
+    lines = [line.split() for line in result.stdout.splitlines() if line.strip()]
+    expected_ref = f"refs/heads/{record.branch}"
+    if (
+        len(lines) != 1
+        or len(lines[0]) != 2
+        or lines[0][1] != expected_ref
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", lines[0][0])
+    ):
+        raise LifecycleError("cleanup refused: live Task branch response is invalid or ambiguous")
+    return lines[0][0].lower()
+
+
+def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
+    assert record.branch is not None
+    remote_head = remote_branch_head(record)
+    if remote_head is not None:
         count = git(
-            "rev-list",
-            "--count",
-            f"{upstream}..{record.branch}",
-            cwd=record.path,
+            "rev-list", "--count", f"{remote_head}..{record.branch}", cwd=record.path
         )
         return int(count or "0")
 
@@ -1011,8 +1034,135 @@ def unpushed_commits(record: WorktreeRecord, state: Path) -> int:
     return int(count or "0")
 
 
-def task_cleanup(root: Path, task: str) -> None:
-    require_main_worktree(root)
+def cleanup_receipt_path(root: Path, task: str) -> Path:
+    validate_task(task)
+    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    path = common_git_dir(root) / "opencode" / "cleanup.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def cleanup_repository(root: Path) -> str:
+    result = gh("repo", "view", "--json", "nameWithOwner", cwd=root, check=False)
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot resolve GitHub repository identity")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid") from exc
+    repository = value.get("nameWithOwner") if isinstance(value, dict) else None
+    if not isinstance(repository, str) or not re.fullmatch(
+        r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository
+    ):
+        raise LifecycleError("cleanup refused: GitHub repository identity is invalid")
+    return repository
+
+
+def cleanup_prs(root: Path, branch: str, repository: str) -> list[dict]:
+    owner = repository.split("/", 1)[0]
+    result = gh(
+        "api",
+        "--method",
+        "GET",
+        "--paginate",
+        "--slurp",
+        f"repos/{repository}/pulls",
+        "-f",
+        "state=all",
+        "-f",
+        f"head={owner}:{branch}",
+        "-f",
+        "per_page=100",
+        cwd=root,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LifecycleError("cleanup refused: cannot reconstruct GitHub pull request evidence")
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid") from exc
+    if not isinstance(value, list) or any(not isinstance(page, list) for page in value):
+        raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+    matches = []
+    for item in (entry for page in value for entry in page):
+        if not isinstance(item, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        head = item.get("head")
+        base = item.get("base")
+        head_repo = head.get("repo") if isinstance(head, dict) else None
+        if not isinstance(head, dict) or not isinstance(base, dict):
+            raise LifecycleError("cleanup refused: GitHub pull request evidence is invalid")
+        if head.get("ref") != branch:
+            continue
+        matches.append(
+            {
+                "number": item.get("number"),
+                "state": "MERGED" if item.get("merged_at") else str(item.get("state", "")).upper(),
+                "headRefName": head.get("ref"),
+                "headRefOid": head.get("sha"),
+                "baseRefName": base.get("ref"),
+                "isCrossRepository": not isinstance(head_repo, dict)
+                or str(head_repo.get("full_name", "")).casefold() != repository.casefold(),
+                "mergeCommit": {"oid": item.get("merge_commit_sha")},
+            }
+        )
+    return matches
+
+
+def merged_cleanup_evidence(
+    root: Path, record: WorktreeRecord, state: Path, local_head: str
+) -> dict:
+    assert record.branch is not None
+    repository = cleanup_repository(root)
+    matches = cleanup_prs(root, record.branch, repository)
+    if len(matches) != 1:
+        raise LifecycleError("cleanup refused: merged Task pull request identity is missing or ambiguous")
+    pr = matches[0]
+    published_head = pr.get("headRefOid")
+    if (
+        pr.get("state") != "MERGED"
+        or pr.get("headRefName") != record.branch
+        or pr.get("baseRefName") != default_branch(root)
+        or pr.get("isCrossRepository") is not False
+        or not isinstance(pr.get("number"), int)
+        or not isinstance(published_head, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", published_head)
+    ):
+        raise LifecycleError("cleanup refused: merged pull request evidence does not match the Task")
+    published_head = published_head.lower()
+    if local_head.lower() != published_head:
+        raise LifecycleError("cleanup refused: local Task head does not match published PR head")
+    ahead = git(
+        "rev-list", "--count", f"{published_head}..{record.branch}", cwd=record.path
+    )
+    if int(ahead or "0") != 0:
+        raise LifecycleError("cleanup refused: local Task branch is ahead of published PR head")
+    recorded = extract_identity_value(state, "Published head SHA")
+    if recorded and recorded.casefold() != "none":
+        if not re.fullmatch(r"[0-9a-fA-F]{40,64}", recorded) or recorded.lower() != published_head:
+            raise LifecycleError("cleanup refused: Task State published head does not match GitHub")
+    remote_head = remote_branch_head(record)
+    if remote_head is not None and remote_head != published_head:
+        raise LifecycleError("cleanup refused: live remote Task branch does not match published PR head")
+    return {
+        "repository": repository,
+        "pr": pr["number"],
+        "published_head": published_head,
+        "upstream": "deleted" if remote_head is None else "live",
+    }
+
+
+def cleanup_plan(root: Path, task: str) -> dict:
     record = worktree_for_task(root, task)
     assert_task_identity(record, task)
     state = state_path(record.path)
@@ -1021,45 +1171,127 @@ def task_cleanup(root: Path, task: str) -> None:
         raise LifecycleError(
             f"cleanup refused while Task status is {status}; expected one of {sorted(TERMINAL_STATES)}"
         )
-    if git("status", "--porcelain", cwd=record.path):
+    if git("status", "--porcelain", "--untracked-files=all", cwd=record.path):
         raise LifecycleError("cleanup refused: Task worktree has uncommitted changes")
-    ahead = unpushed_commits(record, state)
-    if ahead:
-        raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
-
     branch = record.branch
     assert branch is not None
-    pr_result = run(
-        ["gh", "pr", "view", branch, "--json", "state,headRefName,headRefOid"],
-        cwd=record.path,
-        check=False,
-    )
+    local_head = git("rev-parse", "--verify", f"refs/heads/{branch}", cwd=record.path).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise LifecycleError("cleanup refused: registered Task head changed")
+    evidence: dict = {}
     if status == "merged":
-        if pr_result.returncode != 0:
-            raise LifecycleError("cleanup refused: merged Task has no resolvable pull request")
-        data = json.loads(pr_result.stdout)
-        if data.get("state") != "MERGED" or data.get("headRefName") != branch:
-            raise LifecycleError(
-                "cleanup refused: Task pull request is not merged for the expected branch"
-            )
-    elif pr_result.returncode == 0:
-        data = json.loads(pr_result.stdout)
-        if data.get("state") == "OPEN":
+        evidence = merged_cleanup_evidence(root, record, state, local_head)
+    else:
+        ahead = unpushed_commits(record, state)
+        if ahead:
+            raise LifecycleError(f"cleanup refused: Task branch has {ahead} unpushed commit(s)")
+        repository = cleanup_repository(root)
+        if any(pr.get("state") == "OPEN" for pr in cleanup_prs(root, branch, repository)):
             raise LifecycleError("cleanup refused: cancelled Task still has an open pull request")
+        evidence = {"repository": repository, "upstream": "cancelled-safe"}
+    return {
+        "schema_version": 1,
+        "task": task,
+        "status": status,
+        "worktree": str(record.path),
+        "branch": branch,
+        "local_head": local_head,
+        "evidence": evidence,
+    }
 
-    removed_path = str(record.path)
-    run(["git", "worktree", "remove", str(record.path)], cwd=root)
-    run(["git", "branch", "-D", branch], cwd=root)
+
+def read_cleanup_receipt(path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise LifecycleError("cleanup receipt is not a regular local file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LifecycleError("cleanup receipt is invalid") from exc
+    required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != 1
+        or value.get("task") != task
+        or value.get("status") not in TERMINAL_STATES
+        or not isinstance(value.get("worktree"), str)
+        or not branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or not isinstance(value.get("evidence"), dict)
+    ):
+        raise LifecycleError("cleanup receipt is invalid")
+    return value
+
+
+def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+    records = parse_worktrees(root)
+    registered = [r for r in records if r.path == expected_path or r.branch == branch]
+    if registered:
+        if len(registered) != 1 or registered[0].path != expected_path or registered[0].branch != branch:
+            raise LifecycleError("cleanup receipt conflicts with current worktree registration")
+        current = cleanup_plan(root, task)
+        if current != plan:
+            raise LifecycleError("cleanup evidence changed before worktree removal")
+        run(["git", "worktree", "remove", str(expected_path)], cwd=root)
+    if any(r.path == expected_path or r.branch == branch for r in parse_worktrees(root)):
+        raise LifecycleError("cleanup failed to remove the expected worktree registration")
+
+    branch_ref = f"refs/heads/{branch}"
+    actual = git("rev-parse", "--verify", branch_ref, cwd=root, check=False).lower()
+    if actual:
+        if actual != expected_head:
+            raise LifecycleError("cleanup refused: local Task branch moved after validation")
+        if plan["status"] == "merged":
+            # Reconstruct the externally authoritative evidence again after
+            # Task State/worktree removal, using the receipt-bound identity.
+            repository = cleanup_repository(root)
+            if repository.casefold() != plan["evidence"].get("repository", "").casefold():
+                raise LifecycleError("cleanup repository identity changed after worktree removal")
+            matches = cleanup_prs(root, branch, repository)
+            if (
+                len(matches) != 1
+                or matches[0].get("state") != "MERGED"
+                or matches[0].get("headRefOid", "").lower() != expected_head
+                or matches[0].get("headRefName") != branch
+                or matches[0].get("baseRefName") != default_branch(root)
+                or matches[0].get("isCrossRepository") is not False
+                or matches[0].get("number") != plan["evidence"].get("pr")
+            ):
+                raise LifecycleError("cleanup merged PR evidence changed after worktree removal")
+            remote_head = remote_branch_head(WorktreeRecord(root, branch, expected_head))
+            if remote_head is not None and remote_head != expected_head:
+                raise LifecycleError("cleanup remote Task branch changed after worktree removal")
+        run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
+    if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
+        raise LifecycleError("cleanup failed to delete the expected local Task branch")
+    receipt.unlink(missing_ok=True)
     print(
         json.dumps(
             {
                 "task": task,
-                "removedWorktree": removed_path,
+                "removedWorktree": str(expected_path),
                 "removedBranch": branch,
                 "taskStateDiscarded": True,
             }
         )
     )
+
+
+def task_cleanup(root: Path, task: str) -> None:
+    require_main_worktree(root)
+    receipt = cleanup_receipt_path(root, task)
+    with cleanup_lock(root):
+        if receipt.exists():
+            finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
+            return
+        plan = cleanup_plan(root, task)
+        atomic_json(receipt, plan)
+        finish_cleanup(root, plan, receipt)
 
 
 def extract_list(path: Path, heading: str) -> list[str]:

--- a/tests/test_post_merge_finalization.py
+++ b/tests/test_post_merge_finalization.py
@@ -293,6 +293,31 @@ class PostMergeFinalizationTest(RepositoryFixture):
             command("git", "push", "origin", "--delete", branch, cwd=task_worktree)
         return task_worktree, task_head, evidence
 
+    def cancelled_cleanup_fixture(self, *, publish_commit: bool) -> tuple[Path, str, dict]:
+        task_worktree = self.start_task()
+        branch = command("git", "branch", "--show-current", cwd=task_worktree)
+        if publish_commit:
+            (task_worktree / "cancelled.txt").write_text("cancelled\n", encoding="utf-8")
+            command("git", "add", "cancelled.txt", cwd=task_worktree)
+            command("git", "commit", "-m", "cancelled task", cwd=task_worktree)
+            command("git", "push", "-u", "origin", branch, cwd=task_worktree)
+        task_head = command("git", "rev-parse", "HEAD", cwd=task_worktree)
+        state = task_worktree / ".task-state/task.md"
+        state.write_text(
+            state.read_text(encoding="utf-8").replace("Status: initialized", "Status: cancelled"),
+            encoding="utf-8",
+        )
+        evidence = {
+            "number": 94,
+            "state": "CLOSED",
+            "headRefName": branch,
+            "headRefOid": task_head,
+            "baseRefName": "main",
+            "isCrossRepository": False,
+            "mergeCommit": None,
+        }
+        return task_worktree, task_head, evidence
+
     def test_standard_squash_flow_and_idempotent_retry(self) -> None:
         task_worktree, task_head, evidence = self.prepare()
         self.finalize(evidence)
@@ -479,6 +504,93 @@ class PostMergeFinalizationTest(RepositoryFixture):
         with self.assertRaisesRegex(lifecycle.LifecycleError, "unpushed commit"):
             lifecycle.task_cleanup(self.repo, "TASK-1")
         self.assertTrue(task_worktree.exists())
+
+    def test_cancelled_tampered_task_base_cannot_hide_unpublished_commit(self) -> None:
+        task_worktree = self.start_task()
+        (task_worktree / "unpublished.txt").write_text("unpublished\n", encoding="utf-8")
+        command("git", "add", "unpublished.txt", cwd=task_worktree)
+        command("git", "commit", "-m", "unpublished", cwd=task_worktree)
+        task_head = command("git", "rev-parse", "HEAD", cwd=task_worktree)
+        state = task_worktree / ".task-state/task.md"
+        original_base = lifecycle.extract_identity_value(state, "Base revision")
+        self.assertIsNotNone(original_base)
+        state.write_text(
+            state.read_text(encoding="utf-8")
+            .replace("Status: initialized", "Status: cancelled")
+            .replace(f"Base revision: {original_base}", f"Base revision: {task_head}"),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(lifecycle.LifecycleError, "not trusted"):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertTrue(task_worktree.exists())
+
+    def test_cancelled_receipt_retry_rejects_deleted_published_upstream(self) -> None:
+        task_worktree, task_head, evidence = self.cancelled_cleanup_fixture(publish_commit=True)
+        branch = evidence["headRefName"]
+        with self.cleanup_run(evidence, fail_update_ref_once=True), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "injected ref deletion failure"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertFalse(task_worktree.exists())
+        command("git", "push", "origin", "--delete", branch, cwd=self.repo)
+        with self.cleanup_run(evidence), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "unpublished commit"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertEqual(task_head, command("git", "rev-parse", branch, cwd=self.repo))
+        self.assertTrue(lifecycle.cleanup_receipt_path(self.repo, "TASK-1").exists())
+
+    def test_cancelled_receipt_retry_rejects_rewound_published_upstream(self) -> None:
+        task_worktree, task_head, evidence = self.cancelled_cleanup_fixture(publish_commit=True)
+        branch = evidence["headRefName"]
+        with self.cleanup_run(evidence, fail_update_ref_once=True), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "injected ref deletion failure"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertFalse(task_worktree.exists())
+        command("git", "push", "--force", "origin", f"main:refs/heads/{branch}", cwd=self.repo)
+        with self.cleanup_run(evidence), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "unpublished commit"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertEqual(task_head, command("git", "rev-parse", branch, cwd=self.repo))
+        self.assertTrue(lifecycle.cleanup_receipt_path(self.repo, "TASK-1").exists())
+
+    def test_cancelled_tampered_receipt_base_cannot_hide_unpublished_commit(self) -> None:
+        task_worktree, task_head, evidence = self.cancelled_cleanup_fixture(publish_commit=True)
+        branch = evidence["headRefName"]
+        receipt = lifecycle.cleanup_receipt_path(self.repo, "TASK-1")
+        with self.cleanup_run(evidence, fail_update_ref_once=True), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "injected ref deletion failure"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertFalse(task_worktree.exists())
+        command("git", "push", "origin", "--delete", branch, cwd=self.repo)
+        payload = json.loads(receipt.read_text(encoding="utf-8"))
+        payload["evidence"]["base_revision"] = task_head
+        receipt.write_text(json.dumps(payload), encoding="utf-8")
+        with self.cleanup_run(evidence), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "not trusted"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertEqual(task_head, command("git", "rev-parse", branch, cwd=self.repo))
+        self.assertTrue(receipt.exists())
+
+    def test_cancelled_pristine_receipt_retry_uses_base_revision_fallback(self) -> None:
+        task_worktree, _, evidence = self.cancelled_cleanup_fixture(publish_commit=False)
+        branch = evidence["headRefName"]
+        with self.cleanup_run(evidence, fail_update_ref_once=True), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "injected ref deletion failure"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertFalse(task_worktree.exists())
+        with self.cleanup_run(evidence):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertFalse(lifecycle.cleanup_receipt_path(self.repo, "TASK-1").exists())
+        branch_check = subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=self.repo
+        )
+        self.assertNotEqual(branch_check.returncode, 0)
 
     def test_cleanup_removes_only_expected_registration_and_branch(self) -> None:
         task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)

--- a/tests/test_post_merge_finalization.py
+++ b/tests/test_post_merge_finalization.py
@@ -183,6 +183,7 @@ class PostMergeFinalizationTest(RepositoryFixture):
             "number": 93,
             "state": "MERGED",
             "headRefName": command("git", "branch", "--show-current", cwd=task_worktree),
+            "headRefOid": command("git", "rev-parse", "HEAD", cwd=task_worktree),
             "baseRefName": "main",
             "isCrossRepository": False,
             "mergeCommit": {"oid": merge_oid},
@@ -211,6 +212,86 @@ class PostMergeFinalizationTest(RepositoryFixture):
             ),
         ):
             agent_core.integrate_finalize(self.repo, task, "93")
+
+    def cleanup_run(
+        self,
+        evidence: dict,
+        *,
+        fail_update_ref_once: bool = False,
+        fail_worktree_remove_once: bool = False,
+        pr_pages: list[list[dict]] | None = None,
+    ):
+        real_run = lifecycle.run
+        failed = False
+
+        def fake(command_args: list[str], **kwargs):
+            nonlocal failed
+            if command_args[:3] == ["gh", "repo", "view"]:
+                return subprocess.CompletedProcess(
+                    command_args, 0, json.dumps({"nameWithOwner": "acme/widgets"}), ""
+                )
+            if command_args[:2] == ["gh", "api"]:
+                if pr_pages is not None:
+                    return subprocess.CompletedProcess(command_args, 0, json.dumps(pr_pages), "")
+                raw = {
+                    "number": evidence["number"],
+                    "state": "closed" if evidence["state"] == "MERGED" else evidence["state"].lower(),
+                    "merged_at": "2026-08-30T00:00:00Z" if evidence["state"] == "MERGED" else None,
+                    "merge_commit_sha": (evidence.get("mergeCommit") or {}).get("oid"),
+                    "head": {
+                        "ref": evidence["headRefName"],
+                        "sha": evidence["headRefOid"],
+                        "repo": {
+                            "full_name": "other/widgets"
+                            if evidence.get("isCrossRepository")
+                            else "acme/widgets"
+                        },
+                    },
+                    "base": {"ref": evidence["baseRefName"]},
+                }
+                return subprocess.CompletedProcess(command_args, 0, json.dumps([[raw]]), "")
+            if (
+                fail_update_ref_once
+                and not failed
+                and command_args[:4] == ["git", "update-ref", "-d", f"refs/heads/{evidence['headRefName']}"]
+            ):
+                failed = True
+                raise lifecycle.LifecycleError("injected ref deletion failure")
+            if (
+                fail_worktree_remove_once
+                and not failed
+                and command_args[:3] == ["git", "worktree", "remove"]
+            ):
+                failed = True
+                raise lifecycle.LifecycleError("injected worktree removal failure")
+            return real_run(command_args, **kwargs)
+
+        return mock.patch.object(lifecycle, "run", side_effect=fake)
+
+    def merged_cleanup_fixture(
+        self, *, delete_remote: bool, task: str = "TASK-1", slug: str = "demo"
+    ) -> tuple[Path, str, dict]:
+        if task == "TASK-1" and slug == "demo":
+            task_worktree, task_head, evidence = self.prepare()
+        else:
+            task_worktree = self.start_task(task, slug)
+            (task_worktree / "task.txt").write_text("task change\n", encoding="utf-8")
+            command("git", "add", "task.txt", cwd=task_worktree)
+            command("git", "commit", "-m", "task", cwd=task_worktree)
+            task_head = command("git", "rev-parse", "HEAD", cwd=task_worktree)
+            merge_oid = self.publish("squash result")
+            state = task_worktree / ".task-state/task.md"
+            state.write_text(
+                state.read_text(encoding="utf-8").replace("initialized", "integration-pending"),
+                encoding="utf-8",
+            )
+            evidence = self.merged_evidence(task_worktree, merge_oid)
+        branch = evidence["headRefName"]
+        command("git", "push", "-u", "origin", branch, cwd=task_worktree)
+        self.finalize(evidence, task=task)
+        if delete_remote:
+            command("git", "push", "origin", "--delete", branch, cwd=task_worktree)
+        return task_worktree, task_head, evidence
 
     def test_standard_squash_flow_and_idempotent_retry(self) -> None:
         task_worktree, task_head, evidence = self.prepare()
@@ -271,25 +352,7 @@ class PostMergeFinalizationTest(RepositoryFixture):
         branch = evidence["headRefName"]
         command("git", "push", "-u", "origin", branch, cwd=task_worktree)
         self.finalize(evidence)
-        real_run = lifecycle.run
-
-        def fake_gh(command_args: list[str], **kwargs):
-            if command_args[:3] == ["gh", "pr", "view"]:
-                return subprocess.CompletedProcess(
-                    command_args,
-                    0,
-                    json.dumps(
-                        {
-                            "state": "MERGED",
-                            "headRefName": branch,
-                            "headRefOid": command("git", "rev-parse", branch, cwd=self.repo),
-                        }
-                    ),
-                    "",
-                )
-            return real_run(command_args, **kwargs)
-
-        with mock.patch.object(lifecycle, "run", side_effect=fake_gh):
+        with self.cleanup_run(evidence):
             lifecycle.task_cleanup(self.repo, "TASK-1")
         self.assertFalse(task_worktree.exists())
         branch_check = subprocess.run(
@@ -297,6 +360,159 @@ class PostMergeFinalizationTest(RepositoryFixture):
             cwd=self.repo,
         )
         self.assertNotEqual(branch_check.returncode, 0)
+
+    def test_deleted_upstream_merged_pr_head_match_allows_cleanup(self) -> None:
+        task_worktree, task_head, evidence = self.merged_cleanup_fixture(
+            delete_remote=True, task="12", slug="semantic-candidate-expansion"
+        )
+        evidence = dict(evidence, number=18)
+        with self.cleanup_run(evidence):
+            lifecycle.task_cleanup(self.repo, "12")
+        self.assertFalse(task_worktree.exists())
+        branch_check = subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{evidence['headRefName']}"],
+            cwd=self.repo,
+        )
+        self.assertNotEqual(branch_check.returncode, 0)
+        self.assertEqual(evidence["headRefOid"], task_head)
+
+    def test_deleted_upstream_with_local_only_commit_is_rejected(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+        (task_worktree / "local-only.txt").write_text("local\n", encoding="utf-8")
+        command("git", "add", "local-only.txt", cwd=task_worktree)
+        command("git", "commit", "-m", "local only", cwd=task_worktree)
+        with self.cleanup_run(evidence), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "does not match published PR head"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertTrue(task_worktree.exists())
+
+    def test_deleted_upstream_rejects_unmerged_pr(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+        with self.cleanup_run(dict(evidence, state="OPEN")), self.assertRaises(lifecycle.LifecycleError):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertTrue(task_worktree.exists())
+
+    def test_deleted_upstream_rejects_pr_branch_mismatch(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+        with self.cleanup_run(dict(evidence, headRefName="task/TASK-OTHER-demo")), self.assertRaises(lifecycle.LifecycleError):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertTrue(task_worktree.exists())
+
+    def test_deleted_upstream_rejects_pr_sha_mismatch(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+        with self.cleanup_run(dict(evidence, headRefOid="a" * 40)), self.assertRaises(lifecycle.LifecycleError):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertTrue(task_worktree.exists())
+
+    def test_cleanup_pr_query_paginates_all_historical_branch_prs(self) -> None:
+        branch = "task/TASK-1-demo"
+
+        def raw(number: int) -> dict:
+            return {
+                "number": number,
+                "state": "closed",
+                "merged_at": "2026-08-30T00:00:00Z",
+                "merge_commit_sha": "b" * 40,
+                "head": {
+                    "ref": branch,
+                    "sha": "a" * 40,
+                    "repo": {"full_name": "acme/widgets"},
+                },
+                "base": {"ref": "main"},
+            }
+
+        pages = [[raw(number) for number in range(1, 101)], [raw(101)]]
+        with mock.patch.object(
+            lifecycle,
+            "gh",
+            return_value=subprocess.CompletedProcess([], 0, json.dumps(pages), ""),
+        ) as query:
+            matches = lifecycle.cleanup_prs(self.repo, branch, "acme/widgets")
+        self.assertEqual(101, len(matches))
+        self.assertIn("--paginate", query.call_args.args)
+        self.assertIn("--slurp", query.call_args.args)
+
+    def test_cleanup_rejects_ambiguity_beyond_first_pr_page(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+
+        def raw(number: int) -> dict:
+            return {
+                "number": number,
+                "state": "closed",
+                "merged_at": "2026-08-30T00:00:00Z",
+                "merge_commit_sha": evidence["mergeCommit"]["oid"],
+                "head": {
+                    "ref": evidence["headRefName"],
+                    "sha": evidence["headRefOid"],
+                    "repo": {"full_name": "acme/widgets"},
+                },
+                "base": {"ref": evidence["baseRefName"]},
+            }
+
+        pages = [[raw(number) for number in range(1, 101)], [raw(101)]]
+        with self.cleanup_run(evidence, pr_pages=pages), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "missing or ambiguous"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertTrue(task_worktree.exists())
+
+    def test_dirty_merged_worktree_is_rejected(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+        (task_worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+        with self.cleanup_run(evidence), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "uncommitted changes"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertTrue(task_worktree.exists())
+
+    def test_cancelled_missing_upstream_with_unpublished_commit_is_rejected(self) -> None:
+        task_worktree = self.start_task()
+        (task_worktree / "unpublished.txt").write_text("unpublished\n", encoding="utf-8")
+        command("git", "add", "unpublished.txt", cwd=task_worktree)
+        command("git", "commit", "-m", "unpublished", cwd=task_worktree)
+        state = task_worktree / ".task-state/task.md"
+        state.write_text(
+            state.read_text(encoding="utf-8").replace("Status: initialized", "Status: cancelled"),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(lifecycle.LifecycleError, "unpushed commit"):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertTrue(task_worktree.exists())
+
+    def test_cleanup_removes_only_expected_registration_and_branch(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+        command("git", "branch", "keep-me", "main", cwd=self.repo)
+        with self.cleanup_run(evidence):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertFalse(task_worktree.exists())
+        self.assertEqual(command("git", "rev-parse", "keep-me", cwd=self.repo), command("git", "rev-parse", "main", cwd=self.repo))
+
+    def test_partial_branch_deletion_failure_is_retryable(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+        with self.cleanup_run(evidence, fail_update_ref_once=True), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "injected ref deletion failure"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertFalse(task_worktree.exists())
+        self.assertTrue(lifecycle.cleanup_receipt_path(self.repo, "TASK-1").exists())
+        self.assertTrue(command("git", "rev-parse", evidence["headRefName"], cwd=self.repo))
+        with self.cleanup_run(evidence):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertFalse(lifecycle.cleanup_receipt_path(self.repo, "TASK-1").exists())
+
+    def test_worktree_removal_failure_preserves_registration_and_is_retryable(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+        with self.cleanup_run(evidence, fail_worktree_remove_once=True), self.assertRaisesRegex(
+            lifecycle.LifecycleError, "injected worktree removal failure"
+        ):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertTrue(task_worktree.exists())
+        self.assertEqual(lifecycle.worktree_for_task(self.repo, "TASK-1").path, task_worktree)
+        self.assertTrue(lifecycle.cleanup_receipt_path(self.repo, "TASK-1").exists())
+        with self.cleanup_run(evidence):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        self.assertFalse(task_worktree.exists())
 
     def test_merge_commit_identity_is_accepted(self) -> None:
         task_worktree = self.start_task()

--- a/tests/test_worktree_lifecycle_smoke.py
+++ b/tests/test_worktree_lifecycle_smoke.py
@@ -44,7 +44,19 @@ class WorktreeLifecycleSmokeTest(unittest.TestCase):
         fake_bin = temporary_root / "bin"
         fake_bin.mkdir()
         fake_gh = fake_bin / "gh"
-        fake_gh.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        fake_gh.write_text(
+            "#!/bin/sh\n"
+            "if [ \"$1 $2\" = \"repo view\" ]; then\n"
+            "  printf '%s\\n' '{\"nameWithOwner\":\"acme/widgets\"}'\n"
+            "  exit 0\n"
+            "fi\n"
+            "if [ \"$1\" = \"api\" ]; then\n"
+            "  printf '%s\\n' '[[]]'\n"
+            "  exit 0\n"
+            "fi\n"
+            "exit 1\n",
+            encoding="utf-8",
+        )
         fake_gh.chmod(0o755)
         self.env = dict(os.environ)
         self.env["PATH"] = f"{fake_bin}:{self.env['PATH']}"


### PR DESCRIPTION
## Summary

- reconstruct merged cleanup safety from a unique same-repository GitHub PR when the remote Task branch has already been deleted
- require exact local, published, and live-remote OID agreement; persist retryable cleanup receipts and use expected-OID local ref deletion
- preserve cancelled-Task unpublished-commit protection, including receipt retries after partial cleanup failure
- synchronize Agent Core changes into every generated template

Closes #103

## Validation

- `nix develop --no-update-lock-file --command python3 -m unittest discover -s tests -v`: PASS (394 tests)
- focused deleted-upstream / cancelled-retry / tampering regressions: PASS
- `nix develop --no-update-lock-file --command python3 tools/render_templates.py check`: PASS
- `nix develop --no-update-lock-file --command python3 tools/template_distribution.py verify`: PASS
- `nix flake check --all-systems --no-build --no-update-lock-file`: PASS
- `nix build .#checks.x86_64-linux.opencode-policy --no-link --no-update-lock-file`: PASS
- `git diff --check`: PASS
- reviewer: no remaining High/Medium findings after corrective commit `0b431e6`
- security re-review: no High/Medium findings
- Template CI #142: PASS, including contracts and all generated-template smoke jobs

## Risks and unverified areas

- Local generated-template smoke previously exposed a C++/CMake clang-tidy environment issue (`<iostream>` not found), but the same failure reproduced from untouched base. Independent Template CI #142 now passes the C++/CMake generated-template smoke on the latest head.
- Cleanup intentionally fails closed when GitHub PR evidence, repository identity, origin branch inspection, or trusted Base-revision evidence is unavailable or ambiguous.