### PR TITLE
Add downstream pre-release dogfood gate for Agent Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.worktrees/
 __pycache__/
 *.py[cod]
+/.agent-core-release-gate/

--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ Generated Agent-ready repositories include a repository-local `plan` agent for r
 
 Main schedules Tasks. Each Task owns one branch, one repo-local worktree under `.worktrees/`, one disposable `.task-state/task.md`, and one Task Orchestrator. Leaf agents cannot delegate or mutate Task State.
 
+For downstream-sensitive Agent Core changes, use the documented release gate
+from Issue through exact-revision AKV dogfood and post-merge tree equality:
+[`docs/agent-core-release-gate.md`](docs/agent-core-release-gate.md). It is
+human-gated and does not automate merge or release publication.
+
 Typical flow:
 
 ```text

--- a/docs/agent-core-release-gate.md
+++ b/docs/agent-core-release-gate.md
@@ -29,6 +29,12 @@ Issue -> Draft PR -> full Templates CI/review/security
 * A release tag is not a testing primitive. Tests and dogfood bind directly to
   immutable commit IDs and tree IDs; the tag/version is an output of successful
   validation.
+* The gate implementation is itself an immutable commit subject. Every command
+  requires a clean Templates source worktree, resolves its exact full `HEAD`,
+  and verifies the live launcher and Python gate tool against their regular Git
+  blobs and executable modes at that commit. It repeats the implementation
+  `HEAD`, content, mode, and cleanliness checks before returning success and
+  reports the commit as `implementationHead`. No release tag is required.
 * Do not release before downstream dogfood for a downstream-sensitive change.
 * A moving PR head invalidates all candidate, CI/review/security, and dogfood
   evidence bound to the previous head. Re-run the gate from the new head;
@@ -155,10 +161,15 @@ Evidence is local and auditable under:
 Each record is immutable and must not overwrite an earlier record. It binds
 the Templates PR number and exact frozen PR head/tree and the canonical AKV
 repository, operation, PASS outcome, timestamp, and Task/downstream PR when
-present. Run evidence recording and final gate consumption from the same
-operator source checkout so this ignored local directory remains available.
-Keep detailed downstream logs alongside the operational record, and retain or
-archive them according to repository practice.
+present. This is a narrow local operator self-attestation within the trusted
+operator/filesystem boundary, not a cryptographic downstream receipt. Its
+filename is exactly the SHA-256 digest of the canonical repository,
+PR, head, tree, and downstream-repository subject followed by `.json`; records
+under arbitrary or mismatched names are rejected even when their JSON schema is
+otherwise valid. Run evidence recording and final gate consumption from the
+same operator source checkout so this ignored local directory remains
+available. Keep detailed downstream logs alongside the operational record, and
+retain or archive them according to repository practice.
 
 If a guarded downstream operation stops part-way through, preserve its
 receipts and resume through its canonical recovery/resume surface. Do not

--- a/docs/agent-core-release-gate.md
+++ b/docs/agent-core-release-gate.md
@@ -20,10 +20,12 @@ Issue -> Draft PR -> full Templates CI/review/security
 * There is no automatic merge and no automatic release publication. A human
   decides whether to merge and separately performs the release.
 * Run the operator surfaces only from a trusted operator process and
-  environment. As with any dynamically linked command, a process already
-  started under hostile loader injection is outside the tool's recoverable
-  trust boundary. The launcher removes loader variables before starting its
-  validated, root-owned Python interpreter.
+  environment on a trusted local filesystem without a hostile same-identity
+  process. Such a process can replace any operator-owned checkout or evidence
+  regardless of mode bits. As with any dynamically linked command, a process
+  already started under hostile loader injection is outside the tool's
+  recoverable trust boundary. The launcher removes loader variables before
+  starting its validated, root-owned Python interpreter.
 * A release tag is not a testing primitive. Tests and dogfood bind directly to
   immutable commit IDs and tree IDs; the tag/version is an output of successful
   validation.
@@ -48,14 +50,28 @@ just agent-core::dogfood-evidence-record <pr> <operation> [task] [downstream_pr]
 just agent-core::release-gate-check <pr> <merge-commit> <dogfood-head> <dogfood-tree> [version]
 ```
 
-`release-candidate-check` verifies the current open PR and the complete GitHub
-CI rollup for its exact head. Human review and security review remain explicit
-operator prerequisites rather than inferred CI evidence. The result identifies
-the exact PR head that can be frozen. `release-candidate-worktree` creates or
-verifies a clean detached worktree at that head; `<path>` must resolve under
-the source checkout's `.worktrees/` (a name such as `pr-123-rc` or an explicit
-`.worktrees/pr-123-rc` both work), must be disposable, and must not already
-contain unrelated work. Neither surface merges, pushes, tags, or publishes.
+`release-candidate-check` verifies the current open PR and proves that the
+canonical `.github/workflows/template-ci.yml` workflow has exactly one
+unambiguous `pull_request` run for its exact head, with the current attempt
+completed successfully. It also requires the complete GitHub status rollup to
+be successful; an unrelated green context cannot substitute for Template CI.
+Human review and security review remain explicit operator prerequisites rather
+than inferred CI evidence. The result identifies the exact PR head that can be
+frozen.
+
+`release-candidate-worktree` creates or verifies a clean detached worktree at
+that head; `<path>` must resolve under the source checkout's `.worktrees/` (a
+name such as `pr-123-rc` or an explicit `.worktrees/pr-123-rc` both work), must
+be disposable, and must not already contain unrelated work. Before any fetch or
+checkout it requires the canonical Templates HTTPS `origin` and rejects local
+Git include, URL rewrite, HTTP, credential, filter, protocol, SSH/proxy, custom
+upload-pack/receive-pack, hooks, and worktree execution overrides. A missing
+candidate is materialized as a standalone detached Git worktree: its private
+repository is initialized inside the destination, then the exact commit is
+fetched only from the pinned canonical HTTPS URL and checked out without
+consuming the source repository's local transport/filter configuration. An
+existing destination is accepted only when it is already the exact detached,
+clean candidate root. Neither surface merges, pushes, tags, or publishes.
 
 `dogfood-evidence-record` records the auditable PASS outcome and concise
 operation identifier (and, where applicable, the downstream Task and PR) after
@@ -73,8 +89,14 @@ and record the aggregate PASS only after every applicable step has passed.
 `release-gate-check` is the final read-only assertion. It requires the recorded
 evidence, supplied merge commit, exact dogfooded **Templates** PR head/tree,
 and (when supplied) the intended version. It checks that the merge commit has
-the same tree as the frozen candidate. It does not
+the same tree as the frozen candidate. When a version is supplied, both the
+GitHub Release and the exact Git tag must be absent; an existing tag fails
+closed even without a Release object. It does not
 merge, create a release, publish a tag, or claim that a release was published.
+This is point-in-time pre-publication evidence: the separate human-controlled
+publisher must create the version tag at the verified merge commit with
+create-only/fail-if-present semantics, then create the Release from that exact
+tag. It must never reuse a tag that appeared after the gate check.
 
 ## Operating procedure
 

--- a/docs/agent-core-release-gate.md
+++ b/docs/agent-core-release-gate.md
@@ -1,0 +1,160 @@
+# Agent Core release gate
+
+This is the operator guide for releasing a change whose Agent Core behavior may
+affect downstream repositories. It is a gate and evidence protocol, not a
+merge or release publisher. The canonical path is:
+
+```text
+Issue -> Draft PR -> full Templates CI/review/security
+      -> freeze exact PR head
+      -> detached, clean release-candidate worktree
+      -> exact-revision AKV downstream dogfood
+      -> PASS evidence
+      -> human merge
+      -> merge-tree equality
+      -> release
+```
+
+## Boundaries and invariants
+
+* There is no automatic merge and no automatic release publication. A human
+  decides whether to merge and separately performs the release.
+* Run the operator surfaces only from a trusted operator process and
+  environment. As with any dynamically linked command, a process already
+  started under hostile loader injection is outside the tool's recoverable
+  trust boundary. The launcher removes loader variables before starting its
+  validated, root-owned Python interpreter.
+* A release tag is not a testing primitive. Tests and dogfood bind directly to
+  immutable commit IDs and tree IDs; the tag/version is an output of successful
+  validation.
+* Do not release before downstream dogfood for a downstream-sensitive change.
+* A moving PR head invalidates all candidate, CI/review/security, and dogfood
+  evidence bound to the previous head. Re-run the gate from the new head;
+  the preferred repair is another commit on the same Draft PR, not a new PR
+  whose history obscures the review context.
+* The candidate worktree is a clean, detached checkout of the frozen exact PR
+  head. It is suitable as the exact-revision source for
+  `agent-core::maintenance-finalize` when an older consumer needs the
+  source-side bridge; it is not a place to edit or commit the candidate.
+
+## Intended Just surfaces
+
+These are the narrow operator surfaces for the release gate:
+
+```text
+just agent-core::release-candidate-check <pr>
+just agent-core::release-candidate-worktree <pr> <path>
+just agent-core::dogfood-evidence-record <pr> <operation> [task] [downstream_pr]
+just agent-core::release-gate-check <pr> <merge-commit> <dogfood-head> <dogfood-tree> [version]
+```
+
+`release-candidate-check` verifies the current open PR and the complete GitHub
+CI rollup for its exact head. Human review and security review remain explicit
+operator prerequisites rather than inferred CI evidence. The result identifies
+the exact PR head that can be frozen. `release-candidate-worktree` creates or
+verifies a clean detached worktree at that head; `<path>` must resolve under
+the source checkout's `.worktrees/` (a name such as `pr-123-rc` or an explicit
+`.worktrees/pr-123-rc` both work), must be disposable, and must not already
+contain unrelated work. Neither surface merges, pushes, tags, or publishes.
+
+`dogfood-evidence-record` records the auditable PASS outcome and concise
+operation identifier (and, where applicable, the downstream Task and PR) after
+the operator has run AKV against the exact candidate revision. The record binds
+the Templates repository, PR, candidate head/tree, canonical downstream
+repository, operation, optional IDs, PASS, and timestamp. It does not claim to
+capture raw command logs and does not alter downstream Task State, PR metadata,
+or merge state.
+
+There is exactly one immutable PASS record per candidate head/tree. Its
+operation identifier names the overall externally executed dogfood run. When a
+run has several required guarded steps, complete or safely resume all of them
+and record the aggregate PASS only after every applicable step has passed.
+
+`release-gate-check` is the final read-only assertion. It requires the recorded
+evidence, supplied merge commit, exact dogfooded **Templates** PR head/tree,
+and (when supplied) the intended version. It checks that the merge commit has
+the same tree as the frozen candidate. It does not
+merge, create a release, publish a tag, or claim that a release was published.
+
+## Operating procedure
+
+1. Start with the authoritative Issue. Confirm scope, acceptance criteria,
+   risk, and the Task Contract. Implement through the normal Task lifecycle
+   and open a Draft PR through the guarded publication path.
+2. Wait for the complete Templates gate: all required CI/checks, human review,
+   and security review. Include failures and unverified items in the PR
+   evidence; a green subset is not a gate PASS.
+3. Run `release-candidate-check <pr>`. Freeze and record its exact PR-head
+   OID. If the head moves, stop and repeat this step after the Draft PR fix.
+4. Create the detached clean worktree with
+   `release-candidate-worktree <pr> <path>`. Verify its `HEAD` equals the
+   frozen PR head and its tree is clean. Do not use a tag or a mutable branch
+   as the candidate identity.
+5. From that worktree, run the exact-revision AKV downstream dogfood. Use the
+   `maintenance-finalize` bridge when the consumer requires it, supplying the
+   full candidate revision. After the externally executed dogfood has passed,
+   record its concise overall operation with `dogfood-evidence-record`; retain
+   the detailed command output separately and include any downstream Task/PR
+   identity in the narrow record.
+6. Require every applicable dogfood operation to PASS. A blocked, skipped, or
+   unexecuted operation is not PASS. Preserve and resume partial guarded
+   downstream progress rather than resetting it or launching duplicate work.
+7. After a human merges the PR, obtain the actual merge commit and run
+   `release-gate-check <pr> <merge-commit> <dogfood-head> <dogfood-tree>
+   [version]`. Release only after this check is PASS and the operator has
+   retained the evidence.
+
+## Scope of the gate
+
+Treat a change as downstream-sensitive when it touches or changes behavior in
+any of these areas, including their permissions and authority boundaries:
+
+* automation upgrade and maintenance lifecycle;
+* Task lifecycle, Task Contract, Work Units, and recovery/resume behavior;
+* PR publication and post-merge finalization;
+* cleanup/discard and recovery paths;
+* source bridges, including exact-revision maintenance finalization;
+* authority or permission changes affecting any of the paths above.
+
+For these changes, dogfood the exact candidate, not an installed version
+selected by a tag, branch, or floating upstream. Do not edit merged PR
+metadata or mutate Task State merely to make a check pass. Fix the source
+Draft PR, or stop for human handling when the canonical workflow cannot
+continue.
+
+## Evidence and recovery
+
+Evidence is local and auditable under:
+
+```text
+.agent-core-release-gate/evidence/
+```
+
+Each record is immutable and must not overwrite an earlier record. It binds
+the Templates PR number and exact frozen PR head/tree and the canonical AKV
+repository, operation, PASS outcome, timestamp, and Task/downstream PR when
+present. Run evidence recording and final gate consumption from the same
+operator source checkout so this ignored local directory remains available.
+Keep detailed downstream logs alongside the operational record, and retain or
+archive them according to repository practice.
+
+If a guarded downstream operation stops part-way through, preserve its
+receipts and resume through its canonical recovery/resume surface. Do not
+delete evidence, recreate a Task to hide a failure, rewrite the Task Contract,
+or manually change Task State. A new PR head requires a new candidate binding
+and new evidence, even if the resulting files are byte-identical.
+
+## Historical fixture (PR #115)
+
+PR #115 is a historical fixture for checking merge/tree reasoning only:
+
+```text
+PR head:    35b562fca9a4dbc0656b79f98a356c6183034469
+PR tree:    0eeaad174d2ff519a2db4b23ac80252c48d6bec7
+merge:      e50b541e23e1ddb2014f6bfc94855262f47e8162
+merge tree: 0eeaad174d2ff519a2db4b23ac80252c48d6bec7
+```
+
+It is historical documentation, not a production input or a substitute for
+current CI, review, security, dogfood, or human merge evidence. Agent Core
+`VERSION` remains **3**.

--- a/just/agent-core.just
+++ b/just/agent-core.just
@@ -1,5 +1,7 @@
 root := justfile_directory()
 tool := root / "tools/automation_recovery_bridge.py"
+release_gate := root / "tools/agent_core_release_gate.py"
+release_gate_launcher := root / "tools/run_agent_core_release_gate.sh"
 set shell := ["/bin/sh", "-cu"]
 
 [working-directory: root]
@@ -9,6 +11,22 @@ recover-maintenance-authority target:
 [working-directory: root]
 commit-recovered-maintenance target task message="":
     python3 -I {{quote(tool)}} commit-recovered-maintenance {{quote(target)}} {{quote(task)}} {{quote(message)}}
+
+[working-directory: root]
+release-candidate-check pr:
+    /bin/sh {{quote(release_gate_launcher)}} {{quote(release_gate)}} release-candidate-check {{quote(pr)}}
+
+[working-directory: root]
+release-candidate-worktree pr path:
+    /bin/sh {{quote(release_gate_launcher)}} {{quote(release_gate)}} release-candidate-worktree {{quote(pr)}} {{quote(path)}}
+
+[working-directory: root]
+dogfood-evidence-record pr operation task="" downstream_pr="":
+    /bin/sh {{quote(release_gate_launcher)}} {{quote(release_gate)}} dogfood-evidence-record {{quote(pr)}} {{quote(operation)}} --task {{quote(task)}} --downstream-pr {{quote(downstream_pr)}}
+
+[working-directory: root]
+release-gate-check pr merge_commit dogfood_head dogfood_tree version="":
+    /bin/sh {{quote(release_gate_launcher)}} {{quote(release_gate)}} release-gate-check {{quote(pr)}} {{quote(merge_commit)}} {{quote(dogfood_head)}} {{quote(dogfood_tree)}} --version {{quote(version)}}
 
 [working-directory: root]
 recover-task-contract-from-issue target issue:

--- a/tests/test_agent_core_release_gate.py
+++ b/tests/test_agent_core_release_gate.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "agent_core_release_gate.py"
+spec = importlib.util.spec_from_file_location("agent_core_release_gate", MODULE_PATH)
+assert spec and spec.loader
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+
+def run_git(cwd: Path, *args: str) -> str:
+    return subprocess.run(["git", *args], cwd=cwd, text=True, capture_output=True, check=True).stdout.strip()
+
+
+class ReleaseGateTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name) / "repo"
+        self.root.mkdir()
+        run_git(self.root, "init", "-q")
+        run_git(self.root, "config", "user.email", "test@example.invalid")
+        run_git(self.root, "config", "user.name", "Release Gate Test")
+        (self.root / "file").write_text("one\n", encoding="utf-8")
+        run_git(self.root, "add", "file")
+        run_git(self.root, "commit", "-qm", "one")
+        self.head = run_git(self.root, "rev-parse", "HEAD")
+        self.tree = run_git(self.root, "rev-parse", "HEAD^{tree}")
+        (self.root / ".worktrees").mkdir(mode=0o700)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def pr(self, *, head: str | None = None, state: str = "open", merged: bool = False, merge: str | None = None) -> dict:
+        return {
+            "state": state, "merged": merged, "merge_commit_sha": merge,
+            "base": {"ref": "main", "repo": {"full_name": gate.CANONICAL_REPO}},
+            "head": {"sha": head or self.head, "repo": {"full_name": gate.CANONICAL_REPO}},
+        }
+
+    def gh_candidate(self, *, pr_values=None, rollup=None, commit_trees=None, comparison=None):
+        values = iter(pr_values or [self.pr(), self.pr(), self.pr(), self.pr()])
+        trees = commit_trees or {self.head: self.tree}
+        rollup = rollup or {"data": {"repository": {"pullRequest": {"commits": {"nodes": [{"commit": {
+            "oid": self.head, "statusCheckRollup": {"contexts": {"pageInfo": {"hasNextPage": False}, "nodes": [
+                {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}
+            ]}}
+        }}]}}}}}
+
+        def fake(args, cwd):
+            if args[:2] == ["api", "graphql"]:
+                return rollup
+            endpoint = args[1]
+            if "/pulls/" in endpoint:
+                return next(values)
+            if "/git/commits/" in endpoint:
+                sha = endpoint.rsplit("/", 1)[1]
+                return {"sha": sha, "tree": {"sha": trees[sha]}}
+            if "/compare/" in endpoint:
+                return comparison or {"status": "identical"}
+            raise AssertionError(args)
+        return fake
+
+    def test_exact_open_head_tree_and_successful_ci_ready(self) -> None:
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            result = gate.candidate(self.root, "115")
+        self.assertEqual({"pr": 115, "head": self.head, "tree": self.tree, "base": "main", "ci": "PASS", "status": "READY_FOR_DOGFOOD"}, result)
+
+    def test_pending_and_failed_ci_are_blocked(self) -> None:
+        for context in (
+            {"__typename": "CheckRun", "status": "IN_PROGRESS", "conclusion": None},
+            {"__typename": "StatusContext", "state": "FAILURE"},
+        ):
+            rollup = {"data": {"repository": {"pullRequest": {"commits": {"nodes": [{"commit": {
+                "oid": self.head, "statusCheckRollup": {"contexts": {"pageInfo": {"hasNextPage": False}, "nodes": [context]}}
+            }}]}}}}}
+            with mock.patch.object(gate, "gh", side_effect=self.gh_candidate(rollup=rollup)):
+                with self.assertRaisesRegex(gate.GateError, "incomplete or unsuccessful"):
+                    gate.candidate(self.root, "115")
+
+    def test_head_change_during_inspection_is_blocked(self) -> None:
+        changed = "b" * 40
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate(pr_values=[self.pr(), self.pr(head=changed)])):
+            with self.assertRaisesRegex(gate.GateError, "moved"):
+                gate.candidate(self.root, "115")
+
+    def test_detached_exact_clean_worktree_is_created_and_verified(self) -> None:
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            result = gate.create_or_verify_worktree(self.root, "115", "rc")
+        path = self.root / ".worktrees" / "rc"
+        self.assertEqual(result["path"], str(path))
+        self.assertEqual(run_git(path, "rev-parse", "HEAD"), self.head)
+        self.assertEqual(gate.git(["symbolic-ref", "-q", "HEAD"], path, check=False).strip(), "")
+        self.assertEqual(run_git(path, "status", "--porcelain"), "")
+        self.assertEqual(
+            gate.safe_worktree_path(self.root, ".worktrees/rc", create_parents=False),
+            path,
+        )
+
+    def test_registered_wrong_revision_is_blocked_and_unchanged(self) -> None:
+        other = self.root / "other"
+        (other / "x").parent.mkdir()
+        (other / "x").write_text("x", encoding="utf-8")
+        run_git(self.root, "add", "other")
+        run_git(self.root, "commit", "-qm", "other")
+        wrong = run_git(self.root, "rev-parse", "HEAD")
+        path = self.root / ".worktrees" / "rc"
+        run_git(self.root, "worktree", "add", "--detach", str(path), wrong)
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "another revision"):
+                gate.create_or_verify_worktree(self.root, "115", "rc")
+        self.assertEqual(run_git(path, "rev-parse", "HEAD"), wrong)
+
+    def test_dirty_and_unregistered_existing_worktrees_are_rejected(self) -> None:
+        path = self.root / ".worktrees" / "rc"
+        path.mkdir()
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "not a registered"):
+                gate.create_or_verify_worktree(self.root, "115", "rc")
+        path.rmdir()
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            gate.create_or_verify_worktree(self.root, "115", "rc")
+        (path / "dirty").write_text("dirty", encoding="utf-8")
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "not clean"):
+                gate.create_or_verify_worktree(self.root, "115", "rc")
+
+    def evidence(self, *, head=None, tree=None, operation="dogfood") -> dict:
+        return {"schema": "agent-core-release-gate", "version": 1, "repo": gate.CANONICAL_REPO,
+                "pr": 115, "head": head or self.head, "tree": tree or self.tree,
+                "downstreamRepo": gate.DOWNSTREAM_REPO, "task": 116, "downstreamPr": 7,
+                "outcome": "PASS", "operation": operation, "recordedAt": "2026-09-01T00:00:00Z"}
+
+    def write_evidence(self, *records: dict) -> None:
+        directory = gate.evidence_root(self.root, create=True)
+        start = len(list(directory.iterdir()))
+        for index, record in enumerate(records, start=start):
+            (directory / f"{index}.json").write_text(json.dumps(record) + "\n", encoding="utf-8")
+            os.chmod(directory / f"{index}.json", 0o600)
+
+    def test_recorded_pass_evidence_contains_all_identity_bindings(self) -> None:
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            record = gate.record_evidence(self.root, "115", "dogfood-run", "116", "7")
+        self.assertEqual(record["repo"], gate.CANONICAL_REPO)
+        self.assertEqual(record["downstreamRepo"], gate.DOWNSTREAM_REPO)
+        self.assertEqual((record["pr"], record["head"], record["tree"]), (115, self.head, self.tree))
+        self.assertEqual((record["task"], record["downstreamPr"], record["operation"]), (116, 7, "dogfood-run"))
+        self.assertEqual(record["outcome"], "PASS")
+        self.assertTrue(record["recordedAt"].endswith("Z"))
+        records = list(gate.evidence_root(self.root, create=False).iterdir())
+        self.assertEqual(len(records), 1)
+        self.assertRegex(records[0].name, r"^[0-9a-f]{64}\.json$")
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "already exists"):
+                gate.record_evidence(self.root, "115", "second-run", "116", "7")
+        self.assertEqual(len(list(gate.evidence_root(self.root, create=False).iterdir())), 1)
+
+    def test_launcher_rejects_python_from_untrusted_path(self) -> None:
+        fake_bin = Path(self.temp.name) / "fake-bin"
+        fake_bin.mkdir()
+        marker = Path(self.temp.name) / "executed"
+        fake_python = fake_bin / "python3"
+        fake_python.write_text(
+            f"#!/bin/sh\ntouch '{marker}'\n",
+            encoding="utf-8",
+        )
+        fake_python.chmod(0o755)
+        launcher = MODULE_PATH.with_name("run_agent_core_release_gate.sh")
+        result = subprocess.run(
+            ["/bin/sh", str(launcher), str(MODULE_PATH), "release-candidate-check", "115"],
+            env={"PATH": str(fake_bin)},
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("not trusted", result.stderr)
+        self.assertFalse(marker.exists())
+
+    def test_subprocess_environment_discards_transport_overrides(self) -> None:
+        hostile = {
+            "HOME": "/safe-home",
+            "GH_TOKEN": "token",
+            "PATH": "/hostile",
+            "HTTPS_PROXY": "https://attacker.invalid",
+            "SSL_CERT_FILE": "/attacker-ca",
+            "LD_PRELOAD": "/attacker.so",
+        }
+        with mock.patch.dict(os.environ, hostile, clear=True):
+            environment = gate.sanitized_environment()
+        self.assertEqual(environment["HOME"], "/safe-home")
+        self.assertEqual(environment["GH_TOKEN"], "token")
+        for key in ("PATH", "HTTPS_PROXY", "SSL_CERT_FILE", "LD_PRELOAD"):
+            self.assertNotIn(key, environment)
+
+    def test_github_api_is_pinned_to_public_github(self) -> None:
+        response = subprocess.CompletedProcess([], 0, stdout="{}", stderr="")
+        with mock.patch.object(gate, "command", return_value=response) as runner:
+            gate.gh(["api", "repos/upiscium/Templates/pulls/115"], self.root)
+        argv = runner.call_args.args[0]
+        self.assertEqual(argv[:4], ["gh", "api", "--hostname", "github.com"])
+
+    def merge_gh(self, merge: str, merge_tree: str, *, evidence=None, pr_values=None, comparison=None):
+        values = iter(pr_values or [self.pr(state="closed", merged=True, merge=merge)] * 4)
+        trees = {self.head: self.tree, merge: merge_tree}
+        def fake(args, cwd):
+            if args[:2] == ["api", "graphql"]:
+                raise AssertionError("graphql must be routed to the rollup fixture")
+            endpoint = args[1]
+            if "/pulls/" in endpoint:
+                return next(values)
+            if "/git/commits/" in endpoint:
+                sha = endpoint.rsplit("/", 1)[1]
+                return {"sha": sha, "tree": {"sha": trees[sha]}}
+            if "/compare/" in endpoint:
+                return comparison or {"status": "identical"}
+            raise AssertionError(args)
+        # The post-merge candidate still requires a successful rollup for the head.
+        rollup = {"data": {"repository": {"pullRequest": {"commits": {"nodes": [{"commit": {
+            "oid": self.head, "statusCheckRollup": {"contexts": {"pageInfo": {"hasNextPage": False}, "nodes": [{"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}]}}
+        }}]}}}}}
+        def routed(args, cwd):
+            if args[:2] == ["api", "graphql"]: return rollup
+            return fake(args, cwd)
+        return routed
+
+    def test_pass_evidence_binds_identity_and_wrong_identity_is_blocked(self) -> None:
+        record = self.evidence()
+        self.write_evidence(record)
+        merge = "c" * 40
+        with mock.patch.object(gate, "gh", side_effect=self.merge_gh(merge, self.tree)):
+            result = gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
+        self.assertEqual(result["status"], "RELEASE_READY")
+        for key, value in (("repo", "other/repo"), ("pr", 999), ("downstreamRepo", "other/downstream"), ("head", "d" * 40), ("tree", "e" * 40)):
+            bad = self.evidence(); bad[key] = value
+            directory = gate.evidence_root(self.root, create=False)
+            (directory / "0.json").write_text(json.dumps(bad), encoding="utf-8")
+            with mock.patch.object(gate, "gh", side_effect=self.merge_gh(merge, self.tree)):
+                with self.assertRaises(gate.GateError): gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
+            (directory / "0.json").write_text(json.dumps(record), encoding="utf-8")
+
+    def test_old_evidence_moved_head_and_duplicate_conflict_fail_closed(self) -> None:
+        moved = "f" * 40
+        self.write_evidence(self.evidence())
+        moved_merge = "e" * 40
+        moved_pr = self.pr(head=moved, state="closed", merged=True, merge=moved_merge)
+        with mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.merge_gh(
+                moved_merge,
+                "a" * 40,
+                pr_values=[moved_pr, moved_pr, moved_pr, moved_pr],
+            ),
+        ):
+            with self.assertRaisesRegex(gate.GateError, "dogfooded head"):
+                gate.post_merge_gate(self.root, "115", moved_merge, self.head, self.tree, "")
+        self.write_evidence(self.evidence(operation="other"))
+        merge = "c" * 40
+        with mock.patch.object(gate, "gh", side_effect=self.merge_gh(merge, self.tree)):
+            with self.assertRaisesRegex(gate.GateError, "duplicated"):
+                gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
+
+    def test_stale_rollup_oid_is_blocked(self) -> None:
+        rollup = {"data": {"repository": {"pullRequest": {"commits": {"nodes": [{"commit": {
+            "oid": "a" * 40, "statusCheckRollup": {"contexts": {"pageInfo": {"hasNextPage": False}, "nodes": [{"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}]}}
+        }}]}}}}}
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate(rollup=rollup)):
+            with self.assertRaisesRegex(gate.GateError, "stale"):
+                gate.candidate(self.root, "115")
+
+    def test_squash_merge_same_tree_accepted_and_different_tree_blocked(self) -> None:
+        merge = "c" * 40
+        self.write_evidence(self.evidence())
+        with mock.patch.object(gate, "gh", side_effect=self.merge_gh(merge, self.tree)):
+            self.assertTrue(gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")["treeMatch"])
+        with mock.patch.object(gate, "gh", side_effect=self.merge_gh(merge, "d" * 40)):
+            with self.assertRaisesRegex(gate.GateError, "does not match"):
+                gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
+
+    def test_main_containment_compare_uses_merge_as_base(self) -> None:
+        merge = "c" * 40
+        self.write_evidence(self.evidence())
+        observed = []
+        routed = self.merge_gh(merge, self.tree)
+
+        def inspect(args, cwd):
+            if len(args) > 1 and "/compare/" in args[1]:
+                observed.append(args[1])
+            return routed(args, cwd)
+
+        with mock.patch.object(gate, "gh", side_effect=inspect):
+            gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
+        self.assertEqual(
+            observed,
+            [f"repos/{gate.CANONICAL_REPO}/compare/{merge}...main"],
+        )
+
+    def test_path_traversal_symlink_stale_rollup_and_existing_release_rejected(self) -> None:
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            for destination in ("../escape", "/tmp/outside"):
+                with self.assertRaises(gate.GateError): gate.create_or_verify_worktree(self.root, "115", destination)
+        link = self.root / ".worktrees" / "link"
+        link.symlink_to(self.root)
+        with self.assertRaises(gate.GateError): gate.safe_worktree_path(self.root, "link", create_parents=True)
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()), mock.patch.object(gate, "gh_status", return_value=200):
+            with self.assertRaisesRegex(gate.GateError, "already exists"):
+                gate.release_absent(self.root, "v1.2.3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agent_core_release_gate.py
+++ b/tests/test_agent_core_release_gate.py
@@ -32,6 +32,7 @@ class ReleaseGateTest(unittest.TestCase):
         (self.root / "file").write_text("one\n", encoding="utf-8")
         run_git(self.root, "add", "file")
         run_git(self.root, "commit", "-qm", "one")
+        run_git(self.root, "remote", "add", "origin", gate.CANONICAL_GIT_URL)
         self.head = run_git(self.root, "rev-parse", "HEAD")
         self.tree = run_git(self.root, "rev-parse", "HEAD^{tree}")
         (self.root / ".worktrees").mkdir(mode=0o700)
@@ -46,9 +47,59 @@ class ReleaseGateTest(unittest.TestCase):
             "head": {"sha": head or self.head, "repo": {"full_name": gate.CANONICAL_REPO}},
         }
 
-    def gh_candidate(self, *, pr_values=None, rollup=None, commit_trees=None, comparison=None):
+    def workflow_run(
+        self,
+        *,
+        head: str | None = None,
+        status: str = "completed",
+        conclusion: str | None = "success",
+        run_id: int = 700,
+        attempt: int = 1,
+    ) -> dict:
+        return {
+            "id": run_id,
+            "workflow_id": 600,
+            "path": gate.CANONICAL_WORKFLOW_PATH,
+            "event": "pull_request",
+            "head_sha": head or self.head,
+            "run_attempt": attempt,
+            "status": status,
+            "conclusion": conclusion,
+            "pull_requests": [
+                {
+                    "number": 115,
+                    "head": {
+                        "sha": head or self.head,
+                        "repo": {"url": f"https://api.github.com/repos/{gate.CANONICAL_REPO}"},
+                    },
+                    "base": {
+                        "ref": "main",
+                        "repo": {"url": f"https://api.github.com/repos/{gate.CANONICAL_REPO}"},
+                    },
+                }
+            ],
+        }
+
+    def gh_candidate(
+        self,
+        *,
+        pr_values=None,
+        rollup=None,
+        commit_trees=None,
+        comparison=None,
+        workflow_runs=None,
+        workflow_detail=None,
+        workflow=None,
+    ):
         values = iter(pr_values or [self.pr(), self.pr(), self.pr(), self.pr()])
         trees = commit_trees or {self.head: self.tree}
+        runs = [self.workflow_run()] if workflow_runs is None else workflow_runs
+        detail = workflow_detail or (runs[0] if runs else self.workflow_run())
+        workflow_metadata = workflow or {
+            "id": 600,
+            "path": gate.CANONICAL_WORKFLOW_PATH,
+            "state": "active",
+        }
         rollup = rollup or {"data": {"repository": {"pullRequest": {"commits": {"nodes": [{"commit": {
             "oid": self.head, "statusCheckRollup": {"contexts": {"pageInfo": {"hasNextPage": False}, "nodes": [
                 {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}
@@ -59,6 +110,12 @@ class ReleaseGateTest(unittest.TestCase):
             if args[:2] == ["api", "graphql"]:
                 return rollup
             endpoint = args[1]
+            if endpoint.endswith("/actions/workflows/template-ci.yml"):
+                return workflow_metadata
+            if "/actions/workflows/600/runs?" in endpoint:
+                return {"total_count": len(runs), "workflow_runs": runs}
+            if endpoint.endswith("/actions/runs/700"):
+                return detail
             if "/pulls/" in endpoint:
                 return next(values)
             if "/git/commits/" in endpoint:
@@ -73,6 +130,61 @@ class ReleaseGateTest(unittest.TestCase):
         with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
             result = gate.candidate(self.root, "115")
         self.assertEqual({"pr": 115, "head": self.head, "tree": self.tree, "base": "main", "ci": "PASS", "status": "READY_FOR_DOGFOOD"}, result)
+
+    def test_only_unrelated_successful_rollup_without_template_ci_is_blocked(self) -> None:
+        with mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.gh_candidate(workflow_runs=[]),
+        ):
+            with self.assertRaisesRegex(gate.GateError, "Template CI workflow is missing"):
+                gate.candidate(self.root, "115")
+
+    def test_template_ci_for_older_head_is_blocked(self) -> None:
+        older = "a" * 40
+        with mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.gh_candidate(workflow_runs=[self.workflow_run(head=older)]),
+        ):
+            with self.assertRaisesRegex(gate.GateError, "exact candidate"):
+                gate.candidate(self.root, "115")
+
+    def test_template_ci_pending_and_failed_are_blocked(self) -> None:
+        for run in (
+            self.workflow_run(status="in_progress", conclusion=None),
+            self.workflow_run(status="completed", conclusion="failure"),
+        ):
+            with self.subTest(status=run["status"], conclusion=run["conclusion"]):
+                with mock.patch.object(
+                    gate,
+                    "gh",
+                    side_effect=self.gh_candidate(workflow_runs=[run], workflow_detail=run),
+                ):
+                    with self.assertRaisesRegex(gate.GateError, "incomplete or unsuccessful"):
+                        gate.candidate(self.root, "115")
+
+    def test_multiple_exact_head_template_ci_runs_are_ambiguous(self) -> None:
+        with mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.gh_candidate(
+                workflow_runs=[self.workflow_run(), self.workflow_run(run_id=701)]
+            ),
+        ):
+            with self.assertRaisesRegex(gate.GateError, "ambiguous"):
+                gate.candidate(self.root, "115")
+
+    def test_template_ci_for_another_pr_with_same_head_is_blocked(self) -> None:
+        run = self.workflow_run()
+        run["pull_requests"][0]["number"] = 999
+        with mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.gh_candidate(workflow_runs=[run], workflow_detail=run),
+        ):
+            with self.assertRaisesRegex(gate.GateError, "another pull request"):
+                gate.candidate(self.root, "115")
 
     def test_pending_and_failed_ci_are_blocked(self) -> None:
         for context in (
@@ -93,7 +205,9 @@ class ReleaseGateTest(unittest.TestCase):
                 gate.candidate(self.root, "115")
 
     def test_detached_exact_clean_worktree_is_created_and_verified(self) -> None:
-        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()), mock.patch.object(
+            gate, "CANONICAL_GIT_URL", self.root.as_uri()
+        ):
             result = gate.create_or_verify_worktree(self.root, "115", "rc")
         path = self.root / ".worktrees" / "rc"
         self.assertEqual(result["path"], str(path))
@@ -123,14 +237,27 @@ class ReleaseGateTest(unittest.TestCase):
         path = self.root / ".worktrees" / "rc"
         path.mkdir()
         with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
-            with self.assertRaisesRegex(gate.GateError, "not a registered"):
+            with self.assertRaisesRegex(gate.GateError, "exact registered worktree root"):
                 gate.create_or_verify_worktree(self.root, "115", "rc")
         path.rmdir()
-        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()), mock.patch.object(
+            gate, "CANONICAL_GIT_URL", self.root.as_uri()
+        ):
             gate.create_or_verify_worktree(self.root, "115", "rc")
         (path / "dirty").write_text("dirty", encoding="utf-8")
         with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
             with self.assertRaisesRegex(gate.GateError, "not clean"):
+                gate.create_or_verify_worktree(self.root, "115", "rc")
+
+    def test_existing_candidate_with_unsafe_config_is_rejected_before_verification(self) -> None:
+        path = self.root / ".worktrees" / "rc"
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()), mock.patch.object(
+            gate, "CANONICAL_GIT_URL", self.root.as_uri()
+        ):
+            gate.create_or_verify_worktree(self.root, "115", "rc")
+        run_git(path, "config", "--local", "filter.attack.process", "attacker-process")
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "unsafe local Git configuration"):
                 gate.create_or_verify_worktree(self.root, "115", "rc")
 
     def evidence(self, *, head=None, tree=None, operation="dogfood") -> dict:
@@ -208,6 +335,47 @@ class ReleaseGateTest(unittest.TestCase):
         argv = runner.call_args.args[0]
         self.assertEqual(argv[:4], ["gh", "api", "--hostname", "github.com"])
 
+    def test_local_git_configuration_and_canonical_origin_are_required(self) -> None:
+        self.assertEqual(
+            gate.validate_local_git_configuration(self.root),
+            gate.CANONICAL_GIT_URL,
+        )
+        run_git(self.root, "remote", "set-url", "origin", "https://example.invalid/Templates.git")
+        with self.assertRaisesRegex(gate.GateError, "canonical Templates"):
+            gate.validate_local_git_configuration(self.root)
+
+    def test_unsafe_local_git_execution_and_transport_configuration_is_rejected(self) -> None:
+        unsafe = (
+            ("core.sshCommand", "attacker-ssh"),
+            ("url.ssh://attacker.invalid/.insteadOf", "https://github.com/"),
+            ("credential.helper", "attacker-helper"),
+            ("filter.attack.smudge", "attacker-smudge"),
+            ("filter.attack.process", "attacker-process"),
+            ("remote.origin.uploadpack", "attacker-upload-pack"),
+            ("include.path", "/tmp/attacker-config"),
+        )
+        for name, value in unsafe:
+            with self.subTest(name=name):
+                run_git(self.root, "config", "--local", name, value)
+                try:
+                    with self.assertRaisesRegex(gate.GateError, "unsafe local Git configuration"):
+                        gate.validate_local_git_configuration(self.root)
+                finally:
+                    run_git(self.root, "config", "--local", "--unset-all", name)
+
+    def test_worktree_refuses_unsafe_config_before_checkout(self) -> None:
+        run_git(self.root, "config", "--local", "filter.attack.smudge", "attacker-smudge")
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "unsafe local Git configuration"):
+                gate.create_or_verify_worktree(self.root, "115", "unsafe")
+        self.assertFalse((self.root / ".worktrees" / "unsafe").exists())
+
+    def test_unsafe_worktree_scoped_git_configuration_is_rejected(self) -> None:
+        run_git(self.root, "config", "--local", "extensions.worktreeConfig", "true")
+        run_git(self.root, "config", "--worktree", "filter.attack.process", "attacker-process")
+        with self.assertRaisesRegex(gate.GateError, "unsafe worktree Git configuration"):
+            gate.validate_local_git_configuration(self.root)
+
     def merge_gh(self, merge: str, merge_tree: str, *, evidence=None, pr_values=None, comparison=None):
         values = iter(pr_values or [self.pr(state="closed", merged=True, merge=merge)] * 4)
         trees = {self.head: self.tree, merge: merge_tree}
@@ -215,6 +383,13 @@ class ReleaseGateTest(unittest.TestCase):
             if args[:2] == ["api", "graphql"]:
                 raise AssertionError("graphql must be routed to the rollup fixture")
             endpoint = args[1]
+            if endpoint.endswith("/actions/workflows/template-ci.yml"):
+                return {"id": 600, "path": gate.CANONICAL_WORKFLOW_PATH, "state": "active"}
+            if "/actions/workflows/600/runs?" in endpoint:
+                run = self.workflow_run()
+                return {"total_count": 1, "workflow_runs": [run]}
+            if endpoint.endswith("/actions/runs/700"):
+                return self.workflow_run()
             if "/pulls/" in endpoint:
                 return next(values)
             if "/git/commits/" in endpoint:
@@ -304,16 +479,35 @@ class ReleaseGateTest(unittest.TestCase):
             [f"repos/{gate.CANONICAL_REPO}/compare/{merge}...main"],
         )
 
-    def test_path_traversal_symlink_stale_rollup_and_existing_release_rejected(self) -> None:
+    def test_path_traversal_and_symlink_are_rejected(self) -> None:
         with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
             for destination in ("../escape", "/tmp/outside"):
                 with self.assertRaises(gate.GateError): gate.create_or_verify_worktree(self.root, "115", destination)
         link = self.root / ".worktrees" / "link"
         link.symlink_to(self.root)
         with self.assertRaises(gate.GateError): gate.safe_worktree_path(self.root, "link", create_parents=True)
-        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()), mock.patch.object(gate, "gh_status", return_value=200):
-            with self.assertRaisesRegex(gate.GateError, "already exists"):
-                gate.release_absent(self.root, "v1.2.3")
+
+    def test_release_and_tag_must_both_be_absent(self) -> None:
+        cases = (
+            ([200], "release already exists"),
+            ([404, 200], "Git tag already exists"),
+            ([500], "release lookup returned unexpected"),
+            ([404, 500], "Git tag lookup returned unexpected"),
+        )
+        for statuses, message in cases:
+            with self.subTest(statuses=statuses):
+                with mock.patch.object(gate, "gh_status", side_effect=statuses):
+                    with self.assertRaisesRegex(gate.GateError, message):
+                        gate.release_absent(self.root, "v1.2.3")
+        with mock.patch.object(gate, "gh_status", side_effect=[404, 404]) as status:
+            gate.release_absent(self.root, "v1.2.3")
+        self.assertEqual(
+            [call.args[0][1] for call in status.call_args_list],
+            [
+                f"repos/{gate.CANONICAL_REPO}/releases/tags/v1.2.3",
+                f"repos/{gate.CANONICAL_REPO}/git/ref/tags/v1.2.3",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_core_release_gate.py
+++ b/tests/test_agent_core_release_gate.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 
@@ -46,6 +47,65 @@ class ReleaseGateTest(unittest.TestCase):
             "base": {"ref": "main", "repo": {"full_name": gate.CANONICAL_REPO}},
             "head": {"sha": head or self.head, "repo": {"full_name": gate.CANONICAL_REPO}},
         }
+
+    def source_fixture(self) -> tuple[Path, str]:
+        source = Path(tempfile.mkdtemp(dir=self.temp.name))
+        tools = source / "tools"
+        tools.mkdir()
+        (tools / "agent_core_release_gate.py").write_text("gate implementation\n", encoding="utf-8")
+        (tools / "run_agent_core_release_gate.sh").write_text("launcher implementation\n", encoding="utf-8")
+        (source / "unrelated").write_text("tracked\n", encoding="utf-8")
+        run_git(source, "init", "-q")
+        run_git(source, "config", "user.email", "test@example.invalid")
+        run_git(source, "config", "user.name", "Release Gate Test")
+        run_git(source, "add", ".")
+        run_git(source, "commit", "-qm", "source implementation")
+        return source, run_git(source, "rev-parse", "HEAD")
+
+    def test_exact_clean_source_implementation_is_accepted(self) -> None:
+        source, head = self.source_fixture()
+        self.assertEqual(gate.verify_source_implementation(source), head)
+
+    def test_modified_live_gate_tool_is_rejected(self) -> None:
+        source, _ = self.source_fixture()
+        (source / "tools" / "agent_core_release_gate.py").write_text("modified\n", encoding="utf-8")
+        with self.assertRaisesRegex(gate.GateError, "content differs from HEAD"):
+            gate.verify_source_implementation(source)
+
+    def test_modified_live_launcher_is_rejected(self) -> None:
+        source, _ = self.source_fixture()
+        (source / "tools" / "run_agent_core_release_gate.sh").write_text("modified\n", encoding="utf-8")
+        with self.assertRaisesRegex(gate.GateError, "content differs from HEAD"):
+            gate.verify_source_implementation(source)
+
+    def test_dirty_unrelated_tracked_source_file_is_rejected(self) -> None:
+        source, _ = self.source_fixture()
+        (source / "unrelated").write_text("dirty\n", encoding="utf-8")
+        with self.assertRaisesRegex(gate.GateError, "source worktree must be clean"):
+            gate.verify_source_implementation(source)
+
+    def test_source_head_movement_is_rejected(self) -> None:
+        source, head = self.source_fixture()
+        (source / "unrelated").write_text("next\n", encoding="utf-8")
+        run_git(source, "add", "unrelated")
+        run_git(source, "commit", "-qm", "move source head")
+        with self.assertRaisesRegex(gate.GateError, "HEAD moved"):
+            gate.verify_source_implementation(source, expected_head=head)
+
+    def test_operation_fails_when_source_head_moves_before_success(self) -> None:
+        implementation = "a" * 40
+        arguments = SimpleNamespace(command="release-candidate-check", pr="115")
+        parser = mock.Mock()
+        parser.parse_args.return_value = arguments
+        with mock.patch.object(gate, "parser", return_value=parser), mock.patch.object(
+            gate, "source_root", return_value=(self.root, implementation)
+        ), mock.patch.object(gate, "candidate", return_value={"status": "READY_FOR_DOGFOOD"}), mock.patch.object(
+            gate,
+            "verify_source_implementation",
+            side_effect=gate.GateError("source implementation HEAD moved during the operation"),
+        ):
+            with self.assertRaisesRegex(gate.GateError, "HEAD moved"):
+                gate.main()
 
     def workflow_run(
         self,
@@ -268,10 +328,12 @@ class ReleaseGateTest(unittest.TestCase):
 
     def write_evidence(self, *records: dict) -> None:
         directory = gate.evidence_root(self.root, create=True)
-        start = len(list(directory.iterdir()))
-        for index, record in enumerate(records, start=start):
-            (directory / f"{index}.json").write_text(json.dumps(record) + "\n", encoding="utf-8")
-            os.chmod(directory / f"{index}.json", 0o600)
+        for record in records:
+            target = directory / gate.evidence_filename(record)
+            if target.exists():
+                raise AssertionError("test attempted to overwrite canonical evidence")
+            target.write_text(json.dumps(record) + "\n", encoding="utf-8")
+            os.chmod(target, 0o600)
 
     def test_recorded_pass_evidence_contains_all_identity_bindings(self) -> None:
         with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
@@ -289,6 +351,28 @@ class ReleaseGateTest(unittest.TestCase):
             with self.assertRaisesRegex(gate.GateError, "already exists"):
                 gate.record_evidence(self.root, "115", "second-run", "116", "7")
         self.assertEqual(len(list(gate.evidence_root(self.root, create=False).iterdir())), 1)
+
+    def test_evidence_filename_must_match_canonical_subject(self) -> None:
+        record = self.evidence()
+        directory = gate.evidence_root(self.root, create=True)
+        canonical = directory / gate.evidence_filename(record)
+        canonical.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        canonical.chmod(0o600)
+        self.assertEqual(gate.load_evidence(self.root), [record])
+
+        canonical.unlink()
+        arbitrary = directory / "arbitrary.json"
+        arbitrary.write_text(json.dumps(record) + "\n", encoding="utf-8")
+        arbitrary.chmod(0o600)
+        with self.assertRaisesRegex(gate.GateError, "filename does not match"):
+            gate.load_evidence(self.root)
+
+        arbitrary.unlink()
+        changed = dict(record, head="a" * 40)
+        canonical.write_text(json.dumps(changed) + "\n", encoding="utf-8")
+        canonical.chmod(0o600)
+        with self.assertRaisesRegex(gate.GateError, "filename does not match"):
+            gate.load_evidence(self.root)
 
     def test_launcher_rejects_python_from_untrusted_path(self) -> None:
         fake_bin = Path(self.temp.name) / "fake-bin"
@@ -417,10 +501,12 @@ class ReleaseGateTest(unittest.TestCase):
         for key, value in (("repo", "other/repo"), ("pr", 999), ("downstreamRepo", "other/downstream"), ("head", "d" * 40), ("tree", "e" * 40)):
             bad = self.evidence(); bad[key] = value
             directory = gate.evidence_root(self.root, create=False)
-            (directory / "0.json").write_text(json.dumps(bad), encoding="utf-8")
+            manual = directory / "manual.json"
+            manual.write_text(json.dumps(bad), encoding="utf-8")
+            manual.chmod(0o600)
             with mock.patch.object(gate, "gh", side_effect=self.merge_gh(merge, self.tree)):
                 with self.assertRaises(gate.GateError): gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
-            (directory / "0.json").write_text(json.dumps(record), encoding="utf-8")
+            manual.unlink()
 
     def test_old_evidence_moved_head_and_duplicate_conflict_fail_closed(self) -> None:
         moved = "f" * 40
@@ -438,11 +524,6 @@ class ReleaseGateTest(unittest.TestCase):
         ):
             with self.assertRaisesRegex(gate.GateError, "dogfooded head"):
                 gate.post_merge_gate(self.root, "115", moved_merge, self.head, self.tree, "")
-        self.write_evidence(self.evidence(operation="other"))
-        merge = "c" * 40
-        with mock.patch.object(gate, "gh", side_effect=self.merge_gh(merge, self.tree)):
-            with self.assertRaisesRegex(gate.GateError, "duplicated"):
-                gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
 
     def test_stale_rollup_oid_is_blocked(self) -> None:
         rollup = {"data": {"repository": {"pullRequest": {"commits": {"nodes": [{"commit": {

--- a/tools/agent_core_release_gate.py
+++ b/tools/agent_core_release_gate.py
@@ -23,6 +23,8 @@ CANONICAL_WORKFLOW_PATH = ".github/workflows/template-ci.yml"
 DOWNSTREAM_REPO = "upiscium/AgentKnowledgeVault"
 DEFAULT_BRANCH = "main"
 EVIDENCE_ROOT_NAME = ".agent-core-release-gate/evidence"
+GATE_TOOL_RELATIVE = "tools/agent_core_release_gate.py"
+GATE_LAUNCHER_RELATIVE = "tools/run_agent_core_release_gate.sh"
 
 SHA_RE = re.compile(r"[0-9a-f]{40}")
 PR_RE = re.compile(r"[1-9][0-9]{0,8}")
@@ -126,6 +128,31 @@ def git(args: list[str], cwd: Path, *, check: bool = True) -> str:
     return command(["git", "--no-pager", *args], cwd, check=check).stdout
 
 
+def git_bytes(args: list[str], cwd: Path, *, check: bool = True) -> bytes:
+    executable = trusted_executable("git")
+    result = subprocess.run(
+        [
+            str(executable),
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "core.pager=",
+            "--no-pager",
+            *args,
+        ],
+        cwd=cwd,
+        env=sanitized_environment(),
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode:
+        detail = result.stderr.decode("utf-8", "replace").strip() or f"exit {result.returncode}"
+        raise GateError(f"git command failed: {detail}")
+    return result.stdout
+
+
 def gh(args: list[str], cwd: Path) -> Any:
     if not args or args[0] != "api":
         raise GateError("GitHub runner only accepts API reads")
@@ -151,13 +178,95 @@ def gh_status(args: list[str], cwd: Path) -> int:
     return int(statuses[-1])
 
 
-def source_root() -> Path:
+def source_blob(root: Path, revision: str, relative: str) -> tuple[str, int]:
+    if not SHA_RE.fullmatch(revision):
+        raise GateError("source implementation revision is invalid")
+    raw = git_bytes(["ls-tree", "-z", revision, "--", relative], root)
+    records = [record for record in raw.split(b"\0") if record]
+    matches: list[tuple[str, int]] = []
+    for record in records:
+        header, separator, path = record.partition(b"\t")
+        fields = header.split()
+        if (
+            not separator
+            or len(fields) != 3
+            or path.decode("utf-8", "surrogateescape") != relative
+        ):
+            continue
+        mode, kind, oid = fields
+        if kind != b"blob" or mode not in {b"100644", b"100755"} or not SHA_RE.fullmatch(
+            oid.decode("ascii", "strict")
+        ):
+            raise GateError(f"source implementation path is not a safe regular Git blob: {relative}")
+        matches.append((oid.decode("ascii"), int(mode, 8)))
+    if len(matches) != 1:
+        raise GateError(f"source implementation must contain exactly one Git blob: {relative}")
+    return matches[0]
+
+
+def verify_live_source_blob(root: Path, revision: str, relative: str, live_path: Path) -> None:
+    expected_path = root / relative
+    if live_path.resolve() != expected_path.resolve():
+        raise GateError(f"live source implementation path is unexpected: {relative}")
+    oid, git_mode = source_blob(root, revision, relative)
+    try:
+        metadata = expected_path.lstat()
+        live_content = expected_path.read_bytes()
+    except OSError as exc:
+        raise GateError(f"cannot read live source implementation: {relative}") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or bool(stat.S_IMODE(metadata.st_mode) & 0o111) != bool(git_mode & 0o111)
+    ):
+        raise GateError(f"live source implementation type or mode differs from HEAD: {relative}")
+    if live_content != git_bytes(["cat-file", "blob", oid], root):
+        raise GateError(f"live source implementation content differs from HEAD: {relative}")
+
+
+def verify_source_implementation(
+    root: Path,
+    *,
+    expected_head: str | None = None,
+    tool_path: Path | None = None,
+    launcher_path: Path | None = None,
+) -> str:
+    root = root.resolve()
+    head = git(["rev-parse", "--verify", "HEAD^{commit}"], root).strip()
+    valid_sha(head, "source implementation HEAD")
+    if expected_head is not None and head != expected_head:
+        raise GateError("source implementation HEAD moved during the operation")
+    verify_live_source_blob(
+        root,
+        head,
+        GATE_TOOL_RELATIVE,
+        tool_path or root / GATE_TOOL_RELATIVE,
+    )
+    verify_live_source_blob(
+        root,
+        head,
+        GATE_LAUNCHER_RELATIVE,
+        launcher_path or root / GATE_LAUNCHER_RELATIVE,
+    )
+    if git_bytes(["status", "--porcelain=v1", "-z", "--untracked-files=all"], root):
+        raise GateError("Templates source worktree must be clean")
+    if git(["rev-parse", "--verify", "HEAD^{commit}"], root).strip() != head:
+        raise GateError("source implementation HEAD moved during verification")
+    return head
+
+
+def source_root() -> tuple[Path, str]:
     tool_root = Path(__file__).resolve().parent.parent
     root_text = git(["rev-parse", "--show-toplevel"], tool_root).strip()
     root = Path(root_text).resolve()
     if root != tool_root:
         raise GateError("release-gate tool must be installed at the source checkout root")
-    return root
+    head = verify_source_implementation(
+        root,
+        tool_path=Path(__file__),
+        launcher_path=root / GATE_LAUNCHER_RELATIVE,
+    )
+    return root, head
 
 
 def valid_pr(value: str) -> str:
@@ -596,6 +705,31 @@ def validate_evidence_payload(value: Any) -> dict[str, Any]:
     return value
 
 
+def evidence_subject(
+    repository: str,
+    pr: int,
+    head: str,
+    tree: str,
+    downstream_repository: str,
+) -> str:
+    return hashlib.sha256(
+        f"{repository}:{pr}:{head}:{tree}:{downstream_repository}".encode("utf-8")
+    ).hexdigest()
+
+
+def evidence_filename(payload: dict[str, Any]) -> str:
+    return (
+        evidence_subject(
+            payload["repo"],
+            payload["pr"],
+            payload["head"],
+            payload["tree"],
+            payload["downstreamRepo"],
+        )
+        + ".json"
+    )
+
+
 def load_evidence(root: Path, *, create: bool = False) -> list[dict[str, Any]]:
     directory = evidence_root(root, create=create)
     records: list[dict[str, Any]] = []
@@ -613,7 +747,10 @@ def load_evidence(root: Path, *, create: bool = False) -> list[dict[str, Any]]:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise GateError(f"invalid evidence record: {path.name}") from exc
-        records.append(validate_evidence_payload(payload))
+        validated = validate_evidence_payload(payload)
+        if path.name != evidence_filename(validated):
+            raise GateError(f"evidence filename does not match its immutable subject: {path.name}")
+        records.append(validated)
     return records
 
 
@@ -660,13 +797,10 @@ def record_evidence(
         "recordedAt": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
     }
     validate_evidence_payload(payload)
-    subject = hashlib.sha256(
-        f"{CANONICAL_REPO}:{checked['pr']}:{checked['head']}:{checked['tree']}:{DOWNSTREAM_REPO}".encode()
-    ).hexdigest()
     directory = evidence_root(root, create=False)
     # The deterministic subject path makes the check-and-create operation
     # atomic across concurrent recorders. O_EXCL permits exactly one winner.
-    target = directory / f"{subject}.json"
+    target = directory / evidence_filename(payload)
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
     try:
         descriptor = os.open(target, flags, 0o600)
@@ -800,7 +934,7 @@ def parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     arguments = parser().parse_args()
-    root = source_root()
+    root, implementation_head = source_root()
     if arguments.command == "release-candidate-check":
         output = candidate(root, arguments.pr)
     elif arguments.command == "release-candidate-worktree":
@@ -822,6 +956,13 @@ def main() -> int:
             arguments.dogfood_tree,
             arguments.version,
         )
+    verify_source_implementation(
+        root,
+        expected_head=implementation_head,
+        tool_path=Path(__file__),
+        launcher_path=root / GATE_LAUNCHER_RELATIVE,
+    )
+    output["implementationHead"] = implementation_head
     print(json.dumps(output, separators=(",", ":"), sort_keys=True))
     return 0
 

--- a/tools/agent_core_release_gate.py
+++ b/tools/agent_core_release_gate.py
@@ -18,6 +18,8 @@ from typing import Any
 
 
 CANONICAL_REPO = "upiscium/Templates"
+CANONICAL_GIT_URL = "https://github.com/upiscium/Templates.git"
+CANONICAL_WORKFLOW_PATH = ".github/workflows/template-ci.yml"
 DOWNSTREAM_REPO = "upiscium/AgentKnowledgeVault"
 DEFAULT_BRANCH = "main"
 EVIDENCE_ROOT_NAME = ".agent-core-release-gate/evidence"
@@ -26,6 +28,16 @@ SHA_RE = re.compile(r"[0-9a-f]{40}")
 PR_RE = re.compile(r"[1-9][0-9]{0,8}")
 OPERATION_RE = re.compile(r"[a-z][a-z0-9._-]{0,63}")
 VERSION_RE = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?")
+CANONICAL_REMOTE_RE = re.compile(
+    r"https://github\.com/upiscium/Templates(?:\.git)?",
+    re.IGNORECASE,
+)
+UNSAFE_LOCAL_CONFIG_RE = re.compile(
+    r"(?:include(?:if)?\..*|url\..*|http\..*|credential\..*|filter\..*|protocol\..*|"
+    r"core\.(?:gitproxy|hookspath|sshcommand|worktree)|"
+    r"remote\..+\.(?:proxy|proxyauthmethod|receivepack|uploadpack|vcs))",
+    re.IGNORECASE,
+)
 
 _TRUSTED_EXECUTABLES: dict[str, Path] = {}
 
@@ -245,6 +257,110 @@ query($owner:String!,$name:String!,$number:Int!){
             raise GateError("statusCheckRollup contains an unknown context type")
 
 
+def workflow_run_subject(
+    run: Any,
+    workflow_id: int,
+    expected_head: str,
+    expected_pr: int,
+) -> tuple[int, int]:
+    if not isinstance(run, dict):
+        raise GateError("Template CI workflow run is invalid")
+    run_id = run.get("id")
+    attempt = run.get("run_attempt")
+    if (
+        isinstance(run_id, bool)
+        or not isinstance(run_id, int)
+        or run_id <= 0
+        or isinstance(attempt, bool)
+        or not isinstance(attempt, int)
+        or attempt <= 0
+    ):
+        raise GateError("Template CI workflow run identity is invalid")
+    if (
+        run.get("workflow_id") != workflow_id
+        or run.get("path") != CANONICAL_WORKFLOW_PATH
+        or run.get("event") != "pull_request"
+        or run.get("head_sha") != expected_head
+    ):
+        raise GateError("Template CI workflow run is not bound to the exact candidate")
+    pull_requests = run.get("pull_requests")
+    if not isinstance(pull_requests, list) or len(pull_requests) != 1:
+        raise GateError("Template CI workflow run has ambiguous pull request identity")
+    associated = pull_requests[0]
+    if (
+        not isinstance(associated, dict)
+        or associated.get("number") != expected_pr
+        or (associated.get("head") or {}).get("sha") != expected_head
+        or (associated.get("head") or {}).get("repo", {}).get("url")
+        != f"https://api.github.com/repos/{CANONICAL_REPO}"
+        or (associated.get("base") or {}).get("ref") != DEFAULT_BRANCH
+        or (associated.get("base") or {}).get("repo", {}).get("url")
+        != f"https://api.github.com/repos/{CANONICAL_REPO}"
+    ):
+        raise GateError("Template CI workflow run belongs to another pull request")
+    return run_id, attempt
+
+
+def exact_template_ci_run(
+    root: Path,
+    workflow_id: int,
+    expected_head: str,
+    expected_pr: int,
+) -> dict[str, Any]:
+    response = gh(
+        [
+            "api",
+            f"repos/{CANONICAL_REPO}/actions/workflows/{workflow_id}/runs"
+            f"?event=pull_request&head_sha={expected_head}&per_page=100",
+        ],
+        root,
+    )
+    if not isinstance(response, dict):
+        raise GateError("Template CI workflow runs response is invalid")
+    runs = response.get("workflow_runs")
+    total = response.get("total_count")
+    if isinstance(total, bool) or not isinstance(total, int) or not isinstance(runs, list):
+        raise GateError("Template CI workflow runs response is invalid")
+    if total != len(runs):
+        raise GateError("Template CI workflow run pagination is incomplete")
+    if total == 0:
+        raise GateError("Template CI workflow is missing for the exact candidate")
+    if total != 1:
+        raise GateError("Template CI workflow run is ambiguous for the exact candidate")
+    workflow_run_subject(runs[0], workflow_id, expected_head, expected_pr)
+    return runs[0]
+
+
+def check_template_ci(root: Path, expected_head: str, expected_pr: int) -> None:
+    workflow = gh(
+        ["api", f"repos/{CANONICAL_REPO}/actions/workflows/template-ci.yml"],
+        root,
+    )
+    if not isinstance(workflow, dict):
+        raise GateError("canonical Template CI workflow metadata is invalid")
+    workflow_id = workflow.get("id")
+    if (
+        isinstance(workflow_id, bool)
+        or not isinstance(workflow_id, int)
+        or workflow_id <= 0
+        or workflow.get("path") != CANONICAL_WORKFLOW_PATH
+        or workflow.get("state") != "active"
+    ):
+        raise GateError("canonical Template CI workflow is missing or inactive")
+
+    first = exact_template_ci_run(root, workflow_id, expected_head, expected_pr)
+    run_id, attempt = workflow_run_subject(first, workflow_id, expected_head, expected_pr)
+    detail = gh(["api", f"repos/{CANONICAL_REPO}/actions/runs/{run_id}"], root)
+    if workflow_run_subject(detail, workflow_id, expected_head, expected_pr) != (run_id, attempt):
+        raise GateError("Template CI workflow attempt changed during validation")
+    if detail.get("status") != "completed" or detail.get("conclusion") != "success":
+        raise GateError("Template CI workflow is incomplete or unsuccessful")
+
+    final = exact_template_ci_run(root, workflow_id, expected_head, expected_pr)
+    if workflow_run_subject(final, workflow_id, expected_head, expected_pr) != (run_id, attempt):
+        raise GateError("Template CI workflow run changed during validation")
+
+
 def commit_tree(root: Path, commit: str, name: str = "commit") -> str:
     response = gh(["api", f"repos/{CANONICAL_REPO}/git/commits/{commit}"], root)
     if not isinstance(response, dict) or response.get("sha") != commit:
@@ -257,6 +373,7 @@ def candidate(root: Path, number: str, *, require_open: bool = True) -> dict[str
     first = pull_request(root, number)
     head = validate_pr_identity(first, require_open=require_open)
     tree = commit_tree(root, head, "candidate commit")
+    check_template_ci(root, head, int(number))
     check_rollup(root, number, head)
     final = pull_request(root, number)
     final_head = validate_pr_identity(final, require_open=require_open)
@@ -272,22 +389,40 @@ def candidate(root: Path, number: str, *, require_open: bool = True) -> dict[str
     }
 
 
-def worktree_records(root: Path) -> dict[Path, dict[str, Any]]:
-    records: dict[Path, dict[str, Any]] = {}
-    current: dict[str, Any] | None = None
-    for line in git(["worktree", "list", "--porcelain"], root).splitlines() + [""]:
-        if line.startswith("worktree "):
-            if current is not None:
-                records[current["path"]] = current
-            current = {"path": Path(line.removeprefix("worktree ")).resolve(), "detached": False}
-        elif current is not None and line.startswith("HEAD "):
-            current["head"] = line.removeprefix("HEAD ")
-        elif current is not None and line == "detached":
-            current["detached"] = True
-        elif not line and current is not None:
-            records[current["path"]] = current
-            current = None
-    return records
+def validate_git_execution_configuration(root: Path) -> None:
+    raw_names = git(
+        ["config", "--local", "--no-includes", "--null", "--name-only", "--list"],
+        root,
+    )
+    names = [item for item in raw_names.split("\0") if item]
+    for name in names:
+        if UNSAFE_LOCAL_CONFIG_RE.fullmatch(name):
+            raise GateError(f"unsafe local Git configuration is forbidden: {name}")
+
+    if any(name.lower() == "extensions.worktreeconfig" for name in names):
+        worktree_config = git(
+            ["config", "--local", "--bool", "--get", "extensions.worktreeConfig"],
+            root,
+        ).strip()
+        if worktree_config != "true":
+            raise GateError("extensions.worktreeConfig must be a valid true boolean")
+        raw_worktree_names = git(
+            ["config", "--worktree", "--no-includes", "--null", "--name-only", "--list"],
+            root,
+        )
+        for name in (item for item in raw_worktree_names.split("\0") if item):
+            if UNSAFE_LOCAL_CONFIG_RE.fullmatch(name):
+                raise GateError(f"unsafe worktree Git configuration is forbidden: {name}")
+
+
+def validate_local_git_configuration(root: Path) -> str:
+    validate_git_execution_configuration(root)
+
+    raw_urls = git(["remote", "get-url", "--all", "origin"], root)
+    urls = [line for line in raw_urls.splitlines() if line]
+    if len(urls) != 1 or not CANONICAL_REMOTE_RE.fullmatch(urls[0]):
+        raise GateError("origin is not the canonical Templates HTTPS repository")
+    return urls[0]
 
 
 def ensure_owned_directory(path: Path, *, create: bool, private: bool) -> None:
@@ -364,25 +499,25 @@ def verify_worktree(path: Path, expected_head: str, expected_tree: str) -> None:
 
 def create_or_verify_worktree(root: Path, number: str, destination: str) -> dict[str, Any]:
     checked = candidate(root, number)
+    validate_local_git_configuration(root)
     path = safe_worktree_path(root, destination, create_parents=True)
-    records = worktree_records(root)
-    registered = records.get(path.resolve())
-    if registered is not None:
-        if registered.get("head") != checked["head"] or not registered.get("detached"):
-            raise GateError("existing worktree is bound to another revision or branch")
+    if path.exists():
+        validate_git_execution_configuration(path)
         verify_worktree(path, checked["head"], checked["tree"])
     else:
-        if path.exists():
-            raise GateError("existing destination is not a registered worktree")
-        object_type = git(["cat-file", "-t", checked["head"]], root, check=False).strip()
-        if object_type != "commit":
-            git(["fetch", "--no-tags", "origin", checked["head"]], root)
-        if git(["cat-file", "-t", checked["head"]], root).strip() != "commit":
+        path.mkdir(mode=0o700)
+        git(["init", "--quiet", "--initial-branch=main", "."], path)
+        validate_git_execution_configuration(path)
+        git(["fetch", "--no-tags", CANONICAL_GIT_URL, checked["head"]], path)
+        validate_git_execution_configuration(path)
+        if git(["cat-file", "-t", checked["head"]], path).strip() != "commit":
             raise GateError("candidate revision is not an immutable Git commit")
-        local_tree = git(["rev-parse", f"{checked['head']}^{{tree}}"], root).strip()
+        local_tree = git(["rev-parse", f"{checked['head']}^{{tree}}"], path).strip()
         if local_tree != checked["tree"]:
             raise GateError("local candidate object has an unexpected tree")
-        git(["worktree", "add", "--detach", str(path), checked["head"]], root)
+        validate_git_execution_configuration(path)
+        git(["checkout", "--quiet", "--detach", checked["head"]], path)
+        validate_git_execution_configuration(path)
         verify_worktree(path, checked["head"], checked["tree"])
 
     final = candidate(root, number)
@@ -560,11 +695,16 @@ def record_evidence(
 def release_absent(root: Path, version: str) -> None:
     if not VERSION_RE.fullmatch(version):
         raise GateError("invalid release version")
-    status = gh_status(["api", f"repos/{CANONICAL_REPO}/releases/tags/{version}"], root)
-    if status == 200:
+    release_status = gh_status(["api", f"repos/{CANONICAL_REPO}/releases/tags/{version}"], root)
+    if release_status == 200:
         raise GateError("release already exists for the supplied version")
-    if status != 404:
-        raise GateError(f"release lookup returned unexpected HTTP status {status}")
+    if release_status != 404:
+        raise GateError(f"release lookup returned unexpected HTTP status {release_status}")
+    tag_status = gh_status(["api", f"repos/{CANONICAL_REPO}/git/ref/tags/{version}"], root)
+    if tag_status == 200:
+        raise GateError("Git tag already exists for the supplied version")
+    if tag_status != 404:
+        raise GateError(f"Git tag lookup returned unexpected HTTP status {tag_status}")
 
 
 def post_merge_gate(

--- a/tools/agent_core_release_gate.py
+++ b/tools/agent_core_release_gate.py
@@ -1,0 +1,694 @@
+#!/usr/bin/env python3
+"""Narrow operator API for Agent Core release-candidate dogfood gates."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import stat
+import subprocess
+import sys
+from typing import Any
+
+
+CANONICAL_REPO = "upiscium/Templates"
+DOWNSTREAM_REPO = "upiscium/AgentKnowledgeVault"
+DEFAULT_BRANCH = "main"
+EVIDENCE_ROOT_NAME = ".agent-core-release-gate/evidence"
+
+SHA_RE = re.compile(r"[0-9a-f]{40}")
+PR_RE = re.compile(r"[1-9][0-9]{0,8}")
+OPERATION_RE = re.compile(r"[a-z][a-z0-9._-]{0,63}")
+VERSION_RE = re.compile(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?")
+
+_TRUSTED_EXECUTABLES: dict[str, Path] = {}
+
+
+class GateError(RuntimeError):
+    """A fail-closed release-gate error."""
+
+
+class BoundedArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise GateError(message)
+
+
+def trusted_executable(name: str) -> Path:
+    cached = _TRUSTED_EXECUTABLES.get(name)
+    if cached is not None:
+        return cached
+    candidate = shutil.which(name)
+    if not candidate:
+        raise GateError(f"trusted {name} executable is unavailable")
+    executable = Path(candidate).resolve()
+    try:
+        metadata = executable.stat()
+    except OSError as exc:
+        raise GateError(f"trusted {name} executable is unavailable") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != 0
+        or stat.S_IMODE(metadata.st_mode) & 0o022
+        or executable.name != name
+    ):
+        raise GateError(f"{name} executable is not root-owned and immutable: {executable}")
+    _TRUSTED_EXECUTABLES[name] = executable
+    return executable
+
+
+def sanitized_environment() -> dict[str, str]:
+    environment = {}
+    for key in ("HOME", "XDG_CONFIG_HOME", "GH_TOKEN", "GITHUB_TOKEN", "NO_COLOR"):
+        if key in os.environ:
+            environment[key] = os.environ[key]
+    environment.update(
+        {
+            "LC_ALL": "C",
+            "LANG": "C",
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_CONFIG_GLOBAL": os.devnull,
+            "GIT_OPTIONAL_LOCKS": "0",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    return environment
+
+
+def command(argv: list[str], cwd: Path, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    if not argv or argv[0] not in {"git", "gh"}:
+        raise GateError("release-gate runner only accepts Git or GitHub CLI commands")
+    executable = trusted_executable(argv[0])
+    command_argv = [str(executable), *argv[1:]]
+    if argv[0] == "git":
+        command_argv = [
+            str(executable),
+            "-c",
+            "core.fsmonitor=false",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "-c",
+            "core.pager=",
+            *argv[1:],
+        ]
+    result = subprocess.run(
+        command_argv,
+        cwd=cwd,
+        env=sanitized_environment(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise GateError(f"{argv[0]} command failed: {detail}")
+    return result
+
+
+def git(args: list[str], cwd: Path, *, check: bool = True) -> str:
+    return command(["git", "--no-pager", *args], cwd, check=check).stdout
+
+
+def gh(args: list[str], cwd: Path) -> Any:
+    if not args or args[0] != "api":
+        raise GateError("GitHub runner only accepts API reads")
+    text = command(["gh", "api", "--hostname", "github.com", *args[1:]], cwd).stdout
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise GateError("GitHub API returned invalid JSON") from exc
+
+
+def gh_status(args: list[str], cwd: Path) -> int:
+    if not args or args[0] != "api":
+        raise GateError("GitHub status runner only accepts API reads")
+    result = command(
+        ["gh", "api", "--hostname", "github.com", *args[1:], "--include"],
+        cwd,
+        check=False,
+    )
+    statuses = re.findall(r"^HTTP/\S+\s+(\d{3})\b", result.stdout, re.MULTILINE)
+    if not statuses:
+        detail = result.stderr.strip() or "no HTTP status"
+        raise GateError(f"GitHub API status query failed: {detail}")
+    return int(statuses[-1])
+
+
+def source_root() -> Path:
+    tool_root = Path(__file__).resolve().parent.parent
+    root_text = git(["rev-parse", "--show-toplevel"], tool_root).strip()
+    root = Path(root_text).resolve()
+    if root != tool_root:
+        raise GateError("release-gate tool must be installed at the source checkout root")
+    return root
+
+
+def valid_pr(value: str) -> str:
+    if not PR_RE.fullmatch(value):
+        raise GateError("invalid pull request number")
+    return value
+
+
+def valid_sha(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not SHA_RE.fullmatch(value):
+        raise GateError(f"invalid {name}")
+    return value
+
+
+def pull_request(root: Path, number: str) -> dict[str, Any]:
+    value = gh(["api", f"repos/{CANONICAL_REPO}/pulls/{valid_pr(number)}"], root)
+    if not isinstance(value, dict):
+        raise GateError("GitHub returned an invalid pull request response")
+    return value
+
+
+def validate_pr_identity(pr: dict[str, Any], *, require_open: bool) -> str:
+    head = (pr.get("head") or {}).get("sha")
+    valid_sha(head, "pull request head")
+    state = pr.get("state")
+    if require_open and state != "open":
+        raise GateError("pull request is not open")
+    if not require_open and state not in {"open", "closed"}:
+        raise GateError("pull request state is invalid")
+    if (pr.get("base") or {}).get("ref") != DEFAULT_BRANCH:
+        raise GateError("pull request base is not the expected default branch")
+    if ((pr.get("base") or {}).get("repo") or {}).get("full_name") != CANONICAL_REPO:
+        raise GateError("pull request base repository is not canonical")
+    if ((pr.get("head") or {}).get("repo") or {}).get("full_name") != CANONICAL_REPO:
+        raise GateError("cross-repository pull requests are not release candidates")
+    return head
+
+
+def check_rollup(root: Path, number: str, expected_head: str) -> None:
+    query = """
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      commits(last:1){nodes{commit{
+        oid
+        statusCheckRollup{contexts(first:100){
+          pageInfo{hasNextPage}
+          nodes{
+            __typename
+            ... on CheckRun {status conclusion}
+            ... on StatusContext {state}
+          }
+        }}
+      }}}
+    }
+  }
+}
+""".strip()
+    data = gh(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            "owner=upiscium",
+            "-F",
+            "name=Templates",
+            "-F",
+            f"number={number}",
+        ],
+        root,
+    )
+    try:
+        commit = data["data"]["repository"]["pullRequest"]["commits"]["nodes"][0]["commit"]
+        contexts_object = commit["statusCheckRollup"]["contexts"]
+        contexts = contexts_object["nodes"]
+        has_next = contexts_object["pageInfo"]["hasNextPage"]
+    except (KeyError, IndexError, TypeError) as exc:
+        raise GateError("statusCheckRollup is unavailable") from exc
+    if commit.get("oid") != expected_head:
+        raise GateError("CI evidence is stale for a different pull request head")
+    if has_next:
+        raise GateError("statusCheckRollup has unexamined contexts")
+    if not isinstance(contexts, list) or not contexts:
+        raise GateError("statusCheckRollup is empty")
+    for context in contexts:
+        if not isinstance(context, dict):
+            raise GateError("statusCheckRollup contains an invalid context")
+        if context.get("__typename") == "CheckRun":
+            if context.get("status") != "COMPLETED" or context.get("conclusion") != "SUCCESS":
+                raise GateError("CI is incomplete or unsuccessful")
+        elif context.get("__typename") == "StatusContext":
+            if context.get("state") != "SUCCESS":
+                raise GateError("CI is incomplete or unsuccessful")
+        else:
+            raise GateError("statusCheckRollup contains an unknown context type")
+
+
+def commit_tree(root: Path, commit: str, name: str = "commit") -> str:
+    response = gh(["api", f"repos/{CANONICAL_REPO}/git/commits/{commit}"], root)
+    if not isinstance(response, dict) or response.get("sha") != commit:
+        raise GateError(f"GitHub did not return the exact {name}")
+    return valid_sha((response.get("tree") or {}).get("sha"), f"{name} tree")
+
+
+def candidate(root: Path, number: str, *, require_open: bool = True) -> dict[str, Any]:
+    number = valid_pr(number)
+    first = pull_request(root, number)
+    head = validate_pr_identity(first, require_open=require_open)
+    tree = commit_tree(root, head, "candidate commit")
+    check_rollup(root, number, head)
+    final = pull_request(root, number)
+    final_head = validate_pr_identity(final, require_open=require_open)
+    if final_head != head:
+        raise GateError("pull request head moved during validation")
+    return {
+        "pr": int(number),
+        "head": head,
+        "tree": tree,
+        "base": DEFAULT_BRANCH,
+        "ci": "PASS",
+        "status": "READY_FOR_DOGFOOD",
+    }
+
+
+def worktree_records(root: Path) -> dict[Path, dict[str, Any]]:
+    records: dict[Path, dict[str, Any]] = {}
+    current: dict[str, Any] | None = None
+    for line in git(["worktree", "list", "--porcelain"], root).splitlines() + [""]:
+        if line.startswith("worktree "):
+            if current is not None:
+                records[current["path"]] = current
+            current = {"path": Path(line.removeprefix("worktree ")).resolve(), "detached": False}
+        elif current is not None and line.startswith("HEAD "):
+            current["head"] = line.removeprefix("HEAD ")
+        elif current is not None and line == "detached":
+            current["detached"] = True
+        elif not line and current is not None:
+            records[current["path"]] = current
+            current = None
+    return records
+
+
+def ensure_owned_directory(path: Path, *, create: bool, private: bool) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        if not create:
+            raise GateError(f"required directory is missing: {path}")
+        try:
+            path.mkdir(mode=0o700 if private else 0o755)
+        except FileExistsError:
+            pass
+        metadata = path.lstat()
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or stat.S_ISLNK(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) & (0o077 if private else 0o022)
+    ):
+        raise GateError(f"directory is unsafe: {path}")
+
+
+def safe_worktree_path(root: Path, destination: str, *, create_parents: bool) -> Path:
+    base = root / ".worktrees"
+    raw = Path(destination)
+    if raw.is_absolute():
+        selected = raw
+    elif raw.parts and raw.parts[0] == ".worktrees":
+        selected = root / raw
+    else:
+        selected = base / raw
+    absolute = Path(os.path.abspath(selected))
+    try:
+        relative = absolute.relative_to(base)
+    except ValueError as exc:
+        raise GateError("worktree path must be under the source checkout .worktrees directory") from exc
+    if not relative.parts:
+        raise GateError("worktree path cannot be the .worktrees directory itself")
+
+    if base.exists() or base.is_symlink():
+        ensure_owned_directory(base, create=False, private=False)
+    elif create_parents:
+        ensure_owned_directory(base, create=True, private=False)
+
+    cursor = base
+    for component in relative.parts[:-1]:
+        cursor = cursor / component
+        if cursor.exists() or cursor.is_symlink():
+            ensure_owned_directory(cursor, create=False, private=False)
+        elif create_parents:
+            ensure_owned_directory(cursor, create=True, private=False)
+    if absolute.is_symlink():
+        raise GateError("worktree destination cannot be a symlink")
+    if absolute.resolve(strict=False) != absolute:
+        raise GateError("worktree path cannot traverse symlinks")
+    return absolute
+
+
+def verify_worktree(path: Path, expected_head: str, expected_tree: str) -> None:
+    if path.is_symlink() or not path.is_dir():
+        raise GateError("worktree destination is not a safe directory")
+    top = Path(git(["rev-parse", "--show-toplevel"], path).strip()).resolve()
+    if top != path.resolve():
+        raise GateError("destination is not the exact registered worktree root")
+    if git(["rev-parse", "--verify", "HEAD^{commit}"], path).strip() != expected_head:
+        raise GateError("worktree is bound to another revision")
+    if git(["rev-parse", "--verify", "HEAD^{tree}"], path).strip() != expected_tree:
+        raise GateError("worktree tree does not match the candidate tree")
+    if git(["symbolic-ref", "-q", "HEAD"], path, check=False).strip():
+        raise GateError("release-candidate worktree is not detached")
+    if git(["status", "--porcelain=v1", "-z", "--untracked-files=all"], path):
+        raise GateError("release-candidate worktree is not clean")
+
+
+def create_or_verify_worktree(root: Path, number: str, destination: str) -> dict[str, Any]:
+    checked = candidate(root, number)
+    path = safe_worktree_path(root, destination, create_parents=True)
+    records = worktree_records(root)
+    registered = records.get(path.resolve())
+    if registered is not None:
+        if registered.get("head") != checked["head"] or not registered.get("detached"):
+            raise GateError("existing worktree is bound to another revision or branch")
+        verify_worktree(path, checked["head"], checked["tree"])
+    else:
+        if path.exists():
+            raise GateError("existing destination is not a registered worktree")
+        object_type = git(["cat-file", "-t", checked["head"]], root, check=False).strip()
+        if object_type != "commit":
+            git(["fetch", "--no-tags", "origin", checked["head"]], root)
+        if git(["cat-file", "-t", checked["head"]], root).strip() != "commit":
+            raise GateError("candidate revision is not an immutable Git commit")
+        local_tree = git(["rev-parse", f"{checked['head']}^{{tree}}"], root).strip()
+        if local_tree != checked["tree"]:
+            raise GateError("local candidate object has an unexpected tree")
+        git(["worktree", "add", "--detach", str(path), checked["head"]], root)
+        verify_worktree(path, checked["head"], checked["tree"])
+
+    final = candidate(root, number)
+    if final != checked:
+        raise GateError("candidate changed during the worktree operation")
+    return {
+        **checked,
+        "path": str(path),
+        "detached": True,
+        "clean": True,
+    }
+
+
+def evidence_root(root: Path, *, create: bool) -> Path:
+    parent = root / ".agent-core-release-gate"
+    evidence = parent / "evidence"
+    ensure_owned_directory(parent, create=create, private=True)
+    ensure_owned_directory(evidence, create=create, private=True)
+    return evidence
+
+
+def positive_optional_integer(value: Any, name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise GateError(f"evidence {name} is invalid")
+    return value
+
+
+def validate_timestamp(value: Any) -> str:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        raise GateError("evidence timestamp is invalid")
+    try:
+        parsed = dt.datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as exc:
+        raise GateError("evidence timestamp is invalid") from exc
+    if parsed.tzinfo != dt.timezone.utc:
+        raise GateError("evidence timestamp is not UTC")
+    return value
+
+
+def validate_evidence_payload(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise GateError("evidence record is not a JSON object")
+    expected_keys = {
+        "schema",
+        "version",
+        "repo",
+        "pr",
+        "head",
+        "tree",
+        "downstreamRepo",
+        "task",
+        "downstreamPr",
+        "outcome",
+        "operation",
+        "recordedAt",
+    }
+    if set(value) != expected_keys:
+        raise GateError("evidence record has an unexpected schema")
+    if value["schema"] != "agent-core-release-gate" or value["version"] != 1:
+        raise GateError("evidence schema version is unsupported")
+    if value["repo"] != CANONICAL_REPO or value["downstreamRepo"] != DOWNSTREAM_REPO:
+        raise GateError("evidence repository binding is invalid")
+    if isinstance(value["pr"], bool) or not isinstance(value["pr"], int) or value["pr"] <= 0:
+        raise GateError("evidence pull request is invalid")
+    valid_sha(value["head"], "evidence head")
+    valid_sha(value["tree"], "evidence tree")
+    positive_optional_integer(value["task"], "Task ID")
+    positive_optional_integer(value["downstreamPr"], "downstream PR")
+    if value["outcome"] != "PASS":
+        raise GateError("evidence outcome is not PASS")
+    if not isinstance(value["operation"], str) or not OPERATION_RE.fullmatch(value["operation"]):
+        raise GateError("evidence operation is invalid")
+    validate_timestamp(value["recordedAt"])
+    return value
+
+
+def load_evidence(root: Path, *, create: bool = False) -> list[dict[str, Any]]:
+    directory = evidence_root(root, create=create)
+    records: list[dict[str, Any]] = []
+    for path in sorted(directory.iterdir()):
+        metadata = path.lstat()
+        if (
+            path.suffix != ".json"
+            or not stat.S_ISREG(metadata.st_mode)
+            or stat.S_ISLNK(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) & 0o077
+        ):
+            raise GateError(f"unsafe or unexpected evidence entry: {path.name}")
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise GateError(f"invalid evidence record: {path.name}") from exc
+        records.append(validate_evidence_payload(payload))
+    return records
+
+
+def record_evidence(
+    root: Path,
+    number: str,
+    operation: str,
+    task: str,
+    downstream_pr: str,
+) -> dict[str, Any]:
+    if not OPERATION_RE.fullmatch(operation):
+        raise GateError("invalid operation identifier")
+    task_id = int(task) if task and PR_RE.fullmatch(task) else None
+    if task and task_id is None:
+        raise GateError("Task ID must be a positive integer")
+    downstream_pr_id = int(downstream_pr) if downstream_pr and PR_RE.fullmatch(downstream_pr) else None
+    if downstream_pr and downstream_pr_id is None:
+        raise GateError("downstream PR must be a positive integer")
+
+    checked = candidate(root, number)
+    existing = load_evidence(root, create=True)
+    same_subject = [
+        item
+        for item in existing
+        if item["pr"] == checked["pr"]
+        and item["head"] == checked["head"]
+        and item["tree"] == checked["tree"]
+    ]
+    if same_subject:
+        raise GateError("dogfood evidence for this exact candidate already exists")
+
+    payload = {
+        "schema": "agent-core-release-gate",
+        "version": 1,
+        "repo": CANONICAL_REPO,
+        "pr": checked["pr"],
+        "head": checked["head"],
+        "tree": checked["tree"],
+        "downstreamRepo": DOWNSTREAM_REPO,
+        "task": task_id,
+        "downstreamPr": downstream_pr_id,
+        "outcome": "PASS",
+        "operation": operation,
+        "recordedAt": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    validate_evidence_payload(payload)
+    subject = hashlib.sha256(
+        f"{CANONICAL_REPO}:{checked['pr']}:{checked['head']}:{checked['tree']}:{DOWNSTREAM_REPO}".encode()
+    ).hexdigest()
+    directory = evidence_root(root, create=False)
+    # The deterministic subject path makes the check-and-create operation
+    # atomic across concurrent recorders. O_EXCL permits exactly one winner.
+    target = directory / f"{subject}.json"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(target, flags, 0o600)
+    except FileExistsError as exc:
+        raise GateError("dogfood evidence for this exact candidate already exists") from exc
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, separators=(",", ":"), sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        directory_descriptor = os.open(directory, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    except BaseException:
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        raise
+    return payload
+
+
+def release_absent(root: Path, version: str) -> None:
+    if not VERSION_RE.fullmatch(version):
+        raise GateError("invalid release version")
+    status = gh_status(["api", f"repos/{CANONICAL_REPO}/releases/tags/{version}"], root)
+    if status == 200:
+        raise GateError("release already exists for the supplied version")
+    if status != 404:
+        raise GateError(f"release lookup returned unexpected HTTP status {status}")
+
+
+def post_merge_gate(
+    root: Path,
+    number: str,
+    merge_commit: str,
+    dogfood_head: str,
+    dogfood_tree: str,
+    version: str,
+) -> dict[str, Any]:
+    number = valid_pr(number)
+    merge_commit = valid_sha(merge_commit, "merge commit")
+    dogfood_head = valid_sha(dogfood_head, "dogfood head")
+    dogfood_tree = valid_sha(dogfood_tree, "dogfood tree")
+
+    merged = pull_request(root, number)
+    merged_head = validate_pr_identity(merged, require_open=False)
+    if merged.get("state") != "closed" or merged.get("merged") is not True:
+        raise GateError("pull request is not merged")
+    if merged_head != dogfood_head:
+        raise GateError("merged pull request head is not the dogfooded head")
+    if merged.get("merge_commit_sha") != merge_commit:
+        raise GateError("supplied merge commit is not the pull request merge commit")
+
+    checked = candidate(root, number, require_open=False)
+    if checked["head"] != dogfood_head or checked["tree"] != dogfood_tree:
+        raise GateError("dogfood identity does not match the current pull request candidate")
+    merge_tree = commit_tree(root, merge_commit, "merge commit")
+    if merge_tree != dogfood_tree:
+        raise GateError("merge commit tree does not match the dogfooded tree")
+
+    comparison = gh(
+        ["api", f"repos/{CANONICAL_REPO}/compare/{merge_commit}...{DEFAULT_BRANCH}"],
+        root,
+    )
+    if not isinstance(comparison, dict) or comparison.get("status") not in {"identical", "ahead"}:
+        raise GateError("current main does not contain the merge commit")
+
+    records = load_evidence(root)
+    matching = [
+        item
+        for item in records
+        if item["pr"] == checked["pr"]
+        and item["head"] == dogfood_head
+        and item["tree"] == dogfood_tree
+    ]
+    if len(matching) != 1:
+        raise GateError("exact PASS dogfood evidence is missing, duplicated, or conflicting")
+    if version:
+        release_absent(root, version)
+
+    final = pull_request(root, number)
+    if (
+        validate_pr_identity(final, require_open=False) != dogfood_head
+        or final.get("state") != "closed"
+        or final.get("merged") is not True
+        or final.get("merge_commit_sha") != merge_commit
+    ):
+        raise GateError("pull request merge identity changed during release-gate validation")
+    return {
+        "pr": checked["pr"],
+        "status": "RELEASE_READY",
+        "dogfoodHead": dogfood_head,
+        "dogfoodTree": dogfood_tree,
+        "mergeCommit": merge_commit,
+        "mergeTree": merge_tree,
+        "treeMatch": True,
+        "ci": "PASS",
+    }
+
+
+def parser() -> argparse.ArgumentParser:
+    result = BoundedArgumentParser()
+    commands = result.add_subparsers(dest="command", required=True)
+    candidate_parser = commands.add_parser("release-candidate-check")
+    candidate_parser.add_argument("pr")
+    worktree_parser = commands.add_parser("release-candidate-worktree")
+    worktree_parser.add_argument("pr")
+    worktree_parser.add_argument("path")
+    evidence_parser = commands.add_parser("dogfood-evidence-record")
+    evidence_parser.add_argument("pr")
+    evidence_parser.add_argument("operation")
+    evidence_parser.add_argument("--task", default="")
+    evidence_parser.add_argument("--downstream-pr", default="")
+    gate_parser = commands.add_parser("release-gate-check")
+    gate_parser.add_argument("pr")
+    gate_parser.add_argument("merge_commit")
+    gate_parser.add_argument("dogfood_head")
+    gate_parser.add_argument("dogfood_tree")
+    gate_parser.add_argument("--version", default="")
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    root = source_root()
+    if arguments.command == "release-candidate-check":
+        output = candidate(root, arguments.pr)
+    elif arguments.command == "release-candidate-worktree":
+        output = create_or_verify_worktree(root, arguments.pr, arguments.path)
+    elif arguments.command == "dogfood-evidence-record":
+        output = record_evidence(
+            root,
+            arguments.pr,
+            arguments.operation,
+            arguments.task,
+            arguments.downstream_pr,
+        )
+    else:
+        output = post_merge_gate(
+            root,
+            arguments.pr,
+            arguments.merge_commit,
+            arguments.dogfood_head,
+            arguments.dogfood_tree,
+            arguments.version,
+        )
+    print(json.dumps(output, separators=(",", ":"), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (GateError, OSError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(2)

--- a/tools/run_agent_core_release_gate.sh
+++ b/tools/run_agent_core_release_gate.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -lt 2 ]; then
+    printf '%s\n' 'ERROR: release-gate launcher requires a tool and command' >&2
+    exit 2
+fi
+
+tool=$1
+shift
+unset LD_PRELOAD LD_LIBRARY_PATH LD_AUDIT \
+    DYLD_INSERT_LIBRARIES DYLD_LIBRARY_PATH DYLD_FRAMEWORK_PATH \
+    DYLD_FALLBACK_LIBRARY_PATH DYLD_FALLBACK_FRAMEWORK_PATH \
+    DYLD_VERSIONED_LIBRARY_PATH DYLD_VERSIONED_FRAMEWORK_PATH \
+    DYLD_ROOT_PATH DYLD_IMAGE_SUFFIX || {
+        printf '%s\n' 'ERROR: cannot sanitize dynamic-loader environment' >&2
+        exit 2
+    }
+
+selected_python=$(command -v python3) || {
+    printf '%s\n' 'ERROR: trusted Python interpreter is unavailable' >&2
+    exit 2
+}
+case "$selected_python" in
+    /nix/store/*/bin/python3|/usr/bin/python3|/run/current-system/sw/bin/python3|/nix/var/nix/profiles/default/bin/python3) ;;
+    *)
+        printf '%s\n' 'ERROR: selected Python interpreter path is not trusted' >&2
+        exit 2
+        ;;
+esac
+resolved_python=$(
+    "$selected_python" -I -c 'import os, sys; sys.stdout.write(os.path.realpath(sys.executable))'
+) || {
+    printf '%s\n' 'ERROR: trusted Python interpreter resolution failed' >&2
+    exit 2
+}
+case "$resolved_python" in
+    /nix/store/*/bin/python3|/nix/store/*/bin/python3.[0-9]*|/usr/bin/python3|/usr/bin/python3.[0-9]*) ;;
+    *)
+        printf '%s\n' 'ERROR: resolved Python interpreter target is not trusted' >&2
+        exit 2
+        ;;
+esac
+if [ ! -f "$resolved_python" ] || [ ! -x "$resolved_python" ] || [ -L "$resolved_python" ]; then
+    printf '%s\n' 'ERROR: resolved Python interpreter target is unavailable or unsafe' >&2
+    exit 2
+fi
+
+selected_stat=$(command -v stat) || {
+    printf '%s\n' 'ERROR: trusted stat executable is unavailable' >&2
+    exit 2
+}
+case "$selected_stat" in
+    /nix/store/*/bin/stat|/usr/bin/stat|/run/current-system/sw/bin/stat|/nix/var/nix/profiles/default/bin/stat) ;;
+    *)
+        printf '%s\n' 'ERROR: selected stat executable path is not trusted' >&2
+        exit 2
+        ;;
+esac
+python_owner=$($selected_stat -Lc '%u' "$resolved_python") || {
+    printf '%s\n' 'ERROR: cannot inspect trusted Python interpreter ownership' >&2
+    exit 2
+}
+python_mode=$($selected_stat -Lc '%a' "$resolved_python") || {
+    printf '%s\n' 'ERROR: cannot inspect trusted Python interpreter permissions' >&2
+    exit 2
+}
+case "$python_mode" in
+    [0-7][0-7][0-7]) ;;
+    *)
+        printf '%s\n' 'ERROR: trusted Python interpreter permissions are invalid' >&2
+        exit 2
+        ;;
+esac
+group_mode=${python_mode#?}
+group_mode=${group_mode%?}
+other_mode=${python_mode#??}
+case "$python_owner:$group_mode:$other_mode" in
+    0:[0145]:[0145]) ;;
+    *)
+        printf '%s\n' 'ERROR: trusted Python interpreter is not root-owned and immutable' >&2
+        exit 2
+        ;;
+esac
+
+exec "$resolved_python" -I "$tool" "$@"


### PR DESCRIPTION
Closes #116

## Summary
- bind readiness to the exact PR head and canonical Template CI workflow run/attempt
- bind the release-gate launcher and Python implementation to exact clean source HEAD blobs
- create or verify detached clean RC worktrees under `.worktrees/` using isolated canonical transport
- record immutable AKV PASS evidence under the canonical subject-derived filename
- enforce post-merge tree equality and reject pre-existing Release objects or Git tags
- document the downstream-sensitive Agent Core release policy and historical PR #115 fixture

## Verification
- focused release-gate tests: 34 passed
- full unittest suite: 483 passed
- generated template drift: PASS
- template distribution verification: PASS
- all-system flake evaluation: PASS
- OpenCodePolicy contract: PASS
- `git diff --check`: PASS
- correctness review: no findings
- security review: no findings
- full Template CI and GitGuardian: PASS

## Safety
- no automatic merge or release
- GitHub access is read-only and pinned to github.com
- exact Template CI workflow, run attempt, PR, head, and repositories are revalidated
- gate implementation HEAD, launcher/tool blobs, modes, content, and source cleanliness are revalidated before success
- evidence filenames must match the immutable repository/PR/head/tree/downstream subject
- existing Release objects and tags fail closed
- source/destination Git execution configuration and canonical transport are constrained
- evidence authority is fixed to `upiscium/AgentKnowledgeVault`
- Agent Core VERSION remains 3