### PR TITLE
Normalize canonical PR body terminator

### DIFF
--- a/components/agent-core/.automation/bin/agent_core.py
+++ b/components/agent-core/.automation/bin/agent_core.py
@@ -372,9 +372,11 @@ def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Pa
         )
     except publication.PublicationMetadataError as exc:
         raise AutomationError(str(exc)) from exc
-    if title != expected_title or body.rstrip() != expected_body.rstrip():
+    if title != expected_title or not publication.canonical_pr_body_matches(
+        expected_body, body
+    ):
         raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
-    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+    return title, root / ".task-state" / "pr-body.md", body
 
 
 def _base_revision(root: Path) -> str:
@@ -388,9 +390,11 @@ def _base_revision(root: Path) -> str:
 def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
     expected = {
         "headRefName": branch, "baseRefName": base, "headRefOid": head,
-        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+        "title": title, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
     }
     mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if not publication.canonical_pr_body_matches(body, pr.get("body")):
+        mismatches.append("body")
     if mismatches:
         raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
 

--- a/components/agent-core/.automation/bin/maintenance_lifecycle.py
+++ b/components/agent-core/.automation/bin/maintenance_lifecycle.py
@@ -630,7 +630,7 @@ def _publication_evidence(
         )
     except publication.PublicationMetadataError as exc:
         raise MaintenanceError(str(exc)) from exc
-    return paths, title, body.rstrip()
+    return paths, title, body
 
 
 def maintenance_pr_create(root_path: Path, task: str) -> dict:
@@ -729,11 +729,12 @@ def _merged_pr(
         "isCrossRepository": False,
         "state": "MERGED",
         "title": title,
-        "body": body,
     }
     mismatches = [
         name for name, wanted in expected.items() if details.get(name) != wanted
     ]
+    if not publication.canonical_pr_body_matches(body, details.get("body")):
+        mismatches.append("body")
     merge = details.get("mergeCommit")
     merge_oid = merge.get("oid") if isinstance(merge, dict) else None
     if (

--- a/components/agent-core/.automation/bin/publication_metadata.py
+++ b/components/agent-core/.automation/bin/publication_metadata.py
@@ -188,12 +188,28 @@ def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> 
         raise PublicationMetadataError("pull request body is missing required sections")
 
 
+def canonical_pr_body_matches(canonical: str, live: str | None) -> bool:
+    """Compare PR bodies while tolerating only one transport-level terminal LF."""
+
+    if not isinstance(live, str) or canonical.endswith("\r\n") or live.endswith(
+        "\r\n"
+    ):
+        return False
+
+    def without_transport_lf(body: str) -> str:
+        if body.endswith("\n") and not body.endswith("\n\n"):
+            return body[:-1]
+        return body
+
+    return without_transport_lf(canonical) == without_transport_lf(live)
+
+
 def write_metadata(root: Path, title: str, body: str) -> None:
     try:
         task_contract.write_publication_metadata(
             root,
-            (title.strip() + "\n").encode(),
-            (body.rstrip() + "\n").encode(),
+            (title + "\n").encode(),
+            body.encode(),
         )
     except task_contract.ContractError as exc:
         raise PublicationMetadataError(str(exc)) from exc
@@ -203,7 +219,9 @@ def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tu
     title_path = root / ".task-state" / "pr-title.txt"
     body_path = root / ".task-state" / "pr-body.md"
     try:
-        title = title_path.read_text(encoding="utf-8").strip()
+        title = title_path.read_text(encoding="utf-8")
+        if title.endswith("\n"):
+            title = title[:-1]
         body = body_path.read_text(encoding="utf-8")
     except OSError as exc:
         raise PublicationMetadataError("run agent::pr-prepare before publication") from exc

--- a/templates/agent-base/.automation/bin/agent_core.py
+++ b/templates/agent-base/.automation/bin/agent_core.py
@@ -372,9 +372,11 @@ def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Pa
         )
     except publication.PublicationMetadataError as exc:
         raise AutomationError(str(exc)) from exc
-    if title != expected_title or body.rstrip() != expected_body.rstrip():
+    if title != expected_title or not publication.canonical_pr_body_matches(
+        expected_body, body
+    ):
         raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
-    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+    return title, root / ".task-state" / "pr-body.md", body
 
 
 def _base_revision(root: Path) -> str:
@@ -388,9 +390,11 @@ def _base_revision(root: Path) -> str:
 def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
     expected = {
         "headRefName": branch, "baseRefName": base, "headRefOid": head,
-        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+        "title": title, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
     }
     mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if not publication.canonical_pr_body_matches(body, pr.get("body")):
+        mismatches.append("body")
     if mismatches:
         raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
 

--- a/templates/agent-base/.automation/bin/maintenance_lifecycle.py
+++ b/templates/agent-base/.automation/bin/maintenance_lifecycle.py
@@ -630,7 +630,7 @@ def _publication_evidence(
         )
     except publication.PublicationMetadataError as exc:
         raise MaintenanceError(str(exc)) from exc
-    return paths, title, body.rstrip()
+    return paths, title, body
 
 
 def maintenance_pr_create(root_path: Path, task: str) -> dict:
@@ -729,11 +729,12 @@ def _merged_pr(
         "isCrossRepository": False,
         "state": "MERGED",
         "title": title,
-        "body": body,
     }
     mismatches = [
         name for name, wanted in expected.items() if details.get(name) != wanted
     ]
+    if not publication.canonical_pr_body_matches(body, details.get("body")):
+        mismatches.append("body")
     merge = details.get("mergeCommit")
     merge_oid = merge.get("oid") if isinstance(merge, dict) else None
     if (

--- a/templates/agent-base/.automation/bin/publication_metadata.py
+++ b/templates/agent-base/.automation/bin/publication_metadata.py
@@ -188,12 +188,28 @@ def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> 
         raise PublicationMetadataError("pull request body is missing required sections")
 
 
+def canonical_pr_body_matches(canonical: str, live: str | None) -> bool:
+    """Compare PR bodies while tolerating only one transport-level terminal LF."""
+
+    if not isinstance(live, str) or canonical.endswith("\r\n") or live.endswith(
+        "\r\n"
+    ):
+        return False
+
+    def without_transport_lf(body: str) -> str:
+        if body.endswith("\n") and not body.endswith("\n\n"):
+            return body[:-1]
+        return body
+
+    return without_transport_lf(canonical) == without_transport_lf(live)
+
+
 def write_metadata(root: Path, title: str, body: str) -> None:
     try:
         task_contract.write_publication_metadata(
             root,
-            (title.strip() + "\n").encode(),
-            (body.rstrip() + "\n").encode(),
+            (title + "\n").encode(),
+            body.encode(),
         )
     except task_contract.ContractError as exc:
         raise PublicationMetadataError(str(exc)) from exc
@@ -203,7 +219,9 @@ def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tu
     title_path = root / ".task-state" / "pr-title.txt"
     body_path = root / ".task-state" / "pr-body.md"
     try:
-        title = title_path.read_text(encoding="utf-8").strip()
+        title = title_path.read_text(encoding="utf-8")
+        if title.endswith("\n"):
+            title = title[:-1]
         body = body_path.read_text(encoding="utf-8")
     except OSError as exc:
         raise PublicationMetadataError("run agent::pr-prepare before publication") from exc

--- a/templates/agent-cpp-cmake/.automation/bin/agent_core.py
+++ b/templates/agent-cpp-cmake/.automation/bin/agent_core.py
@@ -372,9 +372,11 @@ def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Pa
         )
     except publication.PublicationMetadataError as exc:
         raise AutomationError(str(exc)) from exc
-    if title != expected_title or body.rstrip() != expected_body.rstrip():
+    if title != expected_title or not publication.canonical_pr_body_matches(
+        expected_body, body
+    ):
         raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
-    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+    return title, root / ".task-state" / "pr-body.md", body
 
 
 def _base_revision(root: Path) -> str:
@@ -388,9 +390,11 @@ def _base_revision(root: Path) -> str:
 def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
     expected = {
         "headRefName": branch, "baseRefName": base, "headRefOid": head,
-        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+        "title": title, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
     }
     mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if not publication.canonical_pr_body_matches(body, pr.get("body")):
+        mismatches.append("body")
     if mismatches:
         raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
 

--- a/templates/agent-cpp-cmake/.automation/bin/maintenance_lifecycle.py
+++ b/templates/agent-cpp-cmake/.automation/bin/maintenance_lifecycle.py
@@ -630,7 +630,7 @@ def _publication_evidence(
         )
     except publication.PublicationMetadataError as exc:
         raise MaintenanceError(str(exc)) from exc
-    return paths, title, body.rstrip()
+    return paths, title, body
 
 
 def maintenance_pr_create(root_path: Path, task: str) -> dict:
@@ -729,11 +729,12 @@ def _merged_pr(
         "isCrossRepository": False,
         "state": "MERGED",
         "title": title,
-        "body": body,
     }
     mismatches = [
         name for name, wanted in expected.items() if details.get(name) != wanted
     ]
+    if not publication.canonical_pr_body_matches(body, details.get("body")):
+        mismatches.append("body")
     merge = details.get("mergeCommit")
     merge_oid = merge.get("oid") if isinstance(merge, dict) else None
     if (

--- a/templates/agent-cpp-cmake/.automation/bin/publication_metadata.py
+++ b/templates/agent-cpp-cmake/.automation/bin/publication_metadata.py
@@ -188,12 +188,28 @@ def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> 
         raise PublicationMetadataError("pull request body is missing required sections")
 
 
+def canonical_pr_body_matches(canonical: str, live: str | None) -> bool:
+    """Compare PR bodies while tolerating only one transport-level terminal LF."""
+
+    if not isinstance(live, str) or canonical.endswith("\r\n") or live.endswith(
+        "\r\n"
+    ):
+        return False
+
+    def without_transport_lf(body: str) -> str:
+        if body.endswith("\n") and not body.endswith("\n\n"):
+            return body[:-1]
+        return body
+
+    return without_transport_lf(canonical) == without_transport_lf(live)
+
+
 def write_metadata(root: Path, title: str, body: str) -> None:
     try:
         task_contract.write_publication_metadata(
             root,
-            (title.strip() + "\n").encode(),
-            (body.rstrip() + "\n").encode(),
+            (title + "\n").encode(),
+            body.encode(),
         )
     except task_contract.ContractError as exc:
         raise PublicationMetadataError(str(exc)) from exc
@@ -203,7 +219,9 @@ def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tu
     title_path = root / ".task-state" / "pr-title.txt"
     body_path = root / ".task-state" / "pr-body.md"
     try:
-        title = title_path.read_text(encoding="utf-8").strip()
+        title = title_path.read_text(encoding="utf-8")
+        if title.endswith("\n"):
+            title = title[:-1]
         body = body_path.read_text(encoding="utf-8")
     except OSError as exc:
         raise PublicationMetadataError("run agent::pr-prepare before publication") from exc

--- a/templates/agent-nix/.automation/bin/agent_core.py
+++ b/templates/agent-nix/.automation/bin/agent_core.py
@@ -372,9 +372,11 @@ def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Pa
         )
     except publication.PublicationMetadataError as exc:
         raise AutomationError(str(exc)) from exc
-    if title != expected_title or body.rstrip() != expected_body.rstrip():
+    if title != expected_title or not publication.canonical_pr_body_matches(
+        expected_body, body
+    ):
         raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
-    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+    return title, root / ".task-state" / "pr-body.md", body
 
 
 def _base_revision(root: Path) -> str:
@@ -388,9 +390,11 @@ def _base_revision(root: Path) -> str:
 def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
     expected = {
         "headRefName": branch, "baseRefName": base, "headRefOid": head,
-        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+        "title": title, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
     }
     mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if not publication.canonical_pr_body_matches(body, pr.get("body")):
+        mismatches.append("body")
     if mismatches:
         raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
 

--- a/templates/agent-nix/.automation/bin/maintenance_lifecycle.py
+++ b/templates/agent-nix/.automation/bin/maintenance_lifecycle.py
@@ -630,7 +630,7 @@ def _publication_evidence(
         )
     except publication.PublicationMetadataError as exc:
         raise MaintenanceError(str(exc)) from exc
-    return paths, title, body.rstrip()
+    return paths, title, body
 
 
 def maintenance_pr_create(root_path: Path, task: str) -> dict:
@@ -729,11 +729,12 @@ def _merged_pr(
         "isCrossRepository": False,
         "state": "MERGED",
         "title": title,
-        "body": body,
     }
     mismatches = [
         name for name, wanted in expected.items() if details.get(name) != wanted
     ]
+    if not publication.canonical_pr_body_matches(body, details.get("body")):
+        mismatches.append("body")
     merge = details.get("mergeCommit")
     merge_oid = merge.get("oid") if isinstance(merge, dict) else None
     if (

--- a/templates/agent-nix/.automation/bin/publication_metadata.py
+++ b/templates/agent-nix/.automation/bin/publication_metadata.py
@@ -188,12 +188,28 @@ def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> 
         raise PublicationMetadataError("pull request body is missing required sections")
 
 
+def canonical_pr_body_matches(canonical: str, live: str | None) -> bool:
+    """Compare PR bodies while tolerating only one transport-level terminal LF."""
+
+    if not isinstance(live, str) or canonical.endswith("\r\n") or live.endswith(
+        "\r\n"
+    ):
+        return False
+
+    def without_transport_lf(body: str) -> str:
+        if body.endswith("\n") and not body.endswith("\n\n"):
+            return body[:-1]
+        return body
+
+    return without_transport_lf(canonical) == without_transport_lf(live)
+
+
 def write_metadata(root: Path, title: str, body: str) -> None:
     try:
         task_contract.write_publication_metadata(
             root,
-            (title.strip() + "\n").encode(),
-            (body.rstrip() + "\n").encode(),
+            (title + "\n").encode(),
+            body.encode(),
         )
     except task_contract.ContractError as exc:
         raise PublicationMetadataError(str(exc)) from exc
@@ -203,7 +219,9 @@ def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tu
     title_path = root / ".task-state" / "pr-title.txt"
     body_path = root / ".task-state" / "pr-body.md"
     try:
-        title = title_path.read_text(encoding="utf-8").strip()
+        title = title_path.read_text(encoding="utf-8")
+        if title.endswith("\n"):
+            title = title[:-1]
         body = body_path.read_text(encoding="utf-8")
     except OSError as exc:
         raise PublicationMetadataError("run agent::pr-prepare before publication") from exc

--- a/templates/agent-python/.automation/bin/agent_core.py
+++ b/templates/agent-python/.automation/bin/agent_core.py
@@ -372,9 +372,11 @@ def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Pa
         )
     except publication.PublicationMetadataError as exc:
         raise AutomationError(str(exc)) from exc
-    if title != expected_title or body.rstrip() != expected_body.rstrip():
+    if title != expected_title or not publication.canonical_pr_body_matches(
+        expected_body, body
+    ):
         raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
-    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+    return title, root / ".task-state" / "pr-body.md", body
 
 
 def _base_revision(root: Path) -> str:
@@ -388,9 +390,11 @@ def _base_revision(root: Path) -> str:
 def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
     expected = {
         "headRefName": branch, "baseRefName": base, "headRefOid": head,
-        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+        "title": title, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
     }
     mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if not publication.canonical_pr_body_matches(body, pr.get("body")):
+        mismatches.append("body")
     if mismatches:
         raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
 

--- a/templates/agent-python/.automation/bin/maintenance_lifecycle.py
+++ b/templates/agent-python/.automation/bin/maintenance_lifecycle.py
@@ -630,7 +630,7 @@ def _publication_evidence(
         )
     except publication.PublicationMetadataError as exc:
         raise MaintenanceError(str(exc)) from exc
-    return paths, title, body.rstrip()
+    return paths, title, body
 
 
 def maintenance_pr_create(root_path: Path, task: str) -> dict:
@@ -729,11 +729,12 @@ def _merged_pr(
         "isCrossRepository": False,
         "state": "MERGED",
         "title": title,
-        "body": body,
     }
     mismatches = [
         name for name, wanted in expected.items() if details.get(name) != wanted
     ]
+    if not publication.canonical_pr_body_matches(body, details.get("body")):
+        mismatches.append("body")
     merge = details.get("mergeCommit")
     merge_oid = merge.get("oid") if isinstance(merge, dict) else None
     if (

--- a/templates/agent-python/.automation/bin/publication_metadata.py
+++ b/templates/agent-python/.automation/bin/publication_metadata.py
@@ -188,12 +188,28 @@ def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> 
         raise PublicationMetadataError("pull request body is missing required sections")
 
 
+def canonical_pr_body_matches(canonical: str, live: str | None) -> bool:
+    """Compare PR bodies while tolerating only one transport-level terminal LF."""
+
+    if not isinstance(live, str) or canonical.endswith("\r\n") or live.endswith(
+        "\r\n"
+    ):
+        return False
+
+    def without_transport_lf(body: str) -> str:
+        if body.endswith("\n") and not body.endswith("\n\n"):
+            return body[:-1]
+        return body
+
+    return without_transport_lf(canonical) == without_transport_lf(live)
+
+
 def write_metadata(root: Path, title: str, body: str) -> None:
     try:
         task_contract.write_publication_metadata(
             root,
-            (title.strip() + "\n").encode(),
-            (body.rstrip() + "\n").encode(),
+            (title + "\n").encode(),
+            body.encode(),
         )
     except task_contract.ContractError as exc:
         raise PublicationMetadataError(str(exc)) from exc
@@ -203,7 +219,9 @@ def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tu
     title_path = root / ".task-state" / "pr-title.txt"
     body_path = root / ".task-state" / "pr-body.md"
     try:
-        title = title_path.read_text(encoding="utf-8").strip()
+        title = title_path.read_text(encoding="utf-8")
+        if title.endswith("\n"):
+            title = title[:-1]
         body = body_path.read_text(encoding="utf-8")
     except OSError as exc:
         raise PublicationMetadataError("run agent::pr-prepare before publication") from exc

--- a/templates/agent-rust/.automation/bin/agent_core.py
+++ b/templates/agent-rust/.automation/bin/agent_core.py
@@ -372,9 +372,11 @@ def _validated_local_metadata(root: Path, task: str, head: str) -> tuple[str, Pa
         )
     except publication.PublicationMetadataError as exc:
         raise AutomationError(str(exc)) from exc
-    if title != expected_title or body.rstrip() != expected_body.rstrip():
+    if title != expected_title or not publication.canonical_pr_body_matches(
+        expected_body, body
+    ):
         raise AutomationError("pull request metadata is stale; run agent::pr-prepare")
-    return title, root / ".task-state" / "pr-body.md", body.rstrip()
+    return title, root / ".task-state" / "pr-body.md", body
 
 
 def _base_revision(root: Path) -> str:
@@ -388,9 +390,11 @@ def _base_revision(root: Path) -> str:
 def _validate_live_pr(pr: dict, *, branch: str, base: str, head: str, title: str, body: str, draft: bool) -> None:
     expected = {
         "headRefName": branch, "baseRefName": base, "headRefOid": head,
-        "title": title, "body": body, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
+        "title": title, "isDraft": draft, "isCrossRepository": False, "state": "OPEN",
     }
     mismatches = [name for name, value in expected.items() if pr.get(name) != value]
+    if not publication.canonical_pr_body_matches(body, pr.get("body")):
+        mismatches.append("body")
     if mismatches:
         raise AutomationError("live pull request metadata is stale or inconsistent: " + ", ".join(mismatches))
 

--- a/templates/agent-rust/.automation/bin/maintenance_lifecycle.py
+++ b/templates/agent-rust/.automation/bin/maintenance_lifecycle.py
@@ -630,7 +630,7 @@ def _publication_evidence(
         )
     except publication.PublicationMetadataError as exc:
         raise MaintenanceError(str(exc)) from exc
-    return paths, title, body.rstrip()
+    return paths, title, body
 
 
 def maintenance_pr_create(root_path: Path, task: str) -> dict:
@@ -729,11 +729,12 @@ def _merged_pr(
         "isCrossRepository": False,
         "state": "MERGED",
         "title": title,
-        "body": body,
     }
     mismatches = [
         name for name, wanted in expected.items() if details.get(name) != wanted
     ]
+    if not publication.canonical_pr_body_matches(body, details.get("body")):
+        mismatches.append("body")
     merge = details.get("mergeCommit")
     merge_oid = merge.get("oid") if isinstance(merge, dict) else None
     if (

--- a/templates/agent-rust/.automation/bin/publication_metadata.py
+++ b/templates/agent-rust/.automation/bin/publication_metadata.py
@@ -188,12 +188,28 @@ def validate_metadata(title: str, body: str, *, receipt: dict | None = None) -> 
         raise PublicationMetadataError("pull request body is missing required sections")
 
 
+def canonical_pr_body_matches(canonical: str, live: str | None) -> bool:
+    """Compare PR bodies while tolerating only one transport-level terminal LF."""
+
+    if not isinstance(live, str) or canonical.endswith("\r\n") or live.endswith(
+        "\r\n"
+    ):
+        return False
+
+    def without_transport_lf(body: str) -> str:
+        if body.endswith("\n") and not body.endswith("\n\n"):
+            return body[:-1]
+        return body
+
+    return without_transport_lf(canonical) == without_transport_lf(live)
+
+
 def write_metadata(root: Path, title: str, body: str) -> None:
     try:
         task_contract.write_publication_metadata(
             root,
-            (title.strip() + "\n").encode(),
-            (body.rstrip() + "\n").encode(),
+            (title + "\n").encode(),
+            body.encode(),
         )
     except task_contract.ContractError as exc:
         raise PublicationMetadataError(str(exc)) from exc
@@ -203,7 +219,9 @@ def read_and_validate_metadata(root: Path, *, receipt: dict | None = None) -> tu
     title_path = root / ".task-state" / "pr-title.txt"
     body_path = root / ".task-state" / "pr-body.md"
     try:
-        title = title_path.read_text(encoding="utf-8").strip()
+        title = title_path.read_text(encoding="utf-8")
+        if title.endswith("\n"):
+            title = title[:-1]
         body = body_path.read_text(encoding="utf-8")
     except OSError as exc:
         raise PublicationMetadataError("run agent::pr-prepare before publication") from exc

--- a/tests/test_agent_core_automation.py
+++ b/tests/test_agent_core_automation.py
@@ -76,6 +76,38 @@ class AgentCoreSafetyTest(unittest.TestCase):
 class PublicationMetadataTest(unittest.TestCase):
     HEAD = "a" * 40
 
+    def test_canonical_pr_body_matches_allows_only_one_terminal_lf(self) -> None:
+        matches = agent_core.publication.canonical_pr_body_matches
+        self.assertTrue(matches("canonical body", "canonical body"))
+        self.assertTrue(matches("canonical body", "canonical body\n"))
+        self.assertTrue(matches("canonical body\n", "canonical body"))
+        for actual in (
+            "canonical body\n\n",
+            "canonical body ",
+            "changed body\n",
+            "canonical body\r\n",
+        ):
+            self.assertFalse(matches("canonical body", actual))
+        self.assertFalse(matches("canonical body\r\n", "canonical body\r\n"))
+        self.assertFalse(matches("canonical body\n\n", "canonical body\n"))
+
+    def test_live_validation_uses_terminal_lf_helper(self) -> None:
+        pr = {
+            "headRefName": "task/19", "baseRefName": "main", "headRefOid": self.HEAD,
+            "title": "19: title", "body": "canonical body", "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN",
+        }
+        with mock.patch.object(
+            agent_core.publication,
+            "canonical_pr_body_matches",
+            wraps=agent_core.publication.canonical_pr_body_matches,
+        ) as matches:
+            agent_core._validate_live_pr(
+                pr, branch="task/19", base="main", head=self.HEAD,
+                title="19: title", body="canonical body\n", draft=True,
+            )
+        matches.assert_called_once_with("canonical body\n", "canonical body")
+
     def fixture(self, root: Path, *, reviews: bool = True) -> None:
         state = root / ".task-state"
         state.mkdir()

--- a/tests/test_maintenance_lifecycle.py
+++ b/tests/test_maintenance_lifecycle.py
@@ -753,6 +753,31 @@ class MaintenanceLifecycleTest(unittest.TestCase):
                     "canonical body",
                 )
 
+    def test_merged_pr_uses_terminal_lf_helper(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            record = self._record(root)
+            details = {
+                "number": 22, "title": "21: canonical title", "body": "canonical body",
+                "headRefName": record.branch, "baseRefName": "main", "headRefOid": self.HEAD,
+                "isCrossRepository": False, "state": "MERGED", "mergeCommit": {"oid": self.MERGE},
+            }
+            with (
+                mock.patch.object(maintenance.agent_core, "pr_details", return_value=details),
+                mock.patch.object(maintenance.lifecycle, "default_branch", return_value="main"),
+                mock.patch.object(maintenance.agent_core, "canonical_repository", return_value="example/repo"),
+                mock.patch.object(
+                    maintenance.publication,
+                    "canonical_pr_body_matches",
+                    wraps=maintenance.publication.canonical_pr_body_matches,
+                ) as matches,
+            ):
+                maintenance._merged_pr(
+                    root, record, "example/repo", 22, self.HEAD,
+                    "21: canonical title", "canonical body\n",
+                )
+            matches.assert_called_once_with("canonical body\n", "canonical body")
+
     def test_dedicated_terminal_transition_does_not_change_normal_transition_table(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_source_maintenance_finalize_bridge.py
+++ b/tests/test_source_maintenance_finalize_bridge.py
@@ -123,8 +123,23 @@ class FirstAdoptionFinalizeBridgeTest(unittest.TestCase):
             record = maintenance.lifecycle.WorktreeRecord(
                 task, "task/22-maintenance", task_head
             )
-            publication = (["Justfile"], "22: maintenance", "canonical body")
-            merged = {"mergeCommitOid": merge_oid}
+            canonical_body = "canonical body"
+            live_body = canonical_body + "\n"
+            publication = (["Justfile"], "22: maintenance", canonical_body)
+            merged = {
+                "number": 23,
+                "title": "22: maintenance",
+                "body": live_body,
+                "baseRefName": "main",
+                "headRefName": "task/22-maintenance",
+                "headRefOid": task_head,
+                "isDraft": False,
+                "isCrossRepository": False,
+                "mergeCommit": {"oid": merge_oid},
+                "mergeable": "MERGEABLE",
+                "statusCheckRollup": [],
+                "state": "MERGED",
+            }
             revision = "a" * 40
 
             def run_bridge() -> dict:
@@ -145,14 +160,20 @@ class FirstAdoptionFinalizeBridgeTest(unittest.TestCase):
                 return json.loads(output.getvalue())
 
             with mock.patch.object(
-                maintenance, "_stored_contract", return_value=(record, {"repository": "upiscium/AgentKnowledgeVault"})
+                maintenance,
+                "_stored_contract",
+                return_value=(record, {"repository": "upiscium/AgentKnowledgeVault"}),
             ), mock.patch.object(
                 maintenance, "_validate_consumed_receipt", return_value={"commit_sha": task_head}
             ) as receipts, mock.patch.object(
                 maintenance, "_publication_evidence", return_value=publication
             ) as publications, mock.patch.object(
-                maintenance, "_merged_pr", return_value=merged
+                maintenance.agent_core, "pr_details", return_value=merged
             ) as prs, mock.patch.object(
+                maintenance.agent_core,
+                "canonical_repository",
+                return_value="upiscium/AgentKnowledgeVault",
+            ), mock.patch.object(
                 maintenance.lifecycle, "require_resolved_contract"
             ):
                 first = run_bridge()
@@ -161,13 +182,20 @@ class FirstAdoptionFinalizeBridgeTest(unittest.TestCase):
 
             self.assertEqual(self.git(main, "rev-parse", "HEAD"), merge_oid)
             self.assertEqual(first["transition"], "finalized")
+            self.assertEqual(first["status"], "FINALIZED")
+            self.assertEqual(first["publishedHead"], task_head)
             self.assertEqual(second["transition"], "already-finalized")
+            self.assertEqual(second["status"], "FINALIZED")
             self.assertEqual(state.read_bytes(), first_state)
             self.assertIn("- Status: merged", first_state.decode("utf-8"))
             self.assertEqual(first_state.count(b"### Maintenance publication"), 1)
             self.assertEqual(receipts.call_count, 6)
             self.assertEqual(publications.call_count, 6)
             self.assertEqual(prs.call_count, 6)
+            self.assertTrue(all(call.args[1] == "23" for call in prs.call_args_list))
+            self.assertEqual(merged["body"], live_body)
+            self.assertEqual(live_body.count("\n"), 1)
+            self.assertEqual(publication[2].rstrip("\n"), publication[2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add one strict canonical PR-body comparison helper shared by Draft/open and merged maintenance validation
- tolerate only a single terminal LF representation difference while preserving titles, spaces, blank lines, Markdown, and all PR identity evidence
- exercise AKV #22/#23-shaped source-side finalization through the real merged-PR comparison boundary

## Validation

- focused body/finalization regressions: PASS (47 tests)
- full unittest suite: PASS (449 tests)
- generated template drift: PASS
- distribution verification: PASS
- all-system flake evaluation: PASS
- OpenCodePolicy contract: PASS
- git diff --check: PASS
- correctness review: PASS
- security review: PASS for Issue #114 scope

Closes #114