### PR TITLE
Preserve Template CI identity after merge

### DIFF
--- a/docs/agent-core-release-gate.md
+++ b/docs/agent-core-release-gate.md
@@ -59,8 +59,11 @@ just agent-core::release-gate-check <pr> <merge-commit> <dogfood-head> <dogfood-
 `release-candidate-check` verifies the current open PR and proves that the
 canonical `.github/workflows/template-ci.yml` workflow has exactly one
 unambiguous `pull_request` run for its exact head, with the current attempt
-completed successfully. It also requires the complete GitHub status rollup to
-be successful; an unrelated green context cannot substitute for Template CI.
+completed successfully. The workflow must be the exact active canonical
+workflow, and its workflow ID, path, run ID, and attempt are returned as an
+immutable Template CI identity; list, detail, and final list observations must
+retain that exact run/attempt identity. It also requires the complete GitHub
+status rollup to be successful; an unrelated green context cannot substitute for Template CI.
 Human review and security review remain explicit operator prerequisites rather
 than inferred CI evidence. The result identifies the exact PR head that can be
 frozen.
@@ -83,9 +86,10 @@ clean candidate root. Neither surface merges, pushes, tags, or publishes.
 operation identifier (and, where applicable, the downstream Task and PR) after
 the operator has run AKV against the exact candidate revision. The record binds
 the Templates repository, PR, candidate head/tree, canonical downstream
-repository, operation, optional IDs, PASS, and timestamp. It does not claim to
-capture raw command logs and does not alter downstream Task State, PR metadata,
-or merge state.
+repository, Template CI workflow ID/path and run ID/attempt, operation,
+optional IDs, PASS, and timestamp. New records are schema version 2 and carry
+all four Template CI identity fields. It does not claim to capture raw command
+logs and does not alter downstream Task State, PR metadata, or merge state.
 
 There is exactly one immutable PASS record per candidate head/tree. Its
 operation identifier names the overall externally executed dogfood run. When a
@@ -94,8 +98,12 @@ and record the aggregate PASS only after every applicable step has passed.
 
 `release-gate-check` is the final read-only assertion. It requires the recorded
 evidence, supplied merge commit, exact dogfooded **Templates** PR head/tree,
-and (when supplied) the intended version. It checks that the merge commit has
-the same tree as the frozen candidate. When a version is supplied, both the
+and (when supplied) the intended version. It independently verifies the merged
+PR's canonical repository, base, head, merge state, and merge commit, then
+checks that the merge commit has the same tree as the frozen candidate. The
+recorded workflow run is read again at the final boundary so its stable
+workflow, run, attempt, event, head, status, and conclusion fields must still
+match the immutable pre-merge binding. When a version is supplied, both the
 GitHub Release and the exact Git tag must be absent; an existing tag fails
 closed even without a Release object. It does not
 merge, create a release, publish a tag, or claim that a release was published.
@@ -158,10 +166,14 @@ Evidence is local and auditable under:
 .agent-core-release-gate/evidence/
 ```
 
-Each record is immutable and must not overwrite an earlier record. It binds
-the Templates PR number and exact frozen PR head/tree and the canonical AKV
-repository, operation, PASS outcome, timestamp, and Task/downstream PR when
-present. This is a narrow local operator self-attestation within the trusted
+Each record is immutable and must not overwrite an earlier record. Schema v2
+binds the Templates PR number and exact frozen PR head/tree, the canonical AKV
+repository, the exact Template CI workflow ID/path and run ID/attempt,
+operation, PASS outcome, timestamp, and Task/downstream PR when present. The
+loader accepts schema v1 structurally so old files remain readable; post-merge
+trusts v1 only for the narrow hardcoded issue #117 PR/head/tree/run/workflow/
+attempt/merge binding. There is no migration or evidence-upgrade command; do
+not rewrite evidence files. This is a narrow local operator self-attestation within the trusted
 operator/filesystem boundary, not a cryptographic downstream receipt. Its
 filename is exactly the SHA-256 digest of the canonical repository,
 PR, head, tree, and downstream-repository subject followed by `.json`; records
@@ -191,3 +203,23 @@ merge tree: 0eeaad174d2ff519a2db4b23ac80252c48d6bec7
 It is historical documentation, not a production input or a substitute for
 current CI, review, security, dogfood, or human merge evidence. Agent Core
 `VERSION` remains **3**.
+
+## Issue #117 legacy compatibility binding
+
+This is the sole v1 post-merge compatibility exception. It is an exact,
+hardcoded binding and is not a general legacy trust rule:
+
+```text
+PR:         117
+head:       9eb86882bbb569aeae356c59e7d459e9fd8ba4f9
+tree:       7c5c6fb0bd5e0e881510e256f0b76e95c304c9c5
+merge:      67fbc64e1127c19b9e424ab99dff4626f67be63b
+workflow:   .github/workflows/template-ci.yml (ID 329870494)
+run:        33584314368 (attempt 1)
+```
+
+Post-merge accepts a singleton `pull_requests` association only when it matches
+the merged PR exactly. An empty association is accepted only with immutable v2
+evidence, or with the exact guarded issue #117 compatibility binding above
+after merged-PR proof succeeds;
+non-empty conflicting or ambiguous associations always fail.

--- a/docs/agent-core-release-gate.md
+++ b/docs/agent-core-release-gate.md
@@ -172,7 +172,8 @@ repository, the exact Template CI workflow ID/path and run ID/attempt,
 operation, PASS outcome, timestamp, and Task/downstream PR when present. The
 loader accepts schema v1 structurally so old files remain readable; post-merge
 trusts v1 only for the narrow hardcoded issue #117 PR/head/tree/run/workflow/
-attempt/merge binding. There is no migration or evidence-upgrade command; do
+attempt/merge binding and exact safely read evidence-file SHA-256. There is no
+migration or evidence-upgrade command; do
 not rewrite evidence files. This is a narrow local operator self-attestation within the trusted
 operator/filesystem boundary, not a cryptographic downstream receipt. Its
 filename is exactly the SHA-256 digest of the canonical repository,
@@ -216,7 +217,14 @@ tree:       7c5c6fb0bd5e0e881510e256f0b76e95c304c9c5
 merge:      67fbc64e1127c19b9e424ab99dff4626f67be63b
 workflow:   .github/workflows/template-ci.yml (ID 329870494)
 run:        33584314368 (attempt 1)
+evidence:   317dd08ea4840dac4a820043630315ece7c098e13ff77c992af63568442190ce
 ```
+
+The evidence value is the SHA-256 of the exact existing serialized file bytes.
+The gate opens the canonical evidence file without following symlinks, checks
+its owner, regular-file type, private mode, schema, and subject-derived
+filename, and hashes the bytes read. Semantically equivalent JSON with different
+bytes is not the known record. The old file is neither rewritten nor migrated.
 
 Post-merge accepts a singleton `pull_requests` association only when it matches
 the merged PR exactly. An empty association is accepted only with immutable v2

--- a/tests/test_agent_core_release_gate.py
+++ b/tests/test_agent_core_release_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import os
 import subprocess
@@ -361,16 +362,21 @@ class ReleaseGateTest(unittest.TestCase):
         return {"schema": "agent-core-release-gate", "version": 1, "repo": gate.CANONICAL_REPO,
                 "pr": 117, "head": gate.ISSUE_117_COMPATIBILITY["head"],
                 "tree": gate.ISSUE_117_COMPATIBILITY["tree"],
-                "downstreamRepo": gate.DOWNSTREAM_REPO, "task": 116, "downstreamPr": 7,
-                "outcome": "PASS", "operation": "dogfood", "recordedAt": "2026-09-01T00:00:00Z"}
+                "downstreamRepo": gate.DOWNSTREAM_REPO, "task": 22, "downstreamPr": 23,
+                "outcome": "PASS", "operation": "maintenance-finalize",
+                "recordedAt": "2026-09-02T03:06:11.405547Z"}
 
-    def write_evidence(self, *records: dict) -> None:
+    def write_evidence(self, *records: dict, canonical_bytes: bool = False) -> None:
         directory = gate.evidence_root(self.root, create=True)
         for record in records:
             target = directory / gate.evidence_filename(record)
             if target.exists():
                 raise AssertionError("test attempted to overwrite canonical evidence")
-            target.write_text(json.dumps(record) + "\n", encoding="utf-8")
+            if canonical_bytes:
+                content = json.dumps(record, separators=(",", ":"), sort_keys=True) + "\n"
+            else:
+                content = json.dumps(record) + "\n"
+            target.write_text(content, encoding="utf-8")
             os.chmod(target, 0o600)
 
     def test_recorded_pass_evidence_contains_all_identity_bindings(self) -> None:
@@ -411,6 +417,45 @@ class ReleaseGateTest(unittest.TestCase):
         canonical.chmod(0o600)
         with self.assertRaisesRegex(gate.GateError, "filename does not match"):
             gate.load_evidence(self.root)
+
+    def test_evidence_reader_rejects_symlink_non_private_and_non_regular_entries(self) -> None:
+        record = self.evidence()
+        directory = gate.evidence_root(self.root, create=True)
+        canonical = directory / gate.evidence_filename(record)
+        content = json.dumps(record) + "\n"
+
+        target = self.root / "outside-evidence.json"
+        target.write_text(content, encoding="utf-8")
+        target.chmod(0o600)
+        canonical.symlink_to(target)
+        with self.assertRaisesRegex(gate.GateError, "unsafe or unexpected"):
+            gate.load_evidence(self.root)
+        canonical.unlink()
+
+        canonical.write_text(content, encoding="utf-8")
+        canonical.chmod(0o644)
+        with self.assertRaisesRegex(gate.GateError, "unsafe or unexpected"):
+            gate.load_evidence(self.root)
+        canonical.unlink()
+
+        canonical.mkdir(mode=0o700)
+        with self.assertRaisesRegex(gate.GateError, "unsafe or unexpected"):
+            gate.load_evidence(self.root)
+
+    def test_evidence_reader_rejects_object_replaced_between_lstat_and_open(self) -> None:
+        record = self.evidence()
+        self.write_evidence(record)
+        real_fstat = os.fstat
+
+        def replaced_metadata(descriptor):
+            metadata = real_fstat(descriptor)
+            fields = list(metadata)
+            fields[1] += 1
+            return os.stat_result(fields)
+
+        with mock.patch.object(gate.os, "fstat", side_effect=replaced_metadata):
+            with self.assertRaisesRegex(gate.GateError, "unsafe or unexpected"):
+                gate.load_evidence(self.root)
 
     def test_launcher_rejects_python_from_untrusted_path(self) -> None:
         fake_bin = Path(self.temp.name) / "fake-bin"
@@ -593,8 +638,13 @@ class ReleaseGateTest(unittest.TestCase):
 
     def test_exact_issue_117_v1_fixture_passes_without_changing_evidence(self) -> None:
         record = self.issue_117_evidence()
-        self.write_evidence(record)
-        before = json.dumps(record, sort_keys=True)
+        self.write_evidence(record, canonical_bytes=True)
+        target = gate.evidence_root(self.root, create=False) / gate.evidence_filename(record)
+        before = target.read_bytes()
+        self.assertEqual(
+            hashlib.sha256(before).hexdigest(),
+            gate.ISSUE_117_COMPATIBILITY["evidenceSha256"],
+        )
         merge = gate.ISSUE_117_COMPATIBILITY["merge"]
         pr = self.pr(head=record["head"], state="closed", merged=True, merge=merge)
         with mock.patch.object(
@@ -609,7 +659,82 @@ class ReleaseGateTest(unittest.TestCase):
             ),
         ):
             gate.post_merge_gate(self.root, "117", merge, record["head"], record["tree"], "")
-        self.assertEqual(json.dumps(record, sort_keys=True), before)
+        self.assertEqual(target.read_bytes(), before)
+
+    def test_issue_117_v1_payload_field_changes_fail_digest_binding(self) -> None:
+        merge = gate.ISSUE_117_COMPATIBILITY["merge"]
+        for field, value in (
+            ("task", 116),
+            ("downstreamPr", 7),
+            ("operation", "dogfood"),
+            ("recordedAt", "2026-09-01T00:00:00Z"),
+        ):
+            with self.subTest(field=field):
+                record = self.issue_117_evidence()
+                record[field] = value
+                self.write_evidence(record, canonical_bytes=True)
+                pr = self.pr(head=record["head"], state="closed", merged=True, merge=merge)
+                with mock.patch.object(
+                    gate,
+                    "gh",
+                    side_effect=self.merge_gh(
+                        merge,
+                        record["tree"],
+                        evidence=record,
+                        pr_values=[pr] * 4,
+                        run_pull_requests=[],
+                    ),
+                ):
+                    with self.assertRaisesRegex(gate.GateError, "issue #117"):
+                        gate.post_merge_gate(
+                            self.root, "117", merge, record["head"], record["tree"], ""
+                        )
+                (gate.evidence_root(self.root, create=False) / gate.evidence_filename(record)).unlink()
+
+    def test_issue_117_same_json_with_different_bytes_fails(self) -> None:
+        record = self.issue_117_evidence()
+        self.write_evidence(record)
+        merge = gate.ISSUE_117_COMPATIBILITY["merge"]
+        pr = self.pr(head=record["head"], state="closed", merged=True, merge=merge)
+        with mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.merge_gh(
+                merge,
+                record["tree"],
+                evidence=record,
+                pr_values=[pr] * 4,
+                run_pull_requests=[],
+            ),
+        ):
+            with self.assertRaisesRegex(gate.GateError, "issue #117"):
+                gate.post_merge_gate(
+                    self.root, "117", merge, record["head"], record["tree"], ""
+                )
+
+    def test_issue_117_wrong_known_digest_fails(self) -> None:
+        record = self.issue_117_evidence()
+        self.write_evidence(record, canonical_bytes=True)
+        merge = gate.ISSUE_117_COMPATIBILITY["merge"]
+        pr = self.pr(head=record["head"], state="closed", merged=True, merge=merge)
+        with mock.patch.dict(
+            gate.ISSUE_117_COMPATIBILITY,
+            {"evidenceSha256": "0" * 64},
+        ), mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.merge_gh(
+                merge,
+                record["tree"],
+                evidence=record,
+                pr_values=[pr] * 4,
+                run_pull_requests=[],
+            ),
+        ):
+            with self.assertRaisesRegex(gate.GateError, "issue #117"):
+                gate.post_merge_gate(
+                    self.root, "117", merge, record["head"], record["tree"], ""
+                )
 
     def test_arbitrary_v1_evidence_fails(self) -> None:
         record = self.evidence(version=1)

--- a/tests/test_agent_core_release_gate.py
+++ b/tests/test_agent_core_release_gate.py
@@ -115,29 +115,32 @@ class ReleaseGateTest(unittest.TestCase):
         conclusion: str | None = "success",
         run_id: int = 700,
         attempt: int = 1,
+        workflow_id: int = 600,
+        workflow_path: str = gate.CANONICAL_WORKFLOW_PATH,
+        pr_number: int = 115,
+        pull_requests=None,
     ) -> dict:
+        associated = [{
+            "number": pr_number,
+            "head": {
+                "sha": head or self.head,
+                "repo": {"url": f"https://api.github.com/repos/{gate.CANONICAL_REPO}"},
+            },
+            "base": {
+                "ref": "main",
+                "repo": {"url": f"https://api.github.com/repos/{gate.CANONICAL_REPO}"},
+            },
+        }]
         return {
             "id": run_id,
-            "workflow_id": 600,
-            "path": gate.CANONICAL_WORKFLOW_PATH,
+            "workflow_id": workflow_id,
+            "path": workflow_path,
             "event": "pull_request",
             "head_sha": head or self.head,
             "run_attempt": attempt,
             "status": status,
             "conclusion": conclusion,
-            "pull_requests": [
-                {
-                    "number": 115,
-                    "head": {
-                        "sha": head or self.head,
-                        "repo": {"url": f"https://api.github.com/repos/{gate.CANONICAL_REPO}"},
-                    },
-                    "base": {
-                        "ref": "main",
-                        "repo": {"url": f"https://api.github.com/repos/{gate.CANONICAL_REPO}"},
-                    },
-                }
-            ],
+            "pull_requests": associated if pull_requests is None else pull_requests,
         }
 
     def gh_candidate(
@@ -150,13 +153,14 @@ class ReleaseGateTest(unittest.TestCase):
         workflow_runs=None,
         workflow_detail=None,
         workflow=None,
+        workflow_id=600,
     ):
         values = iter(pr_values or [self.pr(), self.pr(), self.pr(), self.pr()])
         trees = commit_trees or {self.head: self.tree}
         runs = [self.workflow_run()] if workflow_runs is None else workflow_runs
         detail = workflow_detail or (runs[0] if runs else self.workflow_run())
         workflow_metadata = workflow or {
-            "id": 600,
+            "id": workflow_id,
             "path": gate.CANONICAL_WORKFLOW_PATH,
             "state": "active",
         }
@@ -172,9 +176,9 @@ class ReleaseGateTest(unittest.TestCase):
             endpoint = args[1]
             if endpoint.endswith("/actions/workflows/template-ci.yml"):
                 return workflow_metadata
-            if "/actions/workflows/600/runs?" in endpoint:
+            if f"/actions/workflows/{workflow_metadata['id']}/runs?" in endpoint:
                 return {"total_count": len(runs), "workflow_runs": runs}
-            if endpoint.endswith("/actions/runs/700"):
+            if "/actions/runs/" in endpoint:
                 return detail
             if "/pulls/" in endpoint:
                 return next(values)
@@ -189,7 +193,30 @@ class ReleaseGateTest(unittest.TestCase):
     def test_exact_open_head_tree_and_successful_ci_ready(self) -> None:
         with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
             result = gate.candidate(self.root, "115")
-        self.assertEqual({"pr": 115, "head": self.head, "tree": self.tree, "base": "main", "ci": "PASS", "status": "READY_FOR_DOGFOOD"}, result)
+        self.assertEqual({"pr": 115, "head": self.head, "tree": self.tree, "base": "main",
+                          "workflowId": 600, "workflowPath": gate.CANONICAL_WORKFLOW_PATH,
+                          "runId": 700, "runAttempt": 1, "ci": "PASS",
+                          "status": "READY_FOR_DOGFOOD"}, result)
+
+    def test_open_pr_with_empty_workflow_association_is_blocked(self) -> None:
+        run = self.workflow_run(pull_requests=[])
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate(workflow_runs=[run], workflow_detail=run)):
+            with self.assertRaisesRegex(gate.GateError, "ambiguous pull request identity"):
+                gate.candidate(self.root, "115")
+
+    def test_candidate_rejects_each_workflow_identity_mismatch(self) -> None:
+        cases = (
+            ("workflow_id", 601, "exact candidate"),
+            ("workflow_path", "other.yml", "exact candidate"),
+            ("head", "a" * 40, "exact candidate"),
+        )
+        for field, value, message in cases:
+            with self.subTest(field=field):
+                kwargs = {field: value}
+                run = self.workflow_run(**kwargs)
+                with mock.patch.object(gate, "gh", side_effect=self.gh_candidate(workflow_runs=[run], workflow_detail=run)):
+                    with self.assertRaisesRegex(gate.GateError, message):
+                        gate.candidate(self.root, "115")
 
     def test_only_unrelated_successful_rollup_without_template_ci_is_blocked(self) -> None:
         with mock.patch.object(
@@ -320,11 +347,22 @@ class ReleaseGateTest(unittest.TestCase):
             with self.assertRaisesRegex(gate.GateError, "unsafe local Git configuration"):
                 gate.create_or_verify_worktree(self.root, "115", "rc")
 
-    def evidence(self, *, head=None, tree=None, operation="dogfood") -> dict:
+    def evidence(self, *, head=None, tree=None, operation="dogfood", version=2, **identity) -> dict:
+        record = {"schema": "agent-core-release-gate", "version": version, "repo": gate.CANONICAL_REPO,
+                 "pr": 115, "head": head or self.head, "tree": tree or self.tree,
+                 "downstreamRepo": gate.DOWNSTREAM_REPO, "task": 116, "downstreamPr": 7,
+                 "outcome": "PASS", "operation": operation, "recordedAt": "2026-09-01T00:00:00Z"}
+        if version == 2:
+            record.update({"workflowId": 600, "workflowPath": gate.CANONICAL_WORKFLOW_PATH,
+                           "runId": 700, "runAttempt": 1, **identity})
+        return record
+
+    def issue_117_evidence(self) -> dict:
         return {"schema": "agent-core-release-gate", "version": 1, "repo": gate.CANONICAL_REPO,
-                "pr": 115, "head": head or self.head, "tree": tree or self.tree,
+                "pr": 117, "head": gate.ISSUE_117_COMPATIBILITY["head"],
+                "tree": gate.ISSUE_117_COMPATIBILITY["tree"],
                 "downstreamRepo": gate.DOWNSTREAM_REPO, "task": 116, "downstreamPr": 7,
-                "outcome": "PASS", "operation": operation, "recordedAt": "2026-09-01T00:00:00Z"}
+                "outcome": "PASS", "operation": "dogfood", "recordedAt": "2026-09-01T00:00:00Z"}
 
     def write_evidence(self, *records: dict) -> None:
         directory = gate.evidence_root(self.root, create=True)
@@ -460,20 +498,55 @@ class ReleaseGateTest(unittest.TestCase):
         with self.assertRaisesRegex(gate.GateError, "unsafe worktree Git configuration"):
             gate.validate_local_git_configuration(self.root)
 
-    def merge_gh(self, merge: str, merge_tree: str, *, evidence=None, pr_values=None, comparison=None):
+    def merge_gh(
+        self,
+        merge: str,
+        merge_tree: str,
+        *,
+        evidence=None,
+        pr_values=None,
+        comparison=None,
+        run_pull_requests=None,
+    ):
         values = iter(pr_values or [self.pr(state="closed", merged=True, merge=merge)] * 4)
-        trees = {self.head: self.tree, merge: merge_tree}
+        recorded = evidence or self.evidence()
+        recorded_head = recorded.get("head", self.head)
+        recorded_pr = recorded.get("pr", 115)
+        canonical_workflow_id = (gate.ISSUE_117_COMPATIBILITY["workflowId"]
+                                 if recorded.get("version") == 1 else 600)
+        canonical_run_id = (gate.ISSUE_117_COMPATIBILITY["runId"]
+                            if recorded.get("version") == 1 else 700)
+        trees = {self.head: self.tree, recorded_head: recorded.get("tree", self.tree), merge: merge_tree}
         def fake(args, cwd):
             if args[:2] == ["api", "graphql"]:
                 raise AssertionError("graphql must be routed to the rollup fixture")
             endpoint = args[1]
             if endpoint.endswith("/actions/workflows/template-ci.yml"):
-                return {"id": 600, "path": gate.CANONICAL_WORKFLOW_PATH, "state": "active"}
-            if "/actions/workflows/600/runs?" in endpoint:
-                run = self.workflow_run()
+                return {"id": canonical_workflow_id,
+                        "path": gate.CANONICAL_WORKFLOW_PATH,
+                        "state": "active"}
+            if "/actions/workflows/" in endpoint and "/runs?" in endpoint:
+                run = self.workflow_run(
+                    workflow_id=canonical_workflow_id,
+                    workflow_path=gate.CANONICAL_WORKFLOW_PATH,
+                    head=recorded_head,
+                    pr_number=recorded_pr,
+                    run_id=recorded.get("runId", 700),
+                    attempt=recorded.get("runAttempt", 1),
+                    pull_requests=recorded.get("pull_requests", None),
+                )
                 return {"total_count": 1, "workflow_runs": [run]}
-            if endpoint.endswith("/actions/runs/700"):
-                return self.workflow_run()
+            if "/actions/runs/" in endpoint:
+                identity = recorded
+                return self.workflow_run(
+                    workflow_id=canonical_workflow_id,
+                    workflow_path=gate.CANONICAL_WORKFLOW_PATH,
+                    head=recorded_head,
+                    pr_number=recorded_pr,
+                    run_id=canonical_run_id,
+                    attempt=1,
+                    pull_requests=run_pull_requests,
+                )
             if "/pulls/" in endpoint:
                 return next(values)
             if "/git/commits/" in endpoint:
@@ -484,12 +557,110 @@ class ReleaseGateTest(unittest.TestCase):
             raise AssertionError(args)
         # The post-merge candidate still requires a successful rollup for the head.
         rollup = {"data": {"repository": {"pullRequest": {"commits": {"nodes": [{"commit": {
-            "oid": self.head, "statusCheckRollup": {"contexts": {"pageInfo": {"hasNextPage": False}, "nodes": [{"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}]}}
+            "oid": recorded_head, "statusCheckRollup": {"contexts": {"pageInfo": {"hasNextPage": False}, "nodes": [{"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"}]}}
         }}]}}}}}
         def routed(args, cwd):
             if args[:2] == ["api", "graphql"]: return rollup
             return fake(args, cwd)
         return routed
+
+    def test_merged_v2_exact_recorded_empty_association_passes(self) -> None:
+        record = self.evidence(version=2)
+        self.write_evidence(record)
+        merge = "c" * 40
+        with mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.merge_gh(
+                merge, self.tree, evidence=record, run_pull_requests=[]
+            ),
+        ):
+            self.assertEqual(gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")["status"], "RELEASE_READY")
+
+    def test_merged_v2_wrong_recorded_identity_fails(self) -> None:
+        merge = "c" * 40
+        for field, value in (("workflowId", 601), ("workflowPath", "other.yml"),
+                             ("runId", 701), ("runAttempt", 2), ("head", "a" * 40)):
+            with self.subTest(field=field):
+                record = self.evidence(version=2, **({field: value} if field != "head" else {}))
+                if field == "head":
+                    record["head"] = value
+                self.write_evidence(record)
+                with mock.patch.object(gate, "gh", side_effect=self.merge_gh(merge, self.tree, evidence=record)):
+                    with self.assertRaises(gate.GateError):
+                        gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
+                (gate.evidence_root(self.root, create=False) / gate.evidence_filename(record)).unlink()
+
+    def test_exact_issue_117_v1_fixture_passes_without_changing_evidence(self) -> None:
+        record = self.issue_117_evidence()
+        self.write_evidence(record)
+        before = json.dumps(record, sort_keys=True)
+        merge = gate.ISSUE_117_COMPATIBILITY["merge"]
+        pr = self.pr(head=record["head"], state="closed", merged=True, merge=merge)
+        with mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.merge_gh(
+                merge,
+                record["tree"],
+                evidence=record,
+                pr_values=[pr] * 4,
+                run_pull_requests=[],
+            ),
+        ):
+            gate.post_merge_gate(self.root, "117", merge, record["head"], record["tree"], "")
+        self.assertEqual(json.dumps(record, sort_keys=True), before)
+
+    def test_arbitrary_v1_evidence_fails(self) -> None:
+        record = self.evidence(version=1)
+        self.write_evidence(record)
+        merge = "c" * 40
+        with mock.patch.object(gate, "gh", side_effect=self.merge_gh(merge, self.tree, evidence=record)):
+            with self.assertRaisesRegex(gate.GateError, "issue #117"):
+                gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
+
+    def test_merged_v2_conflicting_non_empty_association_fails(self) -> None:
+        record = self.evidence(version=2)
+        self.write_evidence(record)
+        merge = "c" * 40
+        with mock.patch.object(
+            gate,
+            "gh",
+            side_effect=self.merge_gh(
+                merge,
+                self.tree,
+                evidence=record,
+                run_pull_requests=[{"number": 999}],
+            ),
+        ):
+            with self.assertRaisesRegex(gate.GateError, "another pull request"):
+                gate.post_merge_gate(self.root, "115", merge, self.head, self.tree, "")
+
+    def test_post_merge_run_attempt_change_during_validation_fails(self) -> None:
+        record = self.evidence(version=2)
+        self.write_evidence(record)
+        merge = "c" * 40
+        routed = self.merge_gh(
+            merge, self.tree, evidence=record, run_pull_requests=[]
+        )
+        detail_reads = 0
+
+        def changing_attempt(args, cwd):
+            nonlocal detail_reads
+            if len(args) > 1 and "/actions/runs/" in args[1]:
+                detail_reads += 1
+                if detail_reads == 2:
+                    return self.workflow_run(
+                        attempt=2,
+                        pull_requests=[],
+                    )
+            return routed(args, cwd)
+
+        with mock.patch.object(gate, "gh", side_effect=changing_attempt):
+            with self.assertRaisesRegex(gate.GateError, "attempt changed"):
+                gate.post_merge_gate(
+                    self.root, "115", merge, self.head, self.tree, ""
+                )
 
     def test_pass_evidence_binds_identity_and_wrong_identity_is_blocked(self) -> None:
         record = self.evidence()

--- a/tools/agent_core_release_gate.py
+++ b/tools/agent_core_release_gate.py
@@ -37,6 +37,7 @@ ISSUE_117_COMPATIBILITY = {
     "workflowPath": CANONICAL_WORKFLOW_PATH,
     "runId": 33584314368,
     "runAttempt": 1,
+    "evidenceSha256": "317dd08ea4840dac4a820043630315ece7c098e13ff77c992af63568442190ce",
 }
 
 SHA_RE = re.compile(r"[0-9a-f]{40}")
@@ -773,28 +774,63 @@ def evidence_filename(payload: dict[str, Any]) -> str:
     )
 
 
-def load_evidence(root: Path, *, create: bool = False) -> list[dict[str, Any]]:
-    directory = evidence_root(root, create=create)
-    records: list[dict[str, Any]] = []
-    for path in sorted(directory.iterdir()):
-        metadata = path.lstat()
+def read_evidence_record(path: Path) -> tuple[dict[str, Any], str]:
+    if path.suffix != ".json":
+        raise GateError(f"unsafe or unexpected evidence entry: {path.name}")
+    try:
+        initial_metadata = path.lstat()
+    except OSError as exc:
+        raise GateError(f"unsafe or unexpected evidence entry: {path.name}") from exc
+    if (
+        not stat.S_ISREG(initial_metadata.st_mode)
+        or stat.S_ISLNK(initial_metadata.st_mode)
+        or initial_metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(initial_metadata.st_mode) & 0o077
+    ):
+        raise GateError(f"unsafe or unexpected evidence entry: {path.name}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise GateError(f"unsafe or unexpected evidence entry: {path.name}") from exc
+    try:
+        metadata = os.fstat(descriptor)
         if (
-            path.suffix != ".json"
-            or not stat.S_ISREG(metadata.st_mode)
-            or stat.S_ISLNK(metadata.st_mode)
+            not stat.S_ISREG(metadata.st_mode)
             or metadata.st_uid != os.geteuid()
             or stat.S_IMODE(metadata.st_mode) & 0o077
+            or (metadata.st_dev, metadata.st_ino)
+            != (initial_metadata.st_dev, initial_metadata.st_ino)
         ):
             raise GateError(f"unsafe or unexpected evidence entry: {path.name}")
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
-            raise GateError(f"invalid evidence record: {path.name}") from exc
-        validated = validate_evidence_payload(payload)
-        if path.name != evidence_filename(validated):
-            raise GateError(f"evidence filename does not match its immutable subject: {path.name}")
-        records.append(validated)
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            raw = stream.read()
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise GateError(f"invalid evidence record: {path.name}") from exc
+    validated = validate_evidence_payload(payload)
+    if path.name != evidence_filename(validated):
+        raise GateError(f"evidence filename does not match its immutable subject: {path.name}")
+    return validated, hashlib.sha256(raw).hexdigest()
+
+
+def load_evidence_records(
+    root: Path, *, create: bool = False
+) -> list[tuple[dict[str, Any], str]]:
+    directory = evidence_root(root, create=create)
+    records: list[tuple[dict[str, Any], str]] = []
+    for path in sorted(directory.iterdir()):
+        records.append(read_evidence_record(path))
     return records
+
+
+def load_evidence(root: Path, *, create: bool = False) -> list[dict[str, Any]]:
+    return [payload for payload, _digest in load_evidence_records(root, create=create)]
 
 
 def record_evidence(
@@ -941,7 +977,12 @@ def post_merge_template_ci(
 
 
 def evidence_matches_issue_117(
-    evidence: dict[str, Any], pr: int, head: str, tree: str, merge: str
+    evidence: dict[str, Any],
+    evidence_digest: str,
+    pr: int,
+    head: str,
+    tree: str,
+    merge: str,
 ) -> bool:
     return (
         evidence["version"] == 1
@@ -952,6 +993,7 @@ def evidence_matches_issue_117(
         and evidence["pr"] == pr
         and evidence["head"] == head
         and evidence["tree"] == tree
+        and evidence_digest == ISSUE_117_COMPATIBILITY["evidenceSha256"]
     )
 
 
@@ -1018,19 +1060,26 @@ def post_merge_gate(
     if not isinstance(comparison, dict) or comparison.get("status") not in {"identical", "ahead"}:
         raise GateError("current main does not contain the merge commit")
 
-    records = load_evidence(root)
+    records = load_evidence_records(root)
     matching = [
-        item
-        for item in records
+        (item, digest)
+        for item, digest in records
         if item["pr"] == int(number)
         and item["head"] == dogfood_head
         and item["tree"] == dogfood_tree
     ]
     if len(matching) != 1:
         raise GateError("exact PASS dogfood evidence is missing, duplicated, or conflicting")
-    selected = matching[0]
+    selected, selected_digest = matching[0]
     legacy = selected["version"] == 1
-    if legacy and not evidence_matches_issue_117(selected, int(number), dogfood_head, dogfood_tree, merge_commit):
+    if legacy and not evidence_matches_issue_117(
+        selected,
+        selected_digest,
+        int(number),
+        dogfood_head,
+        dogfood_tree,
+        merge_commit,
+    ):
         raise GateError("legacy evidence is not the guarded issue #117 compatibility binding")
     check_rollup(root, number, dogfood_head)
     detail = post_merge_template_ci(root, dogfood_head, int(number), selected)

--- a/tools/agent_core_release_gate.py
+++ b/tools/agent_core_release_gate.py
@@ -26,6 +26,19 @@ EVIDENCE_ROOT_NAME = ".agent-core-release-gate/evidence"
 GATE_TOOL_RELATIVE = "tools/agent_core_release_gate.py"
 GATE_LAUNCHER_RELATIVE = "tools/run_agent_core_release_gate.sh"
 
+# This is the sole legacy exception.  It describes the v1 receipt emitted by
+# issue #117; v1 is otherwise only a loadable file format, never a trust rule.
+ISSUE_117_COMPATIBILITY = {
+    "pr": 117,
+    "head": "9eb86882bbb569aeae356c59e7d459e9fd8ba4f9",
+    "tree": "7c5c6fb0bd5e0e881510e256f0b76e95c304c9c5",
+    "merge": "67fbc64e1127c19b9e424ab99dff4626f67be63b",
+    "workflowId": 329870494,
+    "workflowPath": CANONICAL_WORKFLOW_PATH,
+    "runId": 33584314368,
+    "runAttempt": 1,
+}
+
 SHA_RE = re.compile(r"[0-9a-f]{40}")
 PR_RE = re.compile(r"[1-9][0-9]{0,8}")
 OPERATION_RE = re.compile(r"[a-z][a-z0-9._-]{0,63}")
@@ -371,6 +384,8 @@ def workflow_run_subject(
     workflow_id: int,
     expected_head: str,
     expected_pr: int,
+    *,
+    allow_empty_pull_requests: bool = False,
 ) -> tuple[int, int]:
     if not isinstance(run, dict):
         raise GateError("Template CI workflow run is invalid")
@@ -393,8 +408,13 @@ def workflow_run_subject(
     ):
         raise GateError("Template CI workflow run is not bound to the exact candidate")
     pull_requests = run.get("pull_requests")
-    if not isinstance(pull_requests, list) or len(pull_requests) != 1:
+    if not isinstance(pull_requests, list) or (
+        len(pull_requests) != 1
+        and not (allow_empty_pull_requests and not pull_requests)
+    ):
         raise GateError("Template CI workflow run has ambiguous pull request identity")
+    if not pull_requests:
+        return run_id, attempt
     associated = pull_requests[0]
     if (
         not isinstance(associated, dict)
@@ -440,7 +460,7 @@ def exact_template_ci_run(
     return runs[0]
 
 
-def check_template_ci(root: Path, expected_head: str, expected_pr: int) -> None:
+def check_template_ci(root: Path, expected_head: str, expected_pr: int) -> dict[str, int | str]:
     workflow = gh(
         ["api", f"repos/{CANONICAL_REPO}/actions/workflows/template-ci.yml"],
         root,
@@ -468,6 +488,12 @@ def check_template_ci(root: Path, expected_head: str, expected_pr: int) -> None:
     final = exact_template_ci_run(root, workflow_id, expected_head, expected_pr)
     if workflow_run_subject(final, workflow_id, expected_head, expected_pr) != (run_id, attempt):
         raise GateError("Template CI workflow run changed during validation")
+    return {
+        "workflowId": workflow_id,
+        "workflowPath": CANONICAL_WORKFLOW_PATH,
+        "runId": run_id,
+        "runAttempt": attempt,
+    }
 
 
 def commit_tree(root: Path, commit: str, name: str = "commit") -> str:
@@ -482,7 +508,7 @@ def candidate(root: Path, number: str, *, require_open: bool = True) -> dict[str
     first = pull_request(root, number)
     head = validate_pr_identity(first, require_open=require_open)
     tree = commit_tree(root, head, "candidate commit")
-    check_template_ci(root, head, int(number))
+    template_ci = check_template_ci(root, head, int(number))
     check_rollup(root, number, head)
     final = pull_request(root, number)
     final_head = validate_pr_identity(final, require_open=require_open)
@@ -493,6 +519,7 @@ def candidate(root: Path, number: str, *, require_open: bool = True) -> dict[str
         "head": head,
         "tree": tree,
         "base": DEFAULT_BRANCH,
+        **template_ci,
         "ci": "PASS",
         "status": "READY_FOR_DOGFOOD",
     }
@@ -671,7 +698,7 @@ def validate_timestamp(value: Any) -> str:
 def validate_evidence_payload(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise GateError("evidence record is not a JSON object")
-    expected_keys = {
+    common_keys = {
         "schema",
         "version",
         "repo",
@@ -685,9 +712,19 @@ def validate_evidence_payload(value: Any) -> dict[str, Any]:
         "operation",
         "recordedAt",
     }
+    version = value.get("version")
+    if isinstance(version, bool):
+        version = None
+    identity_keys = {"workflowId", "workflowPath", "runId", "runAttempt"}
+    if version == 1:
+        expected_keys = common_keys
+    elif version == 2:
+        expected_keys = common_keys | identity_keys
+    else:
+        expected_keys = set()
     if set(value) != expected_keys:
         raise GateError("evidence record has an unexpected schema")
-    if value["schema"] != "agent-core-release-gate" or value["version"] != 1:
+    if value["schema"] != "agent-core-release-gate" or version not in {1, 2}:
         raise GateError("evidence schema version is unsupported")
     if value["repo"] != CANONICAL_REPO or value["downstreamRepo"] != DOWNSTREAM_REPO:
         raise GateError("evidence repository binding is invalid")
@@ -695,6 +732,12 @@ def validate_evidence_payload(value: Any) -> dict[str, Any]:
         raise GateError("evidence pull request is invalid")
     valid_sha(value["head"], "evidence head")
     valid_sha(value["tree"], "evidence tree")
+    if version == 2:
+        positive_optional_integer(value["workflowId"], "workflow ID")
+        if value["workflowPath"] != CANONICAL_WORKFLOW_PATH:
+            raise GateError("evidence workflow path is invalid")
+        positive_optional_integer(value["runId"], "run ID")
+        positive_optional_integer(value["runAttempt"], "run attempt")
     positive_optional_integer(value["task"], "Task ID")
     positive_optional_integer(value["downstreamPr"], "downstream PR")
     if value["outcome"] != "PASS":
@@ -784,11 +827,15 @@ def record_evidence(
 
     payload = {
         "schema": "agent-core-release-gate",
-        "version": 1,
+        "version": 2,
         "repo": CANONICAL_REPO,
         "pr": checked["pr"],
         "head": checked["head"],
         "tree": checked["tree"],
+        "workflowId": checked["workflowId"],
+        "workflowPath": checked["workflowPath"],
+        "runId": checked["runId"],
+        "runAttempt": checked["runAttempt"],
         "downstreamRepo": DOWNSTREAM_REPO,
         "task": task_id,
         "downstreamPr": downstream_pr_id,
@@ -841,6 +888,99 @@ def release_absent(root: Path, version: str) -> None:
         raise GateError(f"Git tag lookup returned unexpected HTTP status {tag_status}")
 
 
+def post_merge_template_ci(
+    root: Path,
+    expected_head: str,
+    expected_pr: int,
+    evidence: dict[str, Any],
+) -> dict[str, Any]:
+    """Verify the workflow and the exact run named by the selected receipt."""
+    workflow = gh(["api", f"repos/{CANONICAL_REPO}/actions/workflows/template-ci.yml"], root)
+    if not isinstance(workflow, dict):
+        raise GateError("canonical Template CI workflow metadata is invalid")
+    workflow_id = workflow.get("id")
+    if (
+        isinstance(workflow_id, bool)
+        or not isinstance(workflow_id, int)
+        or workflow_id <= 0
+        or workflow.get("path") != CANONICAL_WORKFLOW_PATH
+        or workflow.get("state") != "active"
+    ):
+        raise GateError("canonical Template CI workflow is missing or inactive")
+
+    if evidence["version"] == 2:
+        identity = {
+            "workflowId": evidence["workflowId"],
+            "workflowPath": evidence["workflowPath"],
+            "runId": evidence["runId"],
+            "runAttempt": evidence["runAttempt"],
+        }
+    else:
+        identity = ISSUE_117_COMPATIBILITY
+    if identity["workflowId"] != workflow_id or identity["workflowPath"] != workflow.get("path"):
+        raise GateError("recorded Template CI workflow identity is not canonical")
+    detail = gh(["api", f"repos/{CANONICAL_REPO}/actions/runs/{identity['runId']}"], root)
+    try:
+        observed = workflow_run_subject(
+            detail,
+            workflow_id,
+            expected_head,
+            expected_pr,
+            # An empty list is safe here only because v1 was already gated by
+            # the exact issue #117 predicate, while v2 carries immutable CI
+            # identity. Arbitrary v1 never reaches this call.
+            allow_empty_pull_requests=True,
+        )
+    except GateError:
+        raise
+    if observed != (identity["runId"], identity["runAttempt"]):
+        raise GateError("recorded Template CI workflow attempt changed during validation")
+    if detail.get("status") != "completed" or detail.get("conclusion") != "success":
+        raise GateError("Template CI workflow is incomplete or unsuccessful")
+    return detail
+
+
+def evidence_matches_issue_117(
+    evidence: dict[str, Any], pr: int, head: str, tree: str, merge: str
+) -> bool:
+    return (
+        evidence["version"] == 1
+        and pr == ISSUE_117_COMPATIBILITY["pr"]
+        and head == ISSUE_117_COMPATIBILITY["head"]
+        and tree == ISSUE_117_COMPATIBILITY["tree"]
+        and merge == ISSUE_117_COMPATIBILITY["merge"]
+        and evidence["pr"] == pr
+        and evidence["head"] == head
+        and evidence["tree"] == tree
+    )
+
+
+def validate_post_merge_run_association(
+    run: dict[str, Any], *, expected_pr: int, expected_head: str, legacy: bool
+) -> None:
+    associations = run.get("pull_requests")
+    if not isinstance(associations, list):
+        raise GateError("Template CI workflow pull request identity is invalid")
+    if not associations:
+        # v1 reaches this point only after the exact issue #117 binding and
+        # merged-PR proof above; v2 has its immutable recorded run identity.
+        return
+    if len(associations) != 1:
+        raise GateError("Template CI workflow has ambiguous pull request identity")
+    associated = associations[0]
+    if (
+        not isinstance(associated, dict)
+        or associated.get("number") != expected_pr
+        or (associated.get("head") or {}).get("sha") != expected_head
+        or (associated.get("head") or {}).get("repo", {}).get("url")
+        != f"https://api.github.com/repos/{CANONICAL_REPO}"
+        or (associated.get("base") or {}).get("ref") != DEFAULT_BRANCH
+        or (associated.get("base") or {}).get("repo", {}).get("url")
+        != f"https://api.github.com/repos/{CANONICAL_REPO}"
+    ):
+        raise GateError("Template CI workflow run belongs to another pull request")
+
+
 def post_merge_gate(
     root: Path,
     number: str,
@@ -863,8 +1003,9 @@ def post_merge_gate(
     if merged.get("merge_commit_sha") != merge_commit:
         raise GateError("supplied merge commit is not the pull request merge commit")
 
-    checked = candidate(root, number, require_open=False)
-    if checked["head"] != dogfood_head or checked["tree"] != dogfood_tree:
+    checked_head = validate_pr_identity(merged, require_open=False)
+    checked_tree = commit_tree(root, checked_head, "candidate commit")
+    if checked_head != dogfood_head or checked_tree != dogfood_tree:
         raise GateError("dogfood identity does not match the current pull request candidate")
     merge_tree = commit_tree(root, merge_commit, "merge commit")
     if merge_tree != dogfood_tree:
@@ -881,12 +1022,21 @@ def post_merge_gate(
     matching = [
         item
         for item in records
-        if item["pr"] == checked["pr"]
+        if item["pr"] == int(number)
         and item["head"] == dogfood_head
         and item["tree"] == dogfood_tree
     ]
     if len(matching) != 1:
         raise GateError("exact PASS dogfood evidence is missing, duplicated, or conflicting")
+    selected = matching[0]
+    legacy = selected["version"] == 1
+    if legacy and not evidence_matches_issue_117(selected, int(number), dogfood_head, dogfood_tree, merge_commit):
+        raise GateError("legacy evidence is not the guarded issue #117 compatibility binding")
+    check_rollup(root, number, dogfood_head)
+    detail = post_merge_template_ci(root, dogfood_head, int(number), selected)
+    validate_post_merge_run_association(
+        detail, expected_pr=int(number), expected_head=dogfood_head, legacy=legacy
+    )
     if version:
         release_absent(root, version)
 
@@ -898,8 +1048,12 @@ def post_merge_gate(
         or final.get("merge_commit_sha") != merge_commit
     ):
         raise GateError("pull request merge identity changed during release-gate validation")
+    final_detail = post_merge_template_ci(root, dogfood_head, int(number), selected)
+    validate_post_merge_run_association(
+        final_detail, expected_pr=int(number), expected_head=dogfood_head, legacy=legacy
+    )
     return {
-        "pr": checked["pr"],
+        "pr": int(number),
         "status": "RELEASE_READY",
         "dogfoodHead": dogfood_head,
         "dogfoodTree": dogfood_tree,


### PR DESCRIPTION
Closes #118

## Summary
- record canonical Template CI workflow/run identity in schema-v2 dogfood evidence
- preserve strict pre-merge PR association while accepting an empty post-merge association only with immutable independent proof
- bind the sole schema-v1 exception to the exact safely read #117 evidence-file bytes
- reject semantically equivalent but byte-different legacy evidence and all arbitrary v1 records
- revalidate the recorded run and merged PR identity at the final release-gate boundary

## Frozen candidate
- PR: #120
- head: `195cc916799e5f0d0a17e31c7e805a6a78139cc4`
- tree: `07fd3978a63381774fcfe34fbdf15b7bc9c4f198`
- Template CI run: `33593924845`
- workflow ID/path: `329870494` / `.github/workflows/template-ci.yml`
- attempt: `1`

## Real dogfood
The exact moved-head candidate implementation re-ran the post-merge release gate for PR #117 and returned `RELEASE_READY`.

- implementation head: `195cc916799e5f0d0a17e31c7e805a6a78139cc4`
- #117 head/tree: `9eb86882bbb569aeae356c59e7d459e9fd8ba4f9` / `7c5c6fb0bd5e0e881510e256f0b76e95c304c9c5`
- #117 merge/tree: `67fbc64e1127c19b9e424ab99dff4626f67be63b` / `7c5c6fb0bd5e0e881510e256f0b76e95c304c9c5`
- existing #117 evidence SHA-256 before/after: `317dd08ea4840dac4a820043630315ece7c098e13ff77c992af63568442190ce`
- additional #120 schema-v2 PASS evidence recorded for the moved head; prior immutable candidate evidence remains preserved

## Verification
- focused release-gate tests: 47 passed
- full unittest suite: 496 passed
- generated template drift: PASS
- template distribution verification: PASS
- all-system flake evaluation: PASS
- OpenCodePolicy contract: PASS
- `git diff --check`: PASS
- correctness review: no findings
- security review: no findings
- Template CI run `33593924845`: PASS
- GitGuardian: PASS

## Safety
- no automatic merge or release
- non-empty conflicting PR associations fail closed
- arbitrary or byte-different schema-v1 evidence is not trusted
- existing immutable PR #117 evidence is not rewritten
- trusted launcher/interpreter, source-blob verification, canonical transport, Git configuration rejection, detached candidate checkout, release/tag rejection, and Agent Core VERSION 3 remain unchanged