### PR TITLE
feat: allow canonical discard of pristine unresolved Tasks

### DIFF
--- a/components/agent-core/.automation/PRISTINE_DISCARD.md
+++ b/components/agent-core/.automation/PRISTINE_DISCARD.md
@@ -1,0 +1,45 @@
+# Guarded pristine Task discard
+
+`just agent::discard-pristine <task>` is the narrow recovery operation for an
+Issue-shaped Task worktree that was materialized but never received a canonical
+Task Contract and never began implementation.
+
+It is intentionally separate from `state-set` and ordinary terminal `cleanup`.
+The operation is destructive, runs only from the default-branch/Main
+Orchestrator worktree, and remains approval-gated by OpenCode policy.
+
+The discard succeeds only when Agent Core can prove all of the following:
+
+- Task status is exactly `initialized`.
+- The Task State is byte-for-byte the unresolved initialization template for
+  that Task identity and Base revision.
+- No canonical Task Contract metadata, Work Unit state, or other Task State
+  evidence exists.
+- The worktree is clean.
+- The registered Task branch and local branch both point exactly at the
+  recorded Base revision, with no additional commits.
+- The recorded Base branch is the repository default branch and the Base
+  revision is trusted default-branch history.
+- The Task branch has no configured upstream/publication metadata, no
+  remote-tracking ref, no live remote branch, and no historical pull request.
+- Repository identity and publication absence still match immediately before
+  local branch deletion.
+
+A private receipt under the common Git directory makes the destructive tail
+retryable. If worktree removal succeeds but local branch deletion fails, a
+later retry revalidates the Base, repository, remote branch, upstream
+configuration, and pull-request absence before deleting the expected local ref.
+If any evidence appears, retry fails closed and preserves the local branch.
+
+After successful discard, synchronize the default branch and restart the same
+Issue through the normal Issue-backed lifecycle:
+
+```text
+just agent::discard-pristine <task>
+just agent::task-start-from-issue <issue> <slug>
+```
+
+Do not use this operation for a resolved Task Contract, a Task with Work Units,
+a dirty or advanced branch, any pushed branch/PR, or any status other than
+`initialized`. Do not fabricate a contract or use raw `git worktree remove` /
+branch deletion as a substitute.

--- a/components/agent-core/.automation/bin/discard_pristine.py
+++ b/components/agent-core/.automation/bin/discard_pristine.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import task_lifecycle as lifecycle
+
+
+RECEIPT_SCHEMA_VERSION = 1
+RECEIPT_OPERATION = "discard-pristine"
+EXPECTED_STATE_FILES = {"task.md"}
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
+def discard_receipt_path(root: Path, task: str) -> Path:
+    lifecycle.validate_task(task)
+    return (
+        lifecycle.common_git_dir(root)
+        / "opencode"
+        / "discard-pristine"
+        / f"{task}.json"
+    )
+
+
+def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
+    assert record.branch is not None
+    evidence: list[str] = []
+    remote = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.remote",
+        cwd=record.path,
+        check=False,
+    )
+    merge = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.merge",
+        cwd=record.path,
+        check=False,
+    )
+    tracking = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/remotes/origin/{record.branch}",
+        cwd=record.path,
+        check=False,
+    )
+    if remote:
+        evidence.append("configured branch remote")
+    if merge:
+        evidence.append("configured upstream merge ref")
+    if tracking:
+        evidence.append("remote-tracking ref")
+    return evidence
+
+
+def _render_expected_pristine_state(
+    record: lifecycle.WorktreeRecord,
+    task: str,
+    base_branch: str,
+    base_revision: str,
+) -> str:
+    template = record.path / ".automation" / "templates" / "task-state.md"
+    if template.is_symlink() or not template.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template is unavailable or unsafe"
+        )
+    text = template.read_text(encoding="utf-8")
+    values = {
+        "@@TASK_ID@@": task,
+        "@@BRANCH@@": record.branch or "",
+        "@@WORKTREE@@": str(record.path),
+        "@@BASE_BRANCH@@": base_branch,
+        "@@BASE_REVISION@@": base_revision,
+    }
+    for marker, value in values.items():
+        text = text.replace(marker, value)
+    if any(marker in text for marker in values):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template contains unresolved identity markers"
+        )
+    return text
+
+
+def _require_pristine_unresolved_state(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    task: str,
+) -> tuple[str, str]:
+    lifecycle.assert_task_identity(record, task)
+    state = lifecycle.state_path(record.path)
+    if state.is_symlink() or not state.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is unavailable or unsafe"
+        )
+    if lifecycle.state_status(state) != "initialized":
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task status must be exactly initialized"
+        )
+
+    state_dir = state.parent
+    if state_dir.is_symlink() or not state_dir.is_dir():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State directory is unavailable or unsafe"
+        )
+    entries = {entry.name for entry in state_dir.iterdir()}
+    if entries != EXPECTED_STATE_FILES:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State contains contract, Work Unit, or other lifecycle evidence"
+        )
+
+    text = state.read_text(encoding="utf-8")
+    if "canonical-contract sha256=" in text:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: canonical Task Contract evidence exists"
+        )
+    for relative in (".task-state/issue.json", ".task-state/contract.json"):
+        if (record.path / relative).exists():
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: canonical Task Contract metadata exists"
+            )
+
+    work_units = lifecycle.read_work_units(record, task)
+    if work_units.get("units"):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Work Units already exist"
+        )
+
+    base_branch = lifecycle.extract_identity_value(state, "Base branch")
+    base_revision = lifecycle.extract_identity_value(state, "Base revision")
+    if (
+        not isinstance(base_branch, str)
+        or not base_branch
+        or not isinstance(base_revision, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base identity is missing or invalid"
+        )
+    base_revision = base_revision.lower()
+
+    expected = _render_expected_pristine_state(
+        record,
+        task,
+        base_branch,
+        base_revision,
+    )
+    if text != expected:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is not the untouched unresolved initialization state"
+        )
+
+    current_default = lifecycle.default_branch(root)
+    if base_branch != current_default:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base branch is not the repository default branch"
+        )
+    lifecycle.require_cleanup_base_revision(root, base_revision)
+    return base_branch, base_revision
+
+
+def _require_no_publication(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    repository: str,
+) -> None:
+    assert record.branch is not None
+    configured = _branch_publication_configuration(record)
+    if configured:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch has publication configuration: "
+            + ", ".join(configured)
+        )
+    remote_head = lifecycle.remote_branch_head(record)
+    if remote_head is not None:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: live remote Task branch exists"
+        )
+    if lifecycle.cleanup_prs(root, record.branch, repository):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: pull request evidence exists for the Task branch"
+        )
+
+
+def pristine_discard_plan(root: Path, task: str) -> dict:
+    lifecycle.require_main_worktree(root)
+    record = lifecycle.worktree_for_task(root, task)
+    lifecycle.assert_task_identity(record, task)
+    if lifecycle.git(
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+        cwd=record.path,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task worktree has uncommitted changes"
+        )
+
+    base_branch, base_revision = _require_pristine_unresolved_state(
+        root,
+        record,
+        task,
+    )
+    branch = record.branch
+    assert branch is not None
+    local_head = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/heads/{branch}",
+        cwd=record.path,
+    ).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: registered Task head changed"
+        )
+    if local_head != base_revision:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch HEAD differs from Base revision"
+        )
+    extra = lifecycle.git(
+        "rev-list",
+        "--count",
+        f"{base_revision}..{branch}",
+        cwd=record.path,
+    )
+    if int(extra or "0") != 0:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch contains commits beyond Base revision"
+        )
+
+    repository = lifecycle.cleanup_repository(root)
+    _require_no_publication(root, record, repository)
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "operation": RECEIPT_OPERATION,
+        "task": task,
+        "status": "initialized",
+        "worktree": str(record.path),
+        "branch": branch,
+        "base_branch": base_branch,
+        "base_revision": base_revision,
+        "local_head": local_head,
+        "repository": repository,
+    }
+
+
+def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine receipt is not a regular local file"
+        )
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
+    required = {
+        "schema_version",
+        "operation",
+        "task",
+        "status",
+        "worktree",
+        "branch",
+        "base_branch",
+        "base_revision",
+        "local_head",
+        "repository",
+    }
+    worktree = (
+        Path(value.get("worktree", "")).resolve()
+        if isinstance(value, dict)
+        else Path()
+    )
+    worktree_is_expected = (
+        worktree.parent == (root / ".worktrees").resolve()
+        and worktree.name not in {"", ".", ".."}
+    )
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != RECEIPT_SCHEMA_VERSION
+        or value.get("operation") != RECEIPT_OPERATION
+        or value.get("task") != task
+        or value.get("status") != "initialized"
+        or not isinstance(value.get("branch"), str)
+        or not lifecycle.branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("base_branch"), str)
+        or not value.get("base_branch")
+        or not isinstance(value.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["base_revision"])
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or value["local_head"].lower() != value["base_revision"].lower()
+        or not isinstance(value.get("repository"), str)
+        or not REPOSITORY_RE.fullmatch(value["repository"])
+        or not worktree_is_expected
+    ):
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid")
+    value["base_revision"] = value["base_revision"].lower()
+    value["local_head"] = value["local_head"].lower()
+    value["worktree"] = str(worktree)
+    return value
+
+
+def _revalidate_after_worktree_removal(root: Path, plan: dict) -> None:
+    if lifecycle.default_branch(root) != plan["base_branch"]:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository default branch changed"
+        )
+    lifecycle.require_cleanup_base_revision(root, plan["base_revision"])
+    repository = lifecycle.cleanup_repository(root)
+    if repository.casefold() != plan["repository"].casefold():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository identity changed"
+        )
+    record = lifecycle.WorktreeRecord(
+        root,
+        plan["branch"],
+        plan["local_head"],
+    )
+    _require_no_publication(root, record, repository)
+
+
+def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+
+    records = lifecycle.parse_worktrees(root)
+    registered = [
+        record
+        for record in records
+        if record.path == expected_path or record.branch == branch
+    ]
+    if registered:
+        if (
+            len(registered) != 1
+            or registered[0].path != expected_path
+            or registered[0].branch != branch
+        ):
+            raise lifecycle.LifecycleError(
+                "discard-pristine receipt conflicts with current worktree registration"
+            )
+        current = pristine_discard_plan(root, task)
+        if current != plan:
+            raise lifecycle.LifecycleError(
+                "discard-pristine evidence changed before worktree removal"
+            )
+        lifecycle.run(
+            ["git", "worktree", "remove", str(expected_path)],
+            cwd=root,
+        )
+
+    if any(
+        record.path == expected_path or record.branch == branch
+        for record in lifecycle.parse_worktrees(root)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to remove the expected worktree registration"
+        )
+
+    _revalidate_after_worktree_removal(root, plan)
+    branch_ref = f"refs/heads/{branch}"
+    actual = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ).lower()
+    if actual:
+        if actual != expected_head:
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: local Task branch moved after validation"
+            )
+        lifecycle.run(
+            ["git", "update-ref", "-d", branch_ref, expected_head],
+            cwd=root,
+        )
+
+    if lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to delete the expected local Task branch"
+        )
+
+    receipt.unlink(missing_ok=True)
+    print(
+        json.dumps(
+            {
+                "task": task,
+                "discarded": True,
+                "removedWorktree": str(expected_path),
+                "removedBranch": branch,
+                "baseRevision": plan["base_revision"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def task_discard_pristine(root: Path, task: str) -> None:
+    lifecycle.require_main_worktree(root)
+    receipt = discard_receipt_path(root, task)
+    with lifecycle.cleanup_lock(root):
+        if receipt.exists():
+            finish_pristine_discard(
+                root,
+                read_discard_receipt(root, receipt, task),
+                receipt,
+            )
+            return
+        plan = pristine_discard_plan(root, task)
+        lifecycle.atomic_json(receipt, plan)
+        finish_pristine_discard(root, plan, receipt)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Guardedly discard an untouched unresolved Task"
+    )
+    result.add_argument("task")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        task_discard_pristine(lifecycle.repo_root(), args.task)
+    except lifecycle.LifecycleError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/components/agent-core/.automation/just/agent.just
+++ b/components/agent-core/.automation/just/agent.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 script := root / ".automation/bin/agent_core.py"
 lifecycle := root / ".automation/bin/task_lifecycle.py"
+discard_pristine := root / ".automation/bin/discard_pristine.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
@@ -94,6 +95,10 @@ pr-edit task:
 [working-directory: root]
 pr-ready task:
     python3 {{quote(script)}} agent pr-ready {{quote(task)}}
+
+[working-directory: root]
+discard-pristine task:
+    python3 {{quote(discard_pristine)}} {{quote(task)}}
 
 [working-directory: root]
 cleanup task:

--- a/components/agent-core/opencode.json
+++ b/components/agent-core/opencode.json
@@ -98,6 +98,7 @@
       "just integrate::check *": "allow",
       "just integrate::finalize *": "allow",
       "just agent::push *": "ask",
+      "just agent::discard-pristine *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
       "git add *": "deny",

--- a/templates/agent-base/.automation/PRISTINE_DISCARD.md
+++ b/templates/agent-base/.automation/PRISTINE_DISCARD.md
@@ -1,0 +1,45 @@
+# Guarded pristine Task discard
+
+`just agent::discard-pristine <task>` is the narrow recovery operation for an
+Issue-shaped Task worktree that was materialized but never received a canonical
+Task Contract and never began implementation.
+
+It is intentionally separate from `state-set` and ordinary terminal `cleanup`.
+The operation is destructive, runs only from the default-branch/Main
+Orchestrator worktree, and remains approval-gated by OpenCode policy.
+
+The discard succeeds only when Agent Core can prove all of the following:
+
+- Task status is exactly `initialized`.
+- The Task State is byte-for-byte the unresolved initialization template for
+  that Task identity and Base revision.
+- No canonical Task Contract metadata, Work Unit state, or other Task State
+  evidence exists.
+- The worktree is clean.
+- The registered Task branch and local branch both point exactly at the
+  recorded Base revision, with no additional commits.
+- The recorded Base branch is the repository default branch and the Base
+  revision is trusted default-branch history.
+- The Task branch has no configured upstream/publication metadata, no
+  remote-tracking ref, no live remote branch, and no historical pull request.
+- Repository identity and publication absence still match immediately before
+  local branch deletion.
+
+A private receipt under the common Git directory makes the destructive tail
+retryable. If worktree removal succeeds but local branch deletion fails, a
+later retry revalidates the Base, repository, remote branch, upstream
+configuration, and pull-request absence before deleting the expected local ref.
+If any evidence appears, retry fails closed and preserves the local branch.
+
+After successful discard, synchronize the default branch and restart the same
+Issue through the normal Issue-backed lifecycle:
+
+```text
+just agent::discard-pristine <task>
+just agent::task-start-from-issue <issue> <slug>
+```
+
+Do not use this operation for a resolved Task Contract, a Task with Work Units,
+a dirty or advanced branch, any pushed branch/PR, or any status other than
+`initialized`. Do not fabricate a contract or use raw `git worktree remove` /
+branch deletion as a substitute.

--- a/templates/agent-base/.automation/bin/discard_pristine.py
+++ b/templates/agent-base/.automation/bin/discard_pristine.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import task_lifecycle as lifecycle
+
+
+RECEIPT_SCHEMA_VERSION = 1
+RECEIPT_OPERATION = "discard-pristine"
+EXPECTED_STATE_FILES = {"task.md"}
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
+def discard_receipt_path(root: Path, task: str) -> Path:
+    lifecycle.validate_task(task)
+    return (
+        lifecycle.common_git_dir(root)
+        / "opencode"
+        / "discard-pristine"
+        / f"{task}.json"
+    )
+
+
+def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
+    assert record.branch is not None
+    evidence: list[str] = []
+    remote = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.remote",
+        cwd=record.path,
+        check=False,
+    )
+    merge = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.merge",
+        cwd=record.path,
+        check=False,
+    )
+    tracking = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/remotes/origin/{record.branch}",
+        cwd=record.path,
+        check=False,
+    )
+    if remote:
+        evidence.append("configured branch remote")
+    if merge:
+        evidence.append("configured upstream merge ref")
+    if tracking:
+        evidence.append("remote-tracking ref")
+    return evidence
+
+
+def _render_expected_pristine_state(
+    record: lifecycle.WorktreeRecord,
+    task: str,
+    base_branch: str,
+    base_revision: str,
+) -> str:
+    template = record.path / ".automation" / "templates" / "task-state.md"
+    if template.is_symlink() or not template.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template is unavailable or unsafe"
+        )
+    text = template.read_text(encoding="utf-8")
+    values = {
+        "@@TASK_ID@@": task,
+        "@@BRANCH@@": record.branch or "",
+        "@@WORKTREE@@": str(record.path),
+        "@@BASE_BRANCH@@": base_branch,
+        "@@BASE_REVISION@@": base_revision,
+    }
+    for marker, value in values.items():
+        text = text.replace(marker, value)
+    if any(marker in text for marker in values):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template contains unresolved identity markers"
+        )
+    return text
+
+
+def _require_pristine_unresolved_state(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    task: str,
+) -> tuple[str, str]:
+    lifecycle.assert_task_identity(record, task)
+    state = lifecycle.state_path(record.path)
+    if state.is_symlink() or not state.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is unavailable or unsafe"
+        )
+    if lifecycle.state_status(state) != "initialized":
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task status must be exactly initialized"
+        )
+
+    state_dir = state.parent
+    if state_dir.is_symlink() or not state_dir.is_dir():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State directory is unavailable or unsafe"
+        )
+    entries = {entry.name for entry in state_dir.iterdir()}
+    if entries != EXPECTED_STATE_FILES:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State contains contract, Work Unit, or other lifecycle evidence"
+        )
+
+    text = state.read_text(encoding="utf-8")
+    if "canonical-contract sha256=" in text:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: canonical Task Contract evidence exists"
+        )
+    for relative in (".task-state/issue.json", ".task-state/contract.json"):
+        if (record.path / relative).exists():
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: canonical Task Contract metadata exists"
+            )
+
+    work_units = lifecycle.read_work_units(record, task)
+    if work_units.get("units"):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Work Units already exist"
+        )
+
+    base_branch = lifecycle.extract_identity_value(state, "Base branch")
+    base_revision = lifecycle.extract_identity_value(state, "Base revision")
+    if (
+        not isinstance(base_branch, str)
+        or not base_branch
+        or not isinstance(base_revision, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base identity is missing or invalid"
+        )
+    base_revision = base_revision.lower()
+
+    expected = _render_expected_pristine_state(
+        record,
+        task,
+        base_branch,
+        base_revision,
+    )
+    if text != expected:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is not the untouched unresolved initialization state"
+        )
+
+    current_default = lifecycle.default_branch(root)
+    if base_branch != current_default:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base branch is not the repository default branch"
+        )
+    lifecycle.require_cleanup_base_revision(root, base_revision)
+    return base_branch, base_revision
+
+
+def _require_no_publication(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    repository: str,
+) -> None:
+    assert record.branch is not None
+    configured = _branch_publication_configuration(record)
+    if configured:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch has publication configuration: "
+            + ", ".join(configured)
+        )
+    remote_head = lifecycle.remote_branch_head(record)
+    if remote_head is not None:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: live remote Task branch exists"
+        )
+    if lifecycle.cleanup_prs(root, record.branch, repository):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: pull request evidence exists for the Task branch"
+        )
+
+
+def pristine_discard_plan(root: Path, task: str) -> dict:
+    lifecycle.require_main_worktree(root)
+    record = lifecycle.worktree_for_task(root, task)
+    lifecycle.assert_task_identity(record, task)
+    if lifecycle.git(
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+        cwd=record.path,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task worktree has uncommitted changes"
+        )
+
+    base_branch, base_revision = _require_pristine_unresolved_state(
+        root,
+        record,
+        task,
+    )
+    branch = record.branch
+    assert branch is not None
+    local_head = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/heads/{branch}",
+        cwd=record.path,
+    ).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: registered Task head changed"
+        )
+    if local_head != base_revision:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch HEAD differs from Base revision"
+        )
+    extra = lifecycle.git(
+        "rev-list",
+        "--count",
+        f"{base_revision}..{branch}",
+        cwd=record.path,
+    )
+    if int(extra or "0") != 0:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch contains commits beyond Base revision"
+        )
+
+    repository = lifecycle.cleanup_repository(root)
+    _require_no_publication(root, record, repository)
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "operation": RECEIPT_OPERATION,
+        "task": task,
+        "status": "initialized",
+        "worktree": str(record.path),
+        "branch": branch,
+        "base_branch": base_branch,
+        "base_revision": base_revision,
+        "local_head": local_head,
+        "repository": repository,
+    }
+
+
+def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine receipt is not a regular local file"
+        )
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
+    required = {
+        "schema_version",
+        "operation",
+        "task",
+        "status",
+        "worktree",
+        "branch",
+        "base_branch",
+        "base_revision",
+        "local_head",
+        "repository",
+    }
+    worktree = (
+        Path(value.get("worktree", "")).resolve()
+        if isinstance(value, dict)
+        else Path()
+    )
+    worktree_is_expected = (
+        worktree.parent == (root / ".worktrees").resolve()
+        and worktree.name not in {"", ".", ".."}
+    )
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != RECEIPT_SCHEMA_VERSION
+        or value.get("operation") != RECEIPT_OPERATION
+        or value.get("task") != task
+        or value.get("status") != "initialized"
+        or not isinstance(value.get("branch"), str)
+        or not lifecycle.branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("base_branch"), str)
+        or not value.get("base_branch")
+        or not isinstance(value.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["base_revision"])
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or value["local_head"].lower() != value["base_revision"].lower()
+        or not isinstance(value.get("repository"), str)
+        or not REPOSITORY_RE.fullmatch(value["repository"])
+        or not worktree_is_expected
+    ):
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid")
+    value["base_revision"] = value["base_revision"].lower()
+    value["local_head"] = value["local_head"].lower()
+    value["worktree"] = str(worktree)
+    return value
+
+
+def _revalidate_after_worktree_removal(root: Path, plan: dict) -> None:
+    if lifecycle.default_branch(root) != plan["base_branch"]:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository default branch changed"
+        )
+    lifecycle.require_cleanup_base_revision(root, plan["base_revision"])
+    repository = lifecycle.cleanup_repository(root)
+    if repository.casefold() != plan["repository"].casefold():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository identity changed"
+        )
+    record = lifecycle.WorktreeRecord(
+        root,
+        plan["branch"],
+        plan["local_head"],
+    )
+    _require_no_publication(root, record, repository)
+
+
+def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+
+    records = lifecycle.parse_worktrees(root)
+    registered = [
+        record
+        for record in records
+        if record.path == expected_path or record.branch == branch
+    ]
+    if registered:
+        if (
+            len(registered) != 1
+            or registered[0].path != expected_path
+            or registered[0].branch != branch
+        ):
+            raise lifecycle.LifecycleError(
+                "discard-pristine receipt conflicts with current worktree registration"
+            )
+        current = pristine_discard_plan(root, task)
+        if current != plan:
+            raise lifecycle.LifecycleError(
+                "discard-pristine evidence changed before worktree removal"
+            )
+        lifecycle.run(
+            ["git", "worktree", "remove", str(expected_path)],
+            cwd=root,
+        )
+
+    if any(
+        record.path == expected_path or record.branch == branch
+        for record in lifecycle.parse_worktrees(root)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to remove the expected worktree registration"
+        )
+
+    _revalidate_after_worktree_removal(root, plan)
+    branch_ref = f"refs/heads/{branch}"
+    actual = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ).lower()
+    if actual:
+        if actual != expected_head:
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: local Task branch moved after validation"
+            )
+        lifecycle.run(
+            ["git", "update-ref", "-d", branch_ref, expected_head],
+            cwd=root,
+        )
+
+    if lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to delete the expected local Task branch"
+        )
+
+    receipt.unlink(missing_ok=True)
+    print(
+        json.dumps(
+            {
+                "task": task,
+                "discarded": True,
+                "removedWorktree": str(expected_path),
+                "removedBranch": branch,
+                "baseRevision": plan["base_revision"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def task_discard_pristine(root: Path, task: str) -> None:
+    lifecycle.require_main_worktree(root)
+    receipt = discard_receipt_path(root, task)
+    with lifecycle.cleanup_lock(root):
+        if receipt.exists():
+            finish_pristine_discard(
+                root,
+                read_discard_receipt(root, receipt, task),
+                receipt,
+            )
+            return
+        plan = pristine_discard_plan(root, task)
+        lifecycle.atomic_json(receipt, plan)
+        finish_pristine_discard(root, plan, receipt)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Guardedly discard an untouched unresolved Task"
+    )
+    result.add_argument("task")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        task_discard_pristine(lifecycle.repo_root(), args.task)
+    except lifecycle.LifecycleError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-base/.automation/just/agent.just
+++ b/templates/agent-base/.automation/just/agent.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 script := root / ".automation/bin/agent_core.py"
 lifecycle := root / ".automation/bin/task_lifecycle.py"
+discard_pristine := root / ".automation/bin/discard_pristine.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
@@ -94,6 +95,10 @@ pr-edit task:
 [working-directory: root]
 pr-ready task:
     python3 {{quote(script)}} agent pr-ready {{quote(task)}}
+
+[working-directory: root]
+discard-pristine task:
+    python3 {{quote(discard_pristine)}} {{quote(task)}}
 
 [working-directory: root]
 cleanup task:

--- a/templates/agent-base/opencode.json
+++ b/templates/agent-base/opencode.json
@@ -98,6 +98,7 @@
       "just integrate::check *": "allow",
       "just integrate::finalize *": "allow",
       "just agent::push *": "ask",
+      "just agent::discard-pristine *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
       "git add *": "deny",

--- a/templates/agent-cpp-cmake/.automation/PRISTINE_DISCARD.md
+++ b/templates/agent-cpp-cmake/.automation/PRISTINE_DISCARD.md
@@ -1,0 +1,45 @@
+# Guarded pristine Task discard
+
+`just agent::discard-pristine <task>` is the narrow recovery operation for an
+Issue-shaped Task worktree that was materialized but never received a canonical
+Task Contract and never began implementation.
+
+It is intentionally separate from `state-set` and ordinary terminal `cleanup`.
+The operation is destructive, runs only from the default-branch/Main
+Orchestrator worktree, and remains approval-gated by OpenCode policy.
+
+The discard succeeds only when Agent Core can prove all of the following:
+
+- Task status is exactly `initialized`.
+- The Task State is byte-for-byte the unresolved initialization template for
+  that Task identity and Base revision.
+- No canonical Task Contract metadata, Work Unit state, or other Task State
+  evidence exists.
+- The worktree is clean.
+- The registered Task branch and local branch both point exactly at the
+  recorded Base revision, with no additional commits.
+- The recorded Base branch is the repository default branch and the Base
+  revision is trusted default-branch history.
+- The Task branch has no configured upstream/publication metadata, no
+  remote-tracking ref, no live remote branch, and no historical pull request.
+- Repository identity and publication absence still match immediately before
+  local branch deletion.
+
+A private receipt under the common Git directory makes the destructive tail
+retryable. If worktree removal succeeds but local branch deletion fails, a
+later retry revalidates the Base, repository, remote branch, upstream
+configuration, and pull-request absence before deleting the expected local ref.
+If any evidence appears, retry fails closed and preserves the local branch.
+
+After successful discard, synchronize the default branch and restart the same
+Issue through the normal Issue-backed lifecycle:
+
+```text
+just agent::discard-pristine <task>
+just agent::task-start-from-issue <issue> <slug>
+```
+
+Do not use this operation for a resolved Task Contract, a Task with Work Units,
+a dirty or advanced branch, any pushed branch/PR, or any status other than
+`initialized`. Do not fabricate a contract or use raw `git worktree remove` /
+branch deletion as a substitute.

--- a/templates/agent-cpp-cmake/.automation/bin/discard_pristine.py
+++ b/templates/agent-cpp-cmake/.automation/bin/discard_pristine.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import task_lifecycle as lifecycle
+
+
+RECEIPT_SCHEMA_VERSION = 1
+RECEIPT_OPERATION = "discard-pristine"
+EXPECTED_STATE_FILES = {"task.md"}
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
+def discard_receipt_path(root: Path, task: str) -> Path:
+    lifecycle.validate_task(task)
+    return (
+        lifecycle.common_git_dir(root)
+        / "opencode"
+        / "discard-pristine"
+        / f"{task}.json"
+    )
+
+
+def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
+    assert record.branch is not None
+    evidence: list[str] = []
+    remote = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.remote",
+        cwd=record.path,
+        check=False,
+    )
+    merge = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.merge",
+        cwd=record.path,
+        check=False,
+    )
+    tracking = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/remotes/origin/{record.branch}",
+        cwd=record.path,
+        check=False,
+    )
+    if remote:
+        evidence.append("configured branch remote")
+    if merge:
+        evidence.append("configured upstream merge ref")
+    if tracking:
+        evidence.append("remote-tracking ref")
+    return evidence
+
+
+def _render_expected_pristine_state(
+    record: lifecycle.WorktreeRecord,
+    task: str,
+    base_branch: str,
+    base_revision: str,
+) -> str:
+    template = record.path / ".automation" / "templates" / "task-state.md"
+    if template.is_symlink() or not template.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template is unavailable or unsafe"
+        )
+    text = template.read_text(encoding="utf-8")
+    values = {
+        "@@TASK_ID@@": task,
+        "@@BRANCH@@": record.branch or "",
+        "@@WORKTREE@@": str(record.path),
+        "@@BASE_BRANCH@@": base_branch,
+        "@@BASE_REVISION@@": base_revision,
+    }
+    for marker, value in values.items():
+        text = text.replace(marker, value)
+    if any(marker in text for marker in values):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template contains unresolved identity markers"
+        )
+    return text
+
+
+def _require_pristine_unresolved_state(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    task: str,
+) -> tuple[str, str]:
+    lifecycle.assert_task_identity(record, task)
+    state = lifecycle.state_path(record.path)
+    if state.is_symlink() or not state.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is unavailable or unsafe"
+        )
+    if lifecycle.state_status(state) != "initialized":
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task status must be exactly initialized"
+        )
+
+    state_dir = state.parent
+    if state_dir.is_symlink() or not state_dir.is_dir():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State directory is unavailable or unsafe"
+        )
+    entries = {entry.name for entry in state_dir.iterdir()}
+    if entries != EXPECTED_STATE_FILES:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State contains contract, Work Unit, or other lifecycle evidence"
+        )
+
+    text = state.read_text(encoding="utf-8")
+    if "canonical-contract sha256=" in text:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: canonical Task Contract evidence exists"
+        )
+    for relative in (".task-state/issue.json", ".task-state/contract.json"):
+        if (record.path / relative).exists():
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: canonical Task Contract metadata exists"
+            )
+
+    work_units = lifecycle.read_work_units(record, task)
+    if work_units.get("units"):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Work Units already exist"
+        )
+
+    base_branch = lifecycle.extract_identity_value(state, "Base branch")
+    base_revision = lifecycle.extract_identity_value(state, "Base revision")
+    if (
+        not isinstance(base_branch, str)
+        or not base_branch
+        or not isinstance(base_revision, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base identity is missing or invalid"
+        )
+    base_revision = base_revision.lower()
+
+    expected = _render_expected_pristine_state(
+        record,
+        task,
+        base_branch,
+        base_revision,
+    )
+    if text != expected:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is not the untouched unresolved initialization state"
+        )
+
+    current_default = lifecycle.default_branch(root)
+    if base_branch != current_default:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base branch is not the repository default branch"
+        )
+    lifecycle.require_cleanup_base_revision(root, base_revision)
+    return base_branch, base_revision
+
+
+def _require_no_publication(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    repository: str,
+) -> None:
+    assert record.branch is not None
+    configured = _branch_publication_configuration(record)
+    if configured:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch has publication configuration: "
+            + ", ".join(configured)
+        )
+    remote_head = lifecycle.remote_branch_head(record)
+    if remote_head is not None:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: live remote Task branch exists"
+        )
+    if lifecycle.cleanup_prs(root, record.branch, repository):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: pull request evidence exists for the Task branch"
+        )
+
+
+def pristine_discard_plan(root: Path, task: str) -> dict:
+    lifecycle.require_main_worktree(root)
+    record = lifecycle.worktree_for_task(root, task)
+    lifecycle.assert_task_identity(record, task)
+    if lifecycle.git(
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+        cwd=record.path,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task worktree has uncommitted changes"
+        )
+
+    base_branch, base_revision = _require_pristine_unresolved_state(
+        root,
+        record,
+        task,
+    )
+    branch = record.branch
+    assert branch is not None
+    local_head = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/heads/{branch}",
+        cwd=record.path,
+    ).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: registered Task head changed"
+        )
+    if local_head != base_revision:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch HEAD differs from Base revision"
+        )
+    extra = lifecycle.git(
+        "rev-list",
+        "--count",
+        f"{base_revision}..{branch}",
+        cwd=record.path,
+    )
+    if int(extra or "0") != 0:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch contains commits beyond Base revision"
+        )
+
+    repository = lifecycle.cleanup_repository(root)
+    _require_no_publication(root, record, repository)
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "operation": RECEIPT_OPERATION,
+        "task": task,
+        "status": "initialized",
+        "worktree": str(record.path),
+        "branch": branch,
+        "base_branch": base_branch,
+        "base_revision": base_revision,
+        "local_head": local_head,
+        "repository": repository,
+    }
+
+
+def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine receipt is not a regular local file"
+        )
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
+    required = {
+        "schema_version",
+        "operation",
+        "task",
+        "status",
+        "worktree",
+        "branch",
+        "base_branch",
+        "base_revision",
+        "local_head",
+        "repository",
+    }
+    worktree = (
+        Path(value.get("worktree", "")).resolve()
+        if isinstance(value, dict)
+        else Path()
+    )
+    worktree_is_expected = (
+        worktree.parent == (root / ".worktrees").resolve()
+        and worktree.name not in {"", ".", ".."}
+    )
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != RECEIPT_SCHEMA_VERSION
+        or value.get("operation") != RECEIPT_OPERATION
+        or value.get("task") != task
+        or value.get("status") != "initialized"
+        or not isinstance(value.get("branch"), str)
+        or not lifecycle.branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("base_branch"), str)
+        or not value.get("base_branch")
+        or not isinstance(value.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["base_revision"])
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or value["local_head"].lower() != value["base_revision"].lower()
+        or not isinstance(value.get("repository"), str)
+        or not REPOSITORY_RE.fullmatch(value["repository"])
+        or not worktree_is_expected
+    ):
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid")
+    value["base_revision"] = value["base_revision"].lower()
+    value["local_head"] = value["local_head"].lower()
+    value["worktree"] = str(worktree)
+    return value
+
+
+def _revalidate_after_worktree_removal(root: Path, plan: dict) -> None:
+    if lifecycle.default_branch(root) != plan["base_branch"]:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository default branch changed"
+        )
+    lifecycle.require_cleanup_base_revision(root, plan["base_revision"])
+    repository = lifecycle.cleanup_repository(root)
+    if repository.casefold() != plan["repository"].casefold():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository identity changed"
+        )
+    record = lifecycle.WorktreeRecord(
+        root,
+        plan["branch"],
+        plan["local_head"],
+    )
+    _require_no_publication(root, record, repository)
+
+
+def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+
+    records = lifecycle.parse_worktrees(root)
+    registered = [
+        record
+        for record in records
+        if record.path == expected_path or record.branch == branch
+    ]
+    if registered:
+        if (
+            len(registered) != 1
+            or registered[0].path != expected_path
+            or registered[0].branch != branch
+        ):
+            raise lifecycle.LifecycleError(
+                "discard-pristine receipt conflicts with current worktree registration"
+            )
+        current = pristine_discard_plan(root, task)
+        if current != plan:
+            raise lifecycle.LifecycleError(
+                "discard-pristine evidence changed before worktree removal"
+            )
+        lifecycle.run(
+            ["git", "worktree", "remove", str(expected_path)],
+            cwd=root,
+        )
+
+    if any(
+        record.path == expected_path or record.branch == branch
+        for record in lifecycle.parse_worktrees(root)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to remove the expected worktree registration"
+        )
+
+    _revalidate_after_worktree_removal(root, plan)
+    branch_ref = f"refs/heads/{branch}"
+    actual = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ).lower()
+    if actual:
+        if actual != expected_head:
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: local Task branch moved after validation"
+            )
+        lifecycle.run(
+            ["git", "update-ref", "-d", branch_ref, expected_head],
+            cwd=root,
+        )
+
+    if lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to delete the expected local Task branch"
+        )
+
+    receipt.unlink(missing_ok=True)
+    print(
+        json.dumps(
+            {
+                "task": task,
+                "discarded": True,
+                "removedWorktree": str(expected_path),
+                "removedBranch": branch,
+                "baseRevision": plan["base_revision"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def task_discard_pristine(root: Path, task: str) -> None:
+    lifecycle.require_main_worktree(root)
+    receipt = discard_receipt_path(root, task)
+    with lifecycle.cleanup_lock(root):
+        if receipt.exists():
+            finish_pristine_discard(
+                root,
+                read_discard_receipt(root, receipt, task),
+                receipt,
+            )
+            return
+        plan = pristine_discard_plan(root, task)
+        lifecycle.atomic_json(receipt, plan)
+        finish_pristine_discard(root, plan, receipt)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Guardedly discard an untouched unresolved Task"
+    )
+    result.add_argument("task")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        task_discard_pristine(lifecycle.repo_root(), args.task)
+    except lifecycle.LifecycleError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-cpp-cmake/.automation/just/agent.just
+++ b/templates/agent-cpp-cmake/.automation/just/agent.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 script := root / ".automation/bin/agent_core.py"
 lifecycle := root / ".automation/bin/task_lifecycle.py"
+discard_pristine := root / ".automation/bin/discard_pristine.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
@@ -94,6 +95,10 @@ pr-edit task:
 [working-directory: root]
 pr-ready task:
     python3 {{quote(script)}} agent pr-ready {{quote(task)}}
+
+[working-directory: root]
+discard-pristine task:
+    python3 {{quote(discard_pristine)}} {{quote(task)}}
 
 [working-directory: root]
 cleanup task:

--- a/templates/agent-cpp-cmake/opencode.json
+++ b/templates/agent-cpp-cmake/opencode.json
@@ -98,6 +98,7 @@
       "just integrate::check *": "allow",
       "just integrate::finalize *": "allow",
       "just agent::push *": "ask",
+      "just agent::discard-pristine *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
       "git add *": "deny",

--- a/templates/agent-nix/.automation/PRISTINE_DISCARD.md
+++ b/templates/agent-nix/.automation/PRISTINE_DISCARD.md
@@ -1,0 +1,45 @@
+# Guarded pristine Task discard
+
+`just agent::discard-pristine <task>` is the narrow recovery operation for an
+Issue-shaped Task worktree that was materialized but never received a canonical
+Task Contract and never began implementation.
+
+It is intentionally separate from `state-set` and ordinary terminal `cleanup`.
+The operation is destructive, runs only from the default-branch/Main
+Orchestrator worktree, and remains approval-gated by OpenCode policy.
+
+The discard succeeds only when Agent Core can prove all of the following:
+
+- Task status is exactly `initialized`.
+- The Task State is byte-for-byte the unresolved initialization template for
+  that Task identity and Base revision.
+- No canonical Task Contract metadata, Work Unit state, or other Task State
+  evidence exists.
+- The worktree is clean.
+- The registered Task branch and local branch both point exactly at the
+  recorded Base revision, with no additional commits.
+- The recorded Base branch is the repository default branch and the Base
+  revision is trusted default-branch history.
+- The Task branch has no configured upstream/publication metadata, no
+  remote-tracking ref, no live remote branch, and no historical pull request.
+- Repository identity and publication absence still match immediately before
+  local branch deletion.
+
+A private receipt under the common Git directory makes the destructive tail
+retryable. If worktree removal succeeds but local branch deletion fails, a
+later retry revalidates the Base, repository, remote branch, upstream
+configuration, and pull-request absence before deleting the expected local ref.
+If any evidence appears, retry fails closed and preserves the local branch.
+
+After successful discard, synchronize the default branch and restart the same
+Issue through the normal Issue-backed lifecycle:
+
+```text
+just agent::discard-pristine <task>
+just agent::task-start-from-issue <issue> <slug>
+```
+
+Do not use this operation for a resolved Task Contract, a Task with Work Units,
+a dirty or advanced branch, any pushed branch/PR, or any status other than
+`initialized`. Do not fabricate a contract or use raw `git worktree remove` /
+branch deletion as a substitute.

--- a/templates/agent-nix/.automation/bin/discard_pristine.py
+++ b/templates/agent-nix/.automation/bin/discard_pristine.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import task_lifecycle as lifecycle
+
+
+RECEIPT_SCHEMA_VERSION = 1
+RECEIPT_OPERATION = "discard-pristine"
+EXPECTED_STATE_FILES = {"task.md"}
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
+def discard_receipt_path(root: Path, task: str) -> Path:
+    lifecycle.validate_task(task)
+    return (
+        lifecycle.common_git_dir(root)
+        / "opencode"
+        / "discard-pristine"
+        / f"{task}.json"
+    )
+
+
+def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
+    assert record.branch is not None
+    evidence: list[str] = []
+    remote = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.remote",
+        cwd=record.path,
+        check=False,
+    )
+    merge = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.merge",
+        cwd=record.path,
+        check=False,
+    )
+    tracking = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/remotes/origin/{record.branch}",
+        cwd=record.path,
+        check=False,
+    )
+    if remote:
+        evidence.append("configured branch remote")
+    if merge:
+        evidence.append("configured upstream merge ref")
+    if tracking:
+        evidence.append("remote-tracking ref")
+    return evidence
+
+
+def _render_expected_pristine_state(
+    record: lifecycle.WorktreeRecord,
+    task: str,
+    base_branch: str,
+    base_revision: str,
+) -> str:
+    template = record.path / ".automation" / "templates" / "task-state.md"
+    if template.is_symlink() or not template.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template is unavailable or unsafe"
+        )
+    text = template.read_text(encoding="utf-8")
+    values = {
+        "@@TASK_ID@@": task,
+        "@@BRANCH@@": record.branch or "",
+        "@@WORKTREE@@": str(record.path),
+        "@@BASE_BRANCH@@": base_branch,
+        "@@BASE_REVISION@@": base_revision,
+    }
+    for marker, value in values.items():
+        text = text.replace(marker, value)
+    if any(marker in text for marker in values):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template contains unresolved identity markers"
+        )
+    return text
+
+
+def _require_pristine_unresolved_state(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    task: str,
+) -> tuple[str, str]:
+    lifecycle.assert_task_identity(record, task)
+    state = lifecycle.state_path(record.path)
+    if state.is_symlink() or not state.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is unavailable or unsafe"
+        )
+    if lifecycle.state_status(state) != "initialized":
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task status must be exactly initialized"
+        )
+
+    state_dir = state.parent
+    if state_dir.is_symlink() or not state_dir.is_dir():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State directory is unavailable or unsafe"
+        )
+    entries = {entry.name for entry in state_dir.iterdir()}
+    if entries != EXPECTED_STATE_FILES:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State contains contract, Work Unit, or other lifecycle evidence"
+        )
+
+    text = state.read_text(encoding="utf-8")
+    if "canonical-contract sha256=" in text:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: canonical Task Contract evidence exists"
+        )
+    for relative in (".task-state/issue.json", ".task-state/contract.json"):
+        if (record.path / relative).exists():
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: canonical Task Contract metadata exists"
+            )
+
+    work_units = lifecycle.read_work_units(record, task)
+    if work_units.get("units"):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Work Units already exist"
+        )
+
+    base_branch = lifecycle.extract_identity_value(state, "Base branch")
+    base_revision = lifecycle.extract_identity_value(state, "Base revision")
+    if (
+        not isinstance(base_branch, str)
+        or not base_branch
+        or not isinstance(base_revision, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base identity is missing or invalid"
+        )
+    base_revision = base_revision.lower()
+
+    expected = _render_expected_pristine_state(
+        record,
+        task,
+        base_branch,
+        base_revision,
+    )
+    if text != expected:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is not the untouched unresolved initialization state"
+        )
+
+    current_default = lifecycle.default_branch(root)
+    if base_branch != current_default:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base branch is not the repository default branch"
+        )
+    lifecycle.require_cleanup_base_revision(root, base_revision)
+    return base_branch, base_revision
+
+
+def _require_no_publication(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    repository: str,
+) -> None:
+    assert record.branch is not None
+    configured = _branch_publication_configuration(record)
+    if configured:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch has publication configuration: "
+            + ", ".join(configured)
+        )
+    remote_head = lifecycle.remote_branch_head(record)
+    if remote_head is not None:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: live remote Task branch exists"
+        )
+    if lifecycle.cleanup_prs(root, record.branch, repository):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: pull request evidence exists for the Task branch"
+        )
+
+
+def pristine_discard_plan(root: Path, task: str) -> dict:
+    lifecycle.require_main_worktree(root)
+    record = lifecycle.worktree_for_task(root, task)
+    lifecycle.assert_task_identity(record, task)
+    if lifecycle.git(
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+        cwd=record.path,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task worktree has uncommitted changes"
+        )
+
+    base_branch, base_revision = _require_pristine_unresolved_state(
+        root,
+        record,
+        task,
+    )
+    branch = record.branch
+    assert branch is not None
+    local_head = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/heads/{branch}",
+        cwd=record.path,
+    ).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: registered Task head changed"
+        )
+    if local_head != base_revision:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch HEAD differs from Base revision"
+        )
+    extra = lifecycle.git(
+        "rev-list",
+        "--count",
+        f"{base_revision}..{branch}",
+        cwd=record.path,
+    )
+    if int(extra or "0") != 0:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch contains commits beyond Base revision"
+        )
+
+    repository = lifecycle.cleanup_repository(root)
+    _require_no_publication(root, record, repository)
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "operation": RECEIPT_OPERATION,
+        "task": task,
+        "status": "initialized",
+        "worktree": str(record.path),
+        "branch": branch,
+        "base_branch": base_branch,
+        "base_revision": base_revision,
+        "local_head": local_head,
+        "repository": repository,
+    }
+
+
+def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine receipt is not a regular local file"
+        )
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
+    required = {
+        "schema_version",
+        "operation",
+        "task",
+        "status",
+        "worktree",
+        "branch",
+        "base_branch",
+        "base_revision",
+        "local_head",
+        "repository",
+    }
+    worktree = (
+        Path(value.get("worktree", "")).resolve()
+        if isinstance(value, dict)
+        else Path()
+    )
+    worktree_is_expected = (
+        worktree.parent == (root / ".worktrees").resolve()
+        and worktree.name not in {"", ".", ".."}
+    )
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != RECEIPT_SCHEMA_VERSION
+        or value.get("operation") != RECEIPT_OPERATION
+        or value.get("task") != task
+        or value.get("status") != "initialized"
+        or not isinstance(value.get("branch"), str)
+        or not lifecycle.branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("base_branch"), str)
+        or not value.get("base_branch")
+        or not isinstance(value.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["base_revision"])
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or value["local_head"].lower() != value["base_revision"].lower()
+        or not isinstance(value.get("repository"), str)
+        or not REPOSITORY_RE.fullmatch(value["repository"])
+        or not worktree_is_expected
+    ):
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid")
+    value["base_revision"] = value["base_revision"].lower()
+    value["local_head"] = value["local_head"].lower()
+    value["worktree"] = str(worktree)
+    return value
+
+
+def _revalidate_after_worktree_removal(root: Path, plan: dict) -> None:
+    if lifecycle.default_branch(root) != plan["base_branch"]:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository default branch changed"
+        )
+    lifecycle.require_cleanup_base_revision(root, plan["base_revision"])
+    repository = lifecycle.cleanup_repository(root)
+    if repository.casefold() != plan["repository"].casefold():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository identity changed"
+        )
+    record = lifecycle.WorktreeRecord(
+        root,
+        plan["branch"],
+        plan["local_head"],
+    )
+    _require_no_publication(root, record, repository)
+
+
+def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+
+    records = lifecycle.parse_worktrees(root)
+    registered = [
+        record
+        for record in records
+        if record.path == expected_path or record.branch == branch
+    ]
+    if registered:
+        if (
+            len(registered) != 1
+            or registered[0].path != expected_path
+            or registered[0].branch != branch
+        ):
+            raise lifecycle.LifecycleError(
+                "discard-pristine receipt conflicts with current worktree registration"
+            )
+        current = pristine_discard_plan(root, task)
+        if current != plan:
+            raise lifecycle.LifecycleError(
+                "discard-pristine evidence changed before worktree removal"
+            )
+        lifecycle.run(
+            ["git", "worktree", "remove", str(expected_path)],
+            cwd=root,
+        )
+
+    if any(
+        record.path == expected_path or record.branch == branch
+        for record in lifecycle.parse_worktrees(root)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to remove the expected worktree registration"
+        )
+
+    _revalidate_after_worktree_removal(root, plan)
+    branch_ref = f"refs/heads/{branch}"
+    actual = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ).lower()
+    if actual:
+        if actual != expected_head:
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: local Task branch moved after validation"
+            )
+        lifecycle.run(
+            ["git", "update-ref", "-d", branch_ref, expected_head],
+            cwd=root,
+        )
+
+    if lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to delete the expected local Task branch"
+        )
+
+    receipt.unlink(missing_ok=True)
+    print(
+        json.dumps(
+            {
+                "task": task,
+                "discarded": True,
+                "removedWorktree": str(expected_path),
+                "removedBranch": branch,
+                "baseRevision": plan["base_revision"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def task_discard_pristine(root: Path, task: str) -> None:
+    lifecycle.require_main_worktree(root)
+    receipt = discard_receipt_path(root, task)
+    with lifecycle.cleanup_lock(root):
+        if receipt.exists():
+            finish_pristine_discard(
+                root,
+                read_discard_receipt(root, receipt, task),
+                receipt,
+            )
+            return
+        plan = pristine_discard_plan(root, task)
+        lifecycle.atomic_json(receipt, plan)
+        finish_pristine_discard(root, plan, receipt)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Guardedly discard an untouched unresolved Task"
+    )
+    result.add_argument("task")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        task_discard_pristine(lifecycle.repo_root(), args.task)
+    except lifecycle.LifecycleError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-nix/.automation/just/agent.just
+++ b/templates/agent-nix/.automation/just/agent.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 script := root / ".automation/bin/agent_core.py"
 lifecycle := root / ".automation/bin/task_lifecycle.py"
+discard_pristine := root / ".automation/bin/discard_pristine.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
@@ -94,6 +95,10 @@ pr-edit task:
 [working-directory: root]
 pr-ready task:
     python3 {{quote(script)}} agent pr-ready {{quote(task)}}
+
+[working-directory: root]
+discard-pristine task:
+    python3 {{quote(discard_pristine)}} {{quote(task)}}
 
 [working-directory: root]
 cleanup task:

--- a/templates/agent-nix/opencode.json
+++ b/templates/agent-nix/opencode.json
@@ -98,6 +98,7 @@
       "just integrate::check *": "allow",
       "just integrate::finalize *": "allow",
       "just agent::push *": "ask",
+      "just agent::discard-pristine *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
       "git add *": "deny",

--- a/templates/agent-python/.automation/PRISTINE_DISCARD.md
+++ b/templates/agent-python/.automation/PRISTINE_DISCARD.md
@@ -1,0 +1,45 @@
+# Guarded pristine Task discard
+
+`just agent::discard-pristine <task>` is the narrow recovery operation for an
+Issue-shaped Task worktree that was materialized but never received a canonical
+Task Contract and never began implementation.
+
+It is intentionally separate from `state-set` and ordinary terminal `cleanup`.
+The operation is destructive, runs only from the default-branch/Main
+Orchestrator worktree, and remains approval-gated by OpenCode policy.
+
+The discard succeeds only when Agent Core can prove all of the following:
+
+- Task status is exactly `initialized`.
+- The Task State is byte-for-byte the unresolved initialization template for
+  that Task identity and Base revision.
+- No canonical Task Contract metadata, Work Unit state, or other Task State
+  evidence exists.
+- The worktree is clean.
+- The registered Task branch and local branch both point exactly at the
+  recorded Base revision, with no additional commits.
+- The recorded Base branch is the repository default branch and the Base
+  revision is trusted default-branch history.
+- The Task branch has no configured upstream/publication metadata, no
+  remote-tracking ref, no live remote branch, and no historical pull request.
+- Repository identity and publication absence still match immediately before
+  local branch deletion.
+
+A private receipt under the common Git directory makes the destructive tail
+retryable. If worktree removal succeeds but local branch deletion fails, a
+later retry revalidates the Base, repository, remote branch, upstream
+configuration, and pull-request absence before deleting the expected local ref.
+If any evidence appears, retry fails closed and preserves the local branch.
+
+After successful discard, synchronize the default branch and restart the same
+Issue through the normal Issue-backed lifecycle:
+
+```text
+just agent::discard-pristine <task>
+just agent::task-start-from-issue <issue> <slug>
+```
+
+Do not use this operation for a resolved Task Contract, a Task with Work Units,
+a dirty or advanced branch, any pushed branch/PR, or any status other than
+`initialized`. Do not fabricate a contract or use raw `git worktree remove` /
+branch deletion as a substitute.

--- a/templates/agent-python/.automation/bin/discard_pristine.py
+++ b/templates/agent-python/.automation/bin/discard_pristine.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import task_lifecycle as lifecycle
+
+
+RECEIPT_SCHEMA_VERSION = 1
+RECEIPT_OPERATION = "discard-pristine"
+EXPECTED_STATE_FILES = {"task.md"}
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
+def discard_receipt_path(root: Path, task: str) -> Path:
+    lifecycle.validate_task(task)
+    return (
+        lifecycle.common_git_dir(root)
+        / "opencode"
+        / "discard-pristine"
+        / f"{task}.json"
+    )
+
+
+def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
+    assert record.branch is not None
+    evidence: list[str] = []
+    remote = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.remote",
+        cwd=record.path,
+        check=False,
+    )
+    merge = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.merge",
+        cwd=record.path,
+        check=False,
+    )
+    tracking = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/remotes/origin/{record.branch}",
+        cwd=record.path,
+        check=False,
+    )
+    if remote:
+        evidence.append("configured branch remote")
+    if merge:
+        evidence.append("configured upstream merge ref")
+    if tracking:
+        evidence.append("remote-tracking ref")
+    return evidence
+
+
+def _render_expected_pristine_state(
+    record: lifecycle.WorktreeRecord,
+    task: str,
+    base_branch: str,
+    base_revision: str,
+) -> str:
+    template = record.path / ".automation" / "templates" / "task-state.md"
+    if template.is_symlink() or not template.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template is unavailable or unsafe"
+        )
+    text = template.read_text(encoding="utf-8")
+    values = {
+        "@@TASK_ID@@": task,
+        "@@BRANCH@@": record.branch or "",
+        "@@WORKTREE@@": str(record.path),
+        "@@BASE_BRANCH@@": base_branch,
+        "@@BASE_REVISION@@": base_revision,
+    }
+    for marker, value in values.items():
+        text = text.replace(marker, value)
+    if any(marker in text for marker in values):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template contains unresolved identity markers"
+        )
+    return text
+
+
+def _require_pristine_unresolved_state(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    task: str,
+) -> tuple[str, str]:
+    lifecycle.assert_task_identity(record, task)
+    state = lifecycle.state_path(record.path)
+    if state.is_symlink() or not state.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is unavailable or unsafe"
+        )
+    if lifecycle.state_status(state) != "initialized":
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task status must be exactly initialized"
+        )
+
+    state_dir = state.parent
+    if state_dir.is_symlink() or not state_dir.is_dir():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State directory is unavailable or unsafe"
+        )
+    entries = {entry.name for entry in state_dir.iterdir()}
+    if entries != EXPECTED_STATE_FILES:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State contains contract, Work Unit, or other lifecycle evidence"
+        )
+
+    text = state.read_text(encoding="utf-8")
+    if "canonical-contract sha256=" in text:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: canonical Task Contract evidence exists"
+        )
+    for relative in (".task-state/issue.json", ".task-state/contract.json"):
+        if (record.path / relative).exists():
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: canonical Task Contract metadata exists"
+            )
+
+    work_units = lifecycle.read_work_units(record, task)
+    if work_units.get("units"):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Work Units already exist"
+        )
+
+    base_branch = lifecycle.extract_identity_value(state, "Base branch")
+    base_revision = lifecycle.extract_identity_value(state, "Base revision")
+    if (
+        not isinstance(base_branch, str)
+        or not base_branch
+        or not isinstance(base_revision, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base identity is missing or invalid"
+        )
+    base_revision = base_revision.lower()
+
+    expected = _render_expected_pristine_state(
+        record,
+        task,
+        base_branch,
+        base_revision,
+    )
+    if text != expected:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is not the untouched unresolved initialization state"
+        )
+
+    current_default = lifecycle.default_branch(root)
+    if base_branch != current_default:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base branch is not the repository default branch"
+        )
+    lifecycle.require_cleanup_base_revision(root, base_revision)
+    return base_branch, base_revision
+
+
+def _require_no_publication(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    repository: str,
+) -> None:
+    assert record.branch is not None
+    configured = _branch_publication_configuration(record)
+    if configured:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch has publication configuration: "
+            + ", ".join(configured)
+        )
+    remote_head = lifecycle.remote_branch_head(record)
+    if remote_head is not None:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: live remote Task branch exists"
+        )
+    if lifecycle.cleanup_prs(root, record.branch, repository):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: pull request evidence exists for the Task branch"
+        )
+
+
+def pristine_discard_plan(root: Path, task: str) -> dict:
+    lifecycle.require_main_worktree(root)
+    record = lifecycle.worktree_for_task(root, task)
+    lifecycle.assert_task_identity(record, task)
+    if lifecycle.git(
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+        cwd=record.path,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task worktree has uncommitted changes"
+        )
+
+    base_branch, base_revision = _require_pristine_unresolved_state(
+        root,
+        record,
+        task,
+    )
+    branch = record.branch
+    assert branch is not None
+    local_head = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/heads/{branch}",
+        cwd=record.path,
+    ).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: registered Task head changed"
+        )
+    if local_head != base_revision:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch HEAD differs from Base revision"
+        )
+    extra = lifecycle.git(
+        "rev-list",
+        "--count",
+        f"{base_revision}..{branch}",
+        cwd=record.path,
+    )
+    if int(extra or "0") != 0:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch contains commits beyond Base revision"
+        )
+
+    repository = lifecycle.cleanup_repository(root)
+    _require_no_publication(root, record, repository)
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "operation": RECEIPT_OPERATION,
+        "task": task,
+        "status": "initialized",
+        "worktree": str(record.path),
+        "branch": branch,
+        "base_branch": base_branch,
+        "base_revision": base_revision,
+        "local_head": local_head,
+        "repository": repository,
+    }
+
+
+def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine receipt is not a regular local file"
+        )
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
+    required = {
+        "schema_version",
+        "operation",
+        "task",
+        "status",
+        "worktree",
+        "branch",
+        "base_branch",
+        "base_revision",
+        "local_head",
+        "repository",
+    }
+    worktree = (
+        Path(value.get("worktree", "")).resolve()
+        if isinstance(value, dict)
+        else Path()
+    )
+    worktree_is_expected = (
+        worktree.parent == (root / ".worktrees").resolve()
+        and worktree.name not in {"", ".", ".."}
+    )
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != RECEIPT_SCHEMA_VERSION
+        or value.get("operation") != RECEIPT_OPERATION
+        or value.get("task") != task
+        or value.get("status") != "initialized"
+        or not isinstance(value.get("branch"), str)
+        or not lifecycle.branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("base_branch"), str)
+        or not value.get("base_branch")
+        or not isinstance(value.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["base_revision"])
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or value["local_head"].lower() != value["base_revision"].lower()
+        or not isinstance(value.get("repository"), str)
+        or not REPOSITORY_RE.fullmatch(value["repository"])
+        or not worktree_is_expected
+    ):
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid")
+    value["base_revision"] = value["base_revision"].lower()
+    value["local_head"] = value["local_head"].lower()
+    value["worktree"] = str(worktree)
+    return value
+
+
+def _revalidate_after_worktree_removal(root: Path, plan: dict) -> None:
+    if lifecycle.default_branch(root) != plan["base_branch"]:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository default branch changed"
+        )
+    lifecycle.require_cleanup_base_revision(root, plan["base_revision"])
+    repository = lifecycle.cleanup_repository(root)
+    if repository.casefold() != plan["repository"].casefold():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository identity changed"
+        )
+    record = lifecycle.WorktreeRecord(
+        root,
+        plan["branch"],
+        plan["local_head"],
+    )
+    _require_no_publication(root, record, repository)
+
+
+def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+
+    records = lifecycle.parse_worktrees(root)
+    registered = [
+        record
+        for record in records
+        if record.path == expected_path or record.branch == branch
+    ]
+    if registered:
+        if (
+            len(registered) != 1
+            or registered[0].path != expected_path
+            or registered[0].branch != branch
+        ):
+            raise lifecycle.LifecycleError(
+                "discard-pristine receipt conflicts with current worktree registration"
+            )
+        current = pristine_discard_plan(root, task)
+        if current != plan:
+            raise lifecycle.LifecycleError(
+                "discard-pristine evidence changed before worktree removal"
+            )
+        lifecycle.run(
+            ["git", "worktree", "remove", str(expected_path)],
+            cwd=root,
+        )
+
+    if any(
+        record.path == expected_path or record.branch == branch
+        for record in lifecycle.parse_worktrees(root)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to remove the expected worktree registration"
+        )
+
+    _revalidate_after_worktree_removal(root, plan)
+    branch_ref = f"refs/heads/{branch}"
+    actual = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ).lower()
+    if actual:
+        if actual != expected_head:
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: local Task branch moved after validation"
+            )
+        lifecycle.run(
+            ["git", "update-ref", "-d", branch_ref, expected_head],
+            cwd=root,
+        )
+
+    if lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to delete the expected local Task branch"
+        )
+
+    receipt.unlink(missing_ok=True)
+    print(
+        json.dumps(
+            {
+                "task": task,
+                "discarded": True,
+                "removedWorktree": str(expected_path),
+                "removedBranch": branch,
+                "baseRevision": plan["base_revision"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def task_discard_pristine(root: Path, task: str) -> None:
+    lifecycle.require_main_worktree(root)
+    receipt = discard_receipt_path(root, task)
+    with lifecycle.cleanup_lock(root):
+        if receipt.exists():
+            finish_pristine_discard(
+                root,
+                read_discard_receipt(root, receipt, task),
+                receipt,
+            )
+            return
+        plan = pristine_discard_plan(root, task)
+        lifecycle.atomic_json(receipt, plan)
+        finish_pristine_discard(root, plan, receipt)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Guardedly discard an untouched unresolved Task"
+    )
+    result.add_argument("task")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        task_discard_pristine(lifecycle.repo_root(), args.task)
+    except lifecycle.LifecycleError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-python/.automation/just/agent.just
+++ b/templates/agent-python/.automation/just/agent.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 script := root / ".automation/bin/agent_core.py"
 lifecycle := root / ".automation/bin/task_lifecycle.py"
+discard_pristine := root / ".automation/bin/discard_pristine.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
@@ -94,6 +95,10 @@ pr-edit task:
 [working-directory: root]
 pr-ready task:
     python3 {{quote(script)}} agent pr-ready {{quote(task)}}
+
+[working-directory: root]
+discard-pristine task:
+    python3 {{quote(discard_pristine)}} {{quote(task)}}
 
 [working-directory: root]
 cleanup task:

--- a/templates/agent-python/opencode.json
+++ b/templates/agent-python/opencode.json
@@ -98,6 +98,7 @@
       "just integrate::check *": "allow",
       "just integrate::finalize *": "allow",
       "just agent::push *": "ask",
+      "just agent::discard-pristine *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
       "git add *": "deny",

--- a/templates/agent-rust/.automation/PRISTINE_DISCARD.md
+++ b/templates/agent-rust/.automation/PRISTINE_DISCARD.md
@@ -1,0 +1,45 @@
+# Guarded pristine Task discard
+
+`just agent::discard-pristine <task>` is the narrow recovery operation for an
+Issue-shaped Task worktree that was materialized but never received a canonical
+Task Contract and never began implementation.
+
+It is intentionally separate from `state-set` and ordinary terminal `cleanup`.
+The operation is destructive, runs only from the default-branch/Main
+Orchestrator worktree, and remains approval-gated by OpenCode policy.
+
+The discard succeeds only when Agent Core can prove all of the following:
+
+- Task status is exactly `initialized`.
+- The Task State is byte-for-byte the unresolved initialization template for
+  that Task identity and Base revision.
+- No canonical Task Contract metadata, Work Unit state, or other Task State
+  evidence exists.
+- The worktree is clean.
+- The registered Task branch and local branch both point exactly at the
+  recorded Base revision, with no additional commits.
+- The recorded Base branch is the repository default branch and the Base
+  revision is trusted default-branch history.
+- The Task branch has no configured upstream/publication metadata, no
+  remote-tracking ref, no live remote branch, and no historical pull request.
+- Repository identity and publication absence still match immediately before
+  local branch deletion.
+
+A private receipt under the common Git directory makes the destructive tail
+retryable. If worktree removal succeeds but local branch deletion fails, a
+later retry revalidates the Base, repository, remote branch, upstream
+configuration, and pull-request absence before deleting the expected local ref.
+If any evidence appears, retry fails closed and preserves the local branch.
+
+After successful discard, synchronize the default branch and restart the same
+Issue through the normal Issue-backed lifecycle:
+
+```text
+just agent::discard-pristine <task>
+just agent::task-start-from-issue <issue> <slug>
+```
+
+Do not use this operation for a resolved Task Contract, a Task with Work Units,
+a dirty or advanced branch, any pushed branch/PR, or any status other than
+`initialized`. Do not fabricate a contract or use raw `git worktree remove` /
+branch deletion as a substitute.

--- a/templates/agent-rust/.automation/bin/discard_pristine.py
+++ b/templates/agent-rust/.automation/bin/discard_pristine.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import task_lifecycle as lifecycle
+
+
+RECEIPT_SCHEMA_VERSION = 1
+RECEIPT_OPERATION = "discard-pristine"
+EXPECTED_STATE_FILES = {"task.md"}
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+
+
+def discard_receipt_path(root: Path, task: str) -> Path:
+    lifecycle.validate_task(task)
+    return (
+        lifecycle.common_git_dir(root)
+        / "opencode"
+        / "discard-pristine"
+        / f"{task}.json"
+    )
+
+
+def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
+    assert record.branch is not None
+    evidence: list[str] = []
+    remote = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.remote",
+        cwd=record.path,
+        check=False,
+    )
+    merge = lifecycle.git(
+        "config",
+        "--get",
+        f"branch.{record.branch}.merge",
+        cwd=record.path,
+        check=False,
+    )
+    tracking = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/remotes/origin/{record.branch}",
+        cwd=record.path,
+        check=False,
+    )
+    if remote:
+        evidence.append("configured branch remote")
+    if merge:
+        evidence.append("configured upstream merge ref")
+    if tracking:
+        evidence.append("remote-tracking ref")
+    return evidence
+
+
+def _render_expected_pristine_state(
+    record: lifecycle.WorktreeRecord,
+    task: str,
+    base_branch: str,
+    base_revision: str,
+) -> str:
+    template = record.path / ".automation" / "templates" / "task-state.md"
+    if template.is_symlink() or not template.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template is unavailable or unsafe"
+        )
+    text = template.read_text(encoding="utf-8")
+    values = {
+        "@@TASK_ID@@": task,
+        "@@BRANCH@@": record.branch or "",
+        "@@WORKTREE@@": str(record.path),
+        "@@BASE_BRANCH@@": base_branch,
+        "@@BASE_REVISION@@": base_revision,
+    }
+    for marker, value in values.items():
+        text = text.replace(marker, value)
+    if any(marker in text for marker in values):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State template contains unresolved identity markers"
+        )
+    return text
+
+
+def _require_pristine_unresolved_state(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    task: str,
+) -> tuple[str, str]:
+    lifecycle.assert_task_identity(record, task)
+    state = lifecycle.state_path(record.path)
+    if state.is_symlink() or not state.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is unavailable or unsafe"
+        )
+    if lifecycle.state_status(state) != "initialized":
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task status must be exactly initialized"
+        )
+
+    state_dir = state.parent
+    if state_dir.is_symlink() or not state_dir.is_dir():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State directory is unavailable or unsafe"
+        )
+    entries = {entry.name for entry in state_dir.iterdir()}
+    if entries != EXPECTED_STATE_FILES:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State contains contract, Work Unit, or other lifecycle evidence"
+        )
+
+    text = state.read_text(encoding="utf-8")
+    if "canonical-contract sha256=" in text:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: canonical Task Contract evidence exists"
+        )
+    for relative in (".task-state/issue.json", ".task-state/contract.json"):
+        if (record.path / relative).exists():
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: canonical Task Contract metadata exists"
+            )
+
+    work_units = lifecycle.read_work_units(record, task)
+    if work_units.get("units"):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Work Units already exist"
+        )
+
+    base_branch = lifecycle.extract_identity_value(state, "Base branch")
+    base_revision = lifecycle.extract_identity_value(state, "Base revision")
+    if (
+        not isinstance(base_branch, str)
+        or not base_branch
+        or not isinstance(base_revision, str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", base_revision)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base identity is missing or invalid"
+        )
+    base_revision = base_revision.lower()
+
+    expected = _render_expected_pristine_state(
+        record,
+        task,
+        base_branch,
+        base_revision,
+    )
+    if text != expected:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task State is not the untouched unresolved initialization state"
+        )
+
+    current_default = lifecycle.default_branch(root)
+    if base_branch != current_default:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task Base branch is not the repository default branch"
+        )
+    lifecycle.require_cleanup_base_revision(root, base_revision)
+    return base_branch, base_revision
+
+
+def _require_no_publication(
+    root: Path,
+    record: lifecycle.WorktreeRecord,
+    repository: str,
+) -> None:
+    assert record.branch is not None
+    configured = _branch_publication_configuration(record)
+    if configured:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch has publication configuration: "
+            + ", ".join(configured)
+        )
+    remote_head = lifecycle.remote_branch_head(record)
+    if remote_head is not None:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: live remote Task branch exists"
+        )
+    if lifecycle.cleanup_prs(root, record.branch, repository):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: pull request evidence exists for the Task branch"
+        )
+
+
+def pristine_discard_plan(root: Path, task: str) -> dict:
+    lifecycle.require_main_worktree(root)
+    record = lifecycle.worktree_for_task(root, task)
+    lifecycle.assert_task_identity(record, task)
+    if lifecycle.git(
+        "status",
+        "--porcelain",
+        "--untracked-files=all",
+        cwd=record.path,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task worktree has uncommitted changes"
+        )
+
+    base_branch, base_revision = _require_pristine_unresolved_state(
+        root,
+        record,
+        task,
+    )
+    branch = record.branch
+    assert branch is not None
+    local_head = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        f"refs/heads/{branch}",
+        cwd=record.path,
+    ).lower()
+    if record.head is None or record.head.lower() != local_head:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: registered Task head changed"
+        )
+    if local_head != base_revision:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch HEAD differs from Base revision"
+        )
+    extra = lifecycle.git(
+        "rev-list",
+        "--count",
+        f"{base_revision}..{branch}",
+        cwd=record.path,
+    )
+    if int(extra or "0") != 0:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: Task branch contains commits beyond Base revision"
+        )
+
+    repository = lifecycle.cleanup_repository(root)
+    _require_no_publication(root, record, repository)
+    return {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "operation": RECEIPT_OPERATION,
+        "task": task,
+        "status": "initialized",
+        "worktree": str(record.path),
+        "branch": branch,
+        "base_branch": base_branch,
+        "base_revision": base_revision,
+        "local_head": local_head,
+        "repository": repository,
+    }
+
+
+def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
+    if path.is_symlink() or not path.is_file():
+        raise lifecycle.LifecycleError(
+            "discard-pristine receipt is not a regular local file"
+        )
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
+    required = {
+        "schema_version",
+        "operation",
+        "task",
+        "status",
+        "worktree",
+        "branch",
+        "base_branch",
+        "base_revision",
+        "local_head",
+        "repository",
+    }
+    worktree = (
+        Path(value.get("worktree", "")).resolve()
+        if isinstance(value, dict)
+        else Path()
+    )
+    worktree_is_expected = (
+        worktree.parent == (root / ".worktrees").resolve()
+        and worktree.name not in {"", ".", ".."}
+    )
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("schema_version") != RECEIPT_SCHEMA_VERSION
+        or value.get("operation") != RECEIPT_OPERATION
+        or value.get("task") != task
+        or value.get("status") != "initialized"
+        or not isinstance(value.get("branch"), str)
+        or not lifecycle.branch_matches_task(value.get("branch"), task)
+        or not isinstance(value.get("base_branch"), str)
+        or not value.get("base_branch")
+        or not isinstance(value.get("base_revision"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["base_revision"])
+        or not isinstance(value.get("local_head"), str)
+        or not re.fullmatch(r"[0-9a-fA-F]{40,64}", value["local_head"])
+        or value["local_head"].lower() != value["base_revision"].lower()
+        or not isinstance(value.get("repository"), str)
+        or not REPOSITORY_RE.fullmatch(value["repository"])
+        or not worktree_is_expected
+    ):
+        raise lifecycle.LifecycleError("discard-pristine receipt is invalid")
+    value["base_revision"] = value["base_revision"].lower()
+    value["local_head"] = value["local_head"].lower()
+    value["worktree"] = str(worktree)
+    return value
+
+
+def _revalidate_after_worktree_removal(root: Path, plan: dict) -> None:
+    if lifecycle.default_branch(root) != plan["base_branch"]:
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository default branch changed"
+        )
+    lifecycle.require_cleanup_base_revision(root, plan["base_revision"])
+    repository = lifecycle.cleanup_repository(root)
+    if repository.casefold() != plan["repository"].casefold():
+        raise lifecycle.LifecycleError(
+            "discard-pristine refused: repository identity changed"
+        )
+    record = lifecycle.WorktreeRecord(
+        root,
+        plan["branch"],
+        plan["local_head"],
+    )
+    _require_no_publication(root, record, repository)
+
+
+def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
+    task = plan["task"]
+    branch = plan["branch"]
+    expected_path = Path(plan["worktree"]).resolve()
+    expected_head = plan["local_head"].lower()
+
+    records = lifecycle.parse_worktrees(root)
+    registered = [
+        record
+        for record in records
+        if record.path == expected_path or record.branch == branch
+    ]
+    if registered:
+        if (
+            len(registered) != 1
+            or registered[0].path != expected_path
+            or registered[0].branch != branch
+        ):
+            raise lifecycle.LifecycleError(
+                "discard-pristine receipt conflicts with current worktree registration"
+            )
+        current = pristine_discard_plan(root, task)
+        if current != plan:
+            raise lifecycle.LifecycleError(
+                "discard-pristine evidence changed before worktree removal"
+            )
+        lifecycle.run(
+            ["git", "worktree", "remove", str(expected_path)],
+            cwd=root,
+        )
+
+    if any(
+        record.path == expected_path or record.branch == branch
+        for record in lifecycle.parse_worktrees(root)
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to remove the expected worktree registration"
+        )
+
+    _revalidate_after_worktree_removal(root, plan)
+    branch_ref = f"refs/heads/{branch}"
+    actual = lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ).lower()
+    if actual:
+        if actual != expected_head:
+            raise lifecycle.LifecycleError(
+                "discard-pristine refused: local Task branch moved after validation"
+            )
+        lifecycle.run(
+            ["git", "update-ref", "-d", branch_ref, expected_head],
+            cwd=root,
+        )
+
+    if lifecycle.git(
+        "rev-parse",
+        "--verify",
+        branch_ref,
+        cwd=root,
+        check=False,
+    ):
+        raise lifecycle.LifecycleError(
+            "discard-pristine failed to delete the expected local Task branch"
+        )
+
+    receipt.unlink(missing_ok=True)
+    print(
+        json.dumps(
+            {
+                "task": task,
+                "discarded": True,
+                "removedWorktree": str(expected_path),
+                "removedBranch": branch,
+                "baseRevision": plan["base_revision"],
+            },
+            sort_keys=True,
+        )
+    )
+
+
+def task_discard_pristine(root: Path, task: str) -> None:
+    lifecycle.require_main_worktree(root)
+    receipt = discard_receipt_path(root, task)
+    with lifecycle.cleanup_lock(root):
+        if receipt.exists():
+            finish_pristine_discard(
+                root,
+                read_discard_receipt(root, receipt, task),
+                receipt,
+            )
+            return
+        plan = pristine_discard_plan(root, task)
+        lifecycle.atomic_json(receipt, plan)
+        finish_pristine_discard(root, plan, receipt)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(
+        description="Guardedly discard an untouched unresolved Task"
+    )
+    result.add_argument("task")
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        task_discard_pristine(lifecycle.repo_root(), args.task)
+    except lifecycle.LifecycleError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/agent-rust/.automation/just/agent.just
+++ b/templates/agent-rust/.automation/just/agent.just
@@ -1,6 +1,7 @@
 root := justfile_directory()
 script := root / ".automation/bin/agent_core.py"
 lifecycle := root / ".automation/bin/task_lifecycle.py"
+discard_pristine := root / ".automation/bin/discard_pristine.py"
 init := root / ".automation/bin/init_context.py"
 
 [working-directory: root]
@@ -94,6 +95,10 @@ pr-edit task:
 [working-directory: root]
 pr-ready task:
     python3 {{quote(script)}} agent pr-ready {{quote(task)}}
+
+[working-directory: root]
+discard-pristine task:
+    python3 {{quote(discard_pristine)}} {{quote(task)}}
 
 [working-directory: root]
 cleanup task:

--- a/templates/agent-rust/opencode.json
+++ b/templates/agent-rust/opencode.json
@@ -98,6 +98,7 @@
       "just integrate::check *": "allow",
       "just integrate::finalize *": "allow",
       "just agent::push *": "ask",
+      "just agent::discard-pristine *": "ask",
       "just agent::cleanup *": "ask",
       "just integrate::merge *": "ask",
       "git add *": "deny",

--- a/tests/test_pristine_discard.py
+++ b/tests/test_pristine_discard.py
@@ -338,7 +338,7 @@ class PristineDiscardTest(unittest.TestCase):
 
         with self.github(), self.assertRaisesRegex(
             lifecycle.LifecycleError,
-            "live remote Task branch exists",
+            "publication configuration|live remote Task branch exists",
         ):
             discard.task_discard_pristine(self.repo, "13")
         self.assertEqual(

--- a/tests/test_pristine_discard.py
+++ b/tests/test_pristine_discard.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+BIN = ROOT / "components" / "agent-core" / ".automation" / "bin"
+
+lifecycle_spec = importlib.util.spec_from_file_location(
+    "task_lifecycle", BIN / "task_lifecycle.py"
+)
+assert lifecycle_spec and lifecycle_spec.loader
+lifecycle = importlib.util.module_from_spec(lifecycle_spec)
+sys.modules[lifecycle_spec.name] = lifecycle
+lifecycle_spec.loader.exec_module(lifecycle)
+
+discard_spec = importlib.util.spec_from_file_location(
+    "discard_pristine", BIN / "discard_pristine.py"
+)
+assert discard_spec and discard_spec.loader
+discard = importlib.util.module_from_spec(discard_spec)
+sys.modules[discard_spec.name] = discard
+discard_spec.loader.exec_module(discard)
+
+
+def command(*args: str, cwd: Path, check: bool = True) -> str:
+    result = subprocess.run(
+        list(args),
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(
+            f"{' '.join(args)} failed: {result.stderr.strip() or result.stdout.strip()}"
+        )
+    return result.stdout.strip()
+
+
+class PristineDiscardTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        temporary_root = Path(self.temporary.name)
+        self.repo = temporary_root / "repo"
+        self.origin = temporary_root / "origin.git"
+        self.repo.mkdir()
+        command("git", "init", "-b", "main", cwd=self.repo)
+        command("git", "config", "user.name", "Agent Core Test", cwd=self.repo)
+        command("git", "config", "user.email", "agent-core@example.invalid", cwd=self.repo)
+
+        template = self.repo / ".automation/templates/task-state.md"
+        template.parent.mkdir(parents=True)
+        template.write_bytes(
+            (
+                ROOT
+                / "components"
+                / "agent-core"
+                / ".automation"
+                / "templates"
+                / "task-state.md"
+            ).read_bytes()
+        )
+        (self.repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+        command("git", "add", ".", cwd=self.repo)
+        command("git", "commit", "-m", "seed", cwd=self.repo)
+
+        command("git", "init", "--bare", str(self.origin), cwd=temporary_root)
+        command("git", "remote", "add", "origin", str(self.origin), cwd=self.repo)
+        command("git", "push", "-u", "origin", "main", cwd=self.repo)
+        command(
+            "git",
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/main",
+            cwd=self.repo,
+        )
+        self.initial_main = command("git", "rev-parse", "main", cwd=self.repo)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def github(self, prs: list[dict] | None = None) -> ExitStack:
+        stack = ExitStack()
+        stack.enter_context(
+            mock.patch.object(
+                lifecycle,
+                "cleanup_repository",
+                return_value="acme/widgets",
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(
+                lifecycle,
+                "cleanup_prs",
+                return_value=[] if prs is None else prs,
+            )
+        )
+        return stack
+
+    def start(self, task: str = "13", slug: str = "hybrid-level1-reranking") -> Path:
+        record = lifecycle.task_start(
+            self.repo,
+            task,
+            slug,
+            quiet=True,
+        )
+        return record.path
+
+    def advance_main(self) -> str:
+        (self.repo / "new-main.txt").write_text("new main\n", encoding="utf-8")
+        command("git", "add", "new-main.txt", cwd=self.repo)
+        command("git", "commit", "-m", "advance main", cwd=self.repo)
+        command("git", "push", "origin", "main", cwd=self.repo)
+        return command("git", "rev-parse", "main", cwd=self.repo)
+
+    def test_akv_shape_discards_and_same_issue_restarts_from_current_main(self) -> None:
+        task_worktree = self.start()
+        self.assertEqual(self.initial_main, command("git", "rev-parse", "HEAD", cwd=task_worktree))
+        current_main = self.advance_main()
+
+        with self.github():
+            discard.task_discard_pristine(self.repo, "13")
+
+        self.assertFalse(task_worktree.exists())
+        self.assertNotEqual(
+            0,
+            subprocess.run(
+                ["git", "show-ref", "--verify", "--quiet", "refs/heads/task/13-hybrid-level1-reranking"],
+                cwd=self.repo,
+            ).returncode,
+        )
+
+        def hydrate(
+            worktree: Path,
+            task: str,
+            issue: str,
+            payload: dict,
+            identity: str,
+        ) -> None:
+            state = worktree / ".task-state/task.md"
+            text = state.read_text(encoding="utf-8")
+            text = text.replace("TBD", "Restarted canonical contract")
+            text = text.replace(
+                "- [ ] Define Task-specific acceptance criteria",
+                "- [ ] Implement Issue-backed acceptance criteria",
+            )
+            text = text.replace(
+                "- Unverified: Task contract",
+                "- Unverified: none",
+            )
+            text += "\ncanonical-contract sha256=" + ("a" * 64) + "\n"
+            state.write_text(text, encoding="utf-8")
+            (worktree / ".task-state/contract.json").write_text(
+                json.dumps({"issue": int(issue), "repository": identity}),
+                encoding="utf-8",
+            )
+
+        fake_contract = mock.Mock(
+            ContractError=lifecycle.LifecycleError,
+            fetch_issue=mock.Mock(return_value=("acme/widgets", {})),
+            hydrate_task_contract=mock.Mock(side_effect=hydrate),
+        )
+        with mock.patch.dict(sys.modules, {"task_contract": fake_contract}):
+            lifecycle.task_start_from_issue(
+                self.repo,
+                "13",
+                "hybrid-level1-reranking",
+            )
+
+        restarted = lifecycle.worktree_for_task(self.repo, "13")
+        self.assertEqual(current_main, restarted.head)
+        state = lifecycle.state_path(restarted.path).read_text(encoding="utf-8")
+        self.assertIn(f"- Base revision: {current_main}", state)
+
+    def test_dirty_worktree_is_rejected(self) -> None:
+        task_worktree = self.start()
+        (task_worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+        with self.github(), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "uncommitted changes",
+        ):
+            discard.task_discard_pristine(self.repo, "13")
+        self.assertTrue(task_worktree.exists())
+
+    def test_head_beyond_base_is_rejected(self) -> None:
+        task_worktree = self.start()
+        (task_worktree / "implementation.txt").write_text("work\n", encoding="utf-8")
+        command("git", "add", "implementation.txt", cwd=task_worktree)
+        command("git", "commit", "-m", "implementation", cwd=task_worktree)
+        with self.github(), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "HEAD differs from Base revision",
+        ):
+            discard.task_discard_pristine(self.repo, "13")
+        self.assertTrue(task_worktree.exists())
+
+    def test_work_unit_evidence_is_rejected(self) -> None:
+        task_worktree = self.start()
+        record = lifecycle.worktree_for_task(self.repo, "13")
+        payload = lifecycle.empty_work_units(record, "13")
+        payload["units"]["WU-13-01"] = {
+            "id": "WU-13-01",
+            "state": "completed",
+        }
+        lifecycle.atomic_json(
+            lifecycle.work_units_path(task_worktree),
+            payload,
+        )
+        with self.github(), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "lifecycle evidence|Work Units",
+        ):
+            discard.task_discard_pristine(self.repo, "13")
+        self.assertTrue(task_worktree.exists())
+
+    def test_contract_metadata_is_rejected(self) -> None:
+        task_worktree = self.start()
+        (task_worktree / ".task-state/contract.json").write_text(
+            "{}\n",
+            encoding="utf-8",
+        )
+        with self.github(), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "lifecycle evidence|Contract metadata",
+        ):
+            discard.task_discard_pristine(self.repo, "13")
+        self.assertTrue(task_worktree.exists())
+
+    def test_non_initialized_task_is_rejected(self) -> None:
+        task_worktree = self.start()
+        state = lifecycle.state_path(task_worktree)
+        state.write_text(
+            state.read_text(encoding="utf-8").replace(
+                "- Status: initialized",
+                "- Status: planning",
+            ),
+            encoding="utf-8",
+        )
+        with self.github(), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "status must be exactly initialized",
+        ):
+            discard.task_discard_pristine(self.repo, "13")
+        self.assertTrue(task_worktree.exists())
+
+    def test_pull_request_evidence_is_rejected(self) -> None:
+        task_worktree = self.start()
+        with self.github(
+            [
+                {
+                    "number": 99,
+                    "state": "CLOSED",
+                    "headRefName": "task/13-hybrid-level1-reranking",
+                }
+            ]
+        ), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "pull request evidence",
+        ):
+            discard.task_discard_pristine(self.repo, "13")
+        self.assertTrue(task_worktree.exists())
+
+    def test_remote_publication_evidence_is_rejected(self) -> None:
+        task_worktree = self.start()
+        branch = command("git", "branch", "--show-current", cwd=task_worktree)
+        command("git", "push", "-u", "origin", branch, cwd=task_worktree)
+        command("git", "push", "origin", "--delete", branch, cwd=task_worktree)
+        with self.github(), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "publication configuration",
+        ):
+            discard.task_discard_pristine(self.repo, "13")
+        self.assertTrue(task_worktree.exists())
+
+    def test_operation_requires_main_authority(self) -> None:
+        task_worktree = self.start()
+        with self.github(), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "default-branch worktree",
+        ):
+            discard.task_discard_pristine(task_worktree, "13")
+
+    def test_only_expected_worktree_and_branch_are_removed(self) -> None:
+        task_worktree = self.start()
+        command("git", "branch", "keep-me", "main", cwd=self.repo)
+        with self.github():
+            discard.task_discard_pristine(self.repo, "13")
+        self.assertFalse(task_worktree.exists())
+        self.assertEqual(
+            command("git", "rev-parse", "main", cwd=self.repo),
+            command("git", "rev-parse", "keep-me", cwd=self.repo),
+        )
+
+    def test_partial_delete_retry_fails_closed_if_remote_publication_appears(self) -> None:
+        task_worktree = self.start()
+        branch = command("git", "branch", "--show-current", cwd=task_worktree)
+        real_run = lifecycle.run
+        failed = False
+
+        def fail_ref_delete_once(command_args: list[str], **kwargs):
+            nonlocal failed
+            if (
+                not failed
+                and command_args[:4]
+                == ["git", "update-ref", "-d", f"refs/heads/{branch}"]
+            ):
+                failed = True
+                raise lifecycle.LifecycleError("injected ref deletion failure")
+            return real_run(command_args, **kwargs)
+
+        with self.github(), mock.patch.object(
+            lifecycle,
+            "run",
+            side_effect=fail_ref_delete_once,
+        ), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "injected ref deletion failure",
+        ):
+            discard.task_discard_pristine(self.repo, "13")
+
+        self.assertFalse(task_worktree.exists())
+        self.assertTrue(discard.discard_receipt_path(self.repo, "13").exists())
+        command(
+            "git",
+            "push",
+            "origin",
+            f"{branch}:refs/heads/{branch}",
+            cwd=self.repo,
+        )
+
+        with self.github(), self.assertRaisesRegex(
+            lifecycle.LifecycleError,
+            "live remote Task branch exists",
+        ):
+            discard.task_discard_pristine(self.repo, "13")
+        self.assertEqual(
+            self.initial_main,
+            command("git", "rev-parse", branch, cwd=self.repo),
+        )
+        self.assertTrue(discard.discard_receipt_path(self.repo, "13").exists())
+
+    def test_permission_surface_is_explicitly_approval_gated(self) -> None:
+        config = json.loads(
+            (ROOT / "components/agent-core/opencode.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            "ask",
+            config["permission"]["bash"]["just agent::discard-pristine *"],
+        )
+        justfile = (
+            ROOT
+            / "components"
+            / "agent-core"
+            / ".automation"
+            / "just"
+            / "agent.just"
+        ).read_text(encoding="utf-8")
+        self.assertIn("discard-pristine task:", justfile)
+
+    def test_generated_discard_scripts_match_source(self) -> None:
+        source = (
+            ROOT
+            / "components"
+            / "agent-core"
+            / ".automation"
+            / "bin"
+            / "discard_pristine.py"
+        ).read_bytes()
+        for name in (
+            "agent-base",
+            "agent-cpp-cmake",
+            "agent-nix",
+            "agent-python",
+            "agent-rust",
+        ):
+            generated = (
+                ROOT
+                / "templates"
+                / name
+                / ".automation"
+                / "bin"
+                / "discard_pristine.py"
+            )
+            self.assertEqual(source, generated.read_bytes(), generated.as_posix())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a dedicated Main-owned `just agent::discard-pristine <task>` recovery operation for untouched unresolved Tasks
- fail closed unless the Task is exactly `initialized`, byte-for-byte pristine against its own initialization template, clean, at its recorded Base revision, and has zero Work Units / contract / implementation / publication evidence
- reject any configured upstream, remote-tracking ref, live remote branch, or historical pull request for the Task branch
- make the destructive worktree/local-ref tail retryable through a private receipt and revalidate repository/Base/publication evidence before expected-OID local branch deletion
- keep ordinary `state-set`, merged/cancelled `cleanup`, Task Contract initialization, and Agent Core VERSION 3 unchanged
- distribute the new managed script, Just API, approval-gated OpenCode permission, and recovery documentation to all generated agent templates

Closes #104

## Validation

- latest head: `61ad62236e30c496ed58cd51962e0173fa24df15`
- based directly on #103 merge / fresh `main` `9186d4bf24dfa8e6b8afb5b2814876d9304e089e`
- full Python contract suite: PASS (407 tests; CI #145)
- generated template drift: PASS
- all-systems flake evaluation: PASS
- OpenCodePolicy contract: PASS
- generated-template smoke: PASS for agent-python, agent-rust, agent-nix, and agent-cpp-cmake
- AgentKnowledgeVault #13-shaped discard + fresh current-main restart regression: PASS
- partial destructive retry with new publication evidence: PASS, fails closed and preserves local branch
- reviewer re-review on latest head: no High/Medium findings
- security review on latest head: no actionable High/Medium findings
- Template CI #145: SUCCESS

CI #144 failed only because one regression asserted a narrower error message (`live remote Task branch`) while the guard correctly failed earlier on the newly-created remote-tracking publication evidence. The test was corrected to accept either valid publication-evidence rejection; no production guard was weakened.

## Risks and unverified areas

- This operation intentionally accepts only the narrow untouched unresolved initialization state; any deviation from the original Task State template fails closed.
- Receipt storage inherits the existing Agent Core common-Git-dir administrative trust boundary used by guarded cleanup; no new filesystem privilege or raw Git authority is introduced.
- AgentKnowledgeVault Task #13 has not been modified or discarded. Downstream dogfood occurs only after this PR is merged, a new Agent Core release is created, and AgentKnowledgeVault is upgraded to that release.
- No release version/tag is selected by this change.