### PR TITLE
Move Agent Core Git-private state out of OpenCode namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,13 +350,20 @@ tracked files unchanged, and reports `PROVENANCE_REBOUND` or idempotent
 `PROVENANCE_ALREADY_BOUND`. Then run ordinary consumer verification and the
 existing `automation::commit`.
 
+Rebind is an operator-serialized maintenance transition: no commit or other
+authority mutation may run concurrently in the target worktree. Current Agent
+Core revisions additionally fence rebind and commit with the same ordered
+common/admin migration locks; explicit quiescence preserves the older pending
+consumer needed to finish an in-flight upgrade.
+
 Eligibility requires the exact registered maintenance Task/worktree/branch/HEAD,
 one standard active receipt matching exactly one authority, no consumed,
 source-recovery, or ambiguous state, and old/expected revisions in the same
 Templates object database. Missing authority remains the Issue #85 route;
 committed or consumed state, including a crossed guarded publication boundary,
 is rejected. Handled failures
-rollback safely and concurrency fails closed. No cross-filesystem atomicity or
+rollback safely; operations by current lock-aware revisions fail closed under
+the shared fence. No cross-filesystem atomicity or
 hard-crash durability claim is made; that remains Issue #89 scope.
 
 For AgentKnowledgeVault Issue #19, the exact command is:

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -184,5 +184,29 @@ upgrade with changes replaces the active receipt and removes the previous consum
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
 receipt lifecycle evidence.
 
+## Git-private runtime state
+
+Agent Core owns only the `agent-core/` namespace beneath Git administrative
+directories. Shared cleanup receipts, pristine-discard receipts, integration
+checkpoints, the cleanup lock, the migration lock, and historical hashed
+maintenance authorities live beneath `<git-common-dir>/agent-core/`.
+Worktree-specific maintenance `authority.json` and
+`source-recovery-proof.json` live beneath
+`<absolute-git-dir>/agent-core/automation-maintenance/`. Repository Task State
+under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
+`opencode.json` configuration are separate ownership surfaces.
+
+The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
+file and Agent Core never changes its bytes, metadata, or identity. A legacy
+directory at that name is accepted only when every entry has an explicitly
+known historical Agent Core path and schema. Known regular records are copied byte for
+byte with durable no-overwrite publication, all conflicts are rejected before
+migration mutation, and legacy records are removed only after every canonical
+destination is verified equivalent. Equivalent dual state and partially
+completed migration are retryable. Unknown entries, unexpected nesting,
+symlinks, and special files fail closed. The historical `cleanup.lock` is
+retained as a mixed-version locking ABI and is acquired before the canonical
+lock; it is never renamed or unlinked automatically.
+
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -148,6 +148,12 @@ files unchanged. It reports `PROVENANCE_REBOUND` or idempotent
 `PROVENANCE_ALREADY_BOUND`; then run ordinary consumer verification and the
 existing `automation::commit`.
 
+Rebind is an operator-serialized maintenance transition: no commit or other
+authority mutation may run concurrently in the target worktree. Current Agent
+Core revisions additionally fence rebind and commit with the same ordered
+common/admin migration locks; the explicit quiescence requirement preserves the
+older pending consumer needed to finish an in-flight upgrade.
+
 Eligibility is exact: registered maintenance Task/worktree/branch/HEAD; one
 standard active receipt matching exactly one authority; safe pending Agent
 Core paths/fingerprints only; no consumed, source-recovery, or ambiguous state;
@@ -155,7 +161,8 @@ the old and expected revisions in the same Templates object database; and an
 identical expected canonical diff. Missing authority remains the Issue #85
 route. Committed or consumed state, including a crossed guarded publication
 boundary, is rejected. Handled
-failures roll back safely and concurrency fails closed. No cross-filesystem
+failures roll back safely; operations by current revisions fail closed under the
+shared fence. No cross-filesystem
 atomicity or hard-crash durability is claimed; that remains Issue #89 scope.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
@@ -198,15 +205,36 @@ under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
 
 The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
 file and Agent Core never changes its bytes, metadata, or identity. A legacy
-directory at that name is accepted only when every entry has an explicitly
-known historical Agent Core path and schema. Known regular records are copied byte for
-byte with durable no-overwrite publication, all conflicts are rejected before
-migration mutation, and legacy records are removed only after every canonical
-destination is verified equivalent. Equivalent dual state and partially
-completed migration are retryable. Unknown entries, unexpected nesting,
-symlinks, and special files fail closed. The historical `cleanup.lock` is
-retained as a mixed-version locking ABI and is acquired before the canonical
-lock; it is never renamed or unlinked automatically.
+directory at that name is accepted only when every entry satisfies the exact
+historical path, schema, Task/branch/worktree identity, repository syntax, and
+authority/proof relationship that Agent Core produced. The legacy namespace,
+subdirectories, records, and lock must be owned by the current effective user.
+Directories require owner access and reject group/other mutation while retaining
+historically produced read/traverse modes such as `0755`; records and locks reject
+group/other mutation and executable bits. Canonical directories
+are exactly mode `0700`, and canonical records, locks, and publication
+artifacts are exactly mode `0600`.
+
+Known records are copied byte for byte with durable no-overwrite publication,
+all conflicts are rejected before migration mutation, and legacy records are
+removed only after every canonical destination is mode-, owner-, and
+content-equivalent. The legacy cleanup-lock inode is acquired nonblocking and
+hard-linked into the canonical cleanup-lock path before its legacy name is
+removed. Existing waiters therefore remain fenced on the same inode. A
+contended legacy lock, or distinct legacy and canonical lock inodes, reports a
+precise `BLOCKED` condition rather than claiming migration success. Successful
+cutover removes the legacy lock last and then removes the empty `opencode/`
+directory, leaving the path available to OpenCode.
+
+Canonical publication is serialized by `migration.lock`. Only exact owned
+`.migrate.<pid>.<16-lowercase-hex>` and
+`.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next
+operation they are validated and durably removed under that lock before the
+legacy source is retried or an already-durable destination is used. Equivalent
+dual state, partial legacy removal, and interruption before or after durable
+publication are therefore retryable. Unknown entries, malformed temporary
+names, unsafe modes/ownership, unexpected nesting, symlinks, and special files
+fail closed without promotion.
 
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/components/agent-core/.automation/bin/agent_core.py
+++ b/components/agent-core/.automation/bin/agent_core.py
@@ -17,6 +17,7 @@ if str(SCRIPT_DIR) not in sys.path:
 import task_lifecycle as lifecycle
 import publication_metadata as publication
 import task_contract
+import git_private_state as private_state
 
 try:
     import tomllib
@@ -527,22 +528,31 @@ def validate_integration(root: Path, pr: str) -> dict:
 
 
 def integration_checkpoint(root: Path, pr: str) -> Path:
-    path = common_git_dir(root) / "opencode" / "integration" / f"pr-{pr}.head"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
+    try:
+        return private_state.integration_checkpoint(root, pr)
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
 
 
 def integrate_check(root: Path, pr: str) -> None:
     data = validate_integration(root, pr)
-    integration_checkpoint(root, pr).write_text(data["headRefOid"] + "\n", encoding="utf-8")
+    try:
+        private_state.prepare(root)
+        checkpoint = integration_checkpoint(root, pr)
+        private_state.write_bytes(checkpoint, (data["headRefOid"] + "\n").encode("utf-8"))
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
     print(json.dumps({"pr": data["number"], "head": data["headRefOid"], "status": "verified"}))
 
 
 def integrate_merge(root: Path, pr: str) -> None:
     checkpoint = integration_checkpoint(root, pr)
-    if not checkpoint.exists():
+    if not checkpoint.exists() or checkpoint.is_symlink() or not checkpoint.is_file():
         raise AutomationError("run integrate::check before merge")
-    expected = checkpoint.read_text(encoding="utf-8").strip()
+    try:
+        expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
+    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+        raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:
         raise AutomationError(f"PR head moved after integration check: expected {expected}, got {data['headRefOid']}")

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -16,6 +16,10 @@ import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 
 class UpgradeError(RuntimeError):
     pass
@@ -120,16 +124,55 @@ def worktree_admin_dir(repo: Path) -> Path:
 
 def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     admin = worktree_admin_dir(repo)
-    new_parent = admin / "opencode" / "automation-maintenance"
+    new_parent = admin / private_state.NAMESPACE / "automation-maintenance"
+    if new_parent.exists() or new_parent.is_symlink():
+        try:
+            private_state.safe_directory(admin / private_state.NAMESPACE)
+            private_state.safe_directory(new_parent)
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError(str(exc)) from exc
     try:
         resolved_parent = new_parent.resolve()
     except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy_location = _safe_legacy_location(repo)
-    legacy = legacy_location[0] if legacy_location is not None else None
+    common = common_git_dir(repo)
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    migrated = common / private_state.NAMESPACE / "automation-maintenance" / f"{key}.json"
+    if os.path.lexists(migrated):
+        try:
+            private_state.safe_directory(common / private_state.NAMESPACE)
+            private_state.safe_directory(migrated.parent)
+            private_state.read_bytes(migrated, "migrated maintenance authority")
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+        legacy = migrated
+    else:
+        old_admin = _safe_old_admin_authority(repo)
+        if old_admin is not None and os.path.lexists(old_admin[0]):
+            legacy = old_admin[0]
+        else:
+            legacy_location = _safe_legacy_location(repo)
+            legacy = legacy_location[0] if legacy_location is not None else None
     return new_parent / "authority.json", legacy
+
+
+def _safe_old_admin_authority(repo: Path) -> tuple[Path, Path] | None:
+    try:
+        admin = worktree_admin_dir(repo)
+        root = admin / "opencode"
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
+            return None
+        parent = root / "automation-maintenance"
+        if parent.is_symlink() or (parent.exists() and not parent.is_dir()):
+            return None
+        resolved = parent.resolve()
+        if resolved != admin and admin not in resolved.parents:
+            return None
+        return parent / "authority.json", admin
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
@@ -144,7 +187,7 @@ def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
             return None
         key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
         return parent / f"{key}.json", common
-    except (OSError, ValueError, RuntimeError, UpgradeError):
+    except (OSError, ValueError, RuntimeError, UpgradeError, private_state.GitPrivateStateError):
         return None
 
 
@@ -167,6 +210,15 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     _write_authority_at(
         authority_path(repo),
         {
@@ -187,33 +239,29 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             parent_before = path.parent.resolve()
             if parent_before != admin and admin not in parent_before.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        path.parent.mkdir(parents=True, exist_ok=True)
+        private_state.ensure_parent(path)
         if admin is not None:
             parent_after = path.parent.resolve()
             if parent_after != admin and admin not in parent_after.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        # The caller has validated the parent; do not replace an existing record.
-        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
-        temporary = Path(temporary_name)
-        try:
-            with os.fdopen(fd, "wb") as stream:
-                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
-                stream.flush()
-                try:
-                    os.fsync(stream.fileno())
-                except OSError:
-                    pass
-            os.link(temporary, path)
-        finally:
-            temporary.unlink(missing_ok=True)
-    except (OSError, ValueError, RuntimeError) as exc:
+        private_state.exclusive_write_bytes(
+            path,
+            json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+        )
+    except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
 
 
 def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    old_admin = _safe_old_admin_authority(repo)
+    if old_admin is not None and authority == old_admin[0]:
+        return old_admin[1]
     legacy = _safe_legacy_location(repo)
     if legacy is not None and authority == legacy[0]:
         return legacy[1]
+    common = common_git_dir(repo)
+    if authority.parent == common / private_state.NAMESPACE / "automation-maintenance":
+        return common
     if authority == authority_path(repo):
         return worktree_admin_dir(repo)
     raise UpgradeError("cannot safely resolve authority location for rollback")
@@ -227,11 +275,10 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError("missing or invalid successful-upgrade authority record")
-        authority = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        authority = json.loads(
+            private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
     expected = {
         "schema_version": 1,
@@ -253,12 +300,15 @@ def _read_json_record(path: Path, error: str) -> dict:
 
 def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError(error)
-        raw = path.read_bytes()
+        if private_state.NAMESPACE in path.parts or "opencode" in path.parts:
+            raw = private_state.read_bytes(path, error)
+        else:
+            metadata = path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+                raise UpgradeError(error)
+            raw = path.read_bytes()
         value = json.loads(raw.decode("utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(error) from exc
     if not isinstance(value, dict):
         raise UpgradeError(error)
@@ -1795,7 +1845,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         raise UpgradeError("receipt source is not compatible with the current Templates source")
     old_revision = _validate_source_revision(source, old["source_revision"])
     authority = _standard_authority_only(repo, old)
-    old_authority_raw = authority.read_bytes()
+    old_authority_raw = private_state.read_bytes(authority, "maintenance authority")
     receipt_identity = (active.lstat().st_dev, active.lstat().st_ino)
     authority_identity = (authority.lstat().st_dev, authority.lstat().st_ino)
     authority_head = validate_commit_oid(repo, old["authority_head"], field="receipt authority HEAD")
@@ -1828,7 +1878,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         current_source, current_revision = resolve_clean_source_worktree(source)
         if expected_implementation_revision is None or current_revision != expected_implementation_revision:
             raise UpgradeError("source implementation changed before provenance replacement")
-    if active.read_bytes() != raw_receipt or authority.read_bytes() != old_authority_raw or pending_paths(repo) != expected_paths \
+    if active.read_bytes() != raw_receipt or private_state.read_bytes(authority, "maintenance authority") != old_authority_raw or pending_paths(repo) != expected_paths \
             or git_head(repo) != authority_head or current_source != source \
             or (require_source_head and current_revision != expected_source_revision) \
             or (active.lstat().st_dev, active.lstat().st_ino) != receipt_identity \
@@ -2021,7 +2071,11 @@ def recover_maintenance_authority_from_source(
             if existing != proof:
                 raise UpgradeError("existing source-recovery proof does not match reconstruction")
         else:
-            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+            private_state.ensure_parent(proof_path)
+            created_proof = private_state.exclusive_write_bytes(
+                proof_path,
+                json.dumps(proof, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            )
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
         if (current_source != source
                 or current_implementation_revision != expected_implementation_revision):
@@ -2040,13 +2094,11 @@ def recover_maintenance_authority_from_source(
             raise UpgradeError("source-recovery proof changed before bridge publication")
         _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
                             admin=worktree_admin_dir(target_repo))
-    except (OSError, UpgradeError):
+    except (OSError, UpgradeError, private_state.GitPrivateStateError):
         if created_proof is not None:
             try:
-                metadata = proof_path.lstat()
-                if (metadata.st_dev, metadata.st_ino) == created_proof:
-                    proof_path.unlink()
-            except OSError as exc:
+                private_state.unlink(proof_path, expected_identity=created_proof)
+            except (OSError, private_state.GitPrivateStateError) as exc:
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
@@ -2209,7 +2261,13 @@ def _commit_mode(
         )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
-        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        try:
+            proof_raw, proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            proof_record = json.loads(proof_raw.decode("utf-8"))
+        except (private_state.GitPrivateStateError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("missing or invalid source-recovery proof") from exc
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
@@ -2221,7 +2279,7 @@ def _commit_mode(
             raise UpgradeError("source-recovery receipt source is incompatible")
         _validate_source_revision(source, receipt["source_revision"])
         authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
-        if proof_path.read_bytes() != proof_raw:
+        if private_state.read_bytes(proof_path, "source-recovery proof") != proof_raw:
             raise UpgradeError("source-recovery proof changed before commit mutation")
     else:  # pragma: no cover
         raise UpgradeError("unsupported commit mode")
@@ -2249,10 +2307,29 @@ def _commit_mode(
         atomic_json_write(consumed, consumed_receipt)
         consumed_metadata = consumed.lstat()
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
-        authority.unlink(missing_ok=True)
+        authority_raw, authority_identity = private_state.read_bytes_identity(
+            authority, "maintenance authority"
+        )
+        expected_authority = (
+            _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest())
+            if mode == "source_recovery" and proof is not None
+            else {
+                "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                "receipt_sha256": receipt_digest(receipt),
+            }
+        )
+        if json.loads(authority_raw.decode("utf-8")) != expected_authority:
+            raise UpgradeError("authority changed before commit mutation")
+        private_state.unlink(authority, expected_identity=authority_identity)
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
-            proof_path.unlink()
+            current_proof, current_proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            if current_proof != proof_raw or current_proof_identity != proof_identity:
+                raise UpgradeError("source-recovery proof changed before removal")
+            private_state.unlink(proof_path, expected_identity=proof_identity)
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2304,7 +2381,7 @@ def _commit_mode(
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except (UpgradeError, OSError) as failure:
+    except (UpgradeError, OSError, private_state.GitPrivateStateError) as failure:
         if committed:
             raise UpgradeError(
                 f"commit {commit_sha} was published but finalization failed"
@@ -2314,8 +2391,8 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
-        except (OSError, UpgradeError) as rollback_error:
+                private_state.exclusive_write_bytes(proof_path, proof_raw)
+        except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
             if authority_removed:

--- a/components/agent-core/.automation/bin/automation_upgrade.py
+++ b/components/agent-core/.automation/bin/automation_upgrade.py
@@ -233,7 +233,13 @@ def write_authority(repo: Path, receipt: dict) -> None:
     )
 
 
-def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
+def _write_authority_at(
+    path: Path,
+    value: dict,
+    *,
+    admin: Path | None = None,
+    lock_held: bool = False,
+) -> None:
     try:
         if admin is not None:
             parent_before = path.parent.resolve()
@@ -247,6 +253,7 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
         private_state.exclusive_write_bytes(
             path,
             json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            _lock_held=lock_held,
         )
     except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
@@ -275,6 +282,7 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
+        private_state.validate_record(path, "successful-upgrade authority record")
         authority = json.loads(
             private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
         )
@@ -1642,9 +1650,10 @@ def _rename_record_at(source: str, destination: str, *, source_dir_fd: int, dest
     )
 
 
-def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
-                           receipt: dict, authority_path_value: Path,
-                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+def _replace_standard_pair_locked(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                                  receipt: dict, authority_path_value: Path,
+                                  receipt_identity: tuple[int, int],
+                                  authority_identity: tuple[int, int]) -> None:
     active = receipt_path(repo)
     admin = _rollback_authority_guard(repo, authority_path_value)
     _validate_admin_record_parent(authority_path_value, admin)
@@ -1823,6 +1832,25 @@ def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw
                 pass
 
 
+def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                           receipt: dict, authority_path_value: Path,
+                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+    """Replace a common/admin record pair under ordered namespace fences."""
+    try:
+        with private_state.mutation_lock(repo, admin=True):
+            _replace_standard_pair_locked(
+                repo,
+                old_receipt_raw,
+                old_authority_raw,
+                receipt,
+                authority_path_value,
+                receipt_identity,
+                authority_identity,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
+
+
 def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_source_revision: str,
                                    *, require_source_head: bool,
                                    expected_implementation_revision: str | None = None) -> dict:
@@ -1994,6 +2022,16 @@ def recover_maintenance_authority_from_source(
         expected_implementation_revision
     )
     task_id, branch, worktree = require_maintenance(target_repo)
+    try:
+        private_state.prepare(
+            target_repo,
+            admin=True,
+            common_dir=common_git_dir(target_repo),
+            admin_dir=worktree_admin_dir(target_repo),
+            _allow_incomplete_recovery=True,
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
     if implementation_revision != expected_implementation_revision:
         raise UpgradeError("source HEAD does not match the expected implementation revision")
@@ -2215,7 +2253,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(
+def _commit_mode_locked(
     repo: Path,
     task: str,
     message: str,
@@ -2321,7 +2359,12 @@ def _commit_mode(
         )
         if json.loads(authority_raw.decode("utf-8")) != expected_authority:
             raise UpgradeError("authority changed before commit mutation")
-        private_state.unlink(authority, expected_identity=authority_identity)
+        private_state.unlink(
+            authority,
+            expected_identity=authority_identity,
+            expected_content=authority_raw,
+            _lock_held=True,
+        )
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
             current_proof, current_proof_identity = private_state.read_bytes_identity(
@@ -2329,7 +2372,12 @@ def _commit_mode(
             )
             if current_proof != proof_raw or current_proof_identity != proof_identity:
                 raise UpgradeError("source-recovery proof changed before removal")
-            private_state.unlink(proof_path, expected_identity=proof_identity)
+            private_state.unlink(
+                proof_path,
+                expected_identity=proof_identity,
+                expected_content=proof_raw,
+                _lock_held=True,
+            )
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2391,7 +2439,9 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                private_state.exclusive_write_bytes(proof_path, proof_raw)
+                private_state.exclusive_write_bytes(
+                    proof_path, proof_raw, _lock_held=True
+                )
         except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
@@ -2401,7 +2451,12 @@ def _commit_mode(
                     "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
                     "receipt_sha256": receipt_digest(receipt),
                 }
-                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
+                _write_authority_at(
+                    authority,
+                    restored,
+                    admin=_rollback_authority_guard(repo, authority),
+                    lock_held=True,
+                )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -2446,6 +2501,35 @@ def _commit_mode(
             "mergePerformed": False,
         })
     return result
+
+
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+        with private_state.mutation_lock(repo, admin=True):
+            return _commit_mode_locked(
+                repo,
+                task,
+                message,
+                mode,
+                source_root=source_root,
+                expected_implementation_revision=expected_implementation_revision,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
 
 
 def commit(repo: Path, task: str, message: str) -> dict[str, object]:

--- a/components/agent-core/.automation/bin/discard_pristine.py
+++ b/components/agent-core/.automation/bin/discard_pristine.py
@@ -7,7 +7,10 @@ import re
 import sys
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
 import task_lifecycle as lifecycle
+import git_private_state as private_state
 
 
 RECEIPT_SCHEMA_VERSION = 1
@@ -18,12 +21,10 @@ REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 
 def discard_receipt_path(root: Path, task: str) -> Path:
     lifecycle.validate_task(task)
-    return (
-        lifecycle.common_git_dir(root)
-        / "opencode"
-        / "discard-pristine"
-        / f"{task}.json"
-    )
+    try:
+        return private_state.discard_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
 
 
 def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
@@ -255,8 +256,8 @@ def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
             "discard-pristine receipt is not a regular local file"
         )
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "discard-pristine receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
     required = {
         "schema_version",
@@ -394,7 +395,10 @@ def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
             "discard-pristine failed to delete the expected local Task branch"
         )
 
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -421,7 +425,12 @@ def task_discard_pristine(root: Path, task: str) -> None:
             )
             return
         plan = pristine_discard_plan(root, task)
-        lifecycle.atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise lifecycle.LifecycleError(str(exc)) from exc
         finish_pristine_discard(root, plan, receipt)
 
 

--- a/components/agent-core/.automation/bin/git_private_state.py
+++ b/components/agent-core/.automation/bin/git_private_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 import fcntl
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -18,9 +19,12 @@ LEGACY_NAMESPACE = "opencode"
 TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 PR_RE = re.compile(r"[1-9][0-9]*")
 HASH_RE = re.compile(r"[0-9a-f]{64}")
+OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
 FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
+TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
 
 
@@ -126,6 +130,43 @@ def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_r
     return metadata
 
 
+def _require_owned_mode(path: Path, metadata: os.stat_result, mode: int, what: str,
+                        *, exact: bool = False) -> None:
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    actual = stat.S_IMODE(metadata.st_mode)
+    unsafe = actual != mode if exact else (actual & mode) != mode
+    unsafe = unsafe or bool(actual & 0o022)
+    if unsafe:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+
+
+def _require_legacy_dir(path: Path, what: str) -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what)
+    return metadata
+
+
+def _require_legacy_record(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o400, what)
+    if metadata.st_mode & 0o111:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir(path: Path, what: str = "canonical private-state directory") -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what, exact=True)
+    return metadata
+
+
+def _require_canonical_file(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o600, what, exact=True)
+    return metadata
+
+
 def _require_regular(path: Path, what: str) -> os.stat_result:
     metadata = _lstat(path, what)
     if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
@@ -134,7 +175,10 @@ def _require_regular(path: Path, what: str) -> os.stat_result:
 
 
 def safe_directory(path: Path) -> None:
-    _require_dir(path)
+    if NAMESPACE in path.parts:
+        _require_canonical_dir(path)
+    else:
+        _require_dir(path)
 
 
 def _open_dir(path: Path) -> int:
@@ -162,7 +206,8 @@ def _open_anchored_parent(path: Path) -> int:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
             os.close(descriptor)
@@ -179,15 +224,24 @@ def _open_anchored_parent(path: Path) -> int:
 def _ensure_child_directory(parent: Path, name: str) -> Path:
     descriptor = _open_dir(parent)
     try:
+        created = False
         try:
             os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
             os.fsync(descriptor)
+            created = True
         except FileExistsError:
             pass
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         child = os.open(name, flags, dir_fd=descriptor)
         try:
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            metadata = os.fstat(child)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+            if not created and (
+                metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o700
+            ):
                 raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
         finally:
             os.close(child)
@@ -205,15 +259,22 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
     try:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
+            created = False
             try:
                 os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
                 os.fsync(descriptor)
+                created = True
             except FileExistsError:
                 pass
             child = os.open(name, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            if child_meta.st_uid != os.geteuid() or stat.S_IMODE(child_meta.st_mode) != 0o700:
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe canonical private-state directory: {current / name}")
             os.close(descriptor)
             descriptor = child
             current /= name
@@ -263,6 +324,14 @@ def read_bytes(path: Path, what: str = "private-state record") -> bytes:
     return read_bytes_identity(path, what)[0]
 
 
+def validate_record(path: Path, what: str = "private-state record") -> None:
+    """Require the ownership and mode contract for a persisted state record."""
+    if NAMESPACE in path.parts:
+        _require_canonical_file(path, what)
+    else:
+        _require_legacy_record(path, what)
+
+
 def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     if directory in {"cleanup", "discard-pristine"}:
         return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
@@ -276,6 +345,34 @@ def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     return False
 
 
+def _recover_canonical_temps(layout: Topology, *, include_admin: bool = True) -> None:
+    """Remove only our exact, owned publication artifacts while fenced."""
+    directories = [layout.common / NAMESPACE]
+    if include_admin and not layout.admin_is_common:
+        directories.append(layout.admin / NAMESPACE)
+    for namespace in directories:
+        if _namespace_kind(namespace, foreign_regular=False) != "directory":
+            continue
+        subdirs = [namespace / name for name in SHARED_DIRS]
+        for directory in subdirs:
+            if not directory.exists():
+                continue
+            _require_canonical_dir(directory)
+            for item in directory.iterdir():
+                if item.name.startswith("."):
+                    if TEMP_RE.fullmatch(item.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical temporary: {item}")
+                    metadata = _require_canonical_file(item, "canonical temporary")
+                    if metadata.st_nlink < 1 or metadata.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {item}")
+                    parent_fd = _open_anchored_parent(item)
+                    try:
+                        os.unlink(item.name, dir_fd=parent_fd)
+                        os.fsync(parent_fd)
+                    finally:
+                        os.close(parent_fd)
+
+
 def _legacy_json(content: bytes, path: Path) -> dict:
     try:
         value = json.loads(content.decode("utf-8"))
@@ -287,7 +384,7 @@ def _legacy_json(content: bytes, path: Path) -> dict:
 
 
 def _valid_oid(value: object) -> bool:
-    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+    return isinstance(value, str) and OID_RE.fullmatch(value) is not None
 
 
 def _valid_digest(value: object) -> bool:
@@ -306,14 +403,101 @@ def _valid_absolute_path(value: object) -> bool:
     return _valid_nonempty(value) and Path(value).is_absolute()
 
 
+def _valid_repository(value: object) -> bool:
+    return isinstance(value, str) and REPOSITORY_RE.fullmatch(value) is not None
+
+
+def _valid_branch_worktree(branch: object, task: object, worktree: object) -> bool:
+    if not (_valid_task_id(task) and isinstance(branch, str) and isinstance(worktree, str)):
+        return False
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        return False
+    path = Path(worktree)
+    return (path.is_absolute() and path.parent.name == ".worktrees" and
+            path.name == branch.split("/", 1)[1])
+
+
+def _valid_task_branch(branch: object, task: object) -> bool:
+    return (
+        _valid_task_id(task)
+        and isinstance(branch, str)
+        and (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-"))
+    )
+
+
 def _valid_authority_fields(value: dict) -> bool:
     return (
         _valid_task_id(value.get("task_id"))
-        and _valid_nonempty(value.get("branch"))
+        and _valid_task_branch(value.get("branch"), value.get("task_id"))
         and _valid_absolute_path(value.get("worktree"))
         and _valid_digest(value.get("authority_nonce"))
         and _valid_digest(value.get("receipt_sha256"))
     )
+
+
+def _valid_cleanup_evidence(value: dict, status: str, local_head: str) -> bool:
+    if status == "merged":
+        return (set(value) == {"repository", "pr", "published_head", "upstream"}
+                and _valid_repository(value.get("repository"))
+                and isinstance(value.get("pr"), int) and not isinstance(value.get("pr"), bool)
+                and value["pr"] > 0 and _valid_oid(value.get("published_head"))
+                and value.get("published_head").casefold() == local_head.casefold()
+                and value.get("upstream") in {"live", "deleted"})
+    return (set(value) == {"repository", "upstream", "base_revision"}
+            and _valid_repository(value.get("repository"))
+            and value.get("upstream") == "cancelled-safe"
+            and _valid_oid(value.get("base_revision")))
+
+
+def _validate_authority_filename(path: Path, content: bytes) -> None:
+    if path.parent.name != "automation-maintenance" or path.name in FIXED_AUTHORITY_FILES:
+        return
+    value = _legacy_json(content, path)
+    expected = hashlib.sha256(str(Path(value["worktree"]).resolve()).encode()).hexdigest()
+    if path.name != expected + ".json":
+        raise GitPrivateStateError(f"invalid private-state authority filename: {path}")
+
+
+def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -> Path:
+    """Bind authority ownership to a worktree registered in this topology."""
+    if path.parent.name != "automation-maintenance":
+        raise GitPrivateStateError(f"authority has an invalid parent: {path}")
+    value = _legacy_json(content, path)
+    worktree = Path(value["worktree"])
+    dot_git = worktree / ".git"
+    try:
+        metadata = dot_git.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError
+        if stat.S_ISDIR(metadata.st_mode):
+            admin = dot_git.resolve(strict=True)
+        elif stat.S_ISREG(metadata.st_mode):
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            if not marker.startswith("gitdir: "):
+                raise ValueError
+            target = Path(marker[8:])
+            admin = (target if target.is_absolute() else worktree / target).resolve(strict=True)
+        else:
+            raise ValueError
+    except (OSError, UnicodeDecodeError, ValueError, KeyError) as exc:
+        raise GitPrivateStateError(f"authority worktree is not registered: {path}") from exc
+    common = layout.common.resolve()
+    allowed = admin == common or admin == layout.admin.resolve()
+    if not allowed and admin.parent.name == "worktrees" and admin.parent.parent == common:
+        try:
+            registered_gitdir = (admin / "gitdir").read_text(encoding="utf-8").strip()
+            allowed = Path(registered_gitdir).resolve(strict=True) == dot_git.resolve(strict=True)
+        except (OSError, UnicodeDecodeError):
+            allowed = False
+    if not allowed:
+        raise GitPrivateStateError(f"authority worktree is outside Git topology: {path}")
+    try:
+        head = (admin / "HEAD").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise GitPrivateStateError(f"authority worktree registration is unreadable: {path}") from exc
+    if head != f"ref: refs/heads/{value['branch']}":
+        raise GitPrivateStateError(f"authority branch does not match worktree registration: {path}")
+    return admin
 
 
 def _validate_legacy_content(path: Path, content: bytes) -> None:
@@ -324,7 +508,8 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             text = content.decode("ascii", errors="strict")
         except UnicodeDecodeError as exc:
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
-        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+        if (not text.endswith("\n") or not _valid_oid(text[:-1]) or
+                text[:-1] != text[:-1].lower()):
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
         return
     value = _legacy_json(content, path)
@@ -335,10 +520,10 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("schema_version") == 1
             and value.get("task") == name[:-5]
             and value.get("status") in {"merged", "cancelled"}
-            and isinstance(value.get("worktree"), str)
-            and isinstance(value.get("branch"), str)
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
             and _valid_oid(value.get("local_head"))
             and isinstance(value.get("evidence"), dict)
+            and _valid_cleanup_evidence(value["evidence"], value["status"], value["local_head"])
         )
     elif directory == "discard-pristine":
         required = {
@@ -351,11 +536,12 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("operation") == "discard-pristine"
             and value.get("task") == name[:-5]
             and value.get("status") == "initialized"
-            and all(isinstance(value.get(field), str) for field in (
-                "worktree", "branch", "base_branch", "repository"
-            ))
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_repository(value.get("repository"))
             and _valid_oid(value.get("base_revision"))
-            and value.get("local_head") == value.get("base_revision")
+            and _valid_oid(value.get("local_head"))
+            and value.get("local_head").casefold() == value.get("base_revision").casefold()
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -413,26 +599,40 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
     if kind != "directory":
         return [], None
     pairs: list[tuple[Path, Path]] = []
+    _require_legacy_dir(root, "legacy private-state directory")
     legacy_lock: Path | None = None
     for entry in root.iterdir():
         if entry.name == "cleanup.lock":
-            _require_regular(entry, "legacy cleanup lock")
+            metadata = _require_regular(entry, "legacy cleanup lock")
+            _require_owned_mode(entry, metadata, 0o600, "legacy cleanup lock")
+            if metadata.st_mode & 0o111:
+                raise GitPrivateStateError(f"unsafe legacy cleanup lock mode: {entry}")
             legacy_lock = entry
             continue
         if entry.name not in SHARED_DIRS:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
-        _require_dir(entry, "legacy private-state directory")
+        _require_legacy_dir(entry, "legacy private-state directory")
         for child in entry.iterdir():
             allow_fixed = entry.name == "automation-maintenance"
             if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
                 raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-            _require_regular(child, "legacy private-state record")
+            _require_legacy_record(child, "legacy private-state record")
+            if entry.name == "automation-maintenance":
+                content = read_bytes(child)
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                authority_admin = _validate_authority_topology(child, content, layout)
             if child.name in FIXED_AUTHORITY_FILES:
-                if layout.admin_is_common:
-                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
-                # In a linked worktree these belong to the main worktree admin.
+                if authority_admin not in {layout.common, layout.admin}:
+                    raise GitPrivateStateError(
+                        f"fixed authority belongs to a different worktree admin: {child}"
+                    )
+                pairs.append((child, authority_admin / NAMESPACE / entry.name / child.name))
             else:
                 pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs, legacy_lock
 
 
@@ -450,55 +650,211 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
     if not entries:
         return []
     maintenance = entries[0]
-    _require_dir(maintenance, "legacy maintenance authority directory")
+    _require_legacy_dir(maintenance, "legacy maintenance authority directory")
     pairs: list[tuple[Path, Path]] = []
     for child in maintenance.iterdir():
         if child.name not in FIXED_AUTHORITY_FILES:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-        _require_regular(child, "legacy private-state record")
+        _require_legacy_record(child, "legacy private-state record")
+        content = read_bytes(child)
+        _validate_legacy_content(child, content)
+        _validate_authority_filename(child, content)
+        if _validate_authority_topology(child, content, layout) != layout.admin:
+            raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs
 
 
-def _validate_canonical(layout: Topology) -> None:
+def _validate_legacy_relations(root: Path, canonical_roots: tuple[Path, Path]) -> None:
+    maintenance = root / "automation-maintenance"
+    if not maintenance.is_dir():
+        return
+    proof = maintenance / "source-recovery-proof.json"
+    authority = maintenance / "authority.json"
+    if authority.exists() and not proof.exists():
+        authority_value = _legacy_json(
+            read_bytes(authority, "legacy maintenance authority"), authority
+        )
+        if authority_value.get("kind") == "source-recovery-bridge":
+            canonical_proofs = [
+                candidate / "automation-maintenance" / "source-recovery-proof.json"
+                for candidate in canonical_roots
+            ]
+            canonical_proof = next((candidate for candidate in canonical_proofs
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        authority_value,
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                    )), None)
+            if canonical_proof is None:
+                raise GitPrivateStateError(
+                    f"legacy source-recovery bridge lacks its proof: {root}"
+                )
+            proof = canonical_proof
+        else:
+            return
+    if proof.exists() and not authority.exists():
+        canonical_authorities = [
+            candidate / "automation-maintenance" / "authority.json"
+            for candidate in canonical_roots
+        ]
+        proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+        canonical_authority = next((candidate for candidate in canonical_authorities
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                        proof_value,
+                                    )), None)
+        if canonical_authority is None:
+            raise GitPrivateStateError(
+                f"legacy source-recovery proof lacks its bridge: {root}"
+            )
+        authority = canonical_authority
+    if not proof.exists() or not authority.exists():
+        return
+    proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+    authority_value = _legacy_json(read_bytes(authority, "legacy maintenance authority"), authority)
+    if not _recovery_pair_matches(authority_value, proof_value):
+        raise GitPrivateStateError(f"conflicting legacy authority and proof identity: {root}")
+
+
+def _recovery_pair_matches(authority: dict, proof: dict) -> bool:
+    if authority.get("kind") != "source-recovery-bridge":
+        return False
+    if any(proof.get(field) != authority.get(field) for field in (
+        "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"
+    )):
+        return False
+    digest = hashlib.sha256(
+        json.dumps(proof, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return authority.get("proof_sha256") == digest
+
+
+def _validate_canonical(
+    layout: Topology, *, allow_incomplete_recovery: bool = False
+) -> None:
     shared = layout.common / NAMESPACE
     kind = _namespace_kind(shared, foreign_regular=False)
     if kind == "directory":
+        _require_canonical_dir(shared)
         for entry in shared.iterdir():
             if entry.name in LOCK_FILES:
-                _require_regular(entry, "canonical private-state lock")
+                _require_canonical_file(entry, "canonical private-state lock")
                 continue
             if entry.name not in SHARED_DIRS:
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
-            _require_dir(entry)
+            _require_canonical_dir(entry)
             for child in entry.iterdir():
+                if child.name.startswith("."):
+                    if TEMP_RE.fullmatch(child.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    temporary = _require_canonical_file(child, "canonical temporary")
+                    if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                    continue
                 # Fixed files in common are the main worktree's admin records.
                 if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
                     raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                _require_regular(child, "canonical private-state record")
+                _require_canonical_file(child, "canonical private-state record")
+                content = read_bytes(child, "canonical private-state record")
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                if entry.name == "automation-maintenance":
+                    authority_admin = _validate_authority_topology(child, content, layout)
+                    if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
     if not layout.admin_is_common:
         admin_root = layout.admin / NAMESPACE
         kind = _namespace_kind(admin_root, foreign_regular=False)
         if kind == "directory":
+            _require_canonical_dir(admin_root)
             entries = list(admin_root.iterdir())
-            if any(entry.name != "automation-maintenance" for entry in entries):
-                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+            if any(entry.name not in {"automation-maintenance", "migration.lock"} for entry in entries):
+                unknown = next(
+                    entry for entry in entries
+                    if entry.name not in {"automation-maintenance", "migration.lock"}
+                )
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
-            if entries:
-                maintenance = entries[0]
-                _require_dir(maintenance)
+            lock = admin_root / "migration.lock"
+            if lock.exists():
+                _require_canonical_file(lock, "canonical private-state lock")
+            maintenance = admin_root / "automation-maintenance"
+            if maintenance.exists():
+                _require_canonical_dir(maintenance)
                 for child in maintenance.iterdir():
+                    if child.name.startswith("."):
+                        if TEMP_RE.fullmatch(child.name) is None:
+                            raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                        temporary = _require_canonical_file(child, "canonical temporary")
+                        if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                            raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                        continue
                     if child.name not in FIXED_AUTHORITY_FILES:
                         raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                    _require_regular(child, "canonical private-state record")
+                    _require_canonical_file(child, "canonical private-state record")
+                    content = read_bytes(child, "canonical private-state record")
+                    _validate_legacy_content(child, content)
+                    _validate_authority_filename(child, content)
+                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
+
+    # Canonical maintenance authority is fixed to the administrative topology;
+    # a bridge, when present, must name the exact canonical proof bytes.
+    for namespace in {layout.common / NAMESPACE, layout.admin / NAMESPACE}:
+        proof = namespace / "automation-maintenance" / "source-recovery-proof.json"
+        bridge = namespace / "automation-maintenance" / "authority.json"
+        proof_exists = proof.is_file()
+        bridge_exists = bridge.is_file()
+        if proof_exists and not bridge_exists:
+            legacy_bridges = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+            }
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            if not allow_incomplete_recovery and not any(candidate.is_file() and _recovery_pair_matches(
+                _legacy_json(read_bytes(candidate), candidate), proof_value
+            ) for candidate in legacy_bridges):
+                raise GitPrivateStateError(f"source-recovery proof lacks bridge authority: {namespace}")
+        if bridge_exists:
+            bridge_value = _legacy_json(read_bytes(bridge), bridge)
+            is_bridge = bridge_value.get("kind") == "source-recovery-bridge"
+            legacy_proofs = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+            }
+            if is_bridge and not proof_exists and not any(
+                candidate.is_file() and _recovery_pair_matches(
+                    bridge_value, _legacy_json(read_bytes(candidate), candidate)
+                ) for candidate in legacy_proofs
+            ):
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+            if not is_bridge and proof_exists:
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+        if proof_exists and bridge_exists:
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            for field in ("task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"):
+                if proof_value.get(field) != bridge_value.get(field):
+                    raise GitPrivateStateError(f"conflicting authority and proof identity: {namespace}")
+            digest = hashlib.sha256(
+                json.dumps(proof_value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
+            if bridge_value.get("proof_sha256") != digest:
+                raise GitPrivateStateError(f"source-recovery proof digest mismatch: {namespace}")
 
 
 def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
     inspected: list[MigrationFile] = []
     for source, target in pairs:
-        metadata = _require_regular(source, "legacy private-state record")
+        metadata = _require_legacy_record(source, "legacy private-state record")
         content = read_bytes(source, "legacy private-state record")
         _validate_legacy_content(source, content)
+        _validate_authority_filename(source, content)
         try:
             target.lstat()
         except FileNotFoundError:
@@ -537,10 +893,15 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
                     follow_symlinks=False)
             os.fsync(parent_fd)
         except FileExistsError:
+            _require_canonical_file(path, "canonical private-state record")
             if read_bytes(path, "canonical private-state record") != content:
                 raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
         published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
-        if not stat.S_ISREG(published.st_mode):
+        if (
+            not stat.S_ISREG(published.st_mode)
+            or published.st_uid != os.geteuid()
+            or stat.S_IMODE(published.st_mode) != 0o600
+        ):
             raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         return published.st_dev, published.st_ino
     except GitPrivateStateError:
@@ -556,6 +917,36 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
             os.close(parent_fd)
 
 
+def _exclusive_publish_direct(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    """Restore an absent legacy record without a visible temporary artifact."""
+    parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            path.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            mode,
+            dir_fd=parent_fd,
+        )
+        os.fchmod(descriptor, mode)
+        view = memoryview(content)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short private-state write")
+            view = view[written:]
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        os.fsync(parent_fd)
+        return metadata.st_dev, metadata.st_ino
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot restore legacy private-state record: {path}") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
 def ensure_parent(path: Path) -> None:
     parts = path.parts
     indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
@@ -569,18 +960,53 @@ def ensure_parent(path: Path) -> None:
     _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
 
 
+def _state_namespace(path: Path) -> Path:
+    """Return the namespace containing a canonical state path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside canonical private-state namespace: {path}")
+    return Path(*path.parts[: indexes[-1] + 1])
+
+
+def _legacy_equivalent(path: Path) -> tuple[Path, Path]:
+    """Return the state root and canonical equivalent of one legacy path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == LEGACY_NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside legacy private-state namespace: {path}")
+    marker = indexes[-1]
+    state_root = Path(*path.parts[:marker])
+    relative = Path(*path.parts[marker + 1:])
+    return state_root, state_root / NAMESPACE / relative
+
+
 def exclusive_write_bytes(
-    path: Path, content: bytes, mode: int = 0o600
+    path: Path, content: bytes, mode: int = 0o600, *, _lock_held: bool = False
 ) -> tuple[int, int]:
     """Durably publish a new state record without replacing any existing object."""
+    if NAMESPACE not in path.parts:
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            if os.path.lexists(path):
+                raise GitPrivateStateError(f"legacy private-state record already exists: {path}")
+            target = canonical if not (state_root / LEGACY_NAMESPACE).exists() else path
+            ensure_parent(target)
+            if target == canonical:
+                return _exclusive_publish(target, content, 0o600)
+            return _exclusive_publish_direct(target, content, mode)
     ensure_parent(path)
-    return _exclusive_publish(path, content, mode)
+    namespace = _state_namespace(path)
+    if _lock_held:
+        return _exclusive_publish(path, content, 0o600)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        return _exclusive_publish(path, content, 0o600)
 
 
 def _identity_unlink(item: MigrationFile) -> None:
     if read_bytes(item.source, "legacy private-state record") != item.content:
         raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
-    metadata = _require_regular(item.source, "legacy private-state record")
+    metadata = _require_legacy_record(item.source, "legacy private-state record")
     if (metadata.st_dev, metadata.st_ino) != item.identity:
         raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
     parent_fd = _open_anchored_parent(item.source)
@@ -598,6 +1024,118 @@ def _identity_unlink(item: MigrationFile) -> None:
         os.close(parent_fd)
 
 
+def _unlink_identity_path(path: Path, identity: tuple[int, int], what: str) -> None:
+    parent_fd = _open_anchored_parent(path)
+    try:
+        metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if ((metadata.st_dev, metadata.st_ino) != identity or
+                not stat.S_ISREG(metadata.st_mode)):
+            raise GitPrivateStateError(f"{what} identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _handoff_cleanup_lock(
+    legacy: Path, canonical: Path, expected_identity: tuple[int, int]
+) -> tuple[int, int]:
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    if (legacy_meta.st_dev, legacy_meta.st_ino) != expected_identity:
+        raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+    legacy_parent_fd = _open_anchored_parent(legacy)
+    canonical_parent_fd = _open_anchored_parent(canonical)
+    try:
+        legacy_fd = os.open(
+            legacy.name,
+            os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=legacy_parent_fd,
+        )
+        try:
+            opened = os.fstat(legacy_fd)
+            if (opened.st_dev, opened.st_ino) != expected_identity:
+                raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+            os.fchmod(legacy_fd, 0o600)
+            os.fsync(legacy_fd)
+        finally:
+            os.close(legacy_fd)
+    finally:
+        os.close(legacy_parent_fd)
+    try:
+        try:
+            canonical_meta = os.stat(
+                canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+            )
+        except FileNotFoundError:
+            canonical_meta = None
+        if canonical_meta is not None:
+            if (
+                not stat.S_ISREG(canonical_meta.st_mode)
+                or canonical_meta.st_uid != os.geteuid()
+                or stat.S_IMODE(canonical_meta.st_mode) != 0o600
+            ):
+                raise GitPrivateStateError(f"unsafe canonical cleanup lock: {canonical}")
+            if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+                expected_identity
+            ):
+                raise GitPrivateStateError(
+                    "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+                    "automatic cutover cannot prove a single cleanup fence"
+                )
+        else:
+            try:
+                source_fd = _open_anchored_parent(legacy)
+                try:
+                    os.link(
+                        legacy.name,
+                        canonical.name,
+                        src_dir_fd=source_fd,
+                        dst_dir_fd=canonical_parent_fd,
+                        follow_symlinks=False,
+                    )
+                finally:
+                    os.close(source_fd)
+                os.fsync(canonical_parent_fd)
+                published = os.stat(
+                    canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+                )
+                if (published.st_dev, published.st_ino) != expected_identity:
+                    raise GitPrivateStateError(
+                        f"legacy cleanup lock identity changed during handoff: {legacy}"
+                    )
+            except OSError as exc:
+                raise GitPrivateStateError(
+                    f"cannot establish cleanup lock handoff: {canonical}"
+                ) from exc
+    finally:
+        os.close(canonical_parent_fd)
+    return expected_identity
+
+
+def _preflight_cleanup_lock_handoff(legacy: Path | None, canonical: Path) -> None:
+    if legacy is None:
+        return
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    try:
+        canonical_meta = canonical.lstat()
+    except FileNotFoundError:
+        return
+    _require_canonical_file(canonical, "canonical cleanup lock")
+    if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+        legacy_meta.st_dev, legacy_meta.st_ino
+    ):
+        raise GitPrivateStateError(
+            "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+            "automatic cutover cannot prove a single cleanup fence"
+        )
+
+
 def _remove_known_empty_legacy_directories(layout: Topology) -> None:
     roots = [layout.common / LEGACY_NAMESPACE]
     if not layout.admin_is_common:
@@ -608,7 +1146,7 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
         for name in SHARED_DIRS:
             child = root / name
             try:
-                _require_dir(child, "legacy private-state directory")
+                _require_legacy_dir(child, "legacy private-state directory")
             except GitPrivateStateError:
                 if child.exists() or child.is_symlink():
                     raise
@@ -620,7 +1158,6 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
                     os.fsync(descriptor)
                 finally:
                     os.close(descriptor)
-        # The shared root remains while its mixed-version cleanup lock exists.
         if not any(root.iterdir()):
             root.rmdir()
             descriptor = _open_dir(root.parent)
@@ -631,24 +1168,46 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
 
 
 @contextmanager
-def _file_lock(path: Path, *, create: bool):
+def _file_lock(path: Path, *, create: bool, nonblocking: bool = False, exact: bool = False):
     flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-    if create:
-        flags |= os.O_CREAT
     parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
     try:
-        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        if create:
+            try:
+                descriptor = os.open(path.name, flags | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=parent_fd)
+                os.fchmod(descriptor, 0o600)
+                os.fsync(parent_fd)
+            except FileExistsError:
+                descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        else:
+            descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise GitPrivateStateError(f"unsafe private-state lock: {path}")
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        yield
+        if metadata.st_uid != os.geteuid() or (exact and stat.S_IMODE(metadata.st_mode) != 0o600) or (
+                not exact and (stat.S_IMODE(metadata.st_mode) & 0o022 or metadata.st_mode & 0o111 or
+                               not (metadata.st_mode & 0o600))):
+            raise GitPrivateStateError(f"unsafe private-state lock mode or ownership: {path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0))
+        except BlockingIOError as exc:
+            raise GitPrivateStateError(f"BLOCKED: private-state lock is contended: {path}") from exc
     except GitPrivateStateError:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise
     except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    try:
+        locked = os.fstat(descriptor)
+        yield (locked.st_dev, locked.st_ino)
     finally:
-        if "descriptor" in locals():
+        if descriptor is not None:
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_UN)
             finally:
@@ -662,7 +1221,8 @@ def prepare(
     admin: bool = False,
     common_dir: Path | None = None,
     admin_dir: Path | None = None,
-    _legacy_lock_held: bool = False,
+    _legacy_lock_identity: tuple[int, int] | None = None,
+    _allow_incomplete_recovery: bool = False,
 ) -> None:
     """Validate and migrate known legacy state before a state mutation."""
     layout = (
@@ -670,25 +1230,38 @@ def prepare(
         if common_dir is not None
         else topology(root)
     )
-    _validate_canonical(layout)
+    _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
     shared_pairs, legacy_lock = _scan_shared_legacy(layout)
     pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
     _inspect_pairs(pairs)  # preflight before creating even the migration lock
-    if legacy_lock is not None and not _legacy_lock_held:
-        with _file_lock(legacy_lock, create=False):
+    if legacy_lock is not None and _legacy_lock_identity is None:
+        with _file_lock(legacy_lock, create=False, nonblocking=True) as lock_identity:
             prepare(
                 root,
                 admin=admin,
                 common_dir=layout.common,
                 admin_dir=layout.admin,
-                _legacy_lock_held=True,
+                _legacy_lock_identity=lock_identity,
+                _allow_incomplete_recovery=_allow_incomplete_recovery,
             )
         return
 
+    _preflight_cleanup_lock_handoff(
+        legacy_lock, layout.common / NAMESPACE / "cleanup.lock"
+    )
     _ensure_namespace(layout.common, ())
-    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+    admin_lock_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_lock_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_lock_context:
         # Repeat all classification under the migration lock.
-        _validate_canonical(layout)
+        _recover_canonical_temps(layout, include_admin=admin)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         shared_pairs, _ = _scan_shared_legacy(layout)
         pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
         inspected = _inspect_pairs(pairs)
@@ -696,28 +1269,67 @@ def prepare(
             _ensure_namespace(layout.common, (name,))
         if admin:
             _ensure_namespace(layout.admin, ("automation-maintenance",))
+        legacy_lock_identity = None
+        if legacy_lock is not None:
+            if _legacy_lock_identity is None:
+                raise GitPrivateStateError("legacy cleanup lock is not held for handoff")
+            legacy_lock_identity = _handoff_cleanup_lock(
+                legacy_lock,
+                layout.common / NAMESPACE / "cleanup.lock",
+                _legacy_lock_identity,
+            )
         for item in inspected:
             try:
                 item.target.lstat()
             except FileNotFoundError:
-                _exclusive_publish(item.target, item.content, item.mode)
+                _exclusive_publish(item.target, item.content, 0o600)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         # No source is removed until every destination is durable and equivalent.
         for item in inspected:
+            _require_canonical_file(item.target, "canonical private-state record")
             if read_bytes(item.target, "canonical private-state record") != item.content:
                 raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
         for item in inspected:
-            metadata = _require_regular(item.source, "legacy private-state record")
+            metadata = _require_legacy_record(item.source, "legacy private-state record")
             if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
                 item.source, "legacy private-state record"
             ) != item.content:
                 raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
         for item in inspected:
             _identity_unlink(item)
+        if legacy_lock is not None and legacy_lock_identity is not None:
+            _unlink_identity_path(legacy_lock, legacy_lock_identity, "legacy cleanup lock")
         _remove_known_empty_legacy_directories(layout)
 
 
 def write_bytes(path: Path, content: bytes) -> None:
     """Atomically and durably replace one prepared canonical regular file."""
+    namespace = _state_namespace(path)
+    ensure_parent(path)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _write_bytes_locked(path, content)
+
+
+@contextmanager
+def mutation_lock(root: Path, *, admin: bool = False):
+    """Fence a caller-managed canonical transaction in global lock order."""
+    layout = topology(root)
+    _ensure_namespace(layout.common, ())
+    admin_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_context:
+        _recover_canonical_temps(layout, include_admin=admin)
+        yield
+
+
+def _write_bytes_locked(path: Path, content: bytes) -> None:
     parent_fd = _open_anchored_parent(path)
     temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
@@ -731,6 +1343,7 @@ def write_bytes(path: Path, content: bytes) -> None:
                 raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
         try:
+            os.fchmod(descriptor, 0o600)
             view = memoryview(content)
             while view:
                 written = os.write(descriptor, view)
@@ -755,8 +1368,51 @@ def write_bytes(path: Path, content: bytes) -> None:
             os.close(parent_fd)
 
 
-def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+def unlink(
+    path: Path,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+    expected_content: bytes | None = None,
+    _lock_held: bool = False,
+) -> None:
     """Remove only a canonical regular file through its verified parent."""
+    if NAMESPACE not in path.parts:
+        # A pre-cutover consumer may need to consume or roll back a validated
+        # historical authority before the upgraded implementation is committed.
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            legacy_exists = os.path.lexists(path)
+            canonical_exists = os.path.lexists(canonical)
+            if legacy_exists and canonical_exists:
+                if expected_content is None:
+                    raise GitPrivateStateError(
+                        f"legacy and canonical private-state records both exist: {path}"
+                    )
+                if read_bytes(path) != expected_content or read_bytes(canonical) != expected_content:
+                    raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+                _unlink_locked(path, expected_identity=expected_identity)
+                _unlink_locked(canonical)
+                return
+            if legacy_exists:
+                _unlink_locked(path, expected_identity=expected_identity)
+                return
+            if not canonical_exists or expected_content is None:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            if read_bytes(canonical, "canonical private-state record") != expected_content:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            _unlink_locked(canonical)
+        return
+    namespace = _state_namespace(path)
+    if _lock_held:
+        _unlink_locked(path, expected_identity=expected_identity)
+        return
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _unlink_locked(path, expected_identity=expected_identity)
+
+
+def _unlink_locked(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
     parent_fd = _open_anchored_parent(path)
     try:
         try:
@@ -779,19 +1435,26 @@ def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> N
 
 @contextmanager
 def cleanup_lock(root: Path):
-    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    """Cut over legacy cleanup locking, then acquire only the canonical lock."""
     layout = topology(root)
     _validate_canonical(layout)
     _, legacy = _scan_shared_legacy(layout)
     # Lock old consumers out while migrating cleanup/discard evidence.
-    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
-    with legacy_context:
+    legacy_context = (_file_lock(legacy, create=False, nonblocking=True)
+                      if legacy is not None else nullcontext())
+    with legacy_context as legacy_identity:
         prepare(
             root,
             common_dir=layout.common,
             admin_dir=layout.admin,
-            _legacy_lock_held=legacy is not None,
+            _legacy_lock_identity=legacy_identity,
         )
-        _ensure_namespace(layout.common, ())
-        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+        if legacy is not None:
+            # The open legacy descriptor now names the same inode as the
+            # canonical path and remains held for the whole caller operation.
             yield
+        else:
+            with _file_lock(
+                layout.common / NAMESPACE / "cleanup.lock", create=True, exact=True
+            ):
+                yield

--- a/components/agent-core/.automation/bin/git_private_state.py
+++ b/components/agent-core/.automation/bin/git_private_state.py
@@ -1,0 +1,797 @@
+"""Owned, fail-closed storage for Agent Core's Git-private runtime state."""
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+import subprocess
+
+
+NAMESPACE = "agent-core"
+LEGACY_NAMESPACE = "opencode"
+TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+PR_RE = re.compile(r"[1-9][0-9]*")
+HASH_RE = re.compile(r"[0-9a-f]{64}")
+SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
+FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+LOCK_FILES = {"cleanup.lock", "migration.lock"}
+_GIT_EXECUTABLE = "git"
+
+
+class GitPrivateStateError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Topology:
+    common: Path
+    admin: Path
+
+    @property
+    def admin_is_common(self) -> bool:
+        return self.admin == self.common
+
+
+@dataclass(frozen=True)
+class MigrationFile:
+    source: Path
+    target: Path
+    identity: tuple[int, int]
+    mode: int
+    content: bytes
+
+
+def _git_path(root: Path, argument: str) -> Path:
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    environment.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    })
+    result = subprocess.run(
+        [_GIT_EXECUTABLE, "-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null",
+         "-c", "core.pager=", "rev-parse", argument],
+        cwd=root, text=True, capture_output=True, check=False, env=environment,
+    )
+    raw = result.stdout.strip()
+    if result.returncode != 0 or not raw:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}")
+    candidate = Path(raw)
+    try:
+        resolved = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+        metadata = resolved.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"Git private-state location is not a directory: {resolved}")
+    return resolved
+
+
+def topology(root: Path) -> Topology:
+    return Topology(_git_path(root, "--git-common-dir"), _git_path(root, "--absolute-git-dir"))
+
+
+def common_git_dir(root: Path) -> Path:
+    return topology(root).common
+
+
+def admin_git_dir(root: Path) -> Path:
+    return topology(root).admin
+
+
+def common_state(root: Path) -> Path:
+    return common_git_dir(root) / NAMESPACE
+
+
+def admin_maintenance(root: Path) -> Path:
+    return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def cleanup_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "cleanup" / f"{task}.json"
+
+
+def discard_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "discard-pristine" / f"{task}.json"
+
+
+def integration_checkpoint(root: Path, pr: str) -> Path:
+    if PR_RE.fullmatch(pr) is None:
+        raise GitPrivateStateError("invalid pull request number")
+    return common_state(root) / "integration" / f"pr-{pr}.head"
+
+
+def _lstat(path: Path, what: str) -> os.stat_result:
+    try:
+        return path.lstat()
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect {what}: {path}") from exc
+
+
+def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def _require_regular(path: Path, what: str) -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def safe_directory(path: Path) -> None:
+    _require_dir(path)
+
+
+def _open_dir(path: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot open private-state directory: {path}") from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise GitPrivateStateError(f"unsafe private-state directory: {path}")
+    return descriptor
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open a state parent without following namespace or descendant symlinks."""
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    descriptor = _open_dir(boundary)
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for component in parts[marker:-1]:
+            child = os.open(component, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except GitPrivateStateError:
+        os.close(descriptor)
+        raise
+    except OSError as exc:
+        os.close(descriptor)
+        raise GitPrivateStateError(f"cannot traverse private-state directory: {path.parent}") from exc
+
+
+def _ensure_child_directory(parent: Path, name: str) -> Path:
+    descriptor = _open_dir(parent)
+    try:
+        try:
+            os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.fsync(descriptor)
+        except FileExistsError:
+            pass
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        child = os.open(name, flags, dir_fd=descriptor)
+        try:
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+        finally:
+            os.close(child)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state directory: {parent / name}") from exc
+    finally:
+        os.close(descriptor)
+    return parent / name
+
+
+def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
+    _require_dir(base, "Git administrative directory")
+    descriptor = _open_dir(base)
+    current = base
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for name in (NAMESPACE, *subdirectories):
+            try:
+                os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.fsync(descriptor)
+            except FileExistsError:
+                pass
+            child = os.open(name, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            os.close(descriptor)
+            descriptor = child
+            current /= name
+        return current
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state namespace below: {base}") from exc
+    finally:
+        os.close(descriptor)
+
+
+def read_bytes_identity(
+    path: Path, what: str = "private-state record"
+) -> tuple[bytes, tuple[int, int]]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe {what}: {path}")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino, metadata.st_size) != (
+                after.st_dev, after.st_ino, after.st_size
+            ):
+                raise GitPrivateStateError(f"{what} changed while reading: {path}")
+            return b"".join(chunks), (metadata.st_dev, metadata.st_ino)
+        finally:
+            os.close(descriptor)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot read {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def read_bytes(path: Path, what: str = "private-state record") -> bytes:
+    return read_bytes_identity(path, what)[0]
+
+
+def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
+    if directory in {"cleanup", "discard-pristine"}:
+        return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
+    if directory == "integration":
+        return re.fullmatch(r"pr-[1-9][0-9]*\.head", name) is not None
+    if directory == "automation-maintenance":
+        return (
+            re.fullmatch(r"[0-9a-f]{64}\.json", name) is not None
+            or (allow_fixed and name in FIXED_AUTHORITY_FILES)
+        )
+    return False
+
+
+def _legacy_json(content: bytes, path: Path) -> dict:
+    try:
+        value = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}") from exc
+    if not isinstance(value, dict):
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+    return value
+
+
+def _valid_oid(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+
+
+def _valid_digest(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+def _valid_task_id(value: object) -> bool:
+    return isinstance(value, str) and TASK_RE.fullmatch(value) is not None
+
+
+def _valid_nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _valid_absolute_path(value: object) -> bool:
+    return _valid_nonempty(value) and Path(value).is_absolute()
+
+
+def _valid_authority_fields(value: dict) -> bool:
+    return (
+        _valid_task_id(value.get("task_id"))
+        and _valid_nonempty(value.get("branch"))
+        and _valid_absolute_path(value.get("worktree"))
+        and _valid_digest(value.get("authority_nonce"))
+        and _valid_digest(value.get("receipt_sha256"))
+    )
+
+
+def _validate_legacy_content(path: Path, content: bytes) -> None:
+    directory = path.parent.name
+    name = path.name
+    if directory == "integration":
+        try:
+            text = content.decode("ascii", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
+        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
+        return
+    value = _legacy_json(content, path)
+    if directory == "cleanup":
+        required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("task") == name[:-5]
+            and value.get("status") in {"merged", "cancelled"}
+            and isinstance(value.get("worktree"), str)
+            and isinstance(value.get("branch"), str)
+            and _valid_oid(value.get("local_head"))
+            and isinstance(value.get("evidence"), dict)
+        )
+    elif directory == "discard-pristine":
+        required = {
+            "schema_version", "operation", "task", "status", "worktree", "branch",
+            "base_branch", "base_revision", "local_head", "repository",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("operation") == "discard-pristine"
+            and value.get("task") == name[:-5]
+            and value.get("status") == "initialized"
+            and all(isinstance(value.get(field), str) for field in (
+                "worktree", "branch", "base_branch", "repository"
+            ))
+            and _valid_oid(value.get("base_revision"))
+            and value.get("local_head") == value.get("base_revision")
+        )
+    elif name == "source-recovery-proof.json":
+        required = {
+            "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+            "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+            "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+            "receipt_source", "receipt_source_revision",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "source-recovery-proof"
+            and _valid_authority_fields(value)
+            and _valid_oid(value.get("authority_head"))
+            and all(_valid_digest(value.get(field)) for field in (
+                "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256",
+            ))
+            and _valid_absolute_path(value.get("implementation_source"))
+            and _valid_oid(value.get("implementation_revision"))
+            and _valid_absolute_path(value.get("receipt_source"))
+            and _valid_oid(value.get("receipt_source_revision"))
+        )
+    else:
+        standard = {"schema_version", "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"}
+        bridge = standard | {"kind", "proof_sha256"}
+        valid = (
+            (set(value) == standard and value.get("schema_version") == 1
+             and _valid_authority_fields(value))
+            or (set(value) == bridge and value.get("schema_version") == 2
+                and value.get("kind") == "source-recovery-bridge"
+                and _valid_authority_fields(value)
+                and _valid_digest(value.get("proof_sha256")))
+        )
+    if not valid:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+
+
+def _namespace_kind(path: Path, *, foreign_regular: bool) -> str:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return "absent"
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect private-state namespace: {path}") from exc
+    if stat.S_ISREG(metadata.st_mode) and foreign_regular:
+        return "foreign"
+    if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+        return "directory"
+    raise GitPrivateStateError(f"unsafe private-state namespace: {path}")
+
+
+def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path | None]:
+    root = layout.common / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return [], None
+    pairs: list[tuple[Path, Path]] = []
+    legacy_lock: Path | None = None
+    for entry in root.iterdir():
+        if entry.name == "cleanup.lock":
+            _require_regular(entry, "legacy cleanup lock")
+            legacy_lock = entry
+            continue
+        if entry.name not in SHARED_DIRS:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
+        _require_dir(entry, "legacy private-state directory")
+        for child in entry.iterdir():
+            allow_fixed = entry.name == "automation-maintenance"
+            if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
+                raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+            _require_regular(child, "legacy private-state record")
+            if child.name in FIXED_AUTHORITY_FILES:
+                if layout.admin_is_common:
+                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
+                # In a linked worktree these belong to the main worktree admin.
+            else:
+                pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    return pairs, legacy_lock
+
+
+def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
+    if layout.admin_is_common:
+        return []
+    root = layout.admin / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return []
+    entries = list(root.iterdir())
+    if any(entry.name != "automation-maintenance" for entry in entries):
+        unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+        raise GitPrivateStateError(f"unknown legacy private-state entry: {unknown}")
+    if not entries:
+        return []
+    maintenance = entries[0]
+    _require_dir(maintenance, "legacy maintenance authority directory")
+    pairs: list[tuple[Path, Path]] = []
+    for child in maintenance.iterdir():
+        if child.name not in FIXED_AUTHORITY_FILES:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+        _require_regular(child, "legacy private-state record")
+        pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    return pairs
+
+
+def _validate_canonical(layout: Topology) -> None:
+    shared = layout.common / NAMESPACE
+    kind = _namespace_kind(shared, foreign_regular=False)
+    if kind == "directory":
+        for entry in shared.iterdir():
+            if entry.name in LOCK_FILES:
+                _require_regular(entry, "canonical private-state lock")
+                continue
+            if entry.name not in SHARED_DIRS:
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
+            _require_dir(entry)
+            for child in entry.iterdir():
+                # Fixed files in common are the main worktree's admin records.
+                if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
+                    raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                _require_regular(child, "canonical private-state record")
+    if not layout.admin_is_common:
+        admin_root = layout.admin / NAMESPACE
+        kind = _namespace_kind(admin_root, foreign_regular=False)
+        if kind == "directory":
+            entries = list(admin_root.iterdir())
+            if any(entry.name != "automation-maintenance" for entry in entries):
+                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
+            if entries:
+                maintenance = entries[0]
+                _require_dir(maintenance)
+                for child in maintenance.iterdir():
+                    if child.name not in FIXED_AUTHORITY_FILES:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    _require_regular(child, "canonical private-state record")
+
+
+def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
+    inspected: list[MigrationFile] = []
+    for source, target in pairs:
+        metadata = _require_regular(source, "legacy private-state record")
+        content = read_bytes(source, "legacy private-state record")
+        _validate_legacy_content(source, content)
+        try:
+            target.lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise GitPrivateStateError(f"cannot inspect canonical private-state record: {target}") from exc
+        else:
+            if read_bytes(target, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting private-state records: {source} and {target}")
+        inspected.append(MigrationFile(
+            source, target, (metadata.st_dev, metadata.st_ino),
+            stat.S_IMODE(metadata.st_mode), content,
+        ))
+    return inspected
+
+
+def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".migrate.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            os.link(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd,
+                    follow_symlinks=False)
+            os.fsync(parent_fd)
+        except FileExistsError:
+            if read_bytes(path, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
+        published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if not stat.S_ISREG(published.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        return published.st_dev, published.st_ino
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot publish private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def ensure_parent(path: Path) -> None:
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
+    if not indexes:
+        # Legacy restoration may use only an already-existing validated parent.
+        descriptor = _open_anchored_parent(path)
+        os.close(descriptor)
+        return
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
+
+
+def exclusive_write_bytes(
+    path: Path, content: bytes, mode: int = 0o600
+) -> tuple[int, int]:
+    """Durably publish a new state record without replacing any existing object."""
+    ensure_parent(path)
+    return _exclusive_publish(path, content, mode)
+
+
+def _identity_unlink(item: MigrationFile) -> None:
+    if read_bytes(item.source, "legacy private-state record") != item.content:
+        raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+    metadata = _require_regular(item.source, "legacy private-state record")
+    if (metadata.st_dev, metadata.st_ino) != item.identity:
+        raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+    parent_fd = _open_anchored_parent(item.source)
+    try:
+        current = os.stat(item.source.name, dir_fd=parent_fd, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) != item.identity or not stat.S_ISREG(current.st_mode):
+            raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+        os.unlink(item.source.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove legacy private-state record: {item.source}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _remove_known_empty_legacy_directories(layout: Topology) -> None:
+    roots = [layout.common / LEGACY_NAMESPACE]
+    if not layout.admin_is_common:
+        roots.append(layout.admin / LEGACY_NAMESPACE)
+    for root in roots:
+        if _namespace_kind(root, foreign_regular=True) != "directory":
+            continue
+        for name in SHARED_DIRS:
+            child = root / name
+            try:
+                _require_dir(child, "legacy private-state directory")
+            except GitPrivateStateError:
+                if child.exists() or child.is_symlink():
+                    raise
+                continue
+            if not any(child.iterdir()):
+                child.rmdir()
+                descriptor = _open_dir(root)
+                try:
+                    os.fsync(descriptor)
+                finally:
+                    os.close(descriptor)
+        # The shared root remains while its mixed-version cleanup lock exists.
+        if not any(root.iterdir()):
+            root.rmdir()
+            descriptor = _open_dir(root.parent)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+
+
+@contextmanager
+def _file_lock(path: Path, *, create: bool):
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    if create:
+        flags |= os.O_CREAT
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe private-state lock: {path}")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    finally:
+        if "descriptor" in locals():
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+        os.close(parent_fd)
+
+
+def prepare(
+    root: Path,
+    *,
+    admin: bool = False,
+    common_dir: Path | None = None,
+    admin_dir: Path | None = None,
+    _legacy_lock_held: bool = False,
+) -> None:
+    """Validate and migrate known legacy state before a state mutation."""
+    layout = (
+        Topology(common_dir.resolve(), (admin_dir or common_dir).resolve())
+        if common_dir is not None
+        else topology(root)
+    )
+    _validate_canonical(layout)
+    shared_pairs, legacy_lock = _scan_shared_legacy(layout)
+    pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+    _inspect_pairs(pairs)  # preflight before creating even the migration lock
+    if legacy_lock is not None and not _legacy_lock_held:
+        with _file_lock(legacy_lock, create=False):
+            prepare(
+                root,
+                admin=admin,
+                common_dir=layout.common,
+                admin_dir=layout.admin,
+                _legacy_lock_held=True,
+            )
+        return
+
+    _ensure_namespace(layout.common, ())
+    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+        # Repeat all classification under the migration lock.
+        _validate_canonical(layout)
+        shared_pairs, _ = _scan_shared_legacy(layout)
+        pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+        inspected = _inspect_pairs(pairs)
+        for name in SHARED_DIRS:
+            _ensure_namespace(layout.common, (name,))
+        if admin:
+            _ensure_namespace(layout.admin, ("automation-maintenance",))
+        for item in inspected:
+            try:
+                item.target.lstat()
+            except FileNotFoundError:
+                _exclusive_publish(item.target, item.content, item.mode)
+        # No source is removed until every destination is durable and equivalent.
+        for item in inspected:
+            if read_bytes(item.target, "canonical private-state record") != item.content:
+                raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
+        for item in inspected:
+            metadata = _require_regular(item.source, "legacy private-state record")
+            if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
+                item.source, "legacy private-state record"
+            ) != item.content:
+                raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+        for item in inspected:
+            _identity_unlink(item)
+        _remove_known_empty_legacy_directories(layout)
+
+
+def write_bytes(path: Path, content: bytes) -> None:
+    """Atomically and durably replace one prepared canonical regular file."""
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        try:
+            current = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            if not stat.S_ISREG(current.st_mode):
+                raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot write private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+    """Remove only a canonical regular file through its verified parent."""
+    parent_fd = _open_anchored_parent(path)
+    try:
+        try:
+            metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        if expected_identity is not None and (metadata.st_dev, metadata.st_ino) != expected_identity:
+            raise GitPrivateStateError(f"private-state record identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove private-state record: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    layout = topology(root)
+    _validate_canonical(layout)
+    _, legacy = _scan_shared_legacy(layout)
+    # Lock old consumers out while migrating cleanup/discard evidence.
+    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
+    with legacy_context:
+        prepare(
+            root,
+            common_dir=layout.common,
+            admin_dir=layout.admin,
+            _legacy_lock_held=legacy is not None,
+        )
+        _ensure_namespace(layout.common, ())
+        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+            yield

--- a/components/agent-core/.automation/bin/task_lifecycle.py
+++ b/components/agent-core/.automation/bin/task_lifecycle.py
@@ -15,6 +15,10 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 WORK_UNIT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -1053,19 +1057,19 @@ def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
     validate_task(task)
-    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+    try:
+        return private_state.cleanup_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 @contextmanager
 def cleanup_lock(root: Path):
-    path = common_git_dir(root) / "opencode" / "cleanup.lock"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        try:
+    try:
+        with private_state.cleanup_lock(root):
             yield
-        finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 def cleanup_repository(root: Path) -> str:
@@ -1230,8 +1234,8 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
     if path.is_symlink() or not path.is_file():
         raise LifecycleError("cleanup receipt is not a regular local file")
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "cleanup receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise LifecycleError("cleanup receipt is invalid") from exc
     required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
     if (
@@ -1317,7 +1321,10 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -1332,13 +1339,18 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
 
 def task_cleanup(root: Path, task: str) -> None:
     require_main_worktree(root)
-    receipt = cleanup_receipt_path(root, task)
     with cleanup_lock(root):
+        receipt = cleanup_receipt_path(root, task)
         if receipt.exists():
             finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
             return
         plan = cleanup_plan(root, task)
-        atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise LifecycleError(str(exc)) from exc
         finish_cleanup(root, plan, receipt)
 
 

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -773,7 +773,11 @@ Tracked files remain unchanged; success reports `PROVENANCE_REBOUND`, while an
 already-correct pair reports `PROVENANCE_ALREADY_BOUND`. Missing authority
 remains the #85 route; committed or consumed state, including a crossed guarded
 publication boundary, rejects.
-Handled failures roll back safely and concurrency fails closed. No
+Rebind is operator-serialized: older pending consumers require quiescence with
+no concurrent commit or authority mutation. Current lock-aware revisions also
+share ordered common/admin migration fences for rebind and commit. Handled
+failures roll back safely, and concurrency among those current revisions fails
+closed. No
 cross-filesystem atomicity or hard-crash durability is claimed; that remains
 #89 scope.
 

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -184,5 +184,29 @@ upgrade with changes replaces the active receipt and removes the previous consum
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
 receipt lifecycle evidence.
 
+## Git-private runtime state
+
+Agent Core owns only the `agent-core/` namespace beneath Git administrative
+directories. Shared cleanup receipts, pristine-discard receipts, integration
+checkpoints, the cleanup lock, the migration lock, and historical hashed
+maintenance authorities live beneath `<git-common-dir>/agent-core/`.
+Worktree-specific maintenance `authority.json` and
+`source-recovery-proof.json` live beneath
+`<absolute-git-dir>/agent-core/automation-maintenance/`. Repository Task State
+under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
+`opencode.json` configuration are separate ownership surfaces.
+
+The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
+file and Agent Core never changes its bytes, metadata, or identity. A legacy
+directory at that name is accepted only when every entry has an explicitly
+known historical Agent Core path and schema. Known regular records are copied byte for
+byte with durable no-overwrite publication, all conflicts are rejected before
+migration mutation, and legacy records are removed only after every canonical
+destination is verified equivalent. Equivalent dual state and partially
+completed migration are retryable. Unknown entries, unexpected nesting,
+symlinks, and special files fail closed. The historical `cleanup.lock` is
+retained as a mixed-version locking ABI and is acquired before the canonical
+lock; it is never renamed or unlinked automatically.
+
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -148,6 +148,12 @@ files unchanged. It reports `PROVENANCE_REBOUND` or idempotent
 `PROVENANCE_ALREADY_BOUND`; then run ordinary consumer verification and the
 existing `automation::commit`.
 
+Rebind is an operator-serialized maintenance transition: no commit or other
+authority mutation may run concurrently in the target worktree. Current Agent
+Core revisions additionally fence rebind and commit with the same ordered
+common/admin migration locks; the explicit quiescence requirement preserves the
+older pending consumer needed to finish an in-flight upgrade.
+
 Eligibility is exact: registered maintenance Task/worktree/branch/HEAD; one
 standard active receipt matching exactly one authority; safe pending Agent
 Core paths/fingerprints only; no consumed, source-recovery, or ambiguous state;
@@ -155,7 +161,8 @@ the old and expected revisions in the same Templates object database; and an
 identical expected canonical diff. Missing authority remains the Issue #85
 route. Committed or consumed state, including a crossed guarded publication
 boundary, is rejected. Handled
-failures roll back safely and concurrency fails closed. No cross-filesystem
+failures roll back safely; operations by current revisions fail closed under the
+shared fence. No cross-filesystem
 atomicity or hard-crash durability is claimed; that remains Issue #89 scope.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
@@ -198,15 +205,36 @@ under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
 
 The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
 file and Agent Core never changes its bytes, metadata, or identity. A legacy
-directory at that name is accepted only when every entry has an explicitly
-known historical Agent Core path and schema. Known regular records are copied byte for
-byte with durable no-overwrite publication, all conflicts are rejected before
-migration mutation, and legacy records are removed only after every canonical
-destination is verified equivalent. Equivalent dual state and partially
-completed migration are retryable. Unknown entries, unexpected nesting,
-symlinks, and special files fail closed. The historical `cleanup.lock` is
-retained as a mixed-version locking ABI and is acquired before the canonical
-lock; it is never renamed or unlinked automatically.
+directory at that name is accepted only when every entry satisfies the exact
+historical path, schema, Task/branch/worktree identity, repository syntax, and
+authority/proof relationship that Agent Core produced. The legacy namespace,
+subdirectories, records, and lock must be owned by the current effective user.
+Directories require owner access and reject group/other mutation while retaining
+historically produced read/traverse modes such as `0755`; records and locks reject
+group/other mutation and executable bits. Canonical directories
+are exactly mode `0700`, and canonical records, locks, and publication
+artifacts are exactly mode `0600`.
+
+Known records are copied byte for byte with durable no-overwrite publication,
+all conflicts are rejected before migration mutation, and legacy records are
+removed only after every canonical destination is mode-, owner-, and
+content-equivalent. The legacy cleanup-lock inode is acquired nonblocking and
+hard-linked into the canonical cleanup-lock path before its legacy name is
+removed. Existing waiters therefore remain fenced on the same inode. A
+contended legacy lock, or distinct legacy and canonical lock inodes, reports a
+precise `BLOCKED` condition rather than claiming migration success. Successful
+cutover removes the legacy lock last and then removes the empty `opencode/`
+directory, leaving the path available to OpenCode.
+
+Canonical publication is serialized by `migration.lock`. Only exact owned
+`.migrate.<pid>.<16-lowercase-hex>` and
+`.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next
+operation they are validated and durably removed under that lock before the
+legacy source is retried or an already-durable destination is used. Equivalent
+dual state, partial legacy removal, and interruption before or after durable
+publication are therefore retryable. Unknown entries, malformed temporary
+names, unsafe modes/ownership, unexpected nesting, symlinks, and special files
+fail closed without promotion.
 
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-base/.automation/bin/agent_core.py
+++ b/templates/agent-base/.automation/bin/agent_core.py
@@ -17,6 +17,7 @@ if str(SCRIPT_DIR) not in sys.path:
 import task_lifecycle as lifecycle
 import publication_metadata as publication
 import task_contract
+import git_private_state as private_state
 
 try:
     import tomllib
@@ -527,22 +528,31 @@ def validate_integration(root: Path, pr: str) -> dict:
 
 
 def integration_checkpoint(root: Path, pr: str) -> Path:
-    path = common_git_dir(root) / "opencode" / "integration" / f"pr-{pr}.head"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
+    try:
+        return private_state.integration_checkpoint(root, pr)
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
 
 
 def integrate_check(root: Path, pr: str) -> None:
     data = validate_integration(root, pr)
-    integration_checkpoint(root, pr).write_text(data["headRefOid"] + "\n", encoding="utf-8")
+    try:
+        private_state.prepare(root)
+        checkpoint = integration_checkpoint(root, pr)
+        private_state.write_bytes(checkpoint, (data["headRefOid"] + "\n").encode("utf-8"))
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
     print(json.dumps({"pr": data["number"], "head": data["headRefOid"], "status": "verified"}))
 
 
 def integrate_merge(root: Path, pr: str) -> None:
     checkpoint = integration_checkpoint(root, pr)
-    if not checkpoint.exists():
+    if not checkpoint.exists() or checkpoint.is_symlink() or not checkpoint.is_file():
         raise AutomationError("run integrate::check before merge")
-    expected = checkpoint.read_text(encoding="utf-8").strip()
+    try:
+        expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
+    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+        raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:
         raise AutomationError(f"PR head moved after integration check: expected {expected}, got {data['headRefOid']}")

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -16,6 +16,10 @@ import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 
 class UpgradeError(RuntimeError):
     pass
@@ -120,16 +124,55 @@ def worktree_admin_dir(repo: Path) -> Path:
 
 def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     admin = worktree_admin_dir(repo)
-    new_parent = admin / "opencode" / "automation-maintenance"
+    new_parent = admin / private_state.NAMESPACE / "automation-maintenance"
+    if new_parent.exists() or new_parent.is_symlink():
+        try:
+            private_state.safe_directory(admin / private_state.NAMESPACE)
+            private_state.safe_directory(new_parent)
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError(str(exc)) from exc
     try:
         resolved_parent = new_parent.resolve()
     except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy_location = _safe_legacy_location(repo)
-    legacy = legacy_location[0] if legacy_location is not None else None
+    common = common_git_dir(repo)
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    migrated = common / private_state.NAMESPACE / "automation-maintenance" / f"{key}.json"
+    if os.path.lexists(migrated):
+        try:
+            private_state.safe_directory(common / private_state.NAMESPACE)
+            private_state.safe_directory(migrated.parent)
+            private_state.read_bytes(migrated, "migrated maintenance authority")
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+        legacy = migrated
+    else:
+        old_admin = _safe_old_admin_authority(repo)
+        if old_admin is not None and os.path.lexists(old_admin[0]):
+            legacy = old_admin[0]
+        else:
+            legacy_location = _safe_legacy_location(repo)
+            legacy = legacy_location[0] if legacy_location is not None else None
     return new_parent / "authority.json", legacy
+
+
+def _safe_old_admin_authority(repo: Path) -> tuple[Path, Path] | None:
+    try:
+        admin = worktree_admin_dir(repo)
+        root = admin / "opencode"
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
+            return None
+        parent = root / "automation-maintenance"
+        if parent.is_symlink() or (parent.exists() and not parent.is_dir()):
+            return None
+        resolved = parent.resolve()
+        if resolved != admin and admin not in resolved.parents:
+            return None
+        return parent / "authority.json", admin
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
@@ -144,7 +187,7 @@ def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
             return None
         key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
         return parent / f"{key}.json", common
-    except (OSError, ValueError, RuntimeError, UpgradeError):
+    except (OSError, ValueError, RuntimeError, UpgradeError, private_state.GitPrivateStateError):
         return None
 
 
@@ -167,6 +210,15 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     _write_authority_at(
         authority_path(repo),
         {
@@ -187,33 +239,29 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             parent_before = path.parent.resolve()
             if parent_before != admin and admin not in parent_before.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        path.parent.mkdir(parents=True, exist_ok=True)
+        private_state.ensure_parent(path)
         if admin is not None:
             parent_after = path.parent.resolve()
             if parent_after != admin and admin not in parent_after.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        # The caller has validated the parent; do not replace an existing record.
-        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
-        temporary = Path(temporary_name)
-        try:
-            with os.fdopen(fd, "wb") as stream:
-                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
-                stream.flush()
-                try:
-                    os.fsync(stream.fileno())
-                except OSError:
-                    pass
-            os.link(temporary, path)
-        finally:
-            temporary.unlink(missing_ok=True)
-    except (OSError, ValueError, RuntimeError) as exc:
+        private_state.exclusive_write_bytes(
+            path,
+            json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+        )
+    except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
 
 
 def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    old_admin = _safe_old_admin_authority(repo)
+    if old_admin is not None and authority == old_admin[0]:
+        return old_admin[1]
     legacy = _safe_legacy_location(repo)
     if legacy is not None and authority == legacy[0]:
         return legacy[1]
+    common = common_git_dir(repo)
+    if authority.parent == common / private_state.NAMESPACE / "automation-maintenance":
+        return common
     if authority == authority_path(repo):
         return worktree_admin_dir(repo)
     raise UpgradeError("cannot safely resolve authority location for rollback")
@@ -227,11 +275,10 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError("missing or invalid successful-upgrade authority record")
-        authority = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        authority = json.loads(
+            private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
     expected = {
         "schema_version": 1,
@@ -253,12 +300,15 @@ def _read_json_record(path: Path, error: str) -> dict:
 
 def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError(error)
-        raw = path.read_bytes()
+        if private_state.NAMESPACE in path.parts or "opencode" in path.parts:
+            raw = private_state.read_bytes(path, error)
+        else:
+            metadata = path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+                raise UpgradeError(error)
+            raw = path.read_bytes()
         value = json.loads(raw.decode("utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(error) from exc
     if not isinstance(value, dict):
         raise UpgradeError(error)
@@ -1795,7 +1845,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         raise UpgradeError("receipt source is not compatible with the current Templates source")
     old_revision = _validate_source_revision(source, old["source_revision"])
     authority = _standard_authority_only(repo, old)
-    old_authority_raw = authority.read_bytes()
+    old_authority_raw = private_state.read_bytes(authority, "maintenance authority")
     receipt_identity = (active.lstat().st_dev, active.lstat().st_ino)
     authority_identity = (authority.lstat().st_dev, authority.lstat().st_ino)
     authority_head = validate_commit_oid(repo, old["authority_head"], field="receipt authority HEAD")
@@ -1828,7 +1878,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         current_source, current_revision = resolve_clean_source_worktree(source)
         if expected_implementation_revision is None or current_revision != expected_implementation_revision:
             raise UpgradeError("source implementation changed before provenance replacement")
-    if active.read_bytes() != raw_receipt or authority.read_bytes() != old_authority_raw or pending_paths(repo) != expected_paths \
+    if active.read_bytes() != raw_receipt or private_state.read_bytes(authority, "maintenance authority") != old_authority_raw or pending_paths(repo) != expected_paths \
             or git_head(repo) != authority_head or current_source != source \
             or (require_source_head and current_revision != expected_source_revision) \
             or (active.lstat().st_dev, active.lstat().st_ino) != receipt_identity \
@@ -2021,7 +2071,11 @@ def recover_maintenance_authority_from_source(
             if existing != proof:
                 raise UpgradeError("existing source-recovery proof does not match reconstruction")
         else:
-            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+            private_state.ensure_parent(proof_path)
+            created_proof = private_state.exclusive_write_bytes(
+                proof_path,
+                json.dumps(proof, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            )
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
         if (current_source != source
                 or current_implementation_revision != expected_implementation_revision):
@@ -2040,13 +2094,11 @@ def recover_maintenance_authority_from_source(
             raise UpgradeError("source-recovery proof changed before bridge publication")
         _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
                             admin=worktree_admin_dir(target_repo))
-    except (OSError, UpgradeError):
+    except (OSError, UpgradeError, private_state.GitPrivateStateError):
         if created_proof is not None:
             try:
-                metadata = proof_path.lstat()
-                if (metadata.st_dev, metadata.st_ino) == created_proof:
-                    proof_path.unlink()
-            except OSError as exc:
+                private_state.unlink(proof_path, expected_identity=created_proof)
+            except (OSError, private_state.GitPrivateStateError) as exc:
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
@@ -2209,7 +2261,13 @@ def _commit_mode(
         )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
-        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        try:
+            proof_raw, proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            proof_record = json.loads(proof_raw.decode("utf-8"))
+        except (private_state.GitPrivateStateError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("missing or invalid source-recovery proof") from exc
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
@@ -2221,7 +2279,7 @@ def _commit_mode(
             raise UpgradeError("source-recovery receipt source is incompatible")
         _validate_source_revision(source, receipt["source_revision"])
         authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
-        if proof_path.read_bytes() != proof_raw:
+        if private_state.read_bytes(proof_path, "source-recovery proof") != proof_raw:
             raise UpgradeError("source-recovery proof changed before commit mutation")
     else:  # pragma: no cover
         raise UpgradeError("unsupported commit mode")
@@ -2249,10 +2307,29 @@ def _commit_mode(
         atomic_json_write(consumed, consumed_receipt)
         consumed_metadata = consumed.lstat()
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
-        authority.unlink(missing_ok=True)
+        authority_raw, authority_identity = private_state.read_bytes_identity(
+            authority, "maintenance authority"
+        )
+        expected_authority = (
+            _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest())
+            if mode == "source_recovery" and proof is not None
+            else {
+                "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                "receipt_sha256": receipt_digest(receipt),
+            }
+        )
+        if json.loads(authority_raw.decode("utf-8")) != expected_authority:
+            raise UpgradeError("authority changed before commit mutation")
+        private_state.unlink(authority, expected_identity=authority_identity)
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
-            proof_path.unlink()
+            current_proof, current_proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            if current_proof != proof_raw or current_proof_identity != proof_identity:
+                raise UpgradeError("source-recovery proof changed before removal")
+            private_state.unlink(proof_path, expected_identity=proof_identity)
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2304,7 +2381,7 @@ def _commit_mode(
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except (UpgradeError, OSError) as failure:
+    except (UpgradeError, OSError, private_state.GitPrivateStateError) as failure:
         if committed:
             raise UpgradeError(
                 f"commit {commit_sha} was published but finalization failed"
@@ -2314,8 +2391,8 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
-        except (OSError, UpgradeError) as rollback_error:
+                private_state.exclusive_write_bytes(proof_path, proof_raw)
+        except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
             if authority_removed:

--- a/templates/agent-base/.automation/bin/automation_upgrade.py
+++ b/templates/agent-base/.automation/bin/automation_upgrade.py
@@ -233,7 +233,13 @@ def write_authority(repo: Path, receipt: dict) -> None:
     )
 
 
-def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
+def _write_authority_at(
+    path: Path,
+    value: dict,
+    *,
+    admin: Path | None = None,
+    lock_held: bool = False,
+) -> None:
     try:
         if admin is not None:
             parent_before = path.parent.resolve()
@@ -247,6 +253,7 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
         private_state.exclusive_write_bytes(
             path,
             json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            _lock_held=lock_held,
         )
     except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
@@ -275,6 +282,7 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
+        private_state.validate_record(path, "successful-upgrade authority record")
         authority = json.loads(
             private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
         )
@@ -1642,9 +1650,10 @@ def _rename_record_at(source: str, destination: str, *, source_dir_fd: int, dest
     )
 
 
-def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
-                           receipt: dict, authority_path_value: Path,
-                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+def _replace_standard_pair_locked(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                                  receipt: dict, authority_path_value: Path,
+                                  receipt_identity: tuple[int, int],
+                                  authority_identity: tuple[int, int]) -> None:
     active = receipt_path(repo)
     admin = _rollback_authority_guard(repo, authority_path_value)
     _validate_admin_record_parent(authority_path_value, admin)
@@ -1823,6 +1832,25 @@ def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw
                 pass
 
 
+def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                           receipt: dict, authority_path_value: Path,
+                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+    """Replace a common/admin record pair under ordered namespace fences."""
+    try:
+        with private_state.mutation_lock(repo, admin=True):
+            _replace_standard_pair_locked(
+                repo,
+                old_receipt_raw,
+                old_authority_raw,
+                receipt,
+                authority_path_value,
+                receipt_identity,
+                authority_identity,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
+
+
 def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_source_revision: str,
                                    *, require_source_head: bool,
                                    expected_implementation_revision: str | None = None) -> dict:
@@ -1994,6 +2022,16 @@ def recover_maintenance_authority_from_source(
         expected_implementation_revision
     )
     task_id, branch, worktree = require_maintenance(target_repo)
+    try:
+        private_state.prepare(
+            target_repo,
+            admin=True,
+            common_dir=common_git_dir(target_repo),
+            admin_dir=worktree_admin_dir(target_repo),
+            _allow_incomplete_recovery=True,
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
     if implementation_revision != expected_implementation_revision:
         raise UpgradeError("source HEAD does not match the expected implementation revision")
@@ -2215,7 +2253,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(
+def _commit_mode_locked(
     repo: Path,
     task: str,
     message: str,
@@ -2321,7 +2359,12 @@ def _commit_mode(
         )
         if json.loads(authority_raw.decode("utf-8")) != expected_authority:
             raise UpgradeError("authority changed before commit mutation")
-        private_state.unlink(authority, expected_identity=authority_identity)
+        private_state.unlink(
+            authority,
+            expected_identity=authority_identity,
+            expected_content=authority_raw,
+            _lock_held=True,
+        )
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
             current_proof, current_proof_identity = private_state.read_bytes_identity(
@@ -2329,7 +2372,12 @@ def _commit_mode(
             )
             if current_proof != proof_raw or current_proof_identity != proof_identity:
                 raise UpgradeError("source-recovery proof changed before removal")
-            private_state.unlink(proof_path, expected_identity=proof_identity)
+            private_state.unlink(
+                proof_path,
+                expected_identity=proof_identity,
+                expected_content=proof_raw,
+                _lock_held=True,
+            )
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2391,7 +2439,9 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                private_state.exclusive_write_bytes(proof_path, proof_raw)
+                private_state.exclusive_write_bytes(
+                    proof_path, proof_raw, _lock_held=True
+                )
         except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
@@ -2401,7 +2451,12 @@ def _commit_mode(
                     "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
                     "receipt_sha256": receipt_digest(receipt),
                 }
-                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
+                _write_authority_at(
+                    authority,
+                    restored,
+                    admin=_rollback_authority_guard(repo, authority),
+                    lock_held=True,
+                )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -2446,6 +2501,35 @@ def _commit_mode(
             "mergePerformed": False,
         })
     return result
+
+
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+        with private_state.mutation_lock(repo, admin=True):
+            return _commit_mode_locked(
+                repo,
+                task,
+                message,
+                mode,
+                source_root=source_root,
+                expected_implementation_revision=expected_implementation_revision,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
 
 
 def commit(repo: Path, task: str, message: str) -> dict[str, object]:

--- a/templates/agent-base/.automation/bin/discard_pristine.py
+++ b/templates/agent-base/.automation/bin/discard_pristine.py
@@ -7,7 +7,10 @@ import re
 import sys
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
 import task_lifecycle as lifecycle
+import git_private_state as private_state
 
 
 RECEIPT_SCHEMA_VERSION = 1
@@ -18,12 +21,10 @@ REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 
 def discard_receipt_path(root: Path, task: str) -> Path:
     lifecycle.validate_task(task)
-    return (
-        lifecycle.common_git_dir(root)
-        / "opencode"
-        / "discard-pristine"
-        / f"{task}.json"
-    )
+    try:
+        return private_state.discard_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
 
 
 def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
@@ -255,8 +256,8 @@ def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
             "discard-pristine receipt is not a regular local file"
         )
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "discard-pristine receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
     required = {
         "schema_version",
@@ -394,7 +395,10 @@ def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
             "discard-pristine failed to delete the expected local Task branch"
         )
 
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -421,7 +425,12 @@ def task_discard_pristine(root: Path, task: str) -> None:
             )
             return
         plan = pristine_discard_plan(root, task)
-        lifecycle.atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise lifecycle.LifecycleError(str(exc)) from exc
         finish_pristine_discard(root, plan, receipt)
 
 

--- a/templates/agent-base/.automation/bin/git_private_state.py
+++ b/templates/agent-base/.automation/bin/git_private_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 import fcntl
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -18,9 +19,12 @@ LEGACY_NAMESPACE = "opencode"
 TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 PR_RE = re.compile(r"[1-9][0-9]*")
 HASH_RE = re.compile(r"[0-9a-f]{64}")
+OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
 FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
+TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
 
 
@@ -126,6 +130,43 @@ def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_r
     return metadata
 
 
+def _require_owned_mode(path: Path, metadata: os.stat_result, mode: int, what: str,
+                        *, exact: bool = False) -> None:
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    actual = stat.S_IMODE(metadata.st_mode)
+    unsafe = actual != mode if exact else (actual & mode) != mode
+    unsafe = unsafe or bool(actual & 0o022)
+    if unsafe:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+
+
+def _require_legacy_dir(path: Path, what: str) -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what)
+    return metadata
+
+
+def _require_legacy_record(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o400, what)
+    if metadata.st_mode & 0o111:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir(path: Path, what: str = "canonical private-state directory") -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what, exact=True)
+    return metadata
+
+
+def _require_canonical_file(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o600, what, exact=True)
+    return metadata
+
+
 def _require_regular(path: Path, what: str) -> os.stat_result:
     metadata = _lstat(path, what)
     if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
@@ -134,7 +175,10 @@ def _require_regular(path: Path, what: str) -> os.stat_result:
 
 
 def safe_directory(path: Path) -> None:
-    _require_dir(path)
+    if NAMESPACE in path.parts:
+        _require_canonical_dir(path)
+    else:
+        _require_dir(path)
 
 
 def _open_dir(path: Path) -> int:
@@ -162,7 +206,8 @@ def _open_anchored_parent(path: Path) -> int:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
             os.close(descriptor)
@@ -179,15 +224,24 @@ def _open_anchored_parent(path: Path) -> int:
 def _ensure_child_directory(parent: Path, name: str) -> Path:
     descriptor = _open_dir(parent)
     try:
+        created = False
         try:
             os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
             os.fsync(descriptor)
+            created = True
         except FileExistsError:
             pass
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         child = os.open(name, flags, dir_fd=descriptor)
         try:
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            metadata = os.fstat(child)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+            if not created and (
+                metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o700
+            ):
                 raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
         finally:
             os.close(child)
@@ -205,15 +259,22 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
     try:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
+            created = False
             try:
                 os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
                 os.fsync(descriptor)
+                created = True
             except FileExistsError:
                 pass
             child = os.open(name, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            if child_meta.st_uid != os.geteuid() or stat.S_IMODE(child_meta.st_mode) != 0o700:
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe canonical private-state directory: {current / name}")
             os.close(descriptor)
             descriptor = child
             current /= name
@@ -263,6 +324,14 @@ def read_bytes(path: Path, what: str = "private-state record") -> bytes:
     return read_bytes_identity(path, what)[0]
 
 
+def validate_record(path: Path, what: str = "private-state record") -> None:
+    """Require the ownership and mode contract for a persisted state record."""
+    if NAMESPACE in path.parts:
+        _require_canonical_file(path, what)
+    else:
+        _require_legacy_record(path, what)
+
+
 def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     if directory in {"cleanup", "discard-pristine"}:
         return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
@@ -276,6 +345,34 @@ def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     return False
 
 
+def _recover_canonical_temps(layout: Topology, *, include_admin: bool = True) -> None:
+    """Remove only our exact, owned publication artifacts while fenced."""
+    directories = [layout.common / NAMESPACE]
+    if include_admin and not layout.admin_is_common:
+        directories.append(layout.admin / NAMESPACE)
+    for namespace in directories:
+        if _namespace_kind(namespace, foreign_regular=False) != "directory":
+            continue
+        subdirs = [namespace / name for name in SHARED_DIRS]
+        for directory in subdirs:
+            if not directory.exists():
+                continue
+            _require_canonical_dir(directory)
+            for item in directory.iterdir():
+                if item.name.startswith("."):
+                    if TEMP_RE.fullmatch(item.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical temporary: {item}")
+                    metadata = _require_canonical_file(item, "canonical temporary")
+                    if metadata.st_nlink < 1 or metadata.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {item}")
+                    parent_fd = _open_anchored_parent(item)
+                    try:
+                        os.unlink(item.name, dir_fd=parent_fd)
+                        os.fsync(parent_fd)
+                    finally:
+                        os.close(parent_fd)
+
+
 def _legacy_json(content: bytes, path: Path) -> dict:
     try:
         value = json.loads(content.decode("utf-8"))
@@ -287,7 +384,7 @@ def _legacy_json(content: bytes, path: Path) -> dict:
 
 
 def _valid_oid(value: object) -> bool:
-    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+    return isinstance(value, str) and OID_RE.fullmatch(value) is not None
 
 
 def _valid_digest(value: object) -> bool:
@@ -306,14 +403,101 @@ def _valid_absolute_path(value: object) -> bool:
     return _valid_nonempty(value) and Path(value).is_absolute()
 
 
+def _valid_repository(value: object) -> bool:
+    return isinstance(value, str) and REPOSITORY_RE.fullmatch(value) is not None
+
+
+def _valid_branch_worktree(branch: object, task: object, worktree: object) -> bool:
+    if not (_valid_task_id(task) and isinstance(branch, str) and isinstance(worktree, str)):
+        return False
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        return False
+    path = Path(worktree)
+    return (path.is_absolute() and path.parent.name == ".worktrees" and
+            path.name == branch.split("/", 1)[1])
+
+
+def _valid_task_branch(branch: object, task: object) -> bool:
+    return (
+        _valid_task_id(task)
+        and isinstance(branch, str)
+        and (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-"))
+    )
+
+
 def _valid_authority_fields(value: dict) -> bool:
     return (
         _valid_task_id(value.get("task_id"))
-        and _valid_nonempty(value.get("branch"))
+        and _valid_task_branch(value.get("branch"), value.get("task_id"))
         and _valid_absolute_path(value.get("worktree"))
         and _valid_digest(value.get("authority_nonce"))
         and _valid_digest(value.get("receipt_sha256"))
     )
+
+
+def _valid_cleanup_evidence(value: dict, status: str, local_head: str) -> bool:
+    if status == "merged":
+        return (set(value) == {"repository", "pr", "published_head", "upstream"}
+                and _valid_repository(value.get("repository"))
+                and isinstance(value.get("pr"), int) and not isinstance(value.get("pr"), bool)
+                and value["pr"] > 0 and _valid_oid(value.get("published_head"))
+                and value.get("published_head").casefold() == local_head.casefold()
+                and value.get("upstream") in {"live", "deleted"})
+    return (set(value) == {"repository", "upstream", "base_revision"}
+            and _valid_repository(value.get("repository"))
+            and value.get("upstream") == "cancelled-safe"
+            and _valid_oid(value.get("base_revision")))
+
+
+def _validate_authority_filename(path: Path, content: bytes) -> None:
+    if path.parent.name != "automation-maintenance" or path.name in FIXED_AUTHORITY_FILES:
+        return
+    value = _legacy_json(content, path)
+    expected = hashlib.sha256(str(Path(value["worktree"]).resolve()).encode()).hexdigest()
+    if path.name != expected + ".json":
+        raise GitPrivateStateError(f"invalid private-state authority filename: {path}")
+
+
+def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -> Path:
+    """Bind authority ownership to a worktree registered in this topology."""
+    if path.parent.name != "automation-maintenance":
+        raise GitPrivateStateError(f"authority has an invalid parent: {path}")
+    value = _legacy_json(content, path)
+    worktree = Path(value["worktree"])
+    dot_git = worktree / ".git"
+    try:
+        metadata = dot_git.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError
+        if stat.S_ISDIR(metadata.st_mode):
+            admin = dot_git.resolve(strict=True)
+        elif stat.S_ISREG(metadata.st_mode):
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            if not marker.startswith("gitdir: "):
+                raise ValueError
+            target = Path(marker[8:])
+            admin = (target if target.is_absolute() else worktree / target).resolve(strict=True)
+        else:
+            raise ValueError
+    except (OSError, UnicodeDecodeError, ValueError, KeyError) as exc:
+        raise GitPrivateStateError(f"authority worktree is not registered: {path}") from exc
+    common = layout.common.resolve()
+    allowed = admin == common or admin == layout.admin.resolve()
+    if not allowed and admin.parent.name == "worktrees" and admin.parent.parent == common:
+        try:
+            registered_gitdir = (admin / "gitdir").read_text(encoding="utf-8").strip()
+            allowed = Path(registered_gitdir).resolve(strict=True) == dot_git.resolve(strict=True)
+        except (OSError, UnicodeDecodeError):
+            allowed = False
+    if not allowed:
+        raise GitPrivateStateError(f"authority worktree is outside Git topology: {path}")
+    try:
+        head = (admin / "HEAD").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise GitPrivateStateError(f"authority worktree registration is unreadable: {path}") from exc
+    if head != f"ref: refs/heads/{value['branch']}":
+        raise GitPrivateStateError(f"authority branch does not match worktree registration: {path}")
+    return admin
 
 
 def _validate_legacy_content(path: Path, content: bytes) -> None:
@@ -324,7 +508,8 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             text = content.decode("ascii", errors="strict")
         except UnicodeDecodeError as exc:
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
-        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+        if (not text.endswith("\n") or not _valid_oid(text[:-1]) or
+                text[:-1] != text[:-1].lower()):
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
         return
     value = _legacy_json(content, path)
@@ -335,10 +520,10 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("schema_version") == 1
             and value.get("task") == name[:-5]
             and value.get("status") in {"merged", "cancelled"}
-            and isinstance(value.get("worktree"), str)
-            and isinstance(value.get("branch"), str)
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
             and _valid_oid(value.get("local_head"))
             and isinstance(value.get("evidence"), dict)
+            and _valid_cleanup_evidence(value["evidence"], value["status"], value["local_head"])
         )
     elif directory == "discard-pristine":
         required = {
@@ -351,11 +536,12 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("operation") == "discard-pristine"
             and value.get("task") == name[:-5]
             and value.get("status") == "initialized"
-            and all(isinstance(value.get(field), str) for field in (
-                "worktree", "branch", "base_branch", "repository"
-            ))
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_repository(value.get("repository"))
             and _valid_oid(value.get("base_revision"))
-            and value.get("local_head") == value.get("base_revision")
+            and _valid_oid(value.get("local_head"))
+            and value.get("local_head").casefold() == value.get("base_revision").casefold()
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -413,26 +599,40 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
     if kind != "directory":
         return [], None
     pairs: list[tuple[Path, Path]] = []
+    _require_legacy_dir(root, "legacy private-state directory")
     legacy_lock: Path | None = None
     for entry in root.iterdir():
         if entry.name == "cleanup.lock":
-            _require_regular(entry, "legacy cleanup lock")
+            metadata = _require_regular(entry, "legacy cleanup lock")
+            _require_owned_mode(entry, metadata, 0o600, "legacy cleanup lock")
+            if metadata.st_mode & 0o111:
+                raise GitPrivateStateError(f"unsafe legacy cleanup lock mode: {entry}")
             legacy_lock = entry
             continue
         if entry.name not in SHARED_DIRS:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
-        _require_dir(entry, "legacy private-state directory")
+        _require_legacy_dir(entry, "legacy private-state directory")
         for child in entry.iterdir():
             allow_fixed = entry.name == "automation-maintenance"
             if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
                 raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-            _require_regular(child, "legacy private-state record")
+            _require_legacy_record(child, "legacy private-state record")
+            if entry.name == "automation-maintenance":
+                content = read_bytes(child)
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                authority_admin = _validate_authority_topology(child, content, layout)
             if child.name in FIXED_AUTHORITY_FILES:
-                if layout.admin_is_common:
-                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
-                # In a linked worktree these belong to the main worktree admin.
+                if authority_admin not in {layout.common, layout.admin}:
+                    raise GitPrivateStateError(
+                        f"fixed authority belongs to a different worktree admin: {child}"
+                    )
+                pairs.append((child, authority_admin / NAMESPACE / entry.name / child.name))
             else:
                 pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs, legacy_lock
 
 
@@ -450,55 +650,211 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
     if not entries:
         return []
     maintenance = entries[0]
-    _require_dir(maintenance, "legacy maintenance authority directory")
+    _require_legacy_dir(maintenance, "legacy maintenance authority directory")
     pairs: list[tuple[Path, Path]] = []
     for child in maintenance.iterdir():
         if child.name not in FIXED_AUTHORITY_FILES:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-        _require_regular(child, "legacy private-state record")
+        _require_legacy_record(child, "legacy private-state record")
+        content = read_bytes(child)
+        _validate_legacy_content(child, content)
+        _validate_authority_filename(child, content)
+        if _validate_authority_topology(child, content, layout) != layout.admin:
+            raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs
 
 
-def _validate_canonical(layout: Topology) -> None:
+def _validate_legacy_relations(root: Path, canonical_roots: tuple[Path, Path]) -> None:
+    maintenance = root / "automation-maintenance"
+    if not maintenance.is_dir():
+        return
+    proof = maintenance / "source-recovery-proof.json"
+    authority = maintenance / "authority.json"
+    if authority.exists() and not proof.exists():
+        authority_value = _legacy_json(
+            read_bytes(authority, "legacy maintenance authority"), authority
+        )
+        if authority_value.get("kind") == "source-recovery-bridge":
+            canonical_proofs = [
+                candidate / "automation-maintenance" / "source-recovery-proof.json"
+                for candidate in canonical_roots
+            ]
+            canonical_proof = next((candidate for candidate in canonical_proofs
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        authority_value,
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                    )), None)
+            if canonical_proof is None:
+                raise GitPrivateStateError(
+                    f"legacy source-recovery bridge lacks its proof: {root}"
+                )
+            proof = canonical_proof
+        else:
+            return
+    if proof.exists() and not authority.exists():
+        canonical_authorities = [
+            candidate / "automation-maintenance" / "authority.json"
+            for candidate in canonical_roots
+        ]
+        proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+        canonical_authority = next((candidate for candidate in canonical_authorities
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                        proof_value,
+                                    )), None)
+        if canonical_authority is None:
+            raise GitPrivateStateError(
+                f"legacy source-recovery proof lacks its bridge: {root}"
+            )
+        authority = canonical_authority
+    if not proof.exists() or not authority.exists():
+        return
+    proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+    authority_value = _legacy_json(read_bytes(authority, "legacy maintenance authority"), authority)
+    if not _recovery_pair_matches(authority_value, proof_value):
+        raise GitPrivateStateError(f"conflicting legacy authority and proof identity: {root}")
+
+
+def _recovery_pair_matches(authority: dict, proof: dict) -> bool:
+    if authority.get("kind") != "source-recovery-bridge":
+        return False
+    if any(proof.get(field) != authority.get(field) for field in (
+        "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"
+    )):
+        return False
+    digest = hashlib.sha256(
+        json.dumps(proof, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return authority.get("proof_sha256") == digest
+
+
+def _validate_canonical(
+    layout: Topology, *, allow_incomplete_recovery: bool = False
+) -> None:
     shared = layout.common / NAMESPACE
     kind = _namespace_kind(shared, foreign_regular=False)
     if kind == "directory":
+        _require_canonical_dir(shared)
         for entry in shared.iterdir():
             if entry.name in LOCK_FILES:
-                _require_regular(entry, "canonical private-state lock")
+                _require_canonical_file(entry, "canonical private-state lock")
                 continue
             if entry.name not in SHARED_DIRS:
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
-            _require_dir(entry)
+            _require_canonical_dir(entry)
             for child in entry.iterdir():
+                if child.name.startswith("."):
+                    if TEMP_RE.fullmatch(child.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    temporary = _require_canonical_file(child, "canonical temporary")
+                    if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                    continue
                 # Fixed files in common are the main worktree's admin records.
                 if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
                     raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                _require_regular(child, "canonical private-state record")
+                _require_canonical_file(child, "canonical private-state record")
+                content = read_bytes(child, "canonical private-state record")
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                if entry.name == "automation-maintenance":
+                    authority_admin = _validate_authority_topology(child, content, layout)
+                    if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
     if not layout.admin_is_common:
         admin_root = layout.admin / NAMESPACE
         kind = _namespace_kind(admin_root, foreign_regular=False)
         if kind == "directory":
+            _require_canonical_dir(admin_root)
             entries = list(admin_root.iterdir())
-            if any(entry.name != "automation-maintenance" for entry in entries):
-                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+            if any(entry.name not in {"automation-maintenance", "migration.lock"} for entry in entries):
+                unknown = next(
+                    entry for entry in entries
+                    if entry.name not in {"automation-maintenance", "migration.lock"}
+                )
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
-            if entries:
-                maintenance = entries[0]
-                _require_dir(maintenance)
+            lock = admin_root / "migration.lock"
+            if lock.exists():
+                _require_canonical_file(lock, "canonical private-state lock")
+            maintenance = admin_root / "automation-maintenance"
+            if maintenance.exists():
+                _require_canonical_dir(maintenance)
                 for child in maintenance.iterdir():
+                    if child.name.startswith("."):
+                        if TEMP_RE.fullmatch(child.name) is None:
+                            raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                        temporary = _require_canonical_file(child, "canonical temporary")
+                        if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                            raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                        continue
                     if child.name not in FIXED_AUTHORITY_FILES:
                         raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                    _require_regular(child, "canonical private-state record")
+                    _require_canonical_file(child, "canonical private-state record")
+                    content = read_bytes(child, "canonical private-state record")
+                    _validate_legacy_content(child, content)
+                    _validate_authority_filename(child, content)
+                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
+
+    # Canonical maintenance authority is fixed to the administrative topology;
+    # a bridge, when present, must name the exact canonical proof bytes.
+    for namespace in {layout.common / NAMESPACE, layout.admin / NAMESPACE}:
+        proof = namespace / "automation-maintenance" / "source-recovery-proof.json"
+        bridge = namespace / "automation-maintenance" / "authority.json"
+        proof_exists = proof.is_file()
+        bridge_exists = bridge.is_file()
+        if proof_exists and not bridge_exists:
+            legacy_bridges = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+            }
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            if not allow_incomplete_recovery and not any(candidate.is_file() and _recovery_pair_matches(
+                _legacy_json(read_bytes(candidate), candidate), proof_value
+            ) for candidate in legacy_bridges):
+                raise GitPrivateStateError(f"source-recovery proof lacks bridge authority: {namespace}")
+        if bridge_exists:
+            bridge_value = _legacy_json(read_bytes(bridge), bridge)
+            is_bridge = bridge_value.get("kind") == "source-recovery-bridge"
+            legacy_proofs = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+            }
+            if is_bridge and not proof_exists and not any(
+                candidate.is_file() and _recovery_pair_matches(
+                    bridge_value, _legacy_json(read_bytes(candidate), candidate)
+                ) for candidate in legacy_proofs
+            ):
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+            if not is_bridge and proof_exists:
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+        if proof_exists and bridge_exists:
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            for field in ("task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"):
+                if proof_value.get(field) != bridge_value.get(field):
+                    raise GitPrivateStateError(f"conflicting authority and proof identity: {namespace}")
+            digest = hashlib.sha256(
+                json.dumps(proof_value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
+            if bridge_value.get("proof_sha256") != digest:
+                raise GitPrivateStateError(f"source-recovery proof digest mismatch: {namespace}")
 
 
 def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
     inspected: list[MigrationFile] = []
     for source, target in pairs:
-        metadata = _require_regular(source, "legacy private-state record")
+        metadata = _require_legacy_record(source, "legacy private-state record")
         content = read_bytes(source, "legacy private-state record")
         _validate_legacy_content(source, content)
+        _validate_authority_filename(source, content)
         try:
             target.lstat()
         except FileNotFoundError:
@@ -537,10 +893,15 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
                     follow_symlinks=False)
             os.fsync(parent_fd)
         except FileExistsError:
+            _require_canonical_file(path, "canonical private-state record")
             if read_bytes(path, "canonical private-state record") != content:
                 raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
         published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
-        if not stat.S_ISREG(published.st_mode):
+        if (
+            not stat.S_ISREG(published.st_mode)
+            or published.st_uid != os.geteuid()
+            or stat.S_IMODE(published.st_mode) != 0o600
+        ):
             raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         return published.st_dev, published.st_ino
     except GitPrivateStateError:
@@ -556,6 +917,36 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
             os.close(parent_fd)
 
 
+def _exclusive_publish_direct(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    """Restore an absent legacy record without a visible temporary artifact."""
+    parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            path.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            mode,
+            dir_fd=parent_fd,
+        )
+        os.fchmod(descriptor, mode)
+        view = memoryview(content)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short private-state write")
+            view = view[written:]
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        os.fsync(parent_fd)
+        return metadata.st_dev, metadata.st_ino
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot restore legacy private-state record: {path}") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
 def ensure_parent(path: Path) -> None:
     parts = path.parts
     indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
@@ -569,18 +960,53 @@ def ensure_parent(path: Path) -> None:
     _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
 
 
+def _state_namespace(path: Path) -> Path:
+    """Return the namespace containing a canonical state path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside canonical private-state namespace: {path}")
+    return Path(*path.parts[: indexes[-1] + 1])
+
+
+def _legacy_equivalent(path: Path) -> tuple[Path, Path]:
+    """Return the state root and canonical equivalent of one legacy path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == LEGACY_NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside legacy private-state namespace: {path}")
+    marker = indexes[-1]
+    state_root = Path(*path.parts[:marker])
+    relative = Path(*path.parts[marker + 1:])
+    return state_root, state_root / NAMESPACE / relative
+
+
 def exclusive_write_bytes(
-    path: Path, content: bytes, mode: int = 0o600
+    path: Path, content: bytes, mode: int = 0o600, *, _lock_held: bool = False
 ) -> tuple[int, int]:
     """Durably publish a new state record without replacing any existing object."""
+    if NAMESPACE not in path.parts:
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            if os.path.lexists(path):
+                raise GitPrivateStateError(f"legacy private-state record already exists: {path}")
+            target = canonical if not (state_root / LEGACY_NAMESPACE).exists() else path
+            ensure_parent(target)
+            if target == canonical:
+                return _exclusive_publish(target, content, 0o600)
+            return _exclusive_publish_direct(target, content, mode)
     ensure_parent(path)
-    return _exclusive_publish(path, content, mode)
+    namespace = _state_namespace(path)
+    if _lock_held:
+        return _exclusive_publish(path, content, 0o600)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        return _exclusive_publish(path, content, 0o600)
 
 
 def _identity_unlink(item: MigrationFile) -> None:
     if read_bytes(item.source, "legacy private-state record") != item.content:
         raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
-    metadata = _require_regular(item.source, "legacy private-state record")
+    metadata = _require_legacy_record(item.source, "legacy private-state record")
     if (metadata.st_dev, metadata.st_ino) != item.identity:
         raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
     parent_fd = _open_anchored_parent(item.source)
@@ -598,6 +1024,118 @@ def _identity_unlink(item: MigrationFile) -> None:
         os.close(parent_fd)
 
 
+def _unlink_identity_path(path: Path, identity: tuple[int, int], what: str) -> None:
+    parent_fd = _open_anchored_parent(path)
+    try:
+        metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if ((metadata.st_dev, metadata.st_ino) != identity or
+                not stat.S_ISREG(metadata.st_mode)):
+            raise GitPrivateStateError(f"{what} identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _handoff_cleanup_lock(
+    legacy: Path, canonical: Path, expected_identity: tuple[int, int]
+) -> tuple[int, int]:
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    if (legacy_meta.st_dev, legacy_meta.st_ino) != expected_identity:
+        raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+    legacy_parent_fd = _open_anchored_parent(legacy)
+    canonical_parent_fd = _open_anchored_parent(canonical)
+    try:
+        legacy_fd = os.open(
+            legacy.name,
+            os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=legacy_parent_fd,
+        )
+        try:
+            opened = os.fstat(legacy_fd)
+            if (opened.st_dev, opened.st_ino) != expected_identity:
+                raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+            os.fchmod(legacy_fd, 0o600)
+            os.fsync(legacy_fd)
+        finally:
+            os.close(legacy_fd)
+    finally:
+        os.close(legacy_parent_fd)
+    try:
+        try:
+            canonical_meta = os.stat(
+                canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+            )
+        except FileNotFoundError:
+            canonical_meta = None
+        if canonical_meta is not None:
+            if (
+                not stat.S_ISREG(canonical_meta.st_mode)
+                or canonical_meta.st_uid != os.geteuid()
+                or stat.S_IMODE(canonical_meta.st_mode) != 0o600
+            ):
+                raise GitPrivateStateError(f"unsafe canonical cleanup lock: {canonical}")
+            if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+                expected_identity
+            ):
+                raise GitPrivateStateError(
+                    "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+                    "automatic cutover cannot prove a single cleanup fence"
+                )
+        else:
+            try:
+                source_fd = _open_anchored_parent(legacy)
+                try:
+                    os.link(
+                        legacy.name,
+                        canonical.name,
+                        src_dir_fd=source_fd,
+                        dst_dir_fd=canonical_parent_fd,
+                        follow_symlinks=False,
+                    )
+                finally:
+                    os.close(source_fd)
+                os.fsync(canonical_parent_fd)
+                published = os.stat(
+                    canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+                )
+                if (published.st_dev, published.st_ino) != expected_identity:
+                    raise GitPrivateStateError(
+                        f"legacy cleanup lock identity changed during handoff: {legacy}"
+                    )
+            except OSError as exc:
+                raise GitPrivateStateError(
+                    f"cannot establish cleanup lock handoff: {canonical}"
+                ) from exc
+    finally:
+        os.close(canonical_parent_fd)
+    return expected_identity
+
+
+def _preflight_cleanup_lock_handoff(legacy: Path | None, canonical: Path) -> None:
+    if legacy is None:
+        return
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    try:
+        canonical_meta = canonical.lstat()
+    except FileNotFoundError:
+        return
+    _require_canonical_file(canonical, "canonical cleanup lock")
+    if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+        legacy_meta.st_dev, legacy_meta.st_ino
+    ):
+        raise GitPrivateStateError(
+            "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+            "automatic cutover cannot prove a single cleanup fence"
+        )
+
+
 def _remove_known_empty_legacy_directories(layout: Topology) -> None:
     roots = [layout.common / LEGACY_NAMESPACE]
     if not layout.admin_is_common:
@@ -608,7 +1146,7 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
         for name in SHARED_DIRS:
             child = root / name
             try:
-                _require_dir(child, "legacy private-state directory")
+                _require_legacy_dir(child, "legacy private-state directory")
             except GitPrivateStateError:
                 if child.exists() or child.is_symlink():
                     raise
@@ -620,7 +1158,6 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
                     os.fsync(descriptor)
                 finally:
                     os.close(descriptor)
-        # The shared root remains while its mixed-version cleanup lock exists.
         if not any(root.iterdir()):
             root.rmdir()
             descriptor = _open_dir(root.parent)
@@ -631,24 +1168,46 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
 
 
 @contextmanager
-def _file_lock(path: Path, *, create: bool):
+def _file_lock(path: Path, *, create: bool, nonblocking: bool = False, exact: bool = False):
     flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-    if create:
-        flags |= os.O_CREAT
     parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
     try:
-        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        if create:
+            try:
+                descriptor = os.open(path.name, flags | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=parent_fd)
+                os.fchmod(descriptor, 0o600)
+                os.fsync(parent_fd)
+            except FileExistsError:
+                descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        else:
+            descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise GitPrivateStateError(f"unsafe private-state lock: {path}")
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        yield
+        if metadata.st_uid != os.geteuid() or (exact and stat.S_IMODE(metadata.st_mode) != 0o600) or (
+                not exact and (stat.S_IMODE(metadata.st_mode) & 0o022 or metadata.st_mode & 0o111 or
+                               not (metadata.st_mode & 0o600))):
+            raise GitPrivateStateError(f"unsafe private-state lock mode or ownership: {path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0))
+        except BlockingIOError as exc:
+            raise GitPrivateStateError(f"BLOCKED: private-state lock is contended: {path}") from exc
     except GitPrivateStateError:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise
     except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    try:
+        locked = os.fstat(descriptor)
+        yield (locked.st_dev, locked.st_ino)
     finally:
-        if "descriptor" in locals():
+        if descriptor is not None:
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_UN)
             finally:
@@ -662,7 +1221,8 @@ def prepare(
     admin: bool = False,
     common_dir: Path | None = None,
     admin_dir: Path | None = None,
-    _legacy_lock_held: bool = False,
+    _legacy_lock_identity: tuple[int, int] | None = None,
+    _allow_incomplete_recovery: bool = False,
 ) -> None:
     """Validate and migrate known legacy state before a state mutation."""
     layout = (
@@ -670,25 +1230,38 @@ def prepare(
         if common_dir is not None
         else topology(root)
     )
-    _validate_canonical(layout)
+    _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
     shared_pairs, legacy_lock = _scan_shared_legacy(layout)
     pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
     _inspect_pairs(pairs)  # preflight before creating even the migration lock
-    if legacy_lock is not None and not _legacy_lock_held:
-        with _file_lock(legacy_lock, create=False):
+    if legacy_lock is not None and _legacy_lock_identity is None:
+        with _file_lock(legacy_lock, create=False, nonblocking=True) as lock_identity:
             prepare(
                 root,
                 admin=admin,
                 common_dir=layout.common,
                 admin_dir=layout.admin,
-                _legacy_lock_held=True,
+                _legacy_lock_identity=lock_identity,
+                _allow_incomplete_recovery=_allow_incomplete_recovery,
             )
         return
 
+    _preflight_cleanup_lock_handoff(
+        legacy_lock, layout.common / NAMESPACE / "cleanup.lock"
+    )
     _ensure_namespace(layout.common, ())
-    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+    admin_lock_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_lock_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_lock_context:
         # Repeat all classification under the migration lock.
-        _validate_canonical(layout)
+        _recover_canonical_temps(layout, include_admin=admin)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         shared_pairs, _ = _scan_shared_legacy(layout)
         pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
         inspected = _inspect_pairs(pairs)
@@ -696,28 +1269,67 @@ def prepare(
             _ensure_namespace(layout.common, (name,))
         if admin:
             _ensure_namespace(layout.admin, ("automation-maintenance",))
+        legacy_lock_identity = None
+        if legacy_lock is not None:
+            if _legacy_lock_identity is None:
+                raise GitPrivateStateError("legacy cleanup lock is not held for handoff")
+            legacy_lock_identity = _handoff_cleanup_lock(
+                legacy_lock,
+                layout.common / NAMESPACE / "cleanup.lock",
+                _legacy_lock_identity,
+            )
         for item in inspected:
             try:
                 item.target.lstat()
             except FileNotFoundError:
-                _exclusive_publish(item.target, item.content, item.mode)
+                _exclusive_publish(item.target, item.content, 0o600)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         # No source is removed until every destination is durable and equivalent.
         for item in inspected:
+            _require_canonical_file(item.target, "canonical private-state record")
             if read_bytes(item.target, "canonical private-state record") != item.content:
                 raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
         for item in inspected:
-            metadata = _require_regular(item.source, "legacy private-state record")
+            metadata = _require_legacy_record(item.source, "legacy private-state record")
             if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
                 item.source, "legacy private-state record"
             ) != item.content:
                 raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
         for item in inspected:
             _identity_unlink(item)
+        if legacy_lock is not None and legacy_lock_identity is not None:
+            _unlink_identity_path(legacy_lock, legacy_lock_identity, "legacy cleanup lock")
         _remove_known_empty_legacy_directories(layout)
 
 
 def write_bytes(path: Path, content: bytes) -> None:
     """Atomically and durably replace one prepared canonical regular file."""
+    namespace = _state_namespace(path)
+    ensure_parent(path)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _write_bytes_locked(path, content)
+
+
+@contextmanager
+def mutation_lock(root: Path, *, admin: bool = False):
+    """Fence a caller-managed canonical transaction in global lock order."""
+    layout = topology(root)
+    _ensure_namespace(layout.common, ())
+    admin_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_context:
+        _recover_canonical_temps(layout, include_admin=admin)
+        yield
+
+
+def _write_bytes_locked(path: Path, content: bytes) -> None:
     parent_fd = _open_anchored_parent(path)
     temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
@@ -731,6 +1343,7 @@ def write_bytes(path: Path, content: bytes) -> None:
                 raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
         try:
+            os.fchmod(descriptor, 0o600)
             view = memoryview(content)
             while view:
                 written = os.write(descriptor, view)
@@ -755,8 +1368,51 @@ def write_bytes(path: Path, content: bytes) -> None:
             os.close(parent_fd)
 
 
-def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+def unlink(
+    path: Path,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+    expected_content: bytes | None = None,
+    _lock_held: bool = False,
+) -> None:
     """Remove only a canonical regular file through its verified parent."""
+    if NAMESPACE not in path.parts:
+        # A pre-cutover consumer may need to consume or roll back a validated
+        # historical authority before the upgraded implementation is committed.
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            legacy_exists = os.path.lexists(path)
+            canonical_exists = os.path.lexists(canonical)
+            if legacy_exists and canonical_exists:
+                if expected_content is None:
+                    raise GitPrivateStateError(
+                        f"legacy and canonical private-state records both exist: {path}"
+                    )
+                if read_bytes(path) != expected_content or read_bytes(canonical) != expected_content:
+                    raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+                _unlink_locked(path, expected_identity=expected_identity)
+                _unlink_locked(canonical)
+                return
+            if legacy_exists:
+                _unlink_locked(path, expected_identity=expected_identity)
+                return
+            if not canonical_exists or expected_content is None:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            if read_bytes(canonical, "canonical private-state record") != expected_content:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            _unlink_locked(canonical)
+        return
+    namespace = _state_namespace(path)
+    if _lock_held:
+        _unlink_locked(path, expected_identity=expected_identity)
+        return
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _unlink_locked(path, expected_identity=expected_identity)
+
+
+def _unlink_locked(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
     parent_fd = _open_anchored_parent(path)
     try:
         try:
@@ -779,19 +1435,26 @@ def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> N
 
 @contextmanager
 def cleanup_lock(root: Path):
-    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    """Cut over legacy cleanup locking, then acquire only the canonical lock."""
     layout = topology(root)
     _validate_canonical(layout)
     _, legacy = _scan_shared_legacy(layout)
     # Lock old consumers out while migrating cleanup/discard evidence.
-    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
-    with legacy_context:
+    legacy_context = (_file_lock(legacy, create=False, nonblocking=True)
+                      if legacy is not None else nullcontext())
+    with legacy_context as legacy_identity:
         prepare(
             root,
             common_dir=layout.common,
             admin_dir=layout.admin,
-            _legacy_lock_held=legacy is not None,
+            _legacy_lock_identity=legacy_identity,
         )
-        _ensure_namespace(layout.common, ())
-        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+        if legacy is not None:
+            # The open legacy descriptor now names the same inode as the
+            # canonical path and remains held for the whole caller operation.
             yield
+        else:
+            with _file_lock(
+                layout.common / NAMESPACE / "cleanup.lock", create=True, exact=True
+            ):
+                yield

--- a/templates/agent-base/.automation/bin/git_private_state.py
+++ b/templates/agent-base/.automation/bin/git_private_state.py
@@ -1,0 +1,797 @@
+"""Owned, fail-closed storage for Agent Core's Git-private runtime state."""
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+import subprocess
+
+
+NAMESPACE = "agent-core"
+LEGACY_NAMESPACE = "opencode"
+TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+PR_RE = re.compile(r"[1-9][0-9]*")
+HASH_RE = re.compile(r"[0-9a-f]{64}")
+SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
+FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+LOCK_FILES = {"cleanup.lock", "migration.lock"}
+_GIT_EXECUTABLE = "git"
+
+
+class GitPrivateStateError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Topology:
+    common: Path
+    admin: Path
+
+    @property
+    def admin_is_common(self) -> bool:
+        return self.admin == self.common
+
+
+@dataclass(frozen=True)
+class MigrationFile:
+    source: Path
+    target: Path
+    identity: tuple[int, int]
+    mode: int
+    content: bytes
+
+
+def _git_path(root: Path, argument: str) -> Path:
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    environment.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    })
+    result = subprocess.run(
+        [_GIT_EXECUTABLE, "-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null",
+         "-c", "core.pager=", "rev-parse", argument],
+        cwd=root, text=True, capture_output=True, check=False, env=environment,
+    )
+    raw = result.stdout.strip()
+    if result.returncode != 0 or not raw:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}")
+    candidate = Path(raw)
+    try:
+        resolved = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+        metadata = resolved.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"Git private-state location is not a directory: {resolved}")
+    return resolved
+
+
+def topology(root: Path) -> Topology:
+    return Topology(_git_path(root, "--git-common-dir"), _git_path(root, "--absolute-git-dir"))
+
+
+def common_git_dir(root: Path) -> Path:
+    return topology(root).common
+
+
+def admin_git_dir(root: Path) -> Path:
+    return topology(root).admin
+
+
+def common_state(root: Path) -> Path:
+    return common_git_dir(root) / NAMESPACE
+
+
+def admin_maintenance(root: Path) -> Path:
+    return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def cleanup_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "cleanup" / f"{task}.json"
+
+
+def discard_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "discard-pristine" / f"{task}.json"
+
+
+def integration_checkpoint(root: Path, pr: str) -> Path:
+    if PR_RE.fullmatch(pr) is None:
+        raise GitPrivateStateError("invalid pull request number")
+    return common_state(root) / "integration" / f"pr-{pr}.head"
+
+
+def _lstat(path: Path, what: str) -> os.stat_result:
+    try:
+        return path.lstat()
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect {what}: {path}") from exc
+
+
+def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def _require_regular(path: Path, what: str) -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def safe_directory(path: Path) -> None:
+    _require_dir(path)
+
+
+def _open_dir(path: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot open private-state directory: {path}") from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise GitPrivateStateError(f"unsafe private-state directory: {path}")
+    return descriptor
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open a state parent without following namespace or descendant symlinks."""
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    descriptor = _open_dir(boundary)
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for component in parts[marker:-1]:
+            child = os.open(component, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except GitPrivateStateError:
+        os.close(descriptor)
+        raise
+    except OSError as exc:
+        os.close(descriptor)
+        raise GitPrivateStateError(f"cannot traverse private-state directory: {path.parent}") from exc
+
+
+def _ensure_child_directory(parent: Path, name: str) -> Path:
+    descriptor = _open_dir(parent)
+    try:
+        try:
+            os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.fsync(descriptor)
+        except FileExistsError:
+            pass
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        child = os.open(name, flags, dir_fd=descriptor)
+        try:
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+        finally:
+            os.close(child)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state directory: {parent / name}") from exc
+    finally:
+        os.close(descriptor)
+    return parent / name
+
+
+def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
+    _require_dir(base, "Git administrative directory")
+    descriptor = _open_dir(base)
+    current = base
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for name in (NAMESPACE, *subdirectories):
+            try:
+                os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.fsync(descriptor)
+            except FileExistsError:
+                pass
+            child = os.open(name, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            os.close(descriptor)
+            descriptor = child
+            current /= name
+        return current
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state namespace below: {base}") from exc
+    finally:
+        os.close(descriptor)
+
+
+def read_bytes_identity(
+    path: Path, what: str = "private-state record"
+) -> tuple[bytes, tuple[int, int]]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe {what}: {path}")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino, metadata.st_size) != (
+                after.st_dev, after.st_ino, after.st_size
+            ):
+                raise GitPrivateStateError(f"{what} changed while reading: {path}")
+            return b"".join(chunks), (metadata.st_dev, metadata.st_ino)
+        finally:
+            os.close(descriptor)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot read {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def read_bytes(path: Path, what: str = "private-state record") -> bytes:
+    return read_bytes_identity(path, what)[0]
+
+
+def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
+    if directory in {"cleanup", "discard-pristine"}:
+        return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
+    if directory == "integration":
+        return re.fullmatch(r"pr-[1-9][0-9]*\.head", name) is not None
+    if directory == "automation-maintenance":
+        return (
+            re.fullmatch(r"[0-9a-f]{64}\.json", name) is not None
+            or (allow_fixed and name in FIXED_AUTHORITY_FILES)
+        )
+    return False
+
+
+def _legacy_json(content: bytes, path: Path) -> dict:
+    try:
+        value = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}") from exc
+    if not isinstance(value, dict):
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+    return value
+
+
+def _valid_oid(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+
+
+def _valid_digest(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+def _valid_task_id(value: object) -> bool:
+    return isinstance(value, str) and TASK_RE.fullmatch(value) is not None
+
+
+def _valid_nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _valid_absolute_path(value: object) -> bool:
+    return _valid_nonempty(value) and Path(value).is_absolute()
+
+
+def _valid_authority_fields(value: dict) -> bool:
+    return (
+        _valid_task_id(value.get("task_id"))
+        and _valid_nonempty(value.get("branch"))
+        and _valid_absolute_path(value.get("worktree"))
+        and _valid_digest(value.get("authority_nonce"))
+        and _valid_digest(value.get("receipt_sha256"))
+    )
+
+
+def _validate_legacy_content(path: Path, content: bytes) -> None:
+    directory = path.parent.name
+    name = path.name
+    if directory == "integration":
+        try:
+            text = content.decode("ascii", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
+        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
+        return
+    value = _legacy_json(content, path)
+    if directory == "cleanup":
+        required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("task") == name[:-5]
+            and value.get("status") in {"merged", "cancelled"}
+            and isinstance(value.get("worktree"), str)
+            and isinstance(value.get("branch"), str)
+            and _valid_oid(value.get("local_head"))
+            and isinstance(value.get("evidence"), dict)
+        )
+    elif directory == "discard-pristine":
+        required = {
+            "schema_version", "operation", "task", "status", "worktree", "branch",
+            "base_branch", "base_revision", "local_head", "repository",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("operation") == "discard-pristine"
+            and value.get("task") == name[:-5]
+            and value.get("status") == "initialized"
+            and all(isinstance(value.get(field), str) for field in (
+                "worktree", "branch", "base_branch", "repository"
+            ))
+            and _valid_oid(value.get("base_revision"))
+            and value.get("local_head") == value.get("base_revision")
+        )
+    elif name == "source-recovery-proof.json":
+        required = {
+            "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+            "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+            "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+            "receipt_source", "receipt_source_revision",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "source-recovery-proof"
+            and _valid_authority_fields(value)
+            and _valid_oid(value.get("authority_head"))
+            and all(_valid_digest(value.get(field)) for field in (
+                "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256",
+            ))
+            and _valid_absolute_path(value.get("implementation_source"))
+            and _valid_oid(value.get("implementation_revision"))
+            and _valid_absolute_path(value.get("receipt_source"))
+            and _valid_oid(value.get("receipt_source_revision"))
+        )
+    else:
+        standard = {"schema_version", "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"}
+        bridge = standard | {"kind", "proof_sha256"}
+        valid = (
+            (set(value) == standard and value.get("schema_version") == 1
+             and _valid_authority_fields(value))
+            or (set(value) == bridge and value.get("schema_version") == 2
+                and value.get("kind") == "source-recovery-bridge"
+                and _valid_authority_fields(value)
+                and _valid_digest(value.get("proof_sha256")))
+        )
+    if not valid:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+
+
+def _namespace_kind(path: Path, *, foreign_regular: bool) -> str:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return "absent"
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect private-state namespace: {path}") from exc
+    if stat.S_ISREG(metadata.st_mode) and foreign_regular:
+        return "foreign"
+    if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+        return "directory"
+    raise GitPrivateStateError(f"unsafe private-state namespace: {path}")
+
+
+def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path | None]:
+    root = layout.common / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return [], None
+    pairs: list[tuple[Path, Path]] = []
+    legacy_lock: Path | None = None
+    for entry in root.iterdir():
+        if entry.name == "cleanup.lock":
+            _require_regular(entry, "legacy cleanup lock")
+            legacy_lock = entry
+            continue
+        if entry.name not in SHARED_DIRS:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
+        _require_dir(entry, "legacy private-state directory")
+        for child in entry.iterdir():
+            allow_fixed = entry.name == "automation-maintenance"
+            if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
+                raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+            _require_regular(child, "legacy private-state record")
+            if child.name in FIXED_AUTHORITY_FILES:
+                if layout.admin_is_common:
+                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
+                # In a linked worktree these belong to the main worktree admin.
+            else:
+                pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    return pairs, legacy_lock
+
+
+def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
+    if layout.admin_is_common:
+        return []
+    root = layout.admin / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return []
+    entries = list(root.iterdir())
+    if any(entry.name != "automation-maintenance" for entry in entries):
+        unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+        raise GitPrivateStateError(f"unknown legacy private-state entry: {unknown}")
+    if not entries:
+        return []
+    maintenance = entries[0]
+    _require_dir(maintenance, "legacy maintenance authority directory")
+    pairs: list[tuple[Path, Path]] = []
+    for child in maintenance.iterdir():
+        if child.name not in FIXED_AUTHORITY_FILES:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+        _require_regular(child, "legacy private-state record")
+        pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    return pairs
+
+
+def _validate_canonical(layout: Topology) -> None:
+    shared = layout.common / NAMESPACE
+    kind = _namespace_kind(shared, foreign_regular=False)
+    if kind == "directory":
+        for entry in shared.iterdir():
+            if entry.name in LOCK_FILES:
+                _require_regular(entry, "canonical private-state lock")
+                continue
+            if entry.name not in SHARED_DIRS:
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
+            _require_dir(entry)
+            for child in entry.iterdir():
+                # Fixed files in common are the main worktree's admin records.
+                if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
+                    raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                _require_regular(child, "canonical private-state record")
+    if not layout.admin_is_common:
+        admin_root = layout.admin / NAMESPACE
+        kind = _namespace_kind(admin_root, foreign_regular=False)
+        if kind == "directory":
+            entries = list(admin_root.iterdir())
+            if any(entry.name != "automation-maintenance" for entry in entries):
+                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
+            if entries:
+                maintenance = entries[0]
+                _require_dir(maintenance)
+                for child in maintenance.iterdir():
+                    if child.name not in FIXED_AUTHORITY_FILES:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    _require_regular(child, "canonical private-state record")
+
+
+def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
+    inspected: list[MigrationFile] = []
+    for source, target in pairs:
+        metadata = _require_regular(source, "legacy private-state record")
+        content = read_bytes(source, "legacy private-state record")
+        _validate_legacy_content(source, content)
+        try:
+            target.lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise GitPrivateStateError(f"cannot inspect canonical private-state record: {target}") from exc
+        else:
+            if read_bytes(target, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting private-state records: {source} and {target}")
+        inspected.append(MigrationFile(
+            source, target, (metadata.st_dev, metadata.st_ino),
+            stat.S_IMODE(metadata.st_mode), content,
+        ))
+    return inspected
+
+
+def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".migrate.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            os.link(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd,
+                    follow_symlinks=False)
+            os.fsync(parent_fd)
+        except FileExistsError:
+            if read_bytes(path, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
+        published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if not stat.S_ISREG(published.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        return published.st_dev, published.st_ino
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot publish private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def ensure_parent(path: Path) -> None:
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
+    if not indexes:
+        # Legacy restoration may use only an already-existing validated parent.
+        descriptor = _open_anchored_parent(path)
+        os.close(descriptor)
+        return
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
+
+
+def exclusive_write_bytes(
+    path: Path, content: bytes, mode: int = 0o600
+) -> tuple[int, int]:
+    """Durably publish a new state record without replacing any existing object."""
+    ensure_parent(path)
+    return _exclusive_publish(path, content, mode)
+
+
+def _identity_unlink(item: MigrationFile) -> None:
+    if read_bytes(item.source, "legacy private-state record") != item.content:
+        raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+    metadata = _require_regular(item.source, "legacy private-state record")
+    if (metadata.st_dev, metadata.st_ino) != item.identity:
+        raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+    parent_fd = _open_anchored_parent(item.source)
+    try:
+        current = os.stat(item.source.name, dir_fd=parent_fd, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) != item.identity or not stat.S_ISREG(current.st_mode):
+            raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+        os.unlink(item.source.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove legacy private-state record: {item.source}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _remove_known_empty_legacy_directories(layout: Topology) -> None:
+    roots = [layout.common / LEGACY_NAMESPACE]
+    if not layout.admin_is_common:
+        roots.append(layout.admin / LEGACY_NAMESPACE)
+    for root in roots:
+        if _namespace_kind(root, foreign_regular=True) != "directory":
+            continue
+        for name in SHARED_DIRS:
+            child = root / name
+            try:
+                _require_dir(child, "legacy private-state directory")
+            except GitPrivateStateError:
+                if child.exists() or child.is_symlink():
+                    raise
+                continue
+            if not any(child.iterdir()):
+                child.rmdir()
+                descriptor = _open_dir(root)
+                try:
+                    os.fsync(descriptor)
+                finally:
+                    os.close(descriptor)
+        # The shared root remains while its mixed-version cleanup lock exists.
+        if not any(root.iterdir()):
+            root.rmdir()
+            descriptor = _open_dir(root.parent)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+
+
+@contextmanager
+def _file_lock(path: Path, *, create: bool):
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    if create:
+        flags |= os.O_CREAT
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe private-state lock: {path}")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    finally:
+        if "descriptor" in locals():
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+        os.close(parent_fd)
+
+
+def prepare(
+    root: Path,
+    *,
+    admin: bool = False,
+    common_dir: Path | None = None,
+    admin_dir: Path | None = None,
+    _legacy_lock_held: bool = False,
+) -> None:
+    """Validate and migrate known legacy state before a state mutation."""
+    layout = (
+        Topology(common_dir.resolve(), (admin_dir or common_dir).resolve())
+        if common_dir is not None
+        else topology(root)
+    )
+    _validate_canonical(layout)
+    shared_pairs, legacy_lock = _scan_shared_legacy(layout)
+    pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+    _inspect_pairs(pairs)  # preflight before creating even the migration lock
+    if legacy_lock is not None and not _legacy_lock_held:
+        with _file_lock(legacy_lock, create=False):
+            prepare(
+                root,
+                admin=admin,
+                common_dir=layout.common,
+                admin_dir=layout.admin,
+                _legacy_lock_held=True,
+            )
+        return
+
+    _ensure_namespace(layout.common, ())
+    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+        # Repeat all classification under the migration lock.
+        _validate_canonical(layout)
+        shared_pairs, _ = _scan_shared_legacy(layout)
+        pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+        inspected = _inspect_pairs(pairs)
+        for name in SHARED_DIRS:
+            _ensure_namespace(layout.common, (name,))
+        if admin:
+            _ensure_namespace(layout.admin, ("automation-maintenance",))
+        for item in inspected:
+            try:
+                item.target.lstat()
+            except FileNotFoundError:
+                _exclusive_publish(item.target, item.content, item.mode)
+        # No source is removed until every destination is durable and equivalent.
+        for item in inspected:
+            if read_bytes(item.target, "canonical private-state record") != item.content:
+                raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
+        for item in inspected:
+            metadata = _require_regular(item.source, "legacy private-state record")
+            if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
+                item.source, "legacy private-state record"
+            ) != item.content:
+                raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+        for item in inspected:
+            _identity_unlink(item)
+        _remove_known_empty_legacy_directories(layout)
+
+
+def write_bytes(path: Path, content: bytes) -> None:
+    """Atomically and durably replace one prepared canonical regular file."""
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        try:
+            current = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            if not stat.S_ISREG(current.st_mode):
+                raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot write private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+    """Remove only a canonical regular file through its verified parent."""
+    parent_fd = _open_anchored_parent(path)
+    try:
+        try:
+            metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        if expected_identity is not None and (metadata.st_dev, metadata.st_ino) != expected_identity:
+            raise GitPrivateStateError(f"private-state record identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove private-state record: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    layout = topology(root)
+    _validate_canonical(layout)
+    _, legacy = _scan_shared_legacy(layout)
+    # Lock old consumers out while migrating cleanup/discard evidence.
+    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
+    with legacy_context:
+        prepare(
+            root,
+            common_dir=layout.common,
+            admin_dir=layout.admin,
+            _legacy_lock_held=legacy is not None,
+        )
+        _ensure_namespace(layout.common, ())
+        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+            yield

--- a/templates/agent-base/.automation/bin/task_lifecycle.py
+++ b/templates/agent-base/.automation/bin/task_lifecycle.py
@@ -15,6 +15,10 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 WORK_UNIT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -1053,19 +1057,19 @@ def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
     validate_task(task)
-    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+    try:
+        return private_state.cleanup_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 @contextmanager
 def cleanup_lock(root: Path):
-    path = common_git_dir(root) / "opencode" / "cleanup.lock"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        try:
+    try:
+        with private_state.cleanup_lock(root):
             yield
-        finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 def cleanup_repository(root: Path) -> str:
@@ -1230,8 +1234,8 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
     if path.is_symlink() or not path.is_file():
         raise LifecycleError("cleanup receipt is not a regular local file")
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "cleanup receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise LifecycleError("cleanup receipt is invalid") from exc
     required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
     if (
@@ -1317,7 +1321,10 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -1332,13 +1339,18 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
 
 def task_cleanup(root: Path, task: str) -> None:
     require_main_worktree(root)
-    receipt = cleanup_receipt_path(root, task)
     with cleanup_lock(root):
+        receipt = cleanup_receipt_path(root, task)
         if receipt.exists():
             finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
             return
         plan = cleanup_plan(root, task)
-        atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise LifecycleError(str(exc)) from exc
         finish_cleanup(root, plan, receipt)
 
 

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -184,5 +184,29 @@ upgrade with changes replaces the active receipt and removes the previous consum
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
 receipt lifecycle evidence.
 
+## Git-private runtime state
+
+Agent Core owns only the `agent-core/` namespace beneath Git administrative
+directories. Shared cleanup receipts, pristine-discard receipts, integration
+checkpoints, the cleanup lock, the migration lock, and historical hashed
+maintenance authorities live beneath `<git-common-dir>/agent-core/`.
+Worktree-specific maintenance `authority.json` and
+`source-recovery-proof.json` live beneath
+`<absolute-git-dir>/agent-core/automation-maintenance/`. Repository Task State
+under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
+`opencode.json` configuration are separate ownership surfaces.
+
+The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
+file and Agent Core never changes its bytes, metadata, or identity. A legacy
+directory at that name is accepted only when every entry has an explicitly
+known historical Agent Core path and schema. Known regular records are copied byte for
+byte with durable no-overwrite publication, all conflicts are rejected before
+migration mutation, and legacy records are removed only after every canonical
+destination is verified equivalent. Equivalent dual state and partially
+completed migration are retryable. Unknown entries, unexpected nesting,
+symlinks, and special files fail closed. The historical `cleanup.lock` is
+retained as a mixed-version locking ABI and is acquired before the canonical
+lock; it is never renamed or unlinked automatically.
+
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -148,6 +148,12 @@ files unchanged. It reports `PROVENANCE_REBOUND` or idempotent
 `PROVENANCE_ALREADY_BOUND`; then run ordinary consumer verification and the
 existing `automation::commit`.
 
+Rebind is an operator-serialized maintenance transition: no commit or other
+authority mutation may run concurrently in the target worktree. Current Agent
+Core revisions additionally fence rebind and commit with the same ordered
+common/admin migration locks; the explicit quiescence requirement preserves the
+older pending consumer needed to finish an in-flight upgrade.
+
 Eligibility is exact: registered maintenance Task/worktree/branch/HEAD; one
 standard active receipt matching exactly one authority; safe pending Agent
 Core paths/fingerprints only; no consumed, source-recovery, or ambiguous state;
@@ -155,7 +161,8 @@ the old and expected revisions in the same Templates object database; and an
 identical expected canonical diff. Missing authority remains the Issue #85
 route. Committed or consumed state, including a crossed guarded publication
 boundary, is rejected. Handled
-failures roll back safely and concurrency fails closed. No cross-filesystem
+failures roll back safely; operations by current revisions fail closed under the
+shared fence. No cross-filesystem
 atomicity or hard-crash durability is claimed; that remains Issue #89 scope.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
@@ -198,15 +205,36 @@ under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
 
 The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
 file and Agent Core never changes its bytes, metadata, or identity. A legacy
-directory at that name is accepted only when every entry has an explicitly
-known historical Agent Core path and schema. Known regular records are copied byte for
-byte with durable no-overwrite publication, all conflicts are rejected before
-migration mutation, and legacy records are removed only after every canonical
-destination is verified equivalent. Equivalent dual state and partially
-completed migration are retryable. Unknown entries, unexpected nesting,
-symlinks, and special files fail closed. The historical `cleanup.lock` is
-retained as a mixed-version locking ABI and is acquired before the canonical
-lock; it is never renamed or unlinked automatically.
+directory at that name is accepted only when every entry satisfies the exact
+historical path, schema, Task/branch/worktree identity, repository syntax, and
+authority/proof relationship that Agent Core produced. The legacy namespace,
+subdirectories, records, and lock must be owned by the current effective user.
+Directories require owner access and reject group/other mutation while retaining
+historically produced read/traverse modes such as `0755`; records and locks reject
+group/other mutation and executable bits. Canonical directories
+are exactly mode `0700`, and canonical records, locks, and publication
+artifacts are exactly mode `0600`.
+
+Known records are copied byte for byte with durable no-overwrite publication,
+all conflicts are rejected before migration mutation, and legacy records are
+removed only after every canonical destination is mode-, owner-, and
+content-equivalent. The legacy cleanup-lock inode is acquired nonblocking and
+hard-linked into the canonical cleanup-lock path before its legacy name is
+removed. Existing waiters therefore remain fenced on the same inode. A
+contended legacy lock, or distinct legacy and canonical lock inodes, reports a
+precise `BLOCKED` condition rather than claiming migration success. Successful
+cutover removes the legacy lock last and then removes the empty `opencode/`
+directory, leaving the path available to OpenCode.
+
+Canonical publication is serialized by `migration.lock`. Only exact owned
+`.migrate.<pid>.<16-lowercase-hex>` and
+`.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next
+operation they are validated and durably removed under that lock before the
+legacy source is retried or an already-durable destination is used. Equivalent
+dual state, partial legacy removal, and interruption before or after durable
+publication are therefore retryable. Unknown entries, malformed temporary
+names, unsafe modes/ownership, unexpected nesting, symlinks, and special files
+fail closed without promotion.
 
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-cpp-cmake/.automation/bin/agent_core.py
+++ b/templates/agent-cpp-cmake/.automation/bin/agent_core.py
@@ -17,6 +17,7 @@ if str(SCRIPT_DIR) not in sys.path:
 import task_lifecycle as lifecycle
 import publication_metadata as publication
 import task_contract
+import git_private_state as private_state
 
 try:
     import tomllib
@@ -527,22 +528,31 @@ def validate_integration(root: Path, pr: str) -> dict:
 
 
 def integration_checkpoint(root: Path, pr: str) -> Path:
-    path = common_git_dir(root) / "opencode" / "integration" / f"pr-{pr}.head"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
+    try:
+        return private_state.integration_checkpoint(root, pr)
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
 
 
 def integrate_check(root: Path, pr: str) -> None:
     data = validate_integration(root, pr)
-    integration_checkpoint(root, pr).write_text(data["headRefOid"] + "\n", encoding="utf-8")
+    try:
+        private_state.prepare(root)
+        checkpoint = integration_checkpoint(root, pr)
+        private_state.write_bytes(checkpoint, (data["headRefOid"] + "\n").encode("utf-8"))
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
     print(json.dumps({"pr": data["number"], "head": data["headRefOid"], "status": "verified"}))
 
 
 def integrate_merge(root: Path, pr: str) -> None:
     checkpoint = integration_checkpoint(root, pr)
-    if not checkpoint.exists():
+    if not checkpoint.exists() or checkpoint.is_symlink() or not checkpoint.is_file():
         raise AutomationError("run integrate::check before merge")
-    expected = checkpoint.read_text(encoding="utf-8").strip()
+    try:
+        expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
+    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+        raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:
         raise AutomationError(f"PR head moved after integration check: expected {expected}, got {data['headRefOid']}")

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -16,6 +16,10 @@ import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 
 class UpgradeError(RuntimeError):
     pass
@@ -120,16 +124,55 @@ def worktree_admin_dir(repo: Path) -> Path:
 
 def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     admin = worktree_admin_dir(repo)
-    new_parent = admin / "opencode" / "automation-maintenance"
+    new_parent = admin / private_state.NAMESPACE / "automation-maintenance"
+    if new_parent.exists() or new_parent.is_symlink():
+        try:
+            private_state.safe_directory(admin / private_state.NAMESPACE)
+            private_state.safe_directory(new_parent)
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError(str(exc)) from exc
     try:
         resolved_parent = new_parent.resolve()
     except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy_location = _safe_legacy_location(repo)
-    legacy = legacy_location[0] if legacy_location is not None else None
+    common = common_git_dir(repo)
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    migrated = common / private_state.NAMESPACE / "automation-maintenance" / f"{key}.json"
+    if os.path.lexists(migrated):
+        try:
+            private_state.safe_directory(common / private_state.NAMESPACE)
+            private_state.safe_directory(migrated.parent)
+            private_state.read_bytes(migrated, "migrated maintenance authority")
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+        legacy = migrated
+    else:
+        old_admin = _safe_old_admin_authority(repo)
+        if old_admin is not None and os.path.lexists(old_admin[0]):
+            legacy = old_admin[0]
+        else:
+            legacy_location = _safe_legacy_location(repo)
+            legacy = legacy_location[0] if legacy_location is not None else None
     return new_parent / "authority.json", legacy
+
+
+def _safe_old_admin_authority(repo: Path) -> tuple[Path, Path] | None:
+    try:
+        admin = worktree_admin_dir(repo)
+        root = admin / "opencode"
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
+            return None
+        parent = root / "automation-maintenance"
+        if parent.is_symlink() or (parent.exists() and not parent.is_dir()):
+            return None
+        resolved = parent.resolve()
+        if resolved != admin and admin not in resolved.parents:
+            return None
+        return parent / "authority.json", admin
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
@@ -144,7 +187,7 @@ def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
             return None
         key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
         return parent / f"{key}.json", common
-    except (OSError, ValueError, RuntimeError, UpgradeError):
+    except (OSError, ValueError, RuntimeError, UpgradeError, private_state.GitPrivateStateError):
         return None
 
 
@@ -167,6 +210,15 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     _write_authority_at(
         authority_path(repo),
         {
@@ -187,33 +239,29 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             parent_before = path.parent.resolve()
             if parent_before != admin and admin not in parent_before.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        path.parent.mkdir(parents=True, exist_ok=True)
+        private_state.ensure_parent(path)
         if admin is not None:
             parent_after = path.parent.resolve()
             if parent_after != admin and admin not in parent_after.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        # The caller has validated the parent; do not replace an existing record.
-        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
-        temporary = Path(temporary_name)
-        try:
-            with os.fdopen(fd, "wb") as stream:
-                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
-                stream.flush()
-                try:
-                    os.fsync(stream.fileno())
-                except OSError:
-                    pass
-            os.link(temporary, path)
-        finally:
-            temporary.unlink(missing_ok=True)
-    except (OSError, ValueError, RuntimeError) as exc:
+        private_state.exclusive_write_bytes(
+            path,
+            json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+        )
+    except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
 
 
 def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    old_admin = _safe_old_admin_authority(repo)
+    if old_admin is not None and authority == old_admin[0]:
+        return old_admin[1]
     legacy = _safe_legacy_location(repo)
     if legacy is not None and authority == legacy[0]:
         return legacy[1]
+    common = common_git_dir(repo)
+    if authority.parent == common / private_state.NAMESPACE / "automation-maintenance":
+        return common
     if authority == authority_path(repo):
         return worktree_admin_dir(repo)
     raise UpgradeError("cannot safely resolve authority location for rollback")
@@ -227,11 +275,10 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError("missing or invalid successful-upgrade authority record")
-        authority = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        authority = json.loads(
+            private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
     expected = {
         "schema_version": 1,
@@ -253,12 +300,15 @@ def _read_json_record(path: Path, error: str) -> dict:
 
 def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError(error)
-        raw = path.read_bytes()
+        if private_state.NAMESPACE in path.parts or "opencode" in path.parts:
+            raw = private_state.read_bytes(path, error)
+        else:
+            metadata = path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+                raise UpgradeError(error)
+            raw = path.read_bytes()
         value = json.loads(raw.decode("utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(error) from exc
     if not isinstance(value, dict):
         raise UpgradeError(error)
@@ -1795,7 +1845,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         raise UpgradeError("receipt source is not compatible with the current Templates source")
     old_revision = _validate_source_revision(source, old["source_revision"])
     authority = _standard_authority_only(repo, old)
-    old_authority_raw = authority.read_bytes()
+    old_authority_raw = private_state.read_bytes(authority, "maintenance authority")
     receipt_identity = (active.lstat().st_dev, active.lstat().st_ino)
     authority_identity = (authority.lstat().st_dev, authority.lstat().st_ino)
     authority_head = validate_commit_oid(repo, old["authority_head"], field="receipt authority HEAD")
@@ -1828,7 +1878,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         current_source, current_revision = resolve_clean_source_worktree(source)
         if expected_implementation_revision is None or current_revision != expected_implementation_revision:
             raise UpgradeError("source implementation changed before provenance replacement")
-    if active.read_bytes() != raw_receipt or authority.read_bytes() != old_authority_raw or pending_paths(repo) != expected_paths \
+    if active.read_bytes() != raw_receipt or private_state.read_bytes(authority, "maintenance authority") != old_authority_raw or pending_paths(repo) != expected_paths \
             or git_head(repo) != authority_head or current_source != source \
             or (require_source_head and current_revision != expected_source_revision) \
             or (active.lstat().st_dev, active.lstat().st_ino) != receipt_identity \
@@ -2021,7 +2071,11 @@ def recover_maintenance_authority_from_source(
             if existing != proof:
                 raise UpgradeError("existing source-recovery proof does not match reconstruction")
         else:
-            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+            private_state.ensure_parent(proof_path)
+            created_proof = private_state.exclusive_write_bytes(
+                proof_path,
+                json.dumps(proof, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            )
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
         if (current_source != source
                 or current_implementation_revision != expected_implementation_revision):
@@ -2040,13 +2094,11 @@ def recover_maintenance_authority_from_source(
             raise UpgradeError("source-recovery proof changed before bridge publication")
         _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
                             admin=worktree_admin_dir(target_repo))
-    except (OSError, UpgradeError):
+    except (OSError, UpgradeError, private_state.GitPrivateStateError):
         if created_proof is not None:
             try:
-                metadata = proof_path.lstat()
-                if (metadata.st_dev, metadata.st_ino) == created_proof:
-                    proof_path.unlink()
-            except OSError as exc:
+                private_state.unlink(proof_path, expected_identity=created_proof)
+            except (OSError, private_state.GitPrivateStateError) as exc:
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
@@ -2209,7 +2261,13 @@ def _commit_mode(
         )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
-        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        try:
+            proof_raw, proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            proof_record = json.loads(proof_raw.decode("utf-8"))
+        except (private_state.GitPrivateStateError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("missing or invalid source-recovery proof") from exc
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
@@ -2221,7 +2279,7 @@ def _commit_mode(
             raise UpgradeError("source-recovery receipt source is incompatible")
         _validate_source_revision(source, receipt["source_revision"])
         authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
-        if proof_path.read_bytes() != proof_raw:
+        if private_state.read_bytes(proof_path, "source-recovery proof") != proof_raw:
             raise UpgradeError("source-recovery proof changed before commit mutation")
     else:  # pragma: no cover
         raise UpgradeError("unsupported commit mode")
@@ -2249,10 +2307,29 @@ def _commit_mode(
         atomic_json_write(consumed, consumed_receipt)
         consumed_metadata = consumed.lstat()
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
-        authority.unlink(missing_ok=True)
+        authority_raw, authority_identity = private_state.read_bytes_identity(
+            authority, "maintenance authority"
+        )
+        expected_authority = (
+            _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest())
+            if mode == "source_recovery" and proof is not None
+            else {
+                "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                "receipt_sha256": receipt_digest(receipt),
+            }
+        )
+        if json.loads(authority_raw.decode("utf-8")) != expected_authority:
+            raise UpgradeError("authority changed before commit mutation")
+        private_state.unlink(authority, expected_identity=authority_identity)
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
-            proof_path.unlink()
+            current_proof, current_proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            if current_proof != proof_raw or current_proof_identity != proof_identity:
+                raise UpgradeError("source-recovery proof changed before removal")
+            private_state.unlink(proof_path, expected_identity=proof_identity)
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2304,7 +2381,7 @@ def _commit_mode(
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except (UpgradeError, OSError) as failure:
+    except (UpgradeError, OSError, private_state.GitPrivateStateError) as failure:
         if committed:
             raise UpgradeError(
                 f"commit {commit_sha} was published but finalization failed"
@@ -2314,8 +2391,8 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
-        except (OSError, UpgradeError) as rollback_error:
+                private_state.exclusive_write_bytes(proof_path, proof_raw)
+        except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
             if authority_removed:

--- a/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
+++ b/templates/agent-cpp-cmake/.automation/bin/automation_upgrade.py
@@ -233,7 +233,13 @@ def write_authority(repo: Path, receipt: dict) -> None:
     )
 
 
-def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
+def _write_authority_at(
+    path: Path,
+    value: dict,
+    *,
+    admin: Path | None = None,
+    lock_held: bool = False,
+) -> None:
     try:
         if admin is not None:
             parent_before = path.parent.resolve()
@@ -247,6 +253,7 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
         private_state.exclusive_write_bytes(
             path,
             json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            _lock_held=lock_held,
         )
     except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
@@ -275,6 +282,7 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
+        private_state.validate_record(path, "successful-upgrade authority record")
         authority = json.loads(
             private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
         )
@@ -1642,9 +1650,10 @@ def _rename_record_at(source: str, destination: str, *, source_dir_fd: int, dest
     )
 
 
-def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
-                           receipt: dict, authority_path_value: Path,
-                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+def _replace_standard_pair_locked(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                                  receipt: dict, authority_path_value: Path,
+                                  receipt_identity: tuple[int, int],
+                                  authority_identity: tuple[int, int]) -> None:
     active = receipt_path(repo)
     admin = _rollback_authority_guard(repo, authority_path_value)
     _validate_admin_record_parent(authority_path_value, admin)
@@ -1823,6 +1832,25 @@ def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw
                 pass
 
 
+def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                           receipt: dict, authority_path_value: Path,
+                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+    """Replace a common/admin record pair under ordered namespace fences."""
+    try:
+        with private_state.mutation_lock(repo, admin=True):
+            _replace_standard_pair_locked(
+                repo,
+                old_receipt_raw,
+                old_authority_raw,
+                receipt,
+                authority_path_value,
+                receipt_identity,
+                authority_identity,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
+
+
 def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_source_revision: str,
                                    *, require_source_head: bool,
                                    expected_implementation_revision: str | None = None) -> dict:
@@ -1994,6 +2022,16 @@ def recover_maintenance_authority_from_source(
         expected_implementation_revision
     )
     task_id, branch, worktree = require_maintenance(target_repo)
+    try:
+        private_state.prepare(
+            target_repo,
+            admin=True,
+            common_dir=common_git_dir(target_repo),
+            admin_dir=worktree_admin_dir(target_repo),
+            _allow_incomplete_recovery=True,
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
     if implementation_revision != expected_implementation_revision:
         raise UpgradeError("source HEAD does not match the expected implementation revision")
@@ -2215,7 +2253,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(
+def _commit_mode_locked(
     repo: Path,
     task: str,
     message: str,
@@ -2321,7 +2359,12 @@ def _commit_mode(
         )
         if json.loads(authority_raw.decode("utf-8")) != expected_authority:
             raise UpgradeError("authority changed before commit mutation")
-        private_state.unlink(authority, expected_identity=authority_identity)
+        private_state.unlink(
+            authority,
+            expected_identity=authority_identity,
+            expected_content=authority_raw,
+            _lock_held=True,
+        )
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
             current_proof, current_proof_identity = private_state.read_bytes_identity(
@@ -2329,7 +2372,12 @@ def _commit_mode(
             )
             if current_proof != proof_raw or current_proof_identity != proof_identity:
                 raise UpgradeError("source-recovery proof changed before removal")
-            private_state.unlink(proof_path, expected_identity=proof_identity)
+            private_state.unlink(
+                proof_path,
+                expected_identity=proof_identity,
+                expected_content=proof_raw,
+                _lock_held=True,
+            )
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2391,7 +2439,9 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                private_state.exclusive_write_bytes(proof_path, proof_raw)
+                private_state.exclusive_write_bytes(
+                    proof_path, proof_raw, _lock_held=True
+                )
         except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
@@ -2401,7 +2451,12 @@ def _commit_mode(
                     "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
                     "receipt_sha256": receipt_digest(receipt),
                 }
-                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
+                _write_authority_at(
+                    authority,
+                    restored,
+                    admin=_rollback_authority_guard(repo, authority),
+                    lock_held=True,
+                )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -2446,6 +2501,35 @@ def _commit_mode(
             "mergePerformed": False,
         })
     return result
+
+
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+        with private_state.mutation_lock(repo, admin=True):
+            return _commit_mode_locked(
+                repo,
+                task,
+                message,
+                mode,
+                source_root=source_root,
+                expected_implementation_revision=expected_implementation_revision,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
 
 
 def commit(repo: Path, task: str, message: str) -> dict[str, object]:

--- a/templates/agent-cpp-cmake/.automation/bin/discard_pristine.py
+++ b/templates/agent-cpp-cmake/.automation/bin/discard_pristine.py
@@ -7,7 +7,10 @@ import re
 import sys
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
 import task_lifecycle as lifecycle
+import git_private_state as private_state
 
 
 RECEIPT_SCHEMA_VERSION = 1
@@ -18,12 +21,10 @@ REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 
 def discard_receipt_path(root: Path, task: str) -> Path:
     lifecycle.validate_task(task)
-    return (
-        lifecycle.common_git_dir(root)
-        / "opencode"
-        / "discard-pristine"
-        / f"{task}.json"
-    )
+    try:
+        return private_state.discard_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
 
 
 def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
@@ -255,8 +256,8 @@ def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
             "discard-pristine receipt is not a regular local file"
         )
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "discard-pristine receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
     required = {
         "schema_version",
@@ -394,7 +395,10 @@ def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
             "discard-pristine failed to delete the expected local Task branch"
         )
 
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -421,7 +425,12 @@ def task_discard_pristine(root: Path, task: str) -> None:
             )
             return
         plan = pristine_discard_plan(root, task)
-        lifecycle.atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise lifecycle.LifecycleError(str(exc)) from exc
         finish_pristine_discard(root, plan, receipt)
 
 

--- a/templates/agent-cpp-cmake/.automation/bin/git_private_state.py
+++ b/templates/agent-cpp-cmake/.automation/bin/git_private_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 import fcntl
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -18,9 +19,12 @@ LEGACY_NAMESPACE = "opencode"
 TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 PR_RE = re.compile(r"[1-9][0-9]*")
 HASH_RE = re.compile(r"[0-9a-f]{64}")
+OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
 FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
+TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
 
 
@@ -126,6 +130,43 @@ def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_r
     return metadata
 
 
+def _require_owned_mode(path: Path, metadata: os.stat_result, mode: int, what: str,
+                        *, exact: bool = False) -> None:
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    actual = stat.S_IMODE(metadata.st_mode)
+    unsafe = actual != mode if exact else (actual & mode) != mode
+    unsafe = unsafe or bool(actual & 0o022)
+    if unsafe:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+
+
+def _require_legacy_dir(path: Path, what: str) -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what)
+    return metadata
+
+
+def _require_legacy_record(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o400, what)
+    if metadata.st_mode & 0o111:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir(path: Path, what: str = "canonical private-state directory") -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what, exact=True)
+    return metadata
+
+
+def _require_canonical_file(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o600, what, exact=True)
+    return metadata
+
+
 def _require_regular(path: Path, what: str) -> os.stat_result:
     metadata = _lstat(path, what)
     if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
@@ -134,7 +175,10 @@ def _require_regular(path: Path, what: str) -> os.stat_result:
 
 
 def safe_directory(path: Path) -> None:
-    _require_dir(path)
+    if NAMESPACE in path.parts:
+        _require_canonical_dir(path)
+    else:
+        _require_dir(path)
 
 
 def _open_dir(path: Path) -> int:
@@ -162,7 +206,8 @@ def _open_anchored_parent(path: Path) -> int:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
             os.close(descriptor)
@@ -179,15 +224,24 @@ def _open_anchored_parent(path: Path) -> int:
 def _ensure_child_directory(parent: Path, name: str) -> Path:
     descriptor = _open_dir(parent)
     try:
+        created = False
         try:
             os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
             os.fsync(descriptor)
+            created = True
         except FileExistsError:
             pass
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         child = os.open(name, flags, dir_fd=descriptor)
         try:
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            metadata = os.fstat(child)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+            if not created and (
+                metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o700
+            ):
                 raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
         finally:
             os.close(child)
@@ -205,15 +259,22 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
     try:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
+            created = False
             try:
                 os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
                 os.fsync(descriptor)
+                created = True
             except FileExistsError:
                 pass
             child = os.open(name, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            if child_meta.st_uid != os.geteuid() or stat.S_IMODE(child_meta.st_mode) != 0o700:
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe canonical private-state directory: {current / name}")
             os.close(descriptor)
             descriptor = child
             current /= name
@@ -263,6 +324,14 @@ def read_bytes(path: Path, what: str = "private-state record") -> bytes:
     return read_bytes_identity(path, what)[0]
 
 
+def validate_record(path: Path, what: str = "private-state record") -> None:
+    """Require the ownership and mode contract for a persisted state record."""
+    if NAMESPACE in path.parts:
+        _require_canonical_file(path, what)
+    else:
+        _require_legacy_record(path, what)
+
+
 def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     if directory in {"cleanup", "discard-pristine"}:
         return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
@@ -276,6 +345,34 @@ def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     return False
 
 
+def _recover_canonical_temps(layout: Topology, *, include_admin: bool = True) -> None:
+    """Remove only our exact, owned publication artifacts while fenced."""
+    directories = [layout.common / NAMESPACE]
+    if include_admin and not layout.admin_is_common:
+        directories.append(layout.admin / NAMESPACE)
+    for namespace in directories:
+        if _namespace_kind(namespace, foreign_regular=False) != "directory":
+            continue
+        subdirs = [namespace / name for name in SHARED_DIRS]
+        for directory in subdirs:
+            if not directory.exists():
+                continue
+            _require_canonical_dir(directory)
+            for item in directory.iterdir():
+                if item.name.startswith("."):
+                    if TEMP_RE.fullmatch(item.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical temporary: {item}")
+                    metadata = _require_canonical_file(item, "canonical temporary")
+                    if metadata.st_nlink < 1 or metadata.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {item}")
+                    parent_fd = _open_anchored_parent(item)
+                    try:
+                        os.unlink(item.name, dir_fd=parent_fd)
+                        os.fsync(parent_fd)
+                    finally:
+                        os.close(parent_fd)
+
+
 def _legacy_json(content: bytes, path: Path) -> dict:
     try:
         value = json.loads(content.decode("utf-8"))
@@ -287,7 +384,7 @@ def _legacy_json(content: bytes, path: Path) -> dict:
 
 
 def _valid_oid(value: object) -> bool:
-    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+    return isinstance(value, str) and OID_RE.fullmatch(value) is not None
 
 
 def _valid_digest(value: object) -> bool:
@@ -306,14 +403,101 @@ def _valid_absolute_path(value: object) -> bool:
     return _valid_nonempty(value) and Path(value).is_absolute()
 
 
+def _valid_repository(value: object) -> bool:
+    return isinstance(value, str) and REPOSITORY_RE.fullmatch(value) is not None
+
+
+def _valid_branch_worktree(branch: object, task: object, worktree: object) -> bool:
+    if not (_valid_task_id(task) and isinstance(branch, str) and isinstance(worktree, str)):
+        return False
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        return False
+    path = Path(worktree)
+    return (path.is_absolute() and path.parent.name == ".worktrees" and
+            path.name == branch.split("/", 1)[1])
+
+
+def _valid_task_branch(branch: object, task: object) -> bool:
+    return (
+        _valid_task_id(task)
+        and isinstance(branch, str)
+        and (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-"))
+    )
+
+
 def _valid_authority_fields(value: dict) -> bool:
     return (
         _valid_task_id(value.get("task_id"))
-        and _valid_nonempty(value.get("branch"))
+        and _valid_task_branch(value.get("branch"), value.get("task_id"))
         and _valid_absolute_path(value.get("worktree"))
         and _valid_digest(value.get("authority_nonce"))
         and _valid_digest(value.get("receipt_sha256"))
     )
+
+
+def _valid_cleanup_evidence(value: dict, status: str, local_head: str) -> bool:
+    if status == "merged":
+        return (set(value) == {"repository", "pr", "published_head", "upstream"}
+                and _valid_repository(value.get("repository"))
+                and isinstance(value.get("pr"), int) and not isinstance(value.get("pr"), bool)
+                and value["pr"] > 0 and _valid_oid(value.get("published_head"))
+                and value.get("published_head").casefold() == local_head.casefold()
+                and value.get("upstream") in {"live", "deleted"})
+    return (set(value) == {"repository", "upstream", "base_revision"}
+            and _valid_repository(value.get("repository"))
+            and value.get("upstream") == "cancelled-safe"
+            and _valid_oid(value.get("base_revision")))
+
+
+def _validate_authority_filename(path: Path, content: bytes) -> None:
+    if path.parent.name != "automation-maintenance" or path.name in FIXED_AUTHORITY_FILES:
+        return
+    value = _legacy_json(content, path)
+    expected = hashlib.sha256(str(Path(value["worktree"]).resolve()).encode()).hexdigest()
+    if path.name != expected + ".json":
+        raise GitPrivateStateError(f"invalid private-state authority filename: {path}")
+
+
+def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -> Path:
+    """Bind authority ownership to a worktree registered in this topology."""
+    if path.parent.name != "automation-maintenance":
+        raise GitPrivateStateError(f"authority has an invalid parent: {path}")
+    value = _legacy_json(content, path)
+    worktree = Path(value["worktree"])
+    dot_git = worktree / ".git"
+    try:
+        metadata = dot_git.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError
+        if stat.S_ISDIR(metadata.st_mode):
+            admin = dot_git.resolve(strict=True)
+        elif stat.S_ISREG(metadata.st_mode):
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            if not marker.startswith("gitdir: "):
+                raise ValueError
+            target = Path(marker[8:])
+            admin = (target if target.is_absolute() else worktree / target).resolve(strict=True)
+        else:
+            raise ValueError
+    except (OSError, UnicodeDecodeError, ValueError, KeyError) as exc:
+        raise GitPrivateStateError(f"authority worktree is not registered: {path}") from exc
+    common = layout.common.resolve()
+    allowed = admin == common or admin == layout.admin.resolve()
+    if not allowed and admin.parent.name == "worktrees" and admin.parent.parent == common:
+        try:
+            registered_gitdir = (admin / "gitdir").read_text(encoding="utf-8").strip()
+            allowed = Path(registered_gitdir).resolve(strict=True) == dot_git.resolve(strict=True)
+        except (OSError, UnicodeDecodeError):
+            allowed = False
+    if not allowed:
+        raise GitPrivateStateError(f"authority worktree is outside Git topology: {path}")
+    try:
+        head = (admin / "HEAD").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise GitPrivateStateError(f"authority worktree registration is unreadable: {path}") from exc
+    if head != f"ref: refs/heads/{value['branch']}":
+        raise GitPrivateStateError(f"authority branch does not match worktree registration: {path}")
+    return admin
 
 
 def _validate_legacy_content(path: Path, content: bytes) -> None:
@@ -324,7 +508,8 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             text = content.decode("ascii", errors="strict")
         except UnicodeDecodeError as exc:
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
-        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+        if (not text.endswith("\n") or not _valid_oid(text[:-1]) or
+                text[:-1] != text[:-1].lower()):
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
         return
     value = _legacy_json(content, path)
@@ -335,10 +520,10 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("schema_version") == 1
             and value.get("task") == name[:-5]
             and value.get("status") in {"merged", "cancelled"}
-            and isinstance(value.get("worktree"), str)
-            and isinstance(value.get("branch"), str)
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
             and _valid_oid(value.get("local_head"))
             and isinstance(value.get("evidence"), dict)
+            and _valid_cleanup_evidence(value["evidence"], value["status"], value["local_head"])
         )
     elif directory == "discard-pristine":
         required = {
@@ -351,11 +536,12 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("operation") == "discard-pristine"
             and value.get("task") == name[:-5]
             and value.get("status") == "initialized"
-            and all(isinstance(value.get(field), str) for field in (
-                "worktree", "branch", "base_branch", "repository"
-            ))
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_repository(value.get("repository"))
             and _valid_oid(value.get("base_revision"))
-            and value.get("local_head") == value.get("base_revision")
+            and _valid_oid(value.get("local_head"))
+            and value.get("local_head").casefold() == value.get("base_revision").casefold()
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -413,26 +599,40 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
     if kind != "directory":
         return [], None
     pairs: list[tuple[Path, Path]] = []
+    _require_legacy_dir(root, "legacy private-state directory")
     legacy_lock: Path | None = None
     for entry in root.iterdir():
         if entry.name == "cleanup.lock":
-            _require_regular(entry, "legacy cleanup lock")
+            metadata = _require_regular(entry, "legacy cleanup lock")
+            _require_owned_mode(entry, metadata, 0o600, "legacy cleanup lock")
+            if metadata.st_mode & 0o111:
+                raise GitPrivateStateError(f"unsafe legacy cleanup lock mode: {entry}")
             legacy_lock = entry
             continue
         if entry.name not in SHARED_DIRS:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
-        _require_dir(entry, "legacy private-state directory")
+        _require_legacy_dir(entry, "legacy private-state directory")
         for child in entry.iterdir():
             allow_fixed = entry.name == "automation-maintenance"
             if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
                 raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-            _require_regular(child, "legacy private-state record")
+            _require_legacy_record(child, "legacy private-state record")
+            if entry.name == "automation-maintenance":
+                content = read_bytes(child)
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                authority_admin = _validate_authority_topology(child, content, layout)
             if child.name in FIXED_AUTHORITY_FILES:
-                if layout.admin_is_common:
-                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
-                # In a linked worktree these belong to the main worktree admin.
+                if authority_admin not in {layout.common, layout.admin}:
+                    raise GitPrivateStateError(
+                        f"fixed authority belongs to a different worktree admin: {child}"
+                    )
+                pairs.append((child, authority_admin / NAMESPACE / entry.name / child.name))
             else:
                 pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs, legacy_lock
 
 
@@ -450,55 +650,211 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
     if not entries:
         return []
     maintenance = entries[0]
-    _require_dir(maintenance, "legacy maintenance authority directory")
+    _require_legacy_dir(maintenance, "legacy maintenance authority directory")
     pairs: list[tuple[Path, Path]] = []
     for child in maintenance.iterdir():
         if child.name not in FIXED_AUTHORITY_FILES:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-        _require_regular(child, "legacy private-state record")
+        _require_legacy_record(child, "legacy private-state record")
+        content = read_bytes(child)
+        _validate_legacy_content(child, content)
+        _validate_authority_filename(child, content)
+        if _validate_authority_topology(child, content, layout) != layout.admin:
+            raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs
 
 
-def _validate_canonical(layout: Topology) -> None:
+def _validate_legacy_relations(root: Path, canonical_roots: tuple[Path, Path]) -> None:
+    maintenance = root / "automation-maintenance"
+    if not maintenance.is_dir():
+        return
+    proof = maintenance / "source-recovery-proof.json"
+    authority = maintenance / "authority.json"
+    if authority.exists() and not proof.exists():
+        authority_value = _legacy_json(
+            read_bytes(authority, "legacy maintenance authority"), authority
+        )
+        if authority_value.get("kind") == "source-recovery-bridge":
+            canonical_proofs = [
+                candidate / "automation-maintenance" / "source-recovery-proof.json"
+                for candidate in canonical_roots
+            ]
+            canonical_proof = next((candidate for candidate in canonical_proofs
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        authority_value,
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                    )), None)
+            if canonical_proof is None:
+                raise GitPrivateStateError(
+                    f"legacy source-recovery bridge lacks its proof: {root}"
+                )
+            proof = canonical_proof
+        else:
+            return
+    if proof.exists() and not authority.exists():
+        canonical_authorities = [
+            candidate / "automation-maintenance" / "authority.json"
+            for candidate in canonical_roots
+        ]
+        proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+        canonical_authority = next((candidate for candidate in canonical_authorities
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                        proof_value,
+                                    )), None)
+        if canonical_authority is None:
+            raise GitPrivateStateError(
+                f"legacy source-recovery proof lacks its bridge: {root}"
+            )
+        authority = canonical_authority
+    if not proof.exists() or not authority.exists():
+        return
+    proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+    authority_value = _legacy_json(read_bytes(authority, "legacy maintenance authority"), authority)
+    if not _recovery_pair_matches(authority_value, proof_value):
+        raise GitPrivateStateError(f"conflicting legacy authority and proof identity: {root}")
+
+
+def _recovery_pair_matches(authority: dict, proof: dict) -> bool:
+    if authority.get("kind") != "source-recovery-bridge":
+        return False
+    if any(proof.get(field) != authority.get(field) for field in (
+        "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"
+    )):
+        return False
+    digest = hashlib.sha256(
+        json.dumps(proof, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return authority.get("proof_sha256") == digest
+
+
+def _validate_canonical(
+    layout: Topology, *, allow_incomplete_recovery: bool = False
+) -> None:
     shared = layout.common / NAMESPACE
     kind = _namespace_kind(shared, foreign_regular=False)
     if kind == "directory":
+        _require_canonical_dir(shared)
         for entry in shared.iterdir():
             if entry.name in LOCK_FILES:
-                _require_regular(entry, "canonical private-state lock")
+                _require_canonical_file(entry, "canonical private-state lock")
                 continue
             if entry.name not in SHARED_DIRS:
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
-            _require_dir(entry)
+            _require_canonical_dir(entry)
             for child in entry.iterdir():
+                if child.name.startswith("."):
+                    if TEMP_RE.fullmatch(child.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    temporary = _require_canonical_file(child, "canonical temporary")
+                    if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                    continue
                 # Fixed files in common are the main worktree's admin records.
                 if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
                     raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                _require_regular(child, "canonical private-state record")
+                _require_canonical_file(child, "canonical private-state record")
+                content = read_bytes(child, "canonical private-state record")
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                if entry.name == "automation-maintenance":
+                    authority_admin = _validate_authority_topology(child, content, layout)
+                    if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
     if not layout.admin_is_common:
         admin_root = layout.admin / NAMESPACE
         kind = _namespace_kind(admin_root, foreign_regular=False)
         if kind == "directory":
+            _require_canonical_dir(admin_root)
             entries = list(admin_root.iterdir())
-            if any(entry.name != "automation-maintenance" for entry in entries):
-                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+            if any(entry.name not in {"automation-maintenance", "migration.lock"} for entry in entries):
+                unknown = next(
+                    entry for entry in entries
+                    if entry.name not in {"automation-maintenance", "migration.lock"}
+                )
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
-            if entries:
-                maintenance = entries[0]
-                _require_dir(maintenance)
+            lock = admin_root / "migration.lock"
+            if lock.exists():
+                _require_canonical_file(lock, "canonical private-state lock")
+            maintenance = admin_root / "automation-maintenance"
+            if maintenance.exists():
+                _require_canonical_dir(maintenance)
                 for child in maintenance.iterdir():
+                    if child.name.startswith("."):
+                        if TEMP_RE.fullmatch(child.name) is None:
+                            raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                        temporary = _require_canonical_file(child, "canonical temporary")
+                        if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                            raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                        continue
                     if child.name not in FIXED_AUTHORITY_FILES:
                         raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                    _require_regular(child, "canonical private-state record")
+                    _require_canonical_file(child, "canonical private-state record")
+                    content = read_bytes(child, "canonical private-state record")
+                    _validate_legacy_content(child, content)
+                    _validate_authority_filename(child, content)
+                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
+
+    # Canonical maintenance authority is fixed to the administrative topology;
+    # a bridge, when present, must name the exact canonical proof bytes.
+    for namespace in {layout.common / NAMESPACE, layout.admin / NAMESPACE}:
+        proof = namespace / "automation-maintenance" / "source-recovery-proof.json"
+        bridge = namespace / "automation-maintenance" / "authority.json"
+        proof_exists = proof.is_file()
+        bridge_exists = bridge.is_file()
+        if proof_exists and not bridge_exists:
+            legacy_bridges = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+            }
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            if not allow_incomplete_recovery and not any(candidate.is_file() and _recovery_pair_matches(
+                _legacy_json(read_bytes(candidate), candidate), proof_value
+            ) for candidate in legacy_bridges):
+                raise GitPrivateStateError(f"source-recovery proof lacks bridge authority: {namespace}")
+        if bridge_exists:
+            bridge_value = _legacy_json(read_bytes(bridge), bridge)
+            is_bridge = bridge_value.get("kind") == "source-recovery-bridge"
+            legacy_proofs = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+            }
+            if is_bridge and not proof_exists and not any(
+                candidate.is_file() and _recovery_pair_matches(
+                    bridge_value, _legacy_json(read_bytes(candidate), candidate)
+                ) for candidate in legacy_proofs
+            ):
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+            if not is_bridge and proof_exists:
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+        if proof_exists and bridge_exists:
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            for field in ("task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"):
+                if proof_value.get(field) != bridge_value.get(field):
+                    raise GitPrivateStateError(f"conflicting authority and proof identity: {namespace}")
+            digest = hashlib.sha256(
+                json.dumps(proof_value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
+            if bridge_value.get("proof_sha256") != digest:
+                raise GitPrivateStateError(f"source-recovery proof digest mismatch: {namespace}")
 
 
 def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
     inspected: list[MigrationFile] = []
     for source, target in pairs:
-        metadata = _require_regular(source, "legacy private-state record")
+        metadata = _require_legacy_record(source, "legacy private-state record")
         content = read_bytes(source, "legacy private-state record")
         _validate_legacy_content(source, content)
+        _validate_authority_filename(source, content)
         try:
             target.lstat()
         except FileNotFoundError:
@@ -537,10 +893,15 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
                     follow_symlinks=False)
             os.fsync(parent_fd)
         except FileExistsError:
+            _require_canonical_file(path, "canonical private-state record")
             if read_bytes(path, "canonical private-state record") != content:
                 raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
         published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
-        if not stat.S_ISREG(published.st_mode):
+        if (
+            not stat.S_ISREG(published.st_mode)
+            or published.st_uid != os.geteuid()
+            or stat.S_IMODE(published.st_mode) != 0o600
+        ):
             raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         return published.st_dev, published.st_ino
     except GitPrivateStateError:
@@ -556,6 +917,36 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
             os.close(parent_fd)
 
 
+def _exclusive_publish_direct(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    """Restore an absent legacy record without a visible temporary artifact."""
+    parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            path.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            mode,
+            dir_fd=parent_fd,
+        )
+        os.fchmod(descriptor, mode)
+        view = memoryview(content)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short private-state write")
+            view = view[written:]
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        os.fsync(parent_fd)
+        return metadata.st_dev, metadata.st_ino
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot restore legacy private-state record: {path}") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
 def ensure_parent(path: Path) -> None:
     parts = path.parts
     indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
@@ -569,18 +960,53 @@ def ensure_parent(path: Path) -> None:
     _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
 
 
+def _state_namespace(path: Path) -> Path:
+    """Return the namespace containing a canonical state path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside canonical private-state namespace: {path}")
+    return Path(*path.parts[: indexes[-1] + 1])
+
+
+def _legacy_equivalent(path: Path) -> tuple[Path, Path]:
+    """Return the state root and canonical equivalent of one legacy path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == LEGACY_NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside legacy private-state namespace: {path}")
+    marker = indexes[-1]
+    state_root = Path(*path.parts[:marker])
+    relative = Path(*path.parts[marker + 1:])
+    return state_root, state_root / NAMESPACE / relative
+
+
 def exclusive_write_bytes(
-    path: Path, content: bytes, mode: int = 0o600
+    path: Path, content: bytes, mode: int = 0o600, *, _lock_held: bool = False
 ) -> tuple[int, int]:
     """Durably publish a new state record without replacing any existing object."""
+    if NAMESPACE not in path.parts:
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            if os.path.lexists(path):
+                raise GitPrivateStateError(f"legacy private-state record already exists: {path}")
+            target = canonical if not (state_root / LEGACY_NAMESPACE).exists() else path
+            ensure_parent(target)
+            if target == canonical:
+                return _exclusive_publish(target, content, 0o600)
+            return _exclusive_publish_direct(target, content, mode)
     ensure_parent(path)
-    return _exclusive_publish(path, content, mode)
+    namespace = _state_namespace(path)
+    if _lock_held:
+        return _exclusive_publish(path, content, 0o600)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        return _exclusive_publish(path, content, 0o600)
 
 
 def _identity_unlink(item: MigrationFile) -> None:
     if read_bytes(item.source, "legacy private-state record") != item.content:
         raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
-    metadata = _require_regular(item.source, "legacy private-state record")
+    metadata = _require_legacy_record(item.source, "legacy private-state record")
     if (metadata.st_dev, metadata.st_ino) != item.identity:
         raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
     parent_fd = _open_anchored_parent(item.source)
@@ -598,6 +1024,118 @@ def _identity_unlink(item: MigrationFile) -> None:
         os.close(parent_fd)
 
 
+def _unlink_identity_path(path: Path, identity: tuple[int, int], what: str) -> None:
+    parent_fd = _open_anchored_parent(path)
+    try:
+        metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if ((metadata.st_dev, metadata.st_ino) != identity or
+                not stat.S_ISREG(metadata.st_mode)):
+            raise GitPrivateStateError(f"{what} identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _handoff_cleanup_lock(
+    legacy: Path, canonical: Path, expected_identity: tuple[int, int]
+) -> tuple[int, int]:
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    if (legacy_meta.st_dev, legacy_meta.st_ino) != expected_identity:
+        raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+    legacy_parent_fd = _open_anchored_parent(legacy)
+    canonical_parent_fd = _open_anchored_parent(canonical)
+    try:
+        legacy_fd = os.open(
+            legacy.name,
+            os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=legacy_parent_fd,
+        )
+        try:
+            opened = os.fstat(legacy_fd)
+            if (opened.st_dev, opened.st_ino) != expected_identity:
+                raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+            os.fchmod(legacy_fd, 0o600)
+            os.fsync(legacy_fd)
+        finally:
+            os.close(legacy_fd)
+    finally:
+        os.close(legacy_parent_fd)
+    try:
+        try:
+            canonical_meta = os.stat(
+                canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+            )
+        except FileNotFoundError:
+            canonical_meta = None
+        if canonical_meta is not None:
+            if (
+                not stat.S_ISREG(canonical_meta.st_mode)
+                or canonical_meta.st_uid != os.geteuid()
+                or stat.S_IMODE(canonical_meta.st_mode) != 0o600
+            ):
+                raise GitPrivateStateError(f"unsafe canonical cleanup lock: {canonical}")
+            if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+                expected_identity
+            ):
+                raise GitPrivateStateError(
+                    "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+                    "automatic cutover cannot prove a single cleanup fence"
+                )
+        else:
+            try:
+                source_fd = _open_anchored_parent(legacy)
+                try:
+                    os.link(
+                        legacy.name,
+                        canonical.name,
+                        src_dir_fd=source_fd,
+                        dst_dir_fd=canonical_parent_fd,
+                        follow_symlinks=False,
+                    )
+                finally:
+                    os.close(source_fd)
+                os.fsync(canonical_parent_fd)
+                published = os.stat(
+                    canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+                )
+                if (published.st_dev, published.st_ino) != expected_identity:
+                    raise GitPrivateStateError(
+                        f"legacy cleanup lock identity changed during handoff: {legacy}"
+                    )
+            except OSError as exc:
+                raise GitPrivateStateError(
+                    f"cannot establish cleanup lock handoff: {canonical}"
+                ) from exc
+    finally:
+        os.close(canonical_parent_fd)
+    return expected_identity
+
+
+def _preflight_cleanup_lock_handoff(legacy: Path | None, canonical: Path) -> None:
+    if legacy is None:
+        return
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    try:
+        canonical_meta = canonical.lstat()
+    except FileNotFoundError:
+        return
+    _require_canonical_file(canonical, "canonical cleanup lock")
+    if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+        legacy_meta.st_dev, legacy_meta.st_ino
+    ):
+        raise GitPrivateStateError(
+            "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+            "automatic cutover cannot prove a single cleanup fence"
+        )
+
+
 def _remove_known_empty_legacy_directories(layout: Topology) -> None:
     roots = [layout.common / LEGACY_NAMESPACE]
     if not layout.admin_is_common:
@@ -608,7 +1146,7 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
         for name in SHARED_DIRS:
             child = root / name
             try:
-                _require_dir(child, "legacy private-state directory")
+                _require_legacy_dir(child, "legacy private-state directory")
             except GitPrivateStateError:
                 if child.exists() or child.is_symlink():
                     raise
@@ -620,7 +1158,6 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
                     os.fsync(descriptor)
                 finally:
                     os.close(descriptor)
-        # The shared root remains while its mixed-version cleanup lock exists.
         if not any(root.iterdir()):
             root.rmdir()
             descriptor = _open_dir(root.parent)
@@ -631,24 +1168,46 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
 
 
 @contextmanager
-def _file_lock(path: Path, *, create: bool):
+def _file_lock(path: Path, *, create: bool, nonblocking: bool = False, exact: bool = False):
     flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-    if create:
-        flags |= os.O_CREAT
     parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
     try:
-        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        if create:
+            try:
+                descriptor = os.open(path.name, flags | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=parent_fd)
+                os.fchmod(descriptor, 0o600)
+                os.fsync(parent_fd)
+            except FileExistsError:
+                descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        else:
+            descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise GitPrivateStateError(f"unsafe private-state lock: {path}")
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        yield
+        if metadata.st_uid != os.geteuid() or (exact and stat.S_IMODE(metadata.st_mode) != 0o600) or (
+                not exact and (stat.S_IMODE(metadata.st_mode) & 0o022 or metadata.st_mode & 0o111 or
+                               not (metadata.st_mode & 0o600))):
+            raise GitPrivateStateError(f"unsafe private-state lock mode or ownership: {path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0))
+        except BlockingIOError as exc:
+            raise GitPrivateStateError(f"BLOCKED: private-state lock is contended: {path}") from exc
     except GitPrivateStateError:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise
     except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    try:
+        locked = os.fstat(descriptor)
+        yield (locked.st_dev, locked.st_ino)
     finally:
-        if "descriptor" in locals():
+        if descriptor is not None:
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_UN)
             finally:
@@ -662,7 +1221,8 @@ def prepare(
     admin: bool = False,
     common_dir: Path | None = None,
     admin_dir: Path | None = None,
-    _legacy_lock_held: bool = False,
+    _legacy_lock_identity: tuple[int, int] | None = None,
+    _allow_incomplete_recovery: bool = False,
 ) -> None:
     """Validate and migrate known legacy state before a state mutation."""
     layout = (
@@ -670,25 +1230,38 @@ def prepare(
         if common_dir is not None
         else topology(root)
     )
-    _validate_canonical(layout)
+    _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
     shared_pairs, legacy_lock = _scan_shared_legacy(layout)
     pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
     _inspect_pairs(pairs)  # preflight before creating even the migration lock
-    if legacy_lock is not None and not _legacy_lock_held:
-        with _file_lock(legacy_lock, create=False):
+    if legacy_lock is not None and _legacy_lock_identity is None:
+        with _file_lock(legacy_lock, create=False, nonblocking=True) as lock_identity:
             prepare(
                 root,
                 admin=admin,
                 common_dir=layout.common,
                 admin_dir=layout.admin,
-                _legacy_lock_held=True,
+                _legacy_lock_identity=lock_identity,
+                _allow_incomplete_recovery=_allow_incomplete_recovery,
             )
         return
 
+    _preflight_cleanup_lock_handoff(
+        legacy_lock, layout.common / NAMESPACE / "cleanup.lock"
+    )
     _ensure_namespace(layout.common, ())
-    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+    admin_lock_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_lock_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_lock_context:
         # Repeat all classification under the migration lock.
-        _validate_canonical(layout)
+        _recover_canonical_temps(layout, include_admin=admin)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         shared_pairs, _ = _scan_shared_legacy(layout)
         pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
         inspected = _inspect_pairs(pairs)
@@ -696,28 +1269,67 @@ def prepare(
             _ensure_namespace(layout.common, (name,))
         if admin:
             _ensure_namespace(layout.admin, ("automation-maintenance",))
+        legacy_lock_identity = None
+        if legacy_lock is not None:
+            if _legacy_lock_identity is None:
+                raise GitPrivateStateError("legacy cleanup lock is not held for handoff")
+            legacy_lock_identity = _handoff_cleanup_lock(
+                legacy_lock,
+                layout.common / NAMESPACE / "cleanup.lock",
+                _legacy_lock_identity,
+            )
         for item in inspected:
             try:
                 item.target.lstat()
             except FileNotFoundError:
-                _exclusive_publish(item.target, item.content, item.mode)
+                _exclusive_publish(item.target, item.content, 0o600)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         # No source is removed until every destination is durable and equivalent.
         for item in inspected:
+            _require_canonical_file(item.target, "canonical private-state record")
             if read_bytes(item.target, "canonical private-state record") != item.content:
                 raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
         for item in inspected:
-            metadata = _require_regular(item.source, "legacy private-state record")
+            metadata = _require_legacy_record(item.source, "legacy private-state record")
             if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
                 item.source, "legacy private-state record"
             ) != item.content:
                 raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
         for item in inspected:
             _identity_unlink(item)
+        if legacy_lock is not None and legacy_lock_identity is not None:
+            _unlink_identity_path(legacy_lock, legacy_lock_identity, "legacy cleanup lock")
         _remove_known_empty_legacy_directories(layout)
 
 
 def write_bytes(path: Path, content: bytes) -> None:
     """Atomically and durably replace one prepared canonical regular file."""
+    namespace = _state_namespace(path)
+    ensure_parent(path)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _write_bytes_locked(path, content)
+
+
+@contextmanager
+def mutation_lock(root: Path, *, admin: bool = False):
+    """Fence a caller-managed canonical transaction in global lock order."""
+    layout = topology(root)
+    _ensure_namespace(layout.common, ())
+    admin_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_context:
+        _recover_canonical_temps(layout, include_admin=admin)
+        yield
+
+
+def _write_bytes_locked(path: Path, content: bytes) -> None:
     parent_fd = _open_anchored_parent(path)
     temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
@@ -731,6 +1343,7 @@ def write_bytes(path: Path, content: bytes) -> None:
                 raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
         try:
+            os.fchmod(descriptor, 0o600)
             view = memoryview(content)
             while view:
                 written = os.write(descriptor, view)
@@ -755,8 +1368,51 @@ def write_bytes(path: Path, content: bytes) -> None:
             os.close(parent_fd)
 
 
-def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+def unlink(
+    path: Path,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+    expected_content: bytes | None = None,
+    _lock_held: bool = False,
+) -> None:
     """Remove only a canonical regular file through its verified parent."""
+    if NAMESPACE not in path.parts:
+        # A pre-cutover consumer may need to consume or roll back a validated
+        # historical authority before the upgraded implementation is committed.
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            legacy_exists = os.path.lexists(path)
+            canonical_exists = os.path.lexists(canonical)
+            if legacy_exists and canonical_exists:
+                if expected_content is None:
+                    raise GitPrivateStateError(
+                        f"legacy and canonical private-state records both exist: {path}"
+                    )
+                if read_bytes(path) != expected_content or read_bytes(canonical) != expected_content:
+                    raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+                _unlink_locked(path, expected_identity=expected_identity)
+                _unlink_locked(canonical)
+                return
+            if legacy_exists:
+                _unlink_locked(path, expected_identity=expected_identity)
+                return
+            if not canonical_exists or expected_content is None:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            if read_bytes(canonical, "canonical private-state record") != expected_content:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            _unlink_locked(canonical)
+        return
+    namespace = _state_namespace(path)
+    if _lock_held:
+        _unlink_locked(path, expected_identity=expected_identity)
+        return
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _unlink_locked(path, expected_identity=expected_identity)
+
+
+def _unlink_locked(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
     parent_fd = _open_anchored_parent(path)
     try:
         try:
@@ -779,19 +1435,26 @@ def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> N
 
 @contextmanager
 def cleanup_lock(root: Path):
-    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    """Cut over legacy cleanup locking, then acquire only the canonical lock."""
     layout = topology(root)
     _validate_canonical(layout)
     _, legacy = _scan_shared_legacy(layout)
     # Lock old consumers out while migrating cleanup/discard evidence.
-    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
-    with legacy_context:
+    legacy_context = (_file_lock(legacy, create=False, nonblocking=True)
+                      if legacy is not None else nullcontext())
+    with legacy_context as legacy_identity:
         prepare(
             root,
             common_dir=layout.common,
             admin_dir=layout.admin,
-            _legacy_lock_held=legacy is not None,
+            _legacy_lock_identity=legacy_identity,
         )
-        _ensure_namespace(layout.common, ())
-        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+        if legacy is not None:
+            # The open legacy descriptor now names the same inode as the
+            # canonical path and remains held for the whole caller operation.
             yield
+        else:
+            with _file_lock(
+                layout.common / NAMESPACE / "cleanup.lock", create=True, exact=True
+            ):
+                yield

--- a/templates/agent-cpp-cmake/.automation/bin/git_private_state.py
+++ b/templates/agent-cpp-cmake/.automation/bin/git_private_state.py
@@ -1,0 +1,797 @@
+"""Owned, fail-closed storage for Agent Core's Git-private runtime state."""
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+import subprocess
+
+
+NAMESPACE = "agent-core"
+LEGACY_NAMESPACE = "opencode"
+TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+PR_RE = re.compile(r"[1-9][0-9]*")
+HASH_RE = re.compile(r"[0-9a-f]{64}")
+SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
+FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+LOCK_FILES = {"cleanup.lock", "migration.lock"}
+_GIT_EXECUTABLE = "git"
+
+
+class GitPrivateStateError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Topology:
+    common: Path
+    admin: Path
+
+    @property
+    def admin_is_common(self) -> bool:
+        return self.admin == self.common
+
+
+@dataclass(frozen=True)
+class MigrationFile:
+    source: Path
+    target: Path
+    identity: tuple[int, int]
+    mode: int
+    content: bytes
+
+
+def _git_path(root: Path, argument: str) -> Path:
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    environment.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    })
+    result = subprocess.run(
+        [_GIT_EXECUTABLE, "-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null",
+         "-c", "core.pager=", "rev-parse", argument],
+        cwd=root, text=True, capture_output=True, check=False, env=environment,
+    )
+    raw = result.stdout.strip()
+    if result.returncode != 0 or not raw:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}")
+    candidate = Path(raw)
+    try:
+        resolved = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+        metadata = resolved.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"Git private-state location is not a directory: {resolved}")
+    return resolved
+
+
+def topology(root: Path) -> Topology:
+    return Topology(_git_path(root, "--git-common-dir"), _git_path(root, "--absolute-git-dir"))
+
+
+def common_git_dir(root: Path) -> Path:
+    return topology(root).common
+
+
+def admin_git_dir(root: Path) -> Path:
+    return topology(root).admin
+
+
+def common_state(root: Path) -> Path:
+    return common_git_dir(root) / NAMESPACE
+
+
+def admin_maintenance(root: Path) -> Path:
+    return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def cleanup_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "cleanup" / f"{task}.json"
+
+
+def discard_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "discard-pristine" / f"{task}.json"
+
+
+def integration_checkpoint(root: Path, pr: str) -> Path:
+    if PR_RE.fullmatch(pr) is None:
+        raise GitPrivateStateError("invalid pull request number")
+    return common_state(root) / "integration" / f"pr-{pr}.head"
+
+
+def _lstat(path: Path, what: str) -> os.stat_result:
+    try:
+        return path.lstat()
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect {what}: {path}") from exc
+
+
+def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def _require_regular(path: Path, what: str) -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def safe_directory(path: Path) -> None:
+    _require_dir(path)
+
+
+def _open_dir(path: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot open private-state directory: {path}") from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise GitPrivateStateError(f"unsafe private-state directory: {path}")
+    return descriptor
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open a state parent without following namespace or descendant symlinks."""
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    descriptor = _open_dir(boundary)
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for component in parts[marker:-1]:
+            child = os.open(component, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except GitPrivateStateError:
+        os.close(descriptor)
+        raise
+    except OSError as exc:
+        os.close(descriptor)
+        raise GitPrivateStateError(f"cannot traverse private-state directory: {path.parent}") from exc
+
+
+def _ensure_child_directory(parent: Path, name: str) -> Path:
+    descriptor = _open_dir(parent)
+    try:
+        try:
+            os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.fsync(descriptor)
+        except FileExistsError:
+            pass
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        child = os.open(name, flags, dir_fd=descriptor)
+        try:
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+        finally:
+            os.close(child)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state directory: {parent / name}") from exc
+    finally:
+        os.close(descriptor)
+    return parent / name
+
+
+def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
+    _require_dir(base, "Git administrative directory")
+    descriptor = _open_dir(base)
+    current = base
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for name in (NAMESPACE, *subdirectories):
+            try:
+                os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.fsync(descriptor)
+            except FileExistsError:
+                pass
+            child = os.open(name, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            os.close(descriptor)
+            descriptor = child
+            current /= name
+        return current
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state namespace below: {base}") from exc
+    finally:
+        os.close(descriptor)
+
+
+def read_bytes_identity(
+    path: Path, what: str = "private-state record"
+) -> tuple[bytes, tuple[int, int]]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe {what}: {path}")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino, metadata.st_size) != (
+                after.st_dev, after.st_ino, after.st_size
+            ):
+                raise GitPrivateStateError(f"{what} changed while reading: {path}")
+            return b"".join(chunks), (metadata.st_dev, metadata.st_ino)
+        finally:
+            os.close(descriptor)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot read {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def read_bytes(path: Path, what: str = "private-state record") -> bytes:
+    return read_bytes_identity(path, what)[0]
+
+
+def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
+    if directory in {"cleanup", "discard-pristine"}:
+        return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
+    if directory == "integration":
+        return re.fullmatch(r"pr-[1-9][0-9]*\.head", name) is not None
+    if directory == "automation-maintenance":
+        return (
+            re.fullmatch(r"[0-9a-f]{64}\.json", name) is not None
+            or (allow_fixed and name in FIXED_AUTHORITY_FILES)
+        )
+    return False
+
+
+def _legacy_json(content: bytes, path: Path) -> dict:
+    try:
+        value = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}") from exc
+    if not isinstance(value, dict):
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+    return value
+
+
+def _valid_oid(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+
+
+def _valid_digest(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+def _valid_task_id(value: object) -> bool:
+    return isinstance(value, str) and TASK_RE.fullmatch(value) is not None
+
+
+def _valid_nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _valid_absolute_path(value: object) -> bool:
+    return _valid_nonempty(value) and Path(value).is_absolute()
+
+
+def _valid_authority_fields(value: dict) -> bool:
+    return (
+        _valid_task_id(value.get("task_id"))
+        and _valid_nonempty(value.get("branch"))
+        and _valid_absolute_path(value.get("worktree"))
+        and _valid_digest(value.get("authority_nonce"))
+        and _valid_digest(value.get("receipt_sha256"))
+    )
+
+
+def _validate_legacy_content(path: Path, content: bytes) -> None:
+    directory = path.parent.name
+    name = path.name
+    if directory == "integration":
+        try:
+            text = content.decode("ascii", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
+        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
+        return
+    value = _legacy_json(content, path)
+    if directory == "cleanup":
+        required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("task") == name[:-5]
+            and value.get("status") in {"merged", "cancelled"}
+            and isinstance(value.get("worktree"), str)
+            and isinstance(value.get("branch"), str)
+            and _valid_oid(value.get("local_head"))
+            and isinstance(value.get("evidence"), dict)
+        )
+    elif directory == "discard-pristine":
+        required = {
+            "schema_version", "operation", "task", "status", "worktree", "branch",
+            "base_branch", "base_revision", "local_head", "repository",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("operation") == "discard-pristine"
+            and value.get("task") == name[:-5]
+            and value.get("status") == "initialized"
+            and all(isinstance(value.get(field), str) for field in (
+                "worktree", "branch", "base_branch", "repository"
+            ))
+            and _valid_oid(value.get("base_revision"))
+            and value.get("local_head") == value.get("base_revision")
+        )
+    elif name == "source-recovery-proof.json":
+        required = {
+            "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+            "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+            "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+            "receipt_source", "receipt_source_revision",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "source-recovery-proof"
+            and _valid_authority_fields(value)
+            and _valid_oid(value.get("authority_head"))
+            and all(_valid_digest(value.get(field)) for field in (
+                "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256",
+            ))
+            and _valid_absolute_path(value.get("implementation_source"))
+            and _valid_oid(value.get("implementation_revision"))
+            and _valid_absolute_path(value.get("receipt_source"))
+            and _valid_oid(value.get("receipt_source_revision"))
+        )
+    else:
+        standard = {"schema_version", "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"}
+        bridge = standard | {"kind", "proof_sha256"}
+        valid = (
+            (set(value) == standard and value.get("schema_version") == 1
+             and _valid_authority_fields(value))
+            or (set(value) == bridge and value.get("schema_version") == 2
+                and value.get("kind") == "source-recovery-bridge"
+                and _valid_authority_fields(value)
+                and _valid_digest(value.get("proof_sha256")))
+        )
+    if not valid:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+
+
+def _namespace_kind(path: Path, *, foreign_regular: bool) -> str:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return "absent"
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect private-state namespace: {path}") from exc
+    if stat.S_ISREG(metadata.st_mode) and foreign_regular:
+        return "foreign"
+    if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+        return "directory"
+    raise GitPrivateStateError(f"unsafe private-state namespace: {path}")
+
+
+def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path | None]:
+    root = layout.common / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return [], None
+    pairs: list[tuple[Path, Path]] = []
+    legacy_lock: Path | None = None
+    for entry in root.iterdir():
+        if entry.name == "cleanup.lock":
+            _require_regular(entry, "legacy cleanup lock")
+            legacy_lock = entry
+            continue
+        if entry.name not in SHARED_DIRS:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
+        _require_dir(entry, "legacy private-state directory")
+        for child in entry.iterdir():
+            allow_fixed = entry.name == "automation-maintenance"
+            if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
+                raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+            _require_regular(child, "legacy private-state record")
+            if child.name in FIXED_AUTHORITY_FILES:
+                if layout.admin_is_common:
+                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
+                # In a linked worktree these belong to the main worktree admin.
+            else:
+                pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    return pairs, legacy_lock
+
+
+def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
+    if layout.admin_is_common:
+        return []
+    root = layout.admin / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return []
+    entries = list(root.iterdir())
+    if any(entry.name != "automation-maintenance" for entry in entries):
+        unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+        raise GitPrivateStateError(f"unknown legacy private-state entry: {unknown}")
+    if not entries:
+        return []
+    maintenance = entries[0]
+    _require_dir(maintenance, "legacy maintenance authority directory")
+    pairs: list[tuple[Path, Path]] = []
+    for child in maintenance.iterdir():
+        if child.name not in FIXED_AUTHORITY_FILES:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+        _require_regular(child, "legacy private-state record")
+        pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    return pairs
+
+
+def _validate_canonical(layout: Topology) -> None:
+    shared = layout.common / NAMESPACE
+    kind = _namespace_kind(shared, foreign_regular=False)
+    if kind == "directory":
+        for entry in shared.iterdir():
+            if entry.name in LOCK_FILES:
+                _require_regular(entry, "canonical private-state lock")
+                continue
+            if entry.name not in SHARED_DIRS:
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
+            _require_dir(entry)
+            for child in entry.iterdir():
+                # Fixed files in common are the main worktree's admin records.
+                if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
+                    raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                _require_regular(child, "canonical private-state record")
+    if not layout.admin_is_common:
+        admin_root = layout.admin / NAMESPACE
+        kind = _namespace_kind(admin_root, foreign_regular=False)
+        if kind == "directory":
+            entries = list(admin_root.iterdir())
+            if any(entry.name != "automation-maintenance" for entry in entries):
+                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
+            if entries:
+                maintenance = entries[0]
+                _require_dir(maintenance)
+                for child in maintenance.iterdir():
+                    if child.name not in FIXED_AUTHORITY_FILES:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    _require_regular(child, "canonical private-state record")
+
+
+def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
+    inspected: list[MigrationFile] = []
+    for source, target in pairs:
+        metadata = _require_regular(source, "legacy private-state record")
+        content = read_bytes(source, "legacy private-state record")
+        _validate_legacy_content(source, content)
+        try:
+            target.lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise GitPrivateStateError(f"cannot inspect canonical private-state record: {target}") from exc
+        else:
+            if read_bytes(target, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting private-state records: {source} and {target}")
+        inspected.append(MigrationFile(
+            source, target, (metadata.st_dev, metadata.st_ino),
+            stat.S_IMODE(metadata.st_mode), content,
+        ))
+    return inspected
+
+
+def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".migrate.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            os.link(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd,
+                    follow_symlinks=False)
+            os.fsync(parent_fd)
+        except FileExistsError:
+            if read_bytes(path, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
+        published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if not stat.S_ISREG(published.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        return published.st_dev, published.st_ino
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot publish private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def ensure_parent(path: Path) -> None:
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
+    if not indexes:
+        # Legacy restoration may use only an already-existing validated parent.
+        descriptor = _open_anchored_parent(path)
+        os.close(descriptor)
+        return
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
+
+
+def exclusive_write_bytes(
+    path: Path, content: bytes, mode: int = 0o600
+) -> tuple[int, int]:
+    """Durably publish a new state record without replacing any existing object."""
+    ensure_parent(path)
+    return _exclusive_publish(path, content, mode)
+
+
+def _identity_unlink(item: MigrationFile) -> None:
+    if read_bytes(item.source, "legacy private-state record") != item.content:
+        raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+    metadata = _require_regular(item.source, "legacy private-state record")
+    if (metadata.st_dev, metadata.st_ino) != item.identity:
+        raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+    parent_fd = _open_anchored_parent(item.source)
+    try:
+        current = os.stat(item.source.name, dir_fd=parent_fd, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) != item.identity or not stat.S_ISREG(current.st_mode):
+            raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+        os.unlink(item.source.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove legacy private-state record: {item.source}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _remove_known_empty_legacy_directories(layout: Topology) -> None:
+    roots = [layout.common / LEGACY_NAMESPACE]
+    if not layout.admin_is_common:
+        roots.append(layout.admin / LEGACY_NAMESPACE)
+    for root in roots:
+        if _namespace_kind(root, foreign_regular=True) != "directory":
+            continue
+        for name in SHARED_DIRS:
+            child = root / name
+            try:
+                _require_dir(child, "legacy private-state directory")
+            except GitPrivateStateError:
+                if child.exists() or child.is_symlink():
+                    raise
+                continue
+            if not any(child.iterdir()):
+                child.rmdir()
+                descriptor = _open_dir(root)
+                try:
+                    os.fsync(descriptor)
+                finally:
+                    os.close(descriptor)
+        # The shared root remains while its mixed-version cleanup lock exists.
+        if not any(root.iterdir()):
+            root.rmdir()
+            descriptor = _open_dir(root.parent)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+
+
+@contextmanager
+def _file_lock(path: Path, *, create: bool):
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    if create:
+        flags |= os.O_CREAT
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe private-state lock: {path}")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    finally:
+        if "descriptor" in locals():
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+        os.close(parent_fd)
+
+
+def prepare(
+    root: Path,
+    *,
+    admin: bool = False,
+    common_dir: Path | None = None,
+    admin_dir: Path | None = None,
+    _legacy_lock_held: bool = False,
+) -> None:
+    """Validate and migrate known legacy state before a state mutation."""
+    layout = (
+        Topology(common_dir.resolve(), (admin_dir or common_dir).resolve())
+        if common_dir is not None
+        else topology(root)
+    )
+    _validate_canonical(layout)
+    shared_pairs, legacy_lock = _scan_shared_legacy(layout)
+    pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+    _inspect_pairs(pairs)  # preflight before creating even the migration lock
+    if legacy_lock is not None and not _legacy_lock_held:
+        with _file_lock(legacy_lock, create=False):
+            prepare(
+                root,
+                admin=admin,
+                common_dir=layout.common,
+                admin_dir=layout.admin,
+                _legacy_lock_held=True,
+            )
+        return
+
+    _ensure_namespace(layout.common, ())
+    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+        # Repeat all classification under the migration lock.
+        _validate_canonical(layout)
+        shared_pairs, _ = _scan_shared_legacy(layout)
+        pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+        inspected = _inspect_pairs(pairs)
+        for name in SHARED_DIRS:
+            _ensure_namespace(layout.common, (name,))
+        if admin:
+            _ensure_namespace(layout.admin, ("automation-maintenance",))
+        for item in inspected:
+            try:
+                item.target.lstat()
+            except FileNotFoundError:
+                _exclusive_publish(item.target, item.content, item.mode)
+        # No source is removed until every destination is durable and equivalent.
+        for item in inspected:
+            if read_bytes(item.target, "canonical private-state record") != item.content:
+                raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
+        for item in inspected:
+            metadata = _require_regular(item.source, "legacy private-state record")
+            if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
+                item.source, "legacy private-state record"
+            ) != item.content:
+                raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+        for item in inspected:
+            _identity_unlink(item)
+        _remove_known_empty_legacy_directories(layout)
+
+
+def write_bytes(path: Path, content: bytes) -> None:
+    """Atomically and durably replace one prepared canonical regular file."""
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        try:
+            current = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            if not stat.S_ISREG(current.st_mode):
+                raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot write private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+    """Remove only a canonical regular file through its verified parent."""
+    parent_fd = _open_anchored_parent(path)
+    try:
+        try:
+            metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        if expected_identity is not None and (metadata.st_dev, metadata.st_ino) != expected_identity:
+            raise GitPrivateStateError(f"private-state record identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove private-state record: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    layout = topology(root)
+    _validate_canonical(layout)
+    _, legacy = _scan_shared_legacy(layout)
+    # Lock old consumers out while migrating cleanup/discard evidence.
+    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
+    with legacy_context:
+        prepare(
+            root,
+            common_dir=layout.common,
+            admin_dir=layout.admin,
+            _legacy_lock_held=legacy is not None,
+        )
+        _ensure_namespace(layout.common, ())
+        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+            yield

--- a/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
+++ b/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
@@ -15,6 +15,10 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 WORK_UNIT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -1053,19 +1057,19 @@ def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
     validate_task(task)
-    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+    try:
+        return private_state.cleanup_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 @contextmanager
 def cleanup_lock(root: Path):
-    path = common_git_dir(root) / "opencode" / "cleanup.lock"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        try:
+    try:
+        with private_state.cleanup_lock(root):
             yield
-        finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 def cleanup_repository(root: Path) -> str:
@@ -1230,8 +1234,8 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
     if path.is_symlink() or not path.is_file():
         raise LifecycleError("cleanup receipt is not a regular local file")
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "cleanup receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise LifecycleError("cleanup receipt is invalid") from exc
     required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
     if (
@@ -1317,7 +1321,10 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -1332,13 +1339,18 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
 
 def task_cleanup(root: Path, task: str) -> None:
     require_main_worktree(root)
-    receipt = cleanup_receipt_path(root, task)
     with cleanup_lock(root):
+        receipt = cleanup_receipt_path(root, task)
         if receipt.exists():
             finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
             return
         plan = cleanup_plan(root, task)
-        atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise LifecycleError(str(exc)) from exc
         finish_cleanup(root, plan, receipt)
 
 

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -184,5 +184,29 @@ upgrade with changes replaces the active receipt and removes the previous consum
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
 receipt lifecycle evidence.
 
+## Git-private runtime state
+
+Agent Core owns only the `agent-core/` namespace beneath Git administrative
+directories. Shared cleanup receipts, pristine-discard receipts, integration
+checkpoints, the cleanup lock, the migration lock, and historical hashed
+maintenance authorities live beneath `<git-common-dir>/agent-core/`.
+Worktree-specific maintenance `authority.json` and
+`source-recovery-proof.json` live beneath
+`<absolute-git-dir>/agent-core/automation-maintenance/`. Repository Task State
+under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
+`opencode.json` configuration are separate ownership surfaces.
+
+The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
+file and Agent Core never changes its bytes, metadata, or identity. A legacy
+directory at that name is accepted only when every entry has an explicitly
+known historical Agent Core path and schema. Known regular records are copied byte for
+byte with durable no-overwrite publication, all conflicts are rejected before
+migration mutation, and legacy records are removed only after every canonical
+destination is verified equivalent. Equivalent dual state and partially
+completed migration are retryable. Unknown entries, unexpected nesting,
+symlinks, and special files fail closed. The historical `cleanup.lock` is
+retained as a mixed-version locking ABI and is acquired before the canonical
+lock; it is never renamed or unlinked automatically.
+
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -148,6 +148,12 @@ files unchanged. It reports `PROVENANCE_REBOUND` or idempotent
 `PROVENANCE_ALREADY_BOUND`; then run ordinary consumer verification and the
 existing `automation::commit`.
 
+Rebind is an operator-serialized maintenance transition: no commit or other
+authority mutation may run concurrently in the target worktree. Current Agent
+Core revisions additionally fence rebind and commit with the same ordered
+common/admin migration locks; the explicit quiescence requirement preserves the
+older pending consumer needed to finish an in-flight upgrade.
+
 Eligibility is exact: registered maintenance Task/worktree/branch/HEAD; one
 standard active receipt matching exactly one authority; safe pending Agent
 Core paths/fingerprints only; no consumed, source-recovery, or ambiguous state;
@@ -155,7 +161,8 @@ the old and expected revisions in the same Templates object database; and an
 identical expected canonical diff. Missing authority remains the Issue #85
 route. Committed or consumed state, including a crossed guarded publication
 boundary, is rejected. Handled
-failures roll back safely and concurrency fails closed. No cross-filesystem
+failures roll back safely; operations by current revisions fail closed under the
+shared fence. No cross-filesystem
 atomicity or hard-crash durability is claimed; that remains Issue #89 scope.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
@@ -198,15 +205,36 @@ under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
 
 The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
 file and Agent Core never changes its bytes, metadata, or identity. A legacy
-directory at that name is accepted only when every entry has an explicitly
-known historical Agent Core path and schema. Known regular records are copied byte for
-byte with durable no-overwrite publication, all conflicts are rejected before
-migration mutation, and legacy records are removed only after every canonical
-destination is verified equivalent. Equivalent dual state and partially
-completed migration are retryable. Unknown entries, unexpected nesting,
-symlinks, and special files fail closed. The historical `cleanup.lock` is
-retained as a mixed-version locking ABI and is acquired before the canonical
-lock; it is never renamed or unlinked automatically.
+directory at that name is accepted only when every entry satisfies the exact
+historical path, schema, Task/branch/worktree identity, repository syntax, and
+authority/proof relationship that Agent Core produced. The legacy namespace,
+subdirectories, records, and lock must be owned by the current effective user.
+Directories require owner access and reject group/other mutation while retaining
+historically produced read/traverse modes such as `0755`; records and locks reject
+group/other mutation and executable bits. Canonical directories
+are exactly mode `0700`, and canonical records, locks, and publication
+artifacts are exactly mode `0600`.
+
+Known records are copied byte for byte with durable no-overwrite publication,
+all conflicts are rejected before migration mutation, and legacy records are
+removed only after every canonical destination is mode-, owner-, and
+content-equivalent. The legacy cleanup-lock inode is acquired nonblocking and
+hard-linked into the canonical cleanup-lock path before its legacy name is
+removed. Existing waiters therefore remain fenced on the same inode. A
+contended legacy lock, or distinct legacy and canonical lock inodes, reports a
+precise `BLOCKED` condition rather than claiming migration success. Successful
+cutover removes the legacy lock last and then removes the empty `opencode/`
+directory, leaving the path available to OpenCode.
+
+Canonical publication is serialized by `migration.lock`. Only exact owned
+`.migrate.<pid>.<16-lowercase-hex>` and
+`.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next
+operation they are validated and durably removed under that lock before the
+legacy source is retried or an already-durable destination is used. Equivalent
+dual state, partial legacy removal, and interruption before or after durable
+publication are therefore retryable. Unknown entries, malformed temporary
+names, unsafe modes/ownership, unexpected nesting, symlinks, and special files
+fail closed without promotion.
 
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-nix/.automation/bin/agent_core.py
+++ b/templates/agent-nix/.automation/bin/agent_core.py
@@ -17,6 +17,7 @@ if str(SCRIPT_DIR) not in sys.path:
 import task_lifecycle as lifecycle
 import publication_metadata as publication
 import task_contract
+import git_private_state as private_state
 
 try:
     import tomllib
@@ -527,22 +528,31 @@ def validate_integration(root: Path, pr: str) -> dict:
 
 
 def integration_checkpoint(root: Path, pr: str) -> Path:
-    path = common_git_dir(root) / "opencode" / "integration" / f"pr-{pr}.head"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
+    try:
+        return private_state.integration_checkpoint(root, pr)
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
 
 
 def integrate_check(root: Path, pr: str) -> None:
     data = validate_integration(root, pr)
-    integration_checkpoint(root, pr).write_text(data["headRefOid"] + "\n", encoding="utf-8")
+    try:
+        private_state.prepare(root)
+        checkpoint = integration_checkpoint(root, pr)
+        private_state.write_bytes(checkpoint, (data["headRefOid"] + "\n").encode("utf-8"))
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
     print(json.dumps({"pr": data["number"], "head": data["headRefOid"], "status": "verified"}))
 
 
 def integrate_merge(root: Path, pr: str) -> None:
     checkpoint = integration_checkpoint(root, pr)
-    if not checkpoint.exists():
+    if not checkpoint.exists() or checkpoint.is_symlink() or not checkpoint.is_file():
         raise AutomationError("run integrate::check before merge")
-    expected = checkpoint.read_text(encoding="utf-8").strip()
+    try:
+        expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
+    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+        raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:
         raise AutomationError(f"PR head moved after integration check: expected {expected}, got {data['headRefOid']}")

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -16,6 +16,10 @@ import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 
 class UpgradeError(RuntimeError):
     pass
@@ -120,16 +124,55 @@ def worktree_admin_dir(repo: Path) -> Path:
 
 def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     admin = worktree_admin_dir(repo)
-    new_parent = admin / "opencode" / "automation-maintenance"
+    new_parent = admin / private_state.NAMESPACE / "automation-maintenance"
+    if new_parent.exists() or new_parent.is_symlink():
+        try:
+            private_state.safe_directory(admin / private_state.NAMESPACE)
+            private_state.safe_directory(new_parent)
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError(str(exc)) from exc
     try:
         resolved_parent = new_parent.resolve()
     except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy_location = _safe_legacy_location(repo)
-    legacy = legacy_location[0] if legacy_location is not None else None
+    common = common_git_dir(repo)
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    migrated = common / private_state.NAMESPACE / "automation-maintenance" / f"{key}.json"
+    if os.path.lexists(migrated):
+        try:
+            private_state.safe_directory(common / private_state.NAMESPACE)
+            private_state.safe_directory(migrated.parent)
+            private_state.read_bytes(migrated, "migrated maintenance authority")
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+        legacy = migrated
+    else:
+        old_admin = _safe_old_admin_authority(repo)
+        if old_admin is not None and os.path.lexists(old_admin[0]):
+            legacy = old_admin[0]
+        else:
+            legacy_location = _safe_legacy_location(repo)
+            legacy = legacy_location[0] if legacy_location is not None else None
     return new_parent / "authority.json", legacy
+
+
+def _safe_old_admin_authority(repo: Path) -> tuple[Path, Path] | None:
+    try:
+        admin = worktree_admin_dir(repo)
+        root = admin / "opencode"
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
+            return None
+        parent = root / "automation-maintenance"
+        if parent.is_symlink() or (parent.exists() and not parent.is_dir()):
+            return None
+        resolved = parent.resolve()
+        if resolved != admin and admin not in resolved.parents:
+            return None
+        return parent / "authority.json", admin
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
@@ -144,7 +187,7 @@ def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
             return None
         key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
         return parent / f"{key}.json", common
-    except (OSError, ValueError, RuntimeError, UpgradeError):
+    except (OSError, ValueError, RuntimeError, UpgradeError, private_state.GitPrivateStateError):
         return None
 
 
@@ -167,6 +210,15 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     _write_authority_at(
         authority_path(repo),
         {
@@ -187,33 +239,29 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             parent_before = path.parent.resolve()
             if parent_before != admin and admin not in parent_before.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        path.parent.mkdir(parents=True, exist_ok=True)
+        private_state.ensure_parent(path)
         if admin is not None:
             parent_after = path.parent.resolve()
             if parent_after != admin and admin not in parent_after.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        # The caller has validated the parent; do not replace an existing record.
-        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
-        temporary = Path(temporary_name)
-        try:
-            with os.fdopen(fd, "wb") as stream:
-                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
-                stream.flush()
-                try:
-                    os.fsync(stream.fileno())
-                except OSError:
-                    pass
-            os.link(temporary, path)
-        finally:
-            temporary.unlink(missing_ok=True)
-    except (OSError, ValueError, RuntimeError) as exc:
+        private_state.exclusive_write_bytes(
+            path,
+            json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+        )
+    except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
 
 
 def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    old_admin = _safe_old_admin_authority(repo)
+    if old_admin is not None and authority == old_admin[0]:
+        return old_admin[1]
     legacy = _safe_legacy_location(repo)
     if legacy is not None and authority == legacy[0]:
         return legacy[1]
+    common = common_git_dir(repo)
+    if authority.parent == common / private_state.NAMESPACE / "automation-maintenance":
+        return common
     if authority == authority_path(repo):
         return worktree_admin_dir(repo)
     raise UpgradeError("cannot safely resolve authority location for rollback")
@@ -227,11 +275,10 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError("missing or invalid successful-upgrade authority record")
-        authority = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        authority = json.loads(
+            private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
     expected = {
         "schema_version": 1,
@@ -253,12 +300,15 @@ def _read_json_record(path: Path, error: str) -> dict:
 
 def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError(error)
-        raw = path.read_bytes()
+        if private_state.NAMESPACE in path.parts or "opencode" in path.parts:
+            raw = private_state.read_bytes(path, error)
+        else:
+            metadata = path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+                raise UpgradeError(error)
+            raw = path.read_bytes()
         value = json.loads(raw.decode("utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(error) from exc
     if not isinstance(value, dict):
         raise UpgradeError(error)
@@ -1795,7 +1845,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         raise UpgradeError("receipt source is not compatible with the current Templates source")
     old_revision = _validate_source_revision(source, old["source_revision"])
     authority = _standard_authority_only(repo, old)
-    old_authority_raw = authority.read_bytes()
+    old_authority_raw = private_state.read_bytes(authority, "maintenance authority")
     receipt_identity = (active.lstat().st_dev, active.lstat().st_ino)
     authority_identity = (authority.lstat().st_dev, authority.lstat().st_ino)
     authority_head = validate_commit_oid(repo, old["authority_head"], field="receipt authority HEAD")
@@ -1828,7 +1878,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         current_source, current_revision = resolve_clean_source_worktree(source)
         if expected_implementation_revision is None or current_revision != expected_implementation_revision:
             raise UpgradeError("source implementation changed before provenance replacement")
-    if active.read_bytes() != raw_receipt or authority.read_bytes() != old_authority_raw or pending_paths(repo) != expected_paths \
+    if active.read_bytes() != raw_receipt or private_state.read_bytes(authority, "maintenance authority") != old_authority_raw or pending_paths(repo) != expected_paths \
             or git_head(repo) != authority_head or current_source != source \
             or (require_source_head and current_revision != expected_source_revision) \
             or (active.lstat().st_dev, active.lstat().st_ino) != receipt_identity \
@@ -2021,7 +2071,11 @@ def recover_maintenance_authority_from_source(
             if existing != proof:
                 raise UpgradeError("existing source-recovery proof does not match reconstruction")
         else:
-            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+            private_state.ensure_parent(proof_path)
+            created_proof = private_state.exclusive_write_bytes(
+                proof_path,
+                json.dumps(proof, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            )
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
         if (current_source != source
                 or current_implementation_revision != expected_implementation_revision):
@@ -2040,13 +2094,11 @@ def recover_maintenance_authority_from_source(
             raise UpgradeError("source-recovery proof changed before bridge publication")
         _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
                             admin=worktree_admin_dir(target_repo))
-    except (OSError, UpgradeError):
+    except (OSError, UpgradeError, private_state.GitPrivateStateError):
         if created_proof is not None:
             try:
-                metadata = proof_path.lstat()
-                if (metadata.st_dev, metadata.st_ino) == created_proof:
-                    proof_path.unlink()
-            except OSError as exc:
+                private_state.unlink(proof_path, expected_identity=created_proof)
+            except (OSError, private_state.GitPrivateStateError) as exc:
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
@@ -2209,7 +2261,13 @@ def _commit_mode(
         )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
-        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        try:
+            proof_raw, proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            proof_record = json.loads(proof_raw.decode("utf-8"))
+        except (private_state.GitPrivateStateError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("missing or invalid source-recovery proof") from exc
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
@@ -2221,7 +2279,7 @@ def _commit_mode(
             raise UpgradeError("source-recovery receipt source is incompatible")
         _validate_source_revision(source, receipt["source_revision"])
         authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
-        if proof_path.read_bytes() != proof_raw:
+        if private_state.read_bytes(proof_path, "source-recovery proof") != proof_raw:
             raise UpgradeError("source-recovery proof changed before commit mutation")
     else:  # pragma: no cover
         raise UpgradeError("unsupported commit mode")
@@ -2249,10 +2307,29 @@ def _commit_mode(
         atomic_json_write(consumed, consumed_receipt)
         consumed_metadata = consumed.lstat()
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
-        authority.unlink(missing_ok=True)
+        authority_raw, authority_identity = private_state.read_bytes_identity(
+            authority, "maintenance authority"
+        )
+        expected_authority = (
+            _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest())
+            if mode == "source_recovery" and proof is not None
+            else {
+                "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                "receipt_sha256": receipt_digest(receipt),
+            }
+        )
+        if json.loads(authority_raw.decode("utf-8")) != expected_authority:
+            raise UpgradeError("authority changed before commit mutation")
+        private_state.unlink(authority, expected_identity=authority_identity)
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
-            proof_path.unlink()
+            current_proof, current_proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            if current_proof != proof_raw or current_proof_identity != proof_identity:
+                raise UpgradeError("source-recovery proof changed before removal")
+            private_state.unlink(proof_path, expected_identity=proof_identity)
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2304,7 +2381,7 @@ def _commit_mode(
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except (UpgradeError, OSError) as failure:
+    except (UpgradeError, OSError, private_state.GitPrivateStateError) as failure:
         if committed:
             raise UpgradeError(
                 f"commit {commit_sha} was published but finalization failed"
@@ -2314,8 +2391,8 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
-        except (OSError, UpgradeError) as rollback_error:
+                private_state.exclusive_write_bytes(proof_path, proof_raw)
+        except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
             if authority_removed:

--- a/templates/agent-nix/.automation/bin/automation_upgrade.py
+++ b/templates/agent-nix/.automation/bin/automation_upgrade.py
@@ -233,7 +233,13 @@ def write_authority(repo: Path, receipt: dict) -> None:
     )
 
 
-def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
+def _write_authority_at(
+    path: Path,
+    value: dict,
+    *,
+    admin: Path | None = None,
+    lock_held: bool = False,
+) -> None:
     try:
         if admin is not None:
             parent_before = path.parent.resolve()
@@ -247,6 +253,7 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
         private_state.exclusive_write_bytes(
             path,
             json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            _lock_held=lock_held,
         )
     except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
@@ -275,6 +282,7 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
+        private_state.validate_record(path, "successful-upgrade authority record")
         authority = json.loads(
             private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
         )
@@ -1642,9 +1650,10 @@ def _rename_record_at(source: str, destination: str, *, source_dir_fd: int, dest
     )
 
 
-def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
-                           receipt: dict, authority_path_value: Path,
-                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+def _replace_standard_pair_locked(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                                  receipt: dict, authority_path_value: Path,
+                                  receipt_identity: tuple[int, int],
+                                  authority_identity: tuple[int, int]) -> None:
     active = receipt_path(repo)
     admin = _rollback_authority_guard(repo, authority_path_value)
     _validate_admin_record_parent(authority_path_value, admin)
@@ -1823,6 +1832,25 @@ def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw
                 pass
 
 
+def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                           receipt: dict, authority_path_value: Path,
+                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+    """Replace a common/admin record pair under ordered namespace fences."""
+    try:
+        with private_state.mutation_lock(repo, admin=True):
+            _replace_standard_pair_locked(
+                repo,
+                old_receipt_raw,
+                old_authority_raw,
+                receipt,
+                authority_path_value,
+                receipt_identity,
+                authority_identity,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
+
+
 def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_source_revision: str,
                                    *, require_source_head: bool,
                                    expected_implementation_revision: str | None = None) -> dict:
@@ -1994,6 +2022,16 @@ def recover_maintenance_authority_from_source(
         expected_implementation_revision
     )
     task_id, branch, worktree = require_maintenance(target_repo)
+    try:
+        private_state.prepare(
+            target_repo,
+            admin=True,
+            common_dir=common_git_dir(target_repo),
+            admin_dir=worktree_admin_dir(target_repo),
+            _allow_incomplete_recovery=True,
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
     if implementation_revision != expected_implementation_revision:
         raise UpgradeError("source HEAD does not match the expected implementation revision")
@@ -2215,7 +2253,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(
+def _commit_mode_locked(
     repo: Path,
     task: str,
     message: str,
@@ -2321,7 +2359,12 @@ def _commit_mode(
         )
         if json.loads(authority_raw.decode("utf-8")) != expected_authority:
             raise UpgradeError("authority changed before commit mutation")
-        private_state.unlink(authority, expected_identity=authority_identity)
+        private_state.unlink(
+            authority,
+            expected_identity=authority_identity,
+            expected_content=authority_raw,
+            _lock_held=True,
+        )
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
             current_proof, current_proof_identity = private_state.read_bytes_identity(
@@ -2329,7 +2372,12 @@ def _commit_mode(
             )
             if current_proof != proof_raw or current_proof_identity != proof_identity:
                 raise UpgradeError("source-recovery proof changed before removal")
-            private_state.unlink(proof_path, expected_identity=proof_identity)
+            private_state.unlink(
+                proof_path,
+                expected_identity=proof_identity,
+                expected_content=proof_raw,
+                _lock_held=True,
+            )
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2391,7 +2439,9 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                private_state.exclusive_write_bytes(proof_path, proof_raw)
+                private_state.exclusive_write_bytes(
+                    proof_path, proof_raw, _lock_held=True
+                )
         except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
@@ -2401,7 +2451,12 @@ def _commit_mode(
                     "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
                     "receipt_sha256": receipt_digest(receipt),
                 }
-                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
+                _write_authority_at(
+                    authority,
+                    restored,
+                    admin=_rollback_authority_guard(repo, authority),
+                    lock_held=True,
+                )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -2446,6 +2501,35 @@ def _commit_mode(
             "mergePerformed": False,
         })
     return result
+
+
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+        with private_state.mutation_lock(repo, admin=True):
+            return _commit_mode_locked(
+                repo,
+                task,
+                message,
+                mode,
+                source_root=source_root,
+                expected_implementation_revision=expected_implementation_revision,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
 
 
 def commit(repo: Path, task: str, message: str) -> dict[str, object]:

--- a/templates/agent-nix/.automation/bin/discard_pristine.py
+++ b/templates/agent-nix/.automation/bin/discard_pristine.py
@@ -7,7 +7,10 @@ import re
 import sys
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
 import task_lifecycle as lifecycle
+import git_private_state as private_state
 
 
 RECEIPT_SCHEMA_VERSION = 1
@@ -18,12 +21,10 @@ REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 
 def discard_receipt_path(root: Path, task: str) -> Path:
     lifecycle.validate_task(task)
-    return (
-        lifecycle.common_git_dir(root)
-        / "opencode"
-        / "discard-pristine"
-        / f"{task}.json"
-    )
+    try:
+        return private_state.discard_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
 
 
 def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
@@ -255,8 +256,8 @@ def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
             "discard-pristine receipt is not a regular local file"
         )
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "discard-pristine receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
     required = {
         "schema_version",
@@ -394,7 +395,10 @@ def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
             "discard-pristine failed to delete the expected local Task branch"
         )
 
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -421,7 +425,12 @@ def task_discard_pristine(root: Path, task: str) -> None:
             )
             return
         plan = pristine_discard_plan(root, task)
-        lifecycle.atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise lifecycle.LifecycleError(str(exc)) from exc
         finish_pristine_discard(root, plan, receipt)
 
 

--- a/templates/agent-nix/.automation/bin/git_private_state.py
+++ b/templates/agent-nix/.automation/bin/git_private_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 import fcntl
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -18,9 +19,12 @@ LEGACY_NAMESPACE = "opencode"
 TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 PR_RE = re.compile(r"[1-9][0-9]*")
 HASH_RE = re.compile(r"[0-9a-f]{64}")
+OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
 FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
+TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
 
 
@@ -126,6 +130,43 @@ def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_r
     return metadata
 
 
+def _require_owned_mode(path: Path, metadata: os.stat_result, mode: int, what: str,
+                        *, exact: bool = False) -> None:
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    actual = stat.S_IMODE(metadata.st_mode)
+    unsafe = actual != mode if exact else (actual & mode) != mode
+    unsafe = unsafe or bool(actual & 0o022)
+    if unsafe:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+
+
+def _require_legacy_dir(path: Path, what: str) -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what)
+    return metadata
+
+
+def _require_legacy_record(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o400, what)
+    if metadata.st_mode & 0o111:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir(path: Path, what: str = "canonical private-state directory") -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what, exact=True)
+    return metadata
+
+
+def _require_canonical_file(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o600, what, exact=True)
+    return metadata
+
+
 def _require_regular(path: Path, what: str) -> os.stat_result:
     metadata = _lstat(path, what)
     if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
@@ -134,7 +175,10 @@ def _require_regular(path: Path, what: str) -> os.stat_result:
 
 
 def safe_directory(path: Path) -> None:
-    _require_dir(path)
+    if NAMESPACE in path.parts:
+        _require_canonical_dir(path)
+    else:
+        _require_dir(path)
 
 
 def _open_dir(path: Path) -> int:
@@ -162,7 +206,8 @@ def _open_anchored_parent(path: Path) -> int:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
             os.close(descriptor)
@@ -179,15 +224,24 @@ def _open_anchored_parent(path: Path) -> int:
 def _ensure_child_directory(parent: Path, name: str) -> Path:
     descriptor = _open_dir(parent)
     try:
+        created = False
         try:
             os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
             os.fsync(descriptor)
+            created = True
         except FileExistsError:
             pass
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         child = os.open(name, flags, dir_fd=descriptor)
         try:
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            metadata = os.fstat(child)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+            if not created and (
+                metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o700
+            ):
                 raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
         finally:
             os.close(child)
@@ -205,15 +259,22 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
     try:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
+            created = False
             try:
                 os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
                 os.fsync(descriptor)
+                created = True
             except FileExistsError:
                 pass
             child = os.open(name, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            if child_meta.st_uid != os.geteuid() or stat.S_IMODE(child_meta.st_mode) != 0o700:
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe canonical private-state directory: {current / name}")
             os.close(descriptor)
             descriptor = child
             current /= name
@@ -263,6 +324,14 @@ def read_bytes(path: Path, what: str = "private-state record") -> bytes:
     return read_bytes_identity(path, what)[0]
 
 
+def validate_record(path: Path, what: str = "private-state record") -> None:
+    """Require the ownership and mode contract for a persisted state record."""
+    if NAMESPACE in path.parts:
+        _require_canonical_file(path, what)
+    else:
+        _require_legacy_record(path, what)
+
+
 def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     if directory in {"cleanup", "discard-pristine"}:
         return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
@@ -276,6 +345,34 @@ def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     return False
 
 
+def _recover_canonical_temps(layout: Topology, *, include_admin: bool = True) -> None:
+    """Remove only our exact, owned publication artifacts while fenced."""
+    directories = [layout.common / NAMESPACE]
+    if include_admin and not layout.admin_is_common:
+        directories.append(layout.admin / NAMESPACE)
+    for namespace in directories:
+        if _namespace_kind(namespace, foreign_regular=False) != "directory":
+            continue
+        subdirs = [namespace / name for name in SHARED_DIRS]
+        for directory in subdirs:
+            if not directory.exists():
+                continue
+            _require_canonical_dir(directory)
+            for item in directory.iterdir():
+                if item.name.startswith("."):
+                    if TEMP_RE.fullmatch(item.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical temporary: {item}")
+                    metadata = _require_canonical_file(item, "canonical temporary")
+                    if metadata.st_nlink < 1 or metadata.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {item}")
+                    parent_fd = _open_anchored_parent(item)
+                    try:
+                        os.unlink(item.name, dir_fd=parent_fd)
+                        os.fsync(parent_fd)
+                    finally:
+                        os.close(parent_fd)
+
+
 def _legacy_json(content: bytes, path: Path) -> dict:
     try:
         value = json.loads(content.decode("utf-8"))
@@ -287,7 +384,7 @@ def _legacy_json(content: bytes, path: Path) -> dict:
 
 
 def _valid_oid(value: object) -> bool:
-    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+    return isinstance(value, str) and OID_RE.fullmatch(value) is not None
 
 
 def _valid_digest(value: object) -> bool:
@@ -306,14 +403,101 @@ def _valid_absolute_path(value: object) -> bool:
     return _valid_nonempty(value) and Path(value).is_absolute()
 
 
+def _valid_repository(value: object) -> bool:
+    return isinstance(value, str) and REPOSITORY_RE.fullmatch(value) is not None
+
+
+def _valid_branch_worktree(branch: object, task: object, worktree: object) -> bool:
+    if not (_valid_task_id(task) and isinstance(branch, str) and isinstance(worktree, str)):
+        return False
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        return False
+    path = Path(worktree)
+    return (path.is_absolute() and path.parent.name == ".worktrees" and
+            path.name == branch.split("/", 1)[1])
+
+
+def _valid_task_branch(branch: object, task: object) -> bool:
+    return (
+        _valid_task_id(task)
+        and isinstance(branch, str)
+        and (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-"))
+    )
+
+
 def _valid_authority_fields(value: dict) -> bool:
     return (
         _valid_task_id(value.get("task_id"))
-        and _valid_nonempty(value.get("branch"))
+        and _valid_task_branch(value.get("branch"), value.get("task_id"))
         and _valid_absolute_path(value.get("worktree"))
         and _valid_digest(value.get("authority_nonce"))
         and _valid_digest(value.get("receipt_sha256"))
     )
+
+
+def _valid_cleanup_evidence(value: dict, status: str, local_head: str) -> bool:
+    if status == "merged":
+        return (set(value) == {"repository", "pr", "published_head", "upstream"}
+                and _valid_repository(value.get("repository"))
+                and isinstance(value.get("pr"), int) and not isinstance(value.get("pr"), bool)
+                and value["pr"] > 0 and _valid_oid(value.get("published_head"))
+                and value.get("published_head").casefold() == local_head.casefold()
+                and value.get("upstream") in {"live", "deleted"})
+    return (set(value) == {"repository", "upstream", "base_revision"}
+            and _valid_repository(value.get("repository"))
+            and value.get("upstream") == "cancelled-safe"
+            and _valid_oid(value.get("base_revision")))
+
+
+def _validate_authority_filename(path: Path, content: bytes) -> None:
+    if path.parent.name != "automation-maintenance" or path.name in FIXED_AUTHORITY_FILES:
+        return
+    value = _legacy_json(content, path)
+    expected = hashlib.sha256(str(Path(value["worktree"]).resolve()).encode()).hexdigest()
+    if path.name != expected + ".json":
+        raise GitPrivateStateError(f"invalid private-state authority filename: {path}")
+
+
+def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -> Path:
+    """Bind authority ownership to a worktree registered in this topology."""
+    if path.parent.name != "automation-maintenance":
+        raise GitPrivateStateError(f"authority has an invalid parent: {path}")
+    value = _legacy_json(content, path)
+    worktree = Path(value["worktree"])
+    dot_git = worktree / ".git"
+    try:
+        metadata = dot_git.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError
+        if stat.S_ISDIR(metadata.st_mode):
+            admin = dot_git.resolve(strict=True)
+        elif stat.S_ISREG(metadata.st_mode):
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            if not marker.startswith("gitdir: "):
+                raise ValueError
+            target = Path(marker[8:])
+            admin = (target if target.is_absolute() else worktree / target).resolve(strict=True)
+        else:
+            raise ValueError
+    except (OSError, UnicodeDecodeError, ValueError, KeyError) as exc:
+        raise GitPrivateStateError(f"authority worktree is not registered: {path}") from exc
+    common = layout.common.resolve()
+    allowed = admin == common or admin == layout.admin.resolve()
+    if not allowed and admin.parent.name == "worktrees" and admin.parent.parent == common:
+        try:
+            registered_gitdir = (admin / "gitdir").read_text(encoding="utf-8").strip()
+            allowed = Path(registered_gitdir).resolve(strict=True) == dot_git.resolve(strict=True)
+        except (OSError, UnicodeDecodeError):
+            allowed = False
+    if not allowed:
+        raise GitPrivateStateError(f"authority worktree is outside Git topology: {path}")
+    try:
+        head = (admin / "HEAD").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise GitPrivateStateError(f"authority worktree registration is unreadable: {path}") from exc
+    if head != f"ref: refs/heads/{value['branch']}":
+        raise GitPrivateStateError(f"authority branch does not match worktree registration: {path}")
+    return admin
 
 
 def _validate_legacy_content(path: Path, content: bytes) -> None:
@@ -324,7 +508,8 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             text = content.decode("ascii", errors="strict")
         except UnicodeDecodeError as exc:
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
-        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+        if (not text.endswith("\n") or not _valid_oid(text[:-1]) or
+                text[:-1] != text[:-1].lower()):
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
         return
     value = _legacy_json(content, path)
@@ -335,10 +520,10 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("schema_version") == 1
             and value.get("task") == name[:-5]
             and value.get("status") in {"merged", "cancelled"}
-            and isinstance(value.get("worktree"), str)
-            and isinstance(value.get("branch"), str)
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
             and _valid_oid(value.get("local_head"))
             and isinstance(value.get("evidence"), dict)
+            and _valid_cleanup_evidence(value["evidence"], value["status"], value["local_head"])
         )
     elif directory == "discard-pristine":
         required = {
@@ -351,11 +536,12 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("operation") == "discard-pristine"
             and value.get("task") == name[:-5]
             and value.get("status") == "initialized"
-            and all(isinstance(value.get(field), str) for field in (
-                "worktree", "branch", "base_branch", "repository"
-            ))
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_repository(value.get("repository"))
             and _valid_oid(value.get("base_revision"))
-            and value.get("local_head") == value.get("base_revision")
+            and _valid_oid(value.get("local_head"))
+            and value.get("local_head").casefold() == value.get("base_revision").casefold()
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -413,26 +599,40 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
     if kind != "directory":
         return [], None
     pairs: list[tuple[Path, Path]] = []
+    _require_legacy_dir(root, "legacy private-state directory")
     legacy_lock: Path | None = None
     for entry in root.iterdir():
         if entry.name == "cleanup.lock":
-            _require_regular(entry, "legacy cleanup lock")
+            metadata = _require_regular(entry, "legacy cleanup lock")
+            _require_owned_mode(entry, metadata, 0o600, "legacy cleanup lock")
+            if metadata.st_mode & 0o111:
+                raise GitPrivateStateError(f"unsafe legacy cleanup lock mode: {entry}")
             legacy_lock = entry
             continue
         if entry.name not in SHARED_DIRS:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
-        _require_dir(entry, "legacy private-state directory")
+        _require_legacy_dir(entry, "legacy private-state directory")
         for child in entry.iterdir():
             allow_fixed = entry.name == "automation-maintenance"
             if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
                 raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-            _require_regular(child, "legacy private-state record")
+            _require_legacy_record(child, "legacy private-state record")
+            if entry.name == "automation-maintenance":
+                content = read_bytes(child)
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                authority_admin = _validate_authority_topology(child, content, layout)
             if child.name in FIXED_AUTHORITY_FILES:
-                if layout.admin_is_common:
-                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
-                # In a linked worktree these belong to the main worktree admin.
+                if authority_admin not in {layout.common, layout.admin}:
+                    raise GitPrivateStateError(
+                        f"fixed authority belongs to a different worktree admin: {child}"
+                    )
+                pairs.append((child, authority_admin / NAMESPACE / entry.name / child.name))
             else:
                 pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs, legacy_lock
 
 
@@ -450,55 +650,211 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
     if not entries:
         return []
     maintenance = entries[0]
-    _require_dir(maintenance, "legacy maintenance authority directory")
+    _require_legacy_dir(maintenance, "legacy maintenance authority directory")
     pairs: list[tuple[Path, Path]] = []
     for child in maintenance.iterdir():
         if child.name not in FIXED_AUTHORITY_FILES:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-        _require_regular(child, "legacy private-state record")
+        _require_legacy_record(child, "legacy private-state record")
+        content = read_bytes(child)
+        _validate_legacy_content(child, content)
+        _validate_authority_filename(child, content)
+        if _validate_authority_topology(child, content, layout) != layout.admin:
+            raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs
 
 
-def _validate_canonical(layout: Topology) -> None:
+def _validate_legacy_relations(root: Path, canonical_roots: tuple[Path, Path]) -> None:
+    maintenance = root / "automation-maintenance"
+    if not maintenance.is_dir():
+        return
+    proof = maintenance / "source-recovery-proof.json"
+    authority = maintenance / "authority.json"
+    if authority.exists() and not proof.exists():
+        authority_value = _legacy_json(
+            read_bytes(authority, "legacy maintenance authority"), authority
+        )
+        if authority_value.get("kind") == "source-recovery-bridge":
+            canonical_proofs = [
+                candidate / "automation-maintenance" / "source-recovery-proof.json"
+                for candidate in canonical_roots
+            ]
+            canonical_proof = next((candidate for candidate in canonical_proofs
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        authority_value,
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                    )), None)
+            if canonical_proof is None:
+                raise GitPrivateStateError(
+                    f"legacy source-recovery bridge lacks its proof: {root}"
+                )
+            proof = canonical_proof
+        else:
+            return
+    if proof.exists() and not authority.exists():
+        canonical_authorities = [
+            candidate / "automation-maintenance" / "authority.json"
+            for candidate in canonical_roots
+        ]
+        proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+        canonical_authority = next((candidate for candidate in canonical_authorities
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                        proof_value,
+                                    )), None)
+        if canonical_authority is None:
+            raise GitPrivateStateError(
+                f"legacy source-recovery proof lacks its bridge: {root}"
+            )
+        authority = canonical_authority
+    if not proof.exists() or not authority.exists():
+        return
+    proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+    authority_value = _legacy_json(read_bytes(authority, "legacy maintenance authority"), authority)
+    if not _recovery_pair_matches(authority_value, proof_value):
+        raise GitPrivateStateError(f"conflicting legacy authority and proof identity: {root}")
+
+
+def _recovery_pair_matches(authority: dict, proof: dict) -> bool:
+    if authority.get("kind") != "source-recovery-bridge":
+        return False
+    if any(proof.get(field) != authority.get(field) for field in (
+        "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"
+    )):
+        return False
+    digest = hashlib.sha256(
+        json.dumps(proof, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return authority.get("proof_sha256") == digest
+
+
+def _validate_canonical(
+    layout: Topology, *, allow_incomplete_recovery: bool = False
+) -> None:
     shared = layout.common / NAMESPACE
     kind = _namespace_kind(shared, foreign_regular=False)
     if kind == "directory":
+        _require_canonical_dir(shared)
         for entry in shared.iterdir():
             if entry.name in LOCK_FILES:
-                _require_regular(entry, "canonical private-state lock")
+                _require_canonical_file(entry, "canonical private-state lock")
                 continue
             if entry.name not in SHARED_DIRS:
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
-            _require_dir(entry)
+            _require_canonical_dir(entry)
             for child in entry.iterdir():
+                if child.name.startswith("."):
+                    if TEMP_RE.fullmatch(child.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    temporary = _require_canonical_file(child, "canonical temporary")
+                    if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                    continue
                 # Fixed files in common are the main worktree's admin records.
                 if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
                     raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                _require_regular(child, "canonical private-state record")
+                _require_canonical_file(child, "canonical private-state record")
+                content = read_bytes(child, "canonical private-state record")
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                if entry.name == "automation-maintenance":
+                    authority_admin = _validate_authority_topology(child, content, layout)
+                    if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
     if not layout.admin_is_common:
         admin_root = layout.admin / NAMESPACE
         kind = _namespace_kind(admin_root, foreign_regular=False)
         if kind == "directory":
+            _require_canonical_dir(admin_root)
             entries = list(admin_root.iterdir())
-            if any(entry.name != "automation-maintenance" for entry in entries):
-                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+            if any(entry.name not in {"automation-maintenance", "migration.lock"} for entry in entries):
+                unknown = next(
+                    entry for entry in entries
+                    if entry.name not in {"automation-maintenance", "migration.lock"}
+                )
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
-            if entries:
-                maintenance = entries[0]
-                _require_dir(maintenance)
+            lock = admin_root / "migration.lock"
+            if lock.exists():
+                _require_canonical_file(lock, "canonical private-state lock")
+            maintenance = admin_root / "automation-maintenance"
+            if maintenance.exists():
+                _require_canonical_dir(maintenance)
                 for child in maintenance.iterdir():
+                    if child.name.startswith("."):
+                        if TEMP_RE.fullmatch(child.name) is None:
+                            raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                        temporary = _require_canonical_file(child, "canonical temporary")
+                        if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                            raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                        continue
                     if child.name not in FIXED_AUTHORITY_FILES:
                         raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                    _require_regular(child, "canonical private-state record")
+                    _require_canonical_file(child, "canonical private-state record")
+                    content = read_bytes(child, "canonical private-state record")
+                    _validate_legacy_content(child, content)
+                    _validate_authority_filename(child, content)
+                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
+
+    # Canonical maintenance authority is fixed to the administrative topology;
+    # a bridge, when present, must name the exact canonical proof bytes.
+    for namespace in {layout.common / NAMESPACE, layout.admin / NAMESPACE}:
+        proof = namespace / "automation-maintenance" / "source-recovery-proof.json"
+        bridge = namespace / "automation-maintenance" / "authority.json"
+        proof_exists = proof.is_file()
+        bridge_exists = bridge.is_file()
+        if proof_exists and not bridge_exists:
+            legacy_bridges = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+            }
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            if not allow_incomplete_recovery and not any(candidate.is_file() and _recovery_pair_matches(
+                _legacy_json(read_bytes(candidate), candidate), proof_value
+            ) for candidate in legacy_bridges):
+                raise GitPrivateStateError(f"source-recovery proof lacks bridge authority: {namespace}")
+        if bridge_exists:
+            bridge_value = _legacy_json(read_bytes(bridge), bridge)
+            is_bridge = bridge_value.get("kind") == "source-recovery-bridge"
+            legacy_proofs = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+            }
+            if is_bridge and not proof_exists and not any(
+                candidate.is_file() and _recovery_pair_matches(
+                    bridge_value, _legacy_json(read_bytes(candidate), candidate)
+                ) for candidate in legacy_proofs
+            ):
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+            if not is_bridge and proof_exists:
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+        if proof_exists and bridge_exists:
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            for field in ("task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"):
+                if proof_value.get(field) != bridge_value.get(field):
+                    raise GitPrivateStateError(f"conflicting authority and proof identity: {namespace}")
+            digest = hashlib.sha256(
+                json.dumps(proof_value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
+            if bridge_value.get("proof_sha256") != digest:
+                raise GitPrivateStateError(f"source-recovery proof digest mismatch: {namespace}")
 
 
 def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
     inspected: list[MigrationFile] = []
     for source, target in pairs:
-        metadata = _require_regular(source, "legacy private-state record")
+        metadata = _require_legacy_record(source, "legacy private-state record")
         content = read_bytes(source, "legacy private-state record")
         _validate_legacy_content(source, content)
+        _validate_authority_filename(source, content)
         try:
             target.lstat()
         except FileNotFoundError:
@@ -537,10 +893,15 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
                     follow_symlinks=False)
             os.fsync(parent_fd)
         except FileExistsError:
+            _require_canonical_file(path, "canonical private-state record")
             if read_bytes(path, "canonical private-state record") != content:
                 raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
         published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
-        if not stat.S_ISREG(published.st_mode):
+        if (
+            not stat.S_ISREG(published.st_mode)
+            or published.st_uid != os.geteuid()
+            or stat.S_IMODE(published.st_mode) != 0o600
+        ):
             raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         return published.st_dev, published.st_ino
     except GitPrivateStateError:
@@ -556,6 +917,36 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
             os.close(parent_fd)
 
 
+def _exclusive_publish_direct(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    """Restore an absent legacy record without a visible temporary artifact."""
+    parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            path.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            mode,
+            dir_fd=parent_fd,
+        )
+        os.fchmod(descriptor, mode)
+        view = memoryview(content)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short private-state write")
+            view = view[written:]
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        os.fsync(parent_fd)
+        return metadata.st_dev, metadata.st_ino
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot restore legacy private-state record: {path}") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
 def ensure_parent(path: Path) -> None:
     parts = path.parts
     indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
@@ -569,18 +960,53 @@ def ensure_parent(path: Path) -> None:
     _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
 
 
+def _state_namespace(path: Path) -> Path:
+    """Return the namespace containing a canonical state path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside canonical private-state namespace: {path}")
+    return Path(*path.parts[: indexes[-1] + 1])
+
+
+def _legacy_equivalent(path: Path) -> tuple[Path, Path]:
+    """Return the state root and canonical equivalent of one legacy path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == LEGACY_NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside legacy private-state namespace: {path}")
+    marker = indexes[-1]
+    state_root = Path(*path.parts[:marker])
+    relative = Path(*path.parts[marker + 1:])
+    return state_root, state_root / NAMESPACE / relative
+
+
 def exclusive_write_bytes(
-    path: Path, content: bytes, mode: int = 0o600
+    path: Path, content: bytes, mode: int = 0o600, *, _lock_held: bool = False
 ) -> tuple[int, int]:
     """Durably publish a new state record without replacing any existing object."""
+    if NAMESPACE not in path.parts:
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            if os.path.lexists(path):
+                raise GitPrivateStateError(f"legacy private-state record already exists: {path}")
+            target = canonical if not (state_root / LEGACY_NAMESPACE).exists() else path
+            ensure_parent(target)
+            if target == canonical:
+                return _exclusive_publish(target, content, 0o600)
+            return _exclusive_publish_direct(target, content, mode)
     ensure_parent(path)
-    return _exclusive_publish(path, content, mode)
+    namespace = _state_namespace(path)
+    if _lock_held:
+        return _exclusive_publish(path, content, 0o600)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        return _exclusive_publish(path, content, 0o600)
 
 
 def _identity_unlink(item: MigrationFile) -> None:
     if read_bytes(item.source, "legacy private-state record") != item.content:
         raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
-    metadata = _require_regular(item.source, "legacy private-state record")
+    metadata = _require_legacy_record(item.source, "legacy private-state record")
     if (metadata.st_dev, metadata.st_ino) != item.identity:
         raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
     parent_fd = _open_anchored_parent(item.source)
@@ -598,6 +1024,118 @@ def _identity_unlink(item: MigrationFile) -> None:
         os.close(parent_fd)
 
 
+def _unlink_identity_path(path: Path, identity: tuple[int, int], what: str) -> None:
+    parent_fd = _open_anchored_parent(path)
+    try:
+        metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if ((metadata.st_dev, metadata.st_ino) != identity or
+                not stat.S_ISREG(metadata.st_mode)):
+            raise GitPrivateStateError(f"{what} identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _handoff_cleanup_lock(
+    legacy: Path, canonical: Path, expected_identity: tuple[int, int]
+) -> tuple[int, int]:
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    if (legacy_meta.st_dev, legacy_meta.st_ino) != expected_identity:
+        raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+    legacy_parent_fd = _open_anchored_parent(legacy)
+    canonical_parent_fd = _open_anchored_parent(canonical)
+    try:
+        legacy_fd = os.open(
+            legacy.name,
+            os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=legacy_parent_fd,
+        )
+        try:
+            opened = os.fstat(legacy_fd)
+            if (opened.st_dev, opened.st_ino) != expected_identity:
+                raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+            os.fchmod(legacy_fd, 0o600)
+            os.fsync(legacy_fd)
+        finally:
+            os.close(legacy_fd)
+    finally:
+        os.close(legacy_parent_fd)
+    try:
+        try:
+            canonical_meta = os.stat(
+                canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+            )
+        except FileNotFoundError:
+            canonical_meta = None
+        if canonical_meta is not None:
+            if (
+                not stat.S_ISREG(canonical_meta.st_mode)
+                or canonical_meta.st_uid != os.geteuid()
+                or stat.S_IMODE(canonical_meta.st_mode) != 0o600
+            ):
+                raise GitPrivateStateError(f"unsafe canonical cleanup lock: {canonical}")
+            if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+                expected_identity
+            ):
+                raise GitPrivateStateError(
+                    "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+                    "automatic cutover cannot prove a single cleanup fence"
+                )
+        else:
+            try:
+                source_fd = _open_anchored_parent(legacy)
+                try:
+                    os.link(
+                        legacy.name,
+                        canonical.name,
+                        src_dir_fd=source_fd,
+                        dst_dir_fd=canonical_parent_fd,
+                        follow_symlinks=False,
+                    )
+                finally:
+                    os.close(source_fd)
+                os.fsync(canonical_parent_fd)
+                published = os.stat(
+                    canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+                )
+                if (published.st_dev, published.st_ino) != expected_identity:
+                    raise GitPrivateStateError(
+                        f"legacy cleanup lock identity changed during handoff: {legacy}"
+                    )
+            except OSError as exc:
+                raise GitPrivateStateError(
+                    f"cannot establish cleanup lock handoff: {canonical}"
+                ) from exc
+    finally:
+        os.close(canonical_parent_fd)
+    return expected_identity
+
+
+def _preflight_cleanup_lock_handoff(legacy: Path | None, canonical: Path) -> None:
+    if legacy is None:
+        return
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    try:
+        canonical_meta = canonical.lstat()
+    except FileNotFoundError:
+        return
+    _require_canonical_file(canonical, "canonical cleanup lock")
+    if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+        legacy_meta.st_dev, legacy_meta.st_ino
+    ):
+        raise GitPrivateStateError(
+            "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+            "automatic cutover cannot prove a single cleanup fence"
+        )
+
+
 def _remove_known_empty_legacy_directories(layout: Topology) -> None:
     roots = [layout.common / LEGACY_NAMESPACE]
     if not layout.admin_is_common:
@@ -608,7 +1146,7 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
         for name in SHARED_DIRS:
             child = root / name
             try:
-                _require_dir(child, "legacy private-state directory")
+                _require_legacy_dir(child, "legacy private-state directory")
             except GitPrivateStateError:
                 if child.exists() or child.is_symlink():
                     raise
@@ -620,7 +1158,6 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
                     os.fsync(descriptor)
                 finally:
                     os.close(descriptor)
-        # The shared root remains while its mixed-version cleanup lock exists.
         if not any(root.iterdir()):
             root.rmdir()
             descriptor = _open_dir(root.parent)
@@ -631,24 +1168,46 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
 
 
 @contextmanager
-def _file_lock(path: Path, *, create: bool):
+def _file_lock(path: Path, *, create: bool, nonblocking: bool = False, exact: bool = False):
     flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-    if create:
-        flags |= os.O_CREAT
     parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
     try:
-        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        if create:
+            try:
+                descriptor = os.open(path.name, flags | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=parent_fd)
+                os.fchmod(descriptor, 0o600)
+                os.fsync(parent_fd)
+            except FileExistsError:
+                descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        else:
+            descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise GitPrivateStateError(f"unsafe private-state lock: {path}")
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        yield
+        if metadata.st_uid != os.geteuid() or (exact and stat.S_IMODE(metadata.st_mode) != 0o600) or (
+                not exact and (stat.S_IMODE(metadata.st_mode) & 0o022 or metadata.st_mode & 0o111 or
+                               not (metadata.st_mode & 0o600))):
+            raise GitPrivateStateError(f"unsafe private-state lock mode or ownership: {path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0))
+        except BlockingIOError as exc:
+            raise GitPrivateStateError(f"BLOCKED: private-state lock is contended: {path}") from exc
     except GitPrivateStateError:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise
     except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    try:
+        locked = os.fstat(descriptor)
+        yield (locked.st_dev, locked.st_ino)
     finally:
-        if "descriptor" in locals():
+        if descriptor is not None:
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_UN)
             finally:
@@ -662,7 +1221,8 @@ def prepare(
     admin: bool = False,
     common_dir: Path | None = None,
     admin_dir: Path | None = None,
-    _legacy_lock_held: bool = False,
+    _legacy_lock_identity: tuple[int, int] | None = None,
+    _allow_incomplete_recovery: bool = False,
 ) -> None:
     """Validate and migrate known legacy state before a state mutation."""
     layout = (
@@ -670,25 +1230,38 @@ def prepare(
         if common_dir is not None
         else topology(root)
     )
-    _validate_canonical(layout)
+    _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
     shared_pairs, legacy_lock = _scan_shared_legacy(layout)
     pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
     _inspect_pairs(pairs)  # preflight before creating even the migration lock
-    if legacy_lock is not None and not _legacy_lock_held:
-        with _file_lock(legacy_lock, create=False):
+    if legacy_lock is not None and _legacy_lock_identity is None:
+        with _file_lock(legacy_lock, create=False, nonblocking=True) as lock_identity:
             prepare(
                 root,
                 admin=admin,
                 common_dir=layout.common,
                 admin_dir=layout.admin,
-                _legacy_lock_held=True,
+                _legacy_lock_identity=lock_identity,
+                _allow_incomplete_recovery=_allow_incomplete_recovery,
             )
         return
 
+    _preflight_cleanup_lock_handoff(
+        legacy_lock, layout.common / NAMESPACE / "cleanup.lock"
+    )
     _ensure_namespace(layout.common, ())
-    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+    admin_lock_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_lock_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_lock_context:
         # Repeat all classification under the migration lock.
-        _validate_canonical(layout)
+        _recover_canonical_temps(layout, include_admin=admin)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         shared_pairs, _ = _scan_shared_legacy(layout)
         pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
         inspected = _inspect_pairs(pairs)
@@ -696,28 +1269,67 @@ def prepare(
             _ensure_namespace(layout.common, (name,))
         if admin:
             _ensure_namespace(layout.admin, ("automation-maintenance",))
+        legacy_lock_identity = None
+        if legacy_lock is not None:
+            if _legacy_lock_identity is None:
+                raise GitPrivateStateError("legacy cleanup lock is not held for handoff")
+            legacy_lock_identity = _handoff_cleanup_lock(
+                legacy_lock,
+                layout.common / NAMESPACE / "cleanup.lock",
+                _legacy_lock_identity,
+            )
         for item in inspected:
             try:
                 item.target.lstat()
             except FileNotFoundError:
-                _exclusive_publish(item.target, item.content, item.mode)
+                _exclusive_publish(item.target, item.content, 0o600)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         # No source is removed until every destination is durable and equivalent.
         for item in inspected:
+            _require_canonical_file(item.target, "canonical private-state record")
             if read_bytes(item.target, "canonical private-state record") != item.content:
                 raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
         for item in inspected:
-            metadata = _require_regular(item.source, "legacy private-state record")
+            metadata = _require_legacy_record(item.source, "legacy private-state record")
             if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
                 item.source, "legacy private-state record"
             ) != item.content:
                 raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
         for item in inspected:
             _identity_unlink(item)
+        if legacy_lock is not None and legacy_lock_identity is not None:
+            _unlink_identity_path(legacy_lock, legacy_lock_identity, "legacy cleanup lock")
         _remove_known_empty_legacy_directories(layout)
 
 
 def write_bytes(path: Path, content: bytes) -> None:
     """Atomically and durably replace one prepared canonical regular file."""
+    namespace = _state_namespace(path)
+    ensure_parent(path)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _write_bytes_locked(path, content)
+
+
+@contextmanager
+def mutation_lock(root: Path, *, admin: bool = False):
+    """Fence a caller-managed canonical transaction in global lock order."""
+    layout = topology(root)
+    _ensure_namespace(layout.common, ())
+    admin_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_context:
+        _recover_canonical_temps(layout, include_admin=admin)
+        yield
+
+
+def _write_bytes_locked(path: Path, content: bytes) -> None:
     parent_fd = _open_anchored_parent(path)
     temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
@@ -731,6 +1343,7 @@ def write_bytes(path: Path, content: bytes) -> None:
                 raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
         try:
+            os.fchmod(descriptor, 0o600)
             view = memoryview(content)
             while view:
                 written = os.write(descriptor, view)
@@ -755,8 +1368,51 @@ def write_bytes(path: Path, content: bytes) -> None:
             os.close(parent_fd)
 
 
-def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+def unlink(
+    path: Path,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+    expected_content: bytes | None = None,
+    _lock_held: bool = False,
+) -> None:
     """Remove only a canonical regular file through its verified parent."""
+    if NAMESPACE not in path.parts:
+        # A pre-cutover consumer may need to consume or roll back a validated
+        # historical authority before the upgraded implementation is committed.
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            legacy_exists = os.path.lexists(path)
+            canonical_exists = os.path.lexists(canonical)
+            if legacy_exists and canonical_exists:
+                if expected_content is None:
+                    raise GitPrivateStateError(
+                        f"legacy and canonical private-state records both exist: {path}"
+                    )
+                if read_bytes(path) != expected_content or read_bytes(canonical) != expected_content:
+                    raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+                _unlink_locked(path, expected_identity=expected_identity)
+                _unlink_locked(canonical)
+                return
+            if legacy_exists:
+                _unlink_locked(path, expected_identity=expected_identity)
+                return
+            if not canonical_exists or expected_content is None:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            if read_bytes(canonical, "canonical private-state record") != expected_content:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            _unlink_locked(canonical)
+        return
+    namespace = _state_namespace(path)
+    if _lock_held:
+        _unlink_locked(path, expected_identity=expected_identity)
+        return
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _unlink_locked(path, expected_identity=expected_identity)
+
+
+def _unlink_locked(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
     parent_fd = _open_anchored_parent(path)
     try:
         try:
@@ -779,19 +1435,26 @@ def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> N
 
 @contextmanager
 def cleanup_lock(root: Path):
-    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    """Cut over legacy cleanup locking, then acquire only the canonical lock."""
     layout = topology(root)
     _validate_canonical(layout)
     _, legacy = _scan_shared_legacy(layout)
     # Lock old consumers out while migrating cleanup/discard evidence.
-    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
-    with legacy_context:
+    legacy_context = (_file_lock(legacy, create=False, nonblocking=True)
+                      if legacy is not None else nullcontext())
+    with legacy_context as legacy_identity:
         prepare(
             root,
             common_dir=layout.common,
             admin_dir=layout.admin,
-            _legacy_lock_held=legacy is not None,
+            _legacy_lock_identity=legacy_identity,
         )
-        _ensure_namespace(layout.common, ())
-        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+        if legacy is not None:
+            # The open legacy descriptor now names the same inode as the
+            # canonical path and remains held for the whole caller operation.
             yield
+        else:
+            with _file_lock(
+                layout.common / NAMESPACE / "cleanup.lock", create=True, exact=True
+            ):
+                yield

--- a/templates/agent-nix/.automation/bin/git_private_state.py
+++ b/templates/agent-nix/.automation/bin/git_private_state.py
@@ -1,0 +1,797 @@
+"""Owned, fail-closed storage for Agent Core's Git-private runtime state."""
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+import subprocess
+
+
+NAMESPACE = "agent-core"
+LEGACY_NAMESPACE = "opencode"
+TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+PR_RE = re.compile(r"[1-9][0-9]*")
+HASH_RE = re.compile(r"[0-9a-f]{64}")
+SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
+FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+LOCK_FILES = {"cleanup.lock", "migration.lock"}
+_GIT_EXECUTABLE = "git"
+
+
+class GitPrivateStateError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Topology:
+    common: Path
+    admin: Path
+
+    @property
+    def admin_is_common(self) -> bool:
+        return self.admin == self.common
+
+
+@dataclass(frozen=True)
+class MigrationFile:
+    source: Path
+    target: Path
+    identity: tuple[int, int]
+    mode: int
+    content: bytes
+
+
+def _git_path(root: Path, argument: str) -> Path:
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    environment.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    })
+    result = subprocess.run(
+        [_GIT_EXECUTABLE, "-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null",
+         "-c", "core.pager=", "rev-parse", argument],
+        cwd=root, text=True, capture_output=True, check=False, env=environment,
+    )
+    raw = result.stdout.strip()
+    if result.returncode != 0 or not raw:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}")
+    candidate = Path(raw)
+    try:
+        resolved = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+        metadata = resolved.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"Git private-state location is not a directory: {resolved}")
+    return resolved
+
+
+def topology(root: Path) -> Topology:
+    return Topology(_git_path(root, "--git-common-dir"), _git_path(root, "--absolute-git-dir"))
+
+
+def common_git_dir(root: Path) -> Path:
+    return topology(root).common
+
+
+def admin_git_dir(root: Path) -> Path:
+    return topology(root).admin
+
+
+def common_state(root: Path) -> Path:
+    return common_git_dir(root) / NAMESPACE
+
+
+def admin_maintenance(root: Path) -> Path:
+    return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def cleanup_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "cleanup" / f"{task}.json"
+
+
+def discard_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "discard-pristine" / f"{task}.json"
+
+
+def integration_checkpoint(root: Path, pr: str) -> Path:
+    if PR_RE.fullmatch(pr) is None:
+        raise GitPrivateStateError("invalid pull request number")
+    return common_state(root) / "integration" / f"pr-{pr}.head"
+
+
+def _lstat(path: Path, what: str) -> os.stat_result:
+    try:
+        return path.lstat()
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect {what}: {path}") from exc
+
+
+def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def _require_regular(path: Path, what: str) -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def safe_directory(path: Path) -> None:
+    _require_dir(path)
+
+
+def _open_dir(path: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot open private-state directory: {path}") from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise GitPrivateStateError(f"unsafe private-state directory: {path}")
+    return descriptor
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open a state parent without following namespace or descendant symlinks."""
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    descriptor = _open_dir(boundary)
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for component in parts[marker:-1]:
+            child = os.open(component, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except GitPrivateStateError:
+        os.close(descriptor)
+        raise
+    except OSError as exc:
+        os.close(descriptor)
+        raise GitPrivateStateError(f"cannot traverse private-state directory: {path.parent}") from exc
+
+
+def _ensure_child_directory(parent: Path, name: str) -> Path:
+    descriptor = _open_dir(parent)
+    try:
+        try:
+            os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.fsync(descriptor)
+        except FileExistsError:
+            pass
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        child = os.open(name, flags, dir_fd=descriptor)
+        try:
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+        finally:
+            os.close(child)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state directory: {parent / name}") from exc
+    finally:
+        os.close(descriptor)
+    return parent / name
+
+
+def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
+    _require_dir(base, "Git administrative directory")
+    descriptor = _open_dir(base)
+    current = base
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for name in (NAMESPACE, *subdirectories):
+            try:
+                os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.fsync(descriptor)
+            except FileExistsError:
+                pass
+            child = os.open(name, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            os.close(descriptor)
+            descriptor = child
+            current /= name
+        return current
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state namespace below: {base}") from exc
+    finally:
+        os.close(descriptor)
+
+
+def read_bytes_identity(
+    path: Path, what: str = "private-state record"
+) -> tuple[bytes, tuple[int, int]]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe {what}: {path}")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino, metadata.st_size) != (
+                after.st_dev, after.st_ino, after.st_size
+            ):
+                raise GitPrivateStateError(f"{what} changed while reading: {path}")
+            return b"".join(chunks), (metadata.st_dev, metadata.st_ino)
+        finally:
+            os.close(descriptor)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot read {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def read_bytes(path: Path, what: str = "private-state record") -> bytes:
+    return read_bytes_identity(path, what)[0]
+
+
+def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
+    if directory in {"cleanup", "discard-pristine"}:
+        return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
+    if directory == "integration":
+        return re.fullmatch(r"pr-[1-9][0-9]*\.head", name) is not None
+    if directory == "automation-maintenance":
+        return (
+            re.fullmatch(r"[0-9a-f]{64}\.json", name) is not None
+            or (allow_fixed and name in FIXED_AUTHORITY_FILES)
+        )
+    return False
+
+
+def _legacy_json(content: bytes, path: Path) -> dict:
+    try:
+        value = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}") from exc
+    if not isinstance(value, dict):
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+    return value
+
+
+def _valid_oid(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+
+
+def _valid_digest(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+def _valid_task_id(value: object) -> bool:
+    return isinstance(value, str) and TASK_RE.fullmatch(value) is not None
+
+
+def _valid_nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _valid_absolute_path(value: object) -> bool:
+    return _valid_nonempty(value) and Path(value).is_absolute()
+
+
+def _valid_authority_fields(value: dict) -> bool:
+    return (
+        _valid_task_id(value.get("task_id"))
+        and _valid_nonempty(value.get("branch"))
+        and _valid_absolute_path(value.get("worktree"))
+        and _valid_digest(value.get("authority_nonce"))
+        and _valid_digest(value.get("receipt_sha256"))
+    )
+
+
+def _validate_legacy_content(path: Path, content: bytes) -> None:
+    directory = path.parent.name
+    name = path.name
+    if directory == "integration":
+        try:
+            text = content.decode("ascii", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
+        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
+        return
+    value = _legacy_json(content, path)
+    if directory == "cleanup":
+        required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("task") == name[:-5]
+            and value.get("status") in {"merged", "cancelled"}
+            and isinstance(value.get("worktree"), str)
+            and isinstance(value.get("branch"), str)
+            and _valid_oid(value.get("local_head"))
+            and isinstance(value.get("evidence"), dict)
+        )
+    elif directory == "discard-pristine":
+        required = {
+            "schema_version", "operation", "task", "status", "worktree", "branch",
+            "base_branch", "base_revision", "local_head", "repository",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("operation") == "discard-pristine"
+            and value.get("task") == name[:-5]
+            and value.get("status") == "initialized"
+            and all(isinstance(value.get(field), str) for field in (
+                "worktree", "branch", "base_branch", "repository"
+            ))
+            and _valid_oid(value.get("base_revision"))
+            and value.get("local_head") == value.get("base_revision")
+        )
+    elif name == "source-recovery-proof.json":
+        required = {
+            "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+            "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+            "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+            "receipt_source", "receipt_source_revision",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "source-recovery-proof"
+            and _valid_authority_fields(value)
+            and _valid_oid(value.get("authority_head"))
+            and all(_valid_digest(value.get(field)) for field in (
+                "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256",
+            ))
+            and _valid_absolute_path(value.get("implementation_source"))
+            and _valid_oid(value.get("implementation_revision"))
+            and _valid_absolute_path(value.get("receipt_source"))
+            and _valid_oid(value.get("receipt_source_revision"))
+        )
+    else:
+        standard = {"schema_version", "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"}
+        bridge = standard | {"kind", "proof_sha256"}
+        valid = (
+            (set(value) == standard and value.get("schema_version") == 1
+             and _valid_authority_fields(value))
+            or (set(value) == bridge and value.get("schema_version") == 2
+                and value.get("kind") == "source-recovery-bridge"
+                and _valid_authority_fields(value)
+                and _valid_digest(value.get("proof_sha256")))
+        )
+    if not valid:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+
+
+def _namespace_kind(path: Path, *, foreign_regular: bool) -> str:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return "absent"
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect private-state namespace: {path}") from exc
+    if stat.S_ISREG(metadata.st_mode) and foreign_regular:
+        return "foreign"
+    if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+        return "directory"
+    raise GitPrivateStateError(f"unsafe private-state namespace: {path}")
+
+
+def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path | None]:
+    root = layout.common / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return [], None
+    pairs: list[tuple[Path, Path]] = []
+    legacy_lock: Path | None = None
+    for entry in root.iterdir():
+        if entry.name == "cleanup.lock":
+            _require_regular(entry, "legacy cleanup lock")
+            legacy_lock = entry
+            continue
+        if entry.name not in SHARED_DIRS:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
+        _require_dir(entry, "legacy private-state directory")
+        for child in entry.iterdir():
+            allow_fixed = entry.name == "automation-maintenance"
+            if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
+                raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+            _require_regular(child, "legacy private-state record")
+            if child.name in FIXED_AUTHORITY_FILES:
+                if layout.admin_is_common:
+                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
+                # In a linked worktree these belong to the main worktree admin.
+            else:
+                pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    return pairs, legacy_lock
+
+
+def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
+    if layout.admin_is_common:
+        return []
+    root = layout.admin / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return []
+    entries = list(root.iterdir())
+    if any(entry.name != "automation-maintenance" for entry in entries):
+        unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+        raise GitPrivateStateError(f"unknown legacy private-state entry: {unknown}")
+    if not entries:
+        return []
+    maintenance = entries[0]
+    _require_dir(maintenance, "legacy maintenance authority directory")
+    pairs: list[tuple[Path, Path]] = []
+    for child in maintenance.iterdir():
+        if child.name not in FIXED_AUTHORITY_FILES:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+        _require_regular(child, "legacy private-state record")
+        pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    return pairs
+
+
+def _validate_canonical(layout: Topology) -> None:
+    shared = layout.common / NAMESPACE
+    kind = _namespace_kind(shared, foreign_regular=False)
+    if kind == "directory":
+        for entry in shared.iterdir():
+            if entry.name in LOCK_FILES:
+                _require_regular(entry, "canonical private-state lock")
+                continue
+            if entry.name not in SHARED_DIRS:
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
+            _require_dir(entry)
+            for child in entry.iterdir():
+                # Fixed files in common are the main worktree's admin records.
+                if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
+                    raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                _require_regular(child, "canonical private-state record")
+    if not layout.admin_is_common:
+        admin_root = layout.admin / NAMESPACE
+        kind = _namespace_kind(admin_root, foreign_regular=False)
+        if kind == "directory":
+            entries = list(admin_root.iterdir())
+            if any(entry.name != "automation-maintenance" for entry in entries):
+                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
+            if entries:
+                maintenance = entries[0]
+                _require_dir(maintenance)
+                for child in maintenance.iterdir():
+                    if child.name not in FIXED_AUTHORITY_FILES:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    _require_regular(child, "canonical private-state record")
+
+
+def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
+    inspected: list[MigrationFile] = []
+    for source, target in pairs:
+        metadata = _require_regular(source, "legacy private-state record")
+        content = read_bytes(source, "legacy private-state record")
+        _validate_legacy_content(source, content)
+        try:
+            target.lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise GitPrivateStateError(f"cannot inspect canonical private-state record: {target}") from exc
+        else:
+            if read_bytes(target, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting private-state records: {source} and {target}")
+        inspected.append(MigrationFile(
+            source, target, (metadata.st_dev, metadata.st_ino),
+            stat.S_IMODE(metadata.st_mode), content,
+        ))
+    return inspected
+
+
+def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".migrate.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            os.link(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd,
+                    follow_symlinks=False)
+            os.fsync(parent_fd)
+        except FileExistsError:
+            if read_bytes(path, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
+        published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if not stat.S_ISREG(published.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        return published.st_dev, published.st_ino
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot publish private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def ensure_parent(path: Path) -> None:
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
+    if not indexes:
+        # Legacy restoration may use only an already-existing validated parent.
+        descriptor = _open_anchored_parent(path)
+        os.close(descriptor)
+        return
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
+
+
+def exclusive_write_bytes(
+    path: Path, content: bytes, mode: int = 0o600
+) -> tuple[int, int]:
+    """Durably publish a new state record without replacing any existing object."""
+    ensure_parent(path)
+    return _exclusive_publish(path, content, mode)
+
+
+def _identity_unlink(item: MigrationFile) -> None:
+    if read_bytes(item.source, "legacy private-state record") != item.content:
+        raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+    metadata = _require_regular(item.source, "legacy private-state record")
+    if (metadata.st_dev, metadata.st_ino) != item.identity:
+        raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+    parent_fd = _open_anchored_parent(item.source)
+    try:
+        current = os.stat(item.source.name, dir_fd=parent_fd, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) != item.identity or not stat.S_ISREG(current.st_mode):
+            raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+        os.unlink(item.source.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove legacy private-state record: {item.source}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _remove_known_empty_legacy_directories(layout: Topology) -> None:
+    roots = [layout.common / LEGACY_NAMESPACE]
+    if not layout.admin_is_common:
+        roots.append(layout.admin / LEGACY_NAMESPACE)
+    for root in roots:
+        if _namespace_kind(root, foreign_regular=True) != "directory":
+            continue
+        for name in SHARED_DIRS:
+            child = root / name
+            try:
+                _require_dir(child, "legacy private-state directory")
+            except GitPrivateStateError:
+                if child.exists() or child.is_symlink():
+                    raise
+                continue
+            if not any(child.iterdir()):
+                child.rmdir()
+                descriptor = _open_dir(root)
+                try:
+                    os.fsync(descriptor)
+                finally:
+                    os.close(descriptor)
+        # The shared root remains while its mixed-version cleanup lock exists.
+        if not any(root.iterdir()):
+            root.rmdir()
+            descriptor = _open_dir(root.parent)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+
+
+@contextmanager
+def _file_lock(path: Path, *, create: bool):
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    if create:
+        flags |= os.O_CREAT
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe private-state lock: {path}")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    finally:
+        if "descriptor" in locals():
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+        os.close(parent_fd)
+
+
+def prepare(
+    root: Path,
+    *,
+    admin: bool = False,
+    common_dir: Path | None = None,
+    admin_dir: Path | None = None,
+    _legacy_lock_held: bool = False,
+) -> None:
+    """Validate and migrate known legacy state before a state mutation."""
+    layout = (
+        Topology(common_dir.resolve(), (admin_dir or common_dir).resolve())
+        if common_dir is not None
+        else topology(root)
+    )
+    _validate_canonical(layout)
+    shared_pairs, legacy_lock = _scan_shared_legacy(layout)
+    pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+    _inspect_pairs(pairs)  # preflight before creating even the migration lock
+    if legacy_lock is not None and not _legacy_lock_held:
+        with _file_lock(legacy_lock, create=False):
+            prepare(
+                root,
+                admin=admin,
+                common_dir=layout.common,
+                admin_dir=layout.admin,
+                _legacy_lock_held=True,
+            )
+        return
+
+    _ensure_namespace(layout.common, ())
+    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+        # Repeat all classification under the migration lock.
+        _validate_canonical(layout)
+        shared_pairs, _ = _scan_shared_legacy(layout)
+        pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+        inspected = _inspect_pairs(pairs)
+        for name in SHARED_DIRS:
+            _ensure_namespace(layout.common, (name,))
+        if admin:
+            _ensure_namespace(layout.admin, ("automation-maintenance",))
+        for item in inspected:
+            try:
+                item.target.lstat()
+            except FileNotFoundError:
+                _exclusive_publish(item.target, item.content, item.mode)
+        # No source is removed until every destination is durable and equivalent.
+        for item in inspected:
+            if read_bytes(item.target, "canonical private-state record") != item.content:
+                raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
+        for item in inspected:
+            metadata = _require_regular(item.source, "legacy private-state record")
+            if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
+                item.source, "legacy private-state record"
+            ) != item.content:
+                raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+        for item in inspected:
+            _identity_unlink(item)
+        _remove_known_empty_legacy_directories(layout)
+
+
+def write_bytes(path: Path, content: bytes) -> None:
+    """Atomically and durably replace one prepared canonical regular file."""
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        try:
+            current = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            if not stat.S_ISREG(current.st_mode):
+                raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot write private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+    """Remove only a canonical regular file through its verified parent."""
+    parent_fd = _open_anchored_parent(path)
+    try:
+        try:
+            metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        if expected_identity is not None and (metadata.st_dev, metadata.st_ino) != expected_identity:
+            raise GitPrivateStateError(f"private-state record identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove private-state record: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    layout = topology(root)
+    _validate_canonical(layout)
+    _, legacy = _scan_shared_legacy(layout)
+    # Lock old consumers out while migrating cleanup/discard evidence.
+    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
+    with legacy_context:
+        prepare(
+            root,
+            common_dir=layout.common,
+            admin_dir=layout.admin,
+            _legacy_lock_held=legacy is not None,
+        )
+        _ensure_namespace(layout.common, ())
+        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+            yield

--- a/templates/agent-nix/.automation/bin/task_lifecycle.py
+++ b/templates/agent-nix/.automation/bin/task_lifecycle.py
@@ -15,6 +15,10 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 WORK_UNIT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -1053,19 +1057,19 @@ def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
     validate_task(task)
-    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+    try:
+        return private_state.cleanup_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 @contextmanager
 def cleanup_lock(root: Path):
-    path = common_git_dir(root) / "opencode" / "cleanup.lock"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        try:
+    try:
+        with private_state.cleanup_lock(root):
             yield
-        finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 def cleanup_repository(root: Path) -> str:
@@ -1230,8 +1234,8 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
     if path.is_symlink() or not path.is_file():
         raise LifecycleError("cleanup receipt is not a regular local file")
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "cleanup receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise LifecycleError("cleanup receipt is invalid") from exc
     required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
     if (
@@ -1317,7 +1321,10 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -1332,13 +1339,18 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
 
 def task_cleanup(root: Path, task: str) -> None:
     require_main_worktree(root)
-    receipt = cleanup_receipt_path(root, task)
     with cleanup_lock(root):
+        receipt = cleanup_receipt_path(root, task)
         if receipt.exists():
             finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
             return
         plan = cleanup_plan(root, task)
-        atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise LifecycleError(str(exc)) from exc
         finish_cleanup(root, plan, receipt)
 
 

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -184,5 +184,29 @@ upgrade with changes replaces the active receipt and removes the previous consum
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
 receipt lifecycle evidence.
 
+## Git-private runtime state
+
+Agent Core owns only the `agent-core/` namespace beneath Git administrative
+directories. Shared cleanup receipts, pristine-discard receipts, integration
+checkpoints, the cleanup lock, the migration lock, and historical hashed
+maintenance authorities live beneath `<git-common-dir>/agent-core/`.
+Worktree-specific maintenance `authority.json` and
+`source-recovery-proof.json` live beneath
+`<absolute-git-dir>/agent-core/automation-maintenance/`. Repository Task State
+under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
+`opencode.json` configuration are separate ownership surfaces.
+
+The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
+file and Agent Core never changes its bytes, metadata, or identity. A legacy
+directory at that name is accepted only when every entry has an explicitly
+known historical Agent Core path and schema. Known regular records are copied byte for
+byte with durable no-overwrite publication, all conflicts are rejected before
+migration mutation, and legacy records are removed only after every canonical
+destination is verified equivalent. Equivalent dual state and partially
+completed migration are retryable. Unknown entries, unexpected nesting,
+symlinks, and special files fail closed. The historical `cleanup.lock` is
+retained as a mixed-version locking ABI and is acquired before the canonical
+lock; it is never renamed or unlinked automatically.
+
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -148,6 +148,12 @@ files unchanged. It reports `PROVENANCE_REBOUND` or idempotent
 `PROVENANCE_ALREADY_BOUND`; then run ordinary consumer verification and the
 existing `automation::commit`.
 
+Rebind is an operator-serialized maintenance transition: no commit or other
+authority mutation may run concurrently in the target worktree. Current Agent
+Core revisions additionally fence rebind and commit with the same ordered
+common/admin migration locks; the explicit quiescence requirement preserves the
+older pending consumer needed to finish an in-flight upgrade.
+
 Eligibility is exact: registered maintenance Task/worktree/branch/HEAD; one
 standard active receipt matching exactly one authority; safe pending Agent
 Core paths/fingerprints only; no consumed, source-recovery, or ambiguous state;
@@ -155,7 +161,8 @@ the old and expected revisions in the same Templates object database; and an
 identical expected canonical diff. Missing authority remains the Issue #85
 route. Committed or consumed state, including a crossed guarded publication
 boundary, is rejected. Handled
-failures roll back safely and concurrency fails closed. No cross-filesystem
+failures roll back safely; operations by current revisions fail closed under the
+shared fence. No cross-filesystem
 atomicity or hard-crash durability is claimed; that remains Issue #89 scope.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
@@ -198,15 +205,36 @@ under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
 
 The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
 file and Agent Core never changes its bytes, metadata, or identity. A legacy
-directory at that name is accepted only when every entry has an explicitly
-known historical Agent Core path and schema. Known regular records are copied byte for
-byte with durable no-overwrite publication, all conflicts are rejected before
-migration mutation, and legacy records are removed only after every canonical
-destination is verified equivalent. Equivalent dual state and partially
-completed migration are retryable. Unknown entries, unexpected nesting,
-symlinks, and special files fail closed. The historical `cleanup.lock` is
-retained as a mixed-version locking ABI and is acquired before the canonical
-lock; it is never renamed or unlinked automatically.
+directory at that name is accepted only when every entry satisfies the exact
+historical path, schema, Task/branch/worktree identity, repository syntax, and
+authority/proof relationship that Agent Core produced. The legacy namespace,
+subdirectories, records, and lock must be owned by the current effective user.
+Directories require owner access and reject group/other mutation while retaining
+historically produced read/traverse modes such as `0755`; records and locks reject
+group/other mutation and executable bits. Canonical directories
+are exactly mode `0700`, and canonical records, locks, and publication
+artifacts are exactly mode `0600`.
+
+Known records are copied byte for byte with durable no-overwrite publication,
+all conflicts are rejected before migration mutation, and legacy records are
+removed only after every canonical destination is mode-, owner-, and
+content-equivalent. The legacy cleanup-lock inode is acquired nonblocking and
+hard-linked into the canonical cleanup-lock path before its legacy name is
+removed. Existing waiters therefore remain fenced on the same inode. A
+contended legacy lock, or distinct legacy and canonical lock inodes, reports a
+precise `BLOCKED` condition rather than claiming migration success. Successful
+cutover removes the legacy lock last and then removes the empty `opencode/`
+directory, leaving the path available to OpenCode.
+
+Canonical publication is serialized by `migration.lock`. Only exact owned
+`.migrate.<pid>.<16-lowercase-hex>` and
+`.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next
+operation they are validated and durably removed under that lock before the
+legacy source is retried or an already-durable destination is used. Equivalent
+dual state, partial legacy removal, and interruption before or after durable
+publication are therefore retryable. Unknown entries, malformed temporary
+names, unsafe modes/ownership, unexpected nesting, symlinks, and special files
+fail closed without promotion.
 
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-python/.automation/bin/agent_core.py
+++ b/templates/agent-python/.automation/bin/agent_core.py
@@ -17,6 +17,7 @@ if str(SCRIPT_DIR) not in sys.path:
 import task_lifecycle as lifecycle
 import publication_metadata as publication
 import task_contract
+import git_private_state as private_state
 
 try:
     import tomllib
@@ -527,22 +528,31 @@ def validate_integration(root: Path, pr: str) -> dict:
 
 
 def integration_checkpoint(root: Path, pr: str) -> Path:
-    path = common_git_dir(root) / "opencode" / "integration" / f"pr-{pr}.head"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
+    try:
+        return private_state.integration_checkpoint(root, pr)
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
 
 
 def integrate_check(root: Path, pr: str) -> None:
     data = validate_integration(root, pr)
-    integration_checkpoint(root, pr).write_text(data["headRefOid"] + "\n", encoding="utf-8")
+    try:
+        private_state.prepare(root)
+        checkpoint = integration_checkpoint(root, pr)
+        private_state.write_bytes(checkpoint, (data["headRefOid"] + "\n").encode("utf-8"))
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
     print(json.dumps({"pr": data["number"], "head": data["headRefOid"], "status": "verified"}))
 
 
 def integrate_merge(root: Path, pr: str) -> None:
     checkpoint = integration_checkpoint(root, pr)
-    if not checkpoint.exists():
+    if not checkpoint.exists() or checkpoint.is_symlink() or not checkpoint.is_file():
         raise AutomationError("run integrate::check before merge")
-    expected = checkpoint.read_text(encoding="utf-8").strip()
+    try:
+        expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
+    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+        raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:
         raise AutomationError(f"PR head moved after integration check: expected {expected}, got {data['headRefOid']}")

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -16,6 +16,10 @@ import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 
 class UpgradeError(RuntimeError):
     pass
@@ -120,16 +124,55 @@ def worktree_admin_dir(repo: Path) -> Path:
 
 def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     admin = worktree_admin_dir(repo)
-    new_parent = admin / "opencode" / "automation-maintenance"
+    new_parent = admin / private_state.NAMESPACE / "automation-maintenance"
+    if new_parent.exists() or new_parent.is_symlink():
+        try:
+            private_state.safe_directory(admin / private_state.NAMESPACE)
+            private_state.safe_directory(new_parent)
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError(str(exc)) from exc
     try:
         resolved_parent = new_parent.resolve()
     except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy_location = _safe_legacy_location(repo)
-    legacy = legacy_location[0] if legacy_location is not None else None
+    common = common_git_dir(repo)
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    migrated = common / private_state.NAMESPACE / "automation-maintenance" / f"{key}.json"
+    if os.path.lexists(migrated):
+        try:
+            private_state.safe_directory(common / private_state.NAMESPACE)
+            private_state.safe_directory(migrated.parent)
+            private_state.read_bytes(migrated, "migrated maintenance authority")
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+        legacy = migrated
+    else:
+        old_admin = _safe_old_admin_authority(repo)
+        if old_admin is not None and os.path.lexists(old_admin[0]):
+            legacy = old_admin[0]
+        else:
+            legacy_location = _safe_legacy_location(repo)
+            legacy = legacy_location[0] if legacy_location is not None else None
     return new_parent / "authority.json", legacy
+
+
+def _safe_old_admin_authority(repo: Path) -> tuple[Path, Path] | None:
+    try:
+        admin = worktree_admin_dir(repo)
+        root = admin / "opencode"
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
+            return None
+        parent = root / "automation-maintenance"
+        if parent.is_symlink() or (parent.exists() and not parent.is_dir()):
+            return None
+        resolved = parent.resolve()
+        if resolved != admin and admin not in resolved.parents:
+            return None
+        return parent / "authority.json", admin
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
@@ -144,7 +187,7 @@ def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
             return None
         key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
         return parent / f"{key}.json", common
-    except (OSError, ValueError, RuntimeError, UpgradeError):
+    except (OSError, ValueError, RuntimeError, UpgradeError, private_state.GitPrivateStateError):
         return None
 
 
@@ -167,6 +210,15 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     _write_authority_at(
         authority_path(repo),
         {
@@ -187,33 +239,29 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             parent_before = path.parent.resolve()
             if parent_before != admin and admin not in parent_before.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        path.parent.mkdir(parents=True, exist_ok=True)
+        private_state.ensure_parent(path)
         if admin is not None:
             parent_after = path.parent.resolve()
             if parent_after != admin and admin not in parent_after.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        # The caller has validated the parent; do not replace an existing record.
-        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
-        temporary = Path(temporary_name)
-        try:
-            with os.fdopen(fd, "wb") as stream:
-                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
-                stream.flush()
-                try:
-                    os.fsync(stream.fileno())
-                except OSError:
-                    pass
-            os.link(temporary, path)
-        finally:
-            temporary.unlink(missing_ok=True)
-    except (OSError, ValueError, RuntimeError) as exc:
+        private_state.exclusive_write_bytes(
+            path,
+            json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+        )
+    except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
 
 
 def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    old_admin = _safe_old_admin_authority(repo)
+    if old_admin is not None and authority == old_admin[0]:
+        return old_admin[1]
     legacy = _safe_legacy_location(repo)
     if legacy is not None and authority == legacy[0]:
         return legacy[1]
+    common = common_git_dir(repo)
+    if authority.parent == common / private_state.NAMESPACE / "automation-maintenance":
+        return common
     if authority == authority_path(repo):
         return worktree_admin_dir(repo)
     raise UpgradeError("cannot safely resolve authority location for rollback")
@@ -227,11 +275,10 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError("missing or invalid successful-upgrade authority record")
-        authority = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        authority = json.loads(
+            private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
     expected = {
         "schema_version": 1,
@@ -253,12 +300,15 @@ def _read_json_record(path: Path, error: str) -> dict:
 
 def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError(error)
-        raw = path.read_bytes()
+        if private_state.NAMESPACE in path.parts or "opencode" in path.parts:
+            raw = private_state.read_bytes(path, error)
+        else:
+            metadata = path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+                raise UpgradeError(error)
+            raw = path.read_bytes()
         value = json.loads(raw.decode("utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(error) from exc
     if not isinstance(value, dict):
         raise UpgradeError(error)
@@ -1795,7 +1845,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         raise UpgradeError("receipt source is not compatible with the current Templates source")
     old_revision = _validate_source_revision(source, old["source_revision"])
     authority = _standard_authority_only(repo, old)
-    old_authority_raw = authority.read_bytes()
+    old_authority_raw = private_state.read_bytes(authority, "maintenance authority")
     receipt_identity = (active.lstat().st_dev, active.lstat().st_ino)
     authority_identity = (authority.lstat().st_dev, authority.lstat().st_ino)
     authority_head = validate_commit_oid(repo, old["authority_head"], field="receipt authority HEAD")
@@ -1828,7 +1878,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         current_source, current_revision = resolve_clean_source_worktree(source)
         if expected_implementation_revision is None or current_revision != expected_implementation_revision:
             raise UpgradeError("source implementation changed before provenance replacement")
-    if active.read_bytes() != raw_receipt or authority.read_bytes() != old_authority_raw or pending_paths(repo) != expected_paths \
+    if active.read_bytes() != raw_receipt or private_state.read_bytes(authority, "maintenance authority") != old_authority_raw or pending_paths(repo) != expected_paths \
             or git_head(repo) != authority_head or current_source != source \
             or (require_source_head and current_revision != expected_source_revision) \
             or (active.lstat().st_dev, active.lstat().st_ino) != receipt_identity \
@@ -2021,7 +2071,11 @@ def recover_maintenance_authority_from_source(
             if existing != proof:
                 raise UpgradeError("existing source-recovery proof does not match reconstruction")
         else:
-            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+            private_state.ensure_parent(proof_path)
+            created_proof = private_state.exclusive_write_bytes(
+                proof_path,
+                json.dumps(proof, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            )
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
         if (current_source != source
                 or current_implementation_revision != expected_implementation_revision):
@@ -2040,13 +2094,11 @@ def recover_maintenance_authority_from_source(
             raise UpgradeError("source-recovery proof changed before bridge publication")
         _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
                             admin=worktree_admin_dir(target_repo))
-    except (OSError, UpgradeError):
+    except (OSError, UpgradeError, private_state.GitPrivateStateError):
         if created_proof is not None:
             try:
-                metadata = proof_path.lstat()
-                if (metadata.st_dev, metadata.st_ino) == created_proof:
-                    proof_path.unlink()
-            except OSError as exc:
+                private_state.unlink(proof_path, expected_identity=created_proof)
+            except (OSError, private_state.GitPrivateStateError) as exc:
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
@@ -2209,7 +2261,13 @@ def _commit_mode(
         )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
-        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        try:
+            proof_raw, proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            proof_record = json.loads(proof_raw.decode("utf-8"))
+        except (private_state.GitPrivateStateError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("missing or invalid source-recovery proof") from exc
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
@@ -2221,7 +2279,7 @@ def _commit_mode(
             raise UpgradeError("source-recovery receipt source is incompatible")
         _validate_source_revision(source, receipt["source_revision"])
         authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
-        if proof_path.read_bytes() != proof_raw:
+        if private_state.read_bytes(proof_path, "source-recovery proof") != proof_raw:
             raise UpgradeError("source-recovery proof changed before commit mutation")
     else:  # pragma: no cover
         raise UpgradeError("unsupported commit mode")
@@ -2249,10 +2307,29 @@ def _commit_mode(
         atomic_json_write(consumed, consumed_receipt)
         consumed_metadata = consumed.lstat()
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
-        authority.unlink(missing_ok=True)
+        authority_raw, authority_identity = private_state.read_bytes_identity(
+            authority, "maintenance authority"
+        )
+        expected_authority = (
+            _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest())
+            if mode == "source_recovery" and proof is not None
+            else {
+                "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                "receipt_sha256": receipt_digest(receipt),
+            }
+        )
+        if json.loads(authority_raw.decode("utf-8")) != expected_authority:
+            raise UpgradeError("authority changed before commit mutation")
+        private_state.unlink(authority, expected_identity=authority_identity)
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
-            proof_path.unlink()
+            current_proof, current_proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            if current_proof != proof_raw or current_proof_identity != proof_identity:
+                raise UpgradeError("source-recovery proof changed before removal")
+            private_state.unlink(proof_path, expected_identity=proof_identity)
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2304,7 +2381,7 @@ def _commit_mode(
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except (UpgradeError, OSError) as failure:
+    except (UpgradeError, OSError, private_state.GitPrivateStateError) as failure:
         if committed:
             raise UpgradeError(
                 f"commit {commit_sha} was published but finalization failed"
@@ -2314,8 +2391,8 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
-        except (OSError, UpgradeError) as rollback_error:
+                private_state.exclusive_write_bytes(proof_path, proof_raw)
+        except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
             if authority_removed:

--- a/templates/agent-python/.automation/bin/automation_upgrade.py
+++ b/templates/agent-python/.automation/bin/automation_upgrade.py
@@ -233,7 +233,13 @@ def write_authority(repo: Path, receipt: dict) -> None:
     )
 
 
-def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
+def _write_authority_at(
+    path: Path,
+    value: dict,
+    *,
+    admin: Path | None = None,
+    lock_held: bool = False,
+) -> None:
     try:
         if admin is not None:
             parent_before = path.parent.resolve()
@@ -247,6 +253,7 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
         private_state.exclusive_write_bytes(
             path,
             json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            _lock_held=lock_held,
         )
     except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
@@ -275,6 +282,7 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
+        private_state.validate_record(path, "successful-upgrade authority record")
         authority = json.loads(
             private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
         )
@@ -1642,9 +1650,10 @@ def _rename_record_at(source: str, destination: str, *, source_dir_fd: int, dest
     )
 
 
-def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
-                           receipt: dict, authority_path_value: Path,
-                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+def _replace_standard_pair_locked(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                                  receipt: dict, authority_path_value: Path,
+                                  receipt_identity: tuple[int, int],
+                                  authority_identity: tuple[int, int]) -> None:
     active = receipt_path(repo)
     admin = _rollback_authority_guard(repo, authority_path_value)
     _validate_admin_record_parent(authority_path_value, admin)
@@ -1823,6 +1832,25 @@ def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw
                 pass
 
 
+def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                           receipt: dict, authority_path_value: Path,
+                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+    """Replace a common/admin record pair under ordered namespace fences."""
+    try:
+        with private_state.mutation_lock(repo, admin=True):
+            _replace_standard_pair_locked(
+                repo,
+                old_receipt_raw,
+                old_authority_raw,
+                receipt,
+                authority_path_value,
+                receipt_identity,
+                authority_identity,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
+
+
 def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_source_revision: str,
                                    *, require_source_head: bool,
                                    expected_implementation_revision: str | None = None) -> dict:
@@ -1994,6 +2022,16 @@ def recover_maintenance_authority_from_source(
         expected_implementation_revision
     )
     task_id, branch, worktree = require_maintenance(target_repo)
+    try:
+        private_state.prepare(
+            target_repo,
+            admin=True,
+            common_dir=common_git_dir(target_repo),
+            admin_dir=worktree_admin_dir(target_repo),
+            _allow_incomplete_recovery=True,
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
     if implementation_revision != expected_implementation_revision:
         raise UpgradeError("source HEAD does not match the expected implementation revision")
@@ -2215,7 +2253,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(
+def _commit_mode_locked(
     repo: Path,
     task: str,
     message: str,
@@ -2321,7 +2359,12 @@ def _commit_mode(
         )
         if json.loads(authority_raw.decode("utf-8")) != expected_authority:
             raise UpgradeError("authority changed before commit mutation")
-        private_state.unlink(authority, expected_identity=authority_identity)
+        private_state.unlink(
+            authority,
+            expected_identity=authority_identity,
+            expected_content=authority_raw,
+            _lock_held=True,
+        )
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
             current_proof, current_proof_identity = private_state.read_bytes_identity(
@@ -2329,7 +2372,12 @@ def _commit_mode(
             )
             if current_proof != proof_raw or current_proof_identity != proof_identity:
                 raise UpgradeError("source-recovery proof changed before removal")
-            private_state.unlink(proof_path, expected_identity=proof_identity)
+            private_state.unlink(
+                proof_path,
+                expected_identity=proof_identity,
+                expected_content=proof_raw,
+                _lock_held=True,
+            )
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2391,7 +2439,9 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                private_state.exclusive_write_bytes(proof_path, proof_raw)
+                private_state.exclusive_write_bytes(
+                    proof_path, proof_raw, _lock_held=True
+                )
         except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
@@ -2401,7 +2451,12 @@ def _commit_mode(
                     "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
                     "receipt_sha256": receipt_digest(receipt),
                 }
-                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
+                _write_authority_at(
+                    authority,
+                    restored,
+                    admin=_rollback_authority_guard(repo, authority),
+                    lock_held=True,
+                )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -2446,6 +2501,35 @@ def _commit_mode(
             "mergePerformed": False,
         })
     return result
+
+
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+        with private_state.mutation_lock(repo, admin=True):
+            return _commit_mode_locked(
+                repo,
+                task,
+                message,
+                mode,
+                source_root=source_root,
+                expected_implementation_revision=expected_implementation_revision,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
 
 
 def commit(repo: Path, task: str, message: str) -> dict[str, object]:

--- a/templates/agent-python/.automation/bin/discard_pristine.py
+++ b/templates/agent-python/.automation/bin/discard_pristine.py
@@ -7,7 +7,10 @@ import re
 import sys
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
 import task_lifecycle as lifecycle
+import git_private_state as private_state
 
 
 RECEIPT_SCHEMA_VERSION = 1
@@ -18,12 +21,10 @@ REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 
 def discard_receipt_path(root: Path, task: str) -> Path:
     lifecycle.validate_task(task)
-    return (
-        lifecycle.common_git_dir(root)
-        / "opencode"
-        / "discard-pristine"
-        / f"{task}.json"
-    )
+    try:
+        return private_state.discard_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
 
 
 def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
@@ -255,8 +256,8 @@ def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
             "discard-pristine receipt is not a regular local file"
         )
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "discard-pristine receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
     required = {
         "schema_version",
@@ -394,7 +395,10 @@ def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
             "discard-pristine failed to delete the expected local Task branch"
         )
 
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -421,7 +425,12 @@ def task_discard_pristine(root: Path, task: str) -> None:
             )
             return
         plan = pristine_discard_plan(root, task)
-        lifecycle.atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise lifecycle.LifecycleError(str(exc)) from exc
         finish_pristine_discard(root, plan, receipt)
 
 

--- a/templates/agent-python/.automation/bin/git_private_state.py
+++ b/templates/agent-python/.automation/bin/git_private_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 import fcntl
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -18,9 +19,12 @@ LEGACY_NAMESPACE = "opencode"
 TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 PR_RE = re.compile(r"[1-9][0-9]*")
 HASH_RE = re.compile(r"[0-9a-f]{64}")
+OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
 FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
+TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
 
 
@@ -126,6 +130,43 @@ def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_r
     return metadata
 
 
+def _require_owned_mode(path: Path, metadata: os.stat_result, mode: int, what: str,
+                        *, exact: bool = False) -> None:
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    actual = stat.S_IMODE(metadata.st_mode)
+    unsafe = actual != mode if exact else (actual & mode) != mode
+    unsafe = unsafe or bool(actual & 0o022)
+    if unsafe:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+
+
+def _require_legacy_dir(path: Path, what: str) -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what)
+    return metadata
+
+
+def _require_legacy_record(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o400, what)
+    if metadata.st_mode & 0o111:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir(path: Path, what: str = "canonical private-state directory") -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what, exact=True)
+    return metadata
+
+
+def _require_canonical_file(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o600, what, exact=True)
+    return metadata
+
+
 def _require_regular(path: Path, what: str) -> os.stat_result:
     metadata = _lstat(path, what)
     if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
@@ -134,7 +175,10 @@ def _require_regular(path: Path, what: str) -> os.stat_result:
 
 
 def safe_directory(path: Path) -> None:
-    _require_dir(path)
+    if NAMESPACE in path.parts:
+        _require_canonical_dir(path)
+    else:
+        _require_dir(path)
 
 
 def _open_dir(path: Path) -> int:
@@ -162,7 +206,8 @@ def _open_anchored_parent(path: Path) -> int:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
             os.close(descriptor)
@@ -179,15 +224,24 @@ def _open_anchored_parent(path: Path) -> int:
 def _ensure_child_directory(parent: Path, name: str) -> Path:
     descriptor = _open_dir(parent)
     try:
+        created = False
         try:
             os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
             os.fsync(descriptor)
+            created = True
         except FileExistsError:
             pass
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         child = os.open(name, flags, dir_fd=descriptor)
         try:
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            metadata = os.fstat(child)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+            if not created and (
+                metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o700
+            ):
                 raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
         finally:
             os.close(child)
@@ -205,15 +259,22 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
     try:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
+            created = False
             try:
                 os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
                 os.fsync(descriptor)
+                created = True
             except FileExistsError:
                 pass
             child = os.open(name, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            if child_meta.st_uid != os.geteuid() or stat.S_IMODE(child_meta.st_mode) != 0o700:
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe canonical private-state directory: {current / name}")
             os.close(descriptor)
             descriptor = child
             current /= name
@@ -263,6 +324,14 @@ def read_bytes(path: Path, what: str = "private-state record") -> bytes:
     return read_bytes_identity(path, what)[0]
 
 
+def validate_record(path: Path, what: str = "private-state record") -> None:
+    """Require the ownership and mode contract for a persisted state record."""
+    if NAMESPACE in path.parts:
+        _require_canonical_file(path, what)
+    else:
+        _require_legacy_record(path, what)
+
+
 def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     if directory in {"cleanup", "discard-pristine"}:
         return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
@@ -276,6 +345,34 @@ def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     return False
 
 
+def _recover_canonical_temps(layout: Topology, *, include_admin: bool = True) -> None:
+    """Remove only our exact, owned publication artifacts while fenced."""
+    directories = [layout.common / NAMESPACE]
+    if include_admin and not layout.admin_is_common:
+        directories.append(layout.admin / NAMESPACE)
+    for namespace in directories:
+        if _namespace_kind(namespace, foreign_regular=False) != "directory":
+            continue
+        subdirs = [namespace / name for name in SHARED_DIRS]
+        for directory in subdirs:
+            if not directory.exists():
+                continue
+            _require_canonical_dir(directory)
+            for item in directory.iterdir():
+                if item.name.startswith("."):
+                    if TEMP_RE.fullmatch(item.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical temporary: {item}")
+                    metadata = _require_canonical_file(item, "canonical temporary")
+                    if metadata.st_nlink < 1 or metadata.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {item}")
+                    parent_fd = _open_anchored_parent(item)
+                    try:
+                        os.unlink(item.name, dir_fd=parent_fd)
+                        os.fsync(parent_fd)
+                    finally:
+                        os.close(parent_fd)
+
+
 def _legacy_json(content: bytes, path: Path) -> dict:
     try:
         value = json.loads(content.decode("utf-8"))
@@ -287,7 +384,7 @@ def _legacy_json(content: bytes, path: Path) -> dict:
 
 
 def _valid_oid(value: object) -> bool:
-    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+    return isinstance(value, str) and OID_RE.fullmatch(value) is not None
 
 
 def _valid_digest(value: object) -> bool:
@@ -306,14 +403,101 @@ def _valid_absolute_path(value: object) -> bool:
     return _valid_nonempty(value) and Path(value).is_absolute()
 
 
+def _valid_repository(value: object) -> bool:
+    return isinstance(value, str) and REPOSITORY_RE.fullmatch(value) is not None
+
+
+def _valid_branch_worktree(branch: object, task: object, worktree: object) -> bool:
+    if not (_valid_task_id(task) and isinstance(branch, str) and isinstance(worktree, str)):
+        return False
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        return False
+    path = Path(worktree)
+    return (path.is_absolute() and path.parent.name == ".worktrees" and
+            path.name == branch.split("/", 1)[1])
+
+
+def _valid_task_branch(branch: object, task: object) -> bool:
+    return (
+        _valid_task_id(task)
+        and isinstance(branch, str)
+        and (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-"))
+    )
+
+
 def _valid_authority_fields(value: dict) -> bool:
     return (
         _valid_task_id(value.get("task_id"))
-        and _valid_nonempty(value.get("branch"))
+        and _valid_task_branch(value.get("branch"), value.get("task_id"))
         and _valid_absolute_path(value.get("worktree"))
         and _valid_digest(value.get("authority_nonce"))
         and _valid_digest(value.get("receipt_sha256"))
     )
+
+
+def _valid_cleanup_evidence(value: dict, status: str, local_head: str) -> bool:
+    if status == "merged":
+        return (set(value) == {"repository", "pr", "published_head", "upstream"}
+                and _valid_repository(value.get("repository"))
+                and isinstance(value.get("pr"), int) and not isinstance(value.get("pr"), bool)
+                and value["pr"] > 0 and _valid_oid(value.get("published_head"))
+                and value.get("published_head").casefold() == local_head.casefold()
+                and value.get("upstream") in {"live", "deleted"})
+    return (set(value) == {"repository", "upstream", "base_revision"}
+            and _valid_repository(value.get("repository"))
+            and value.get("upstream") == "cancelled-safe"
+            and _valid_oid(value.get("base_revision")))
+
+
+def _validate_authority_filename(path: Path, content: bytes) -> None:
+    if path.parent.name != "automation-maintenance" or path.name in FIXED_AUTHORITY_FILES:
+        return
+    value = _legacy_json(content, path)
+    expected = hashlib.sha256(str(Path(value["worktree"]).resolve()).encode()).hexdigest()
+    if path.name != expected + ".json":
+        raise GitPrivateStateError(f"invalid private-state authority filename: {path}")
+
+
+def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -> Path:
+    """Bind authority ownership to a worktree registered in this topology."""
+    if path.parent.name != "automation-maintenance":
+        raise GitPrivateStateError(f"authority has an invalid parent: {path}")
+    value = _legacy_json(content, path)
+    worktree = Path(value["worktree"])
+    dot_git = worktree / ".git"
+    try:
+        metadata = dot_git.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError
+        if stat.S_ISDIR(metadata.st_mode):
+            admin = dot_git.resolve(strict=True)
+        elif stat.S_ISREG(metadata.st_mode):
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            if not marker.startswith("gitdir: "):
+                raise ValueError
+            target = Path(marker[8:])
+            admin = (target if target.is_absolute() else worktree / target).resolve(strict=True)
+        else:
+            raise ValueError
+    except (OSError, UnicodeDecodeError, ValueError, KeyError) as exc:
+        raise GitPrivateStateError(f"authority worktree is not registered: {path}") from exc
+    common = layout.common.resolve()
+    allowed = admin == common or admin == layout.admin.resolve()
+    if not allowed and admin.parent.name == "worktrees" and admin.parent.parent == common:
+        try:
+            registered_gitdir = (admin / "gitdir").read_text(encoding="utf-8").strip()
+            allowed = Path(registered_gitdir).resolve(strict=True) == dot_git.resolve(strict=True)
+        except (OSError, UnicodeDecodeError):
+            allowed = False
+    if not allowed:
+        raise GitPrivateStateError(f"authority worktree is outside Git topology: {path}")
+    try:
+        head = (admin / "HEAD").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise GitPrivateStateError(f"authority worktree registration is unreadable: {path}") from exc
+    if head != f"ref: refs/heads/{value['branch']}":
+        raise GitPrivateStateError(f"authority branch does not match worktree registration: {path}")
+    return admin
 
 
 def _validate_legacy_content(path: Path, content: bytes) -> None:
@@ -324,7 +508,8 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             text = content.decode("ascii", errors="strict")
         except UnicodeDecodeError as exc:
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
-        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+        if (not text.endswith("\n") or not _valid_oid(text[:-1]) or
+                text[:-1] != text[:-1].lower()):
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
         return
     value = _legacy_json(content, path)
@@ -335,10 +520,10 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("schema_version") == 1
             and value.get("task") == name[:-5]
             and value.get("status") in {"merged", "cancelled"}
-            and isinstance(value.get("worktree"), str)
-            and isinstance(value.get("branch"), str)
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
             and _valid_oid(value.get("local_head"))
             and isinstance(value.get("evidence"), dict)
+            and _valid_cleanup_evidence(value["evidence"], value["status"], value["local_head"])
         )
     elif directory == "discard-pristine":
         required = {
@@ -351,11 +536,12 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("operation") == "discard-pristine"
             and value.get("task") == name[:-5]
             and value.get("status") == "initialized"
-            and all(isinstance(value.get(field), str) for field in (
-                "worktree", "branch", "base_branch", "repository"
-            ))
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_repository(value.get("repository"))
             and _valid_oid(value.get("base_revision"))
-            and value.get("local_head") == value.get("base_revision")
+            and _valid_oid(value.get("local_head"))
+            and value.get("local_head").casefold() == value.get("base_revision").casefold()
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -413,26 +599,40 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
     if kind != "directory":
         return [], None
     pairs: list[tuple[Path, Path]] = []
+    _require_legacy_dir(root, "legacy private-state directory")
     legacy_lock: Path | None = None
     for entry in root.iterdir():
         if entry.name == "cleanup.lock":
-            _require_regular(entry, "legacy cleanup lock")
+            metadata = _require_regular(entry, "legacy cleanup lock")
+            _require_owned_mode(entry, metadata, 0o600, "legacy cleanup lock")
+            if metadata.st_mode & 0o111:
+                raise GitPrivateStateError(f"unsafe legacy cleanup lock mode: {entry}")
             legacy_lock = entry
             continue
         if entry.name not in SHARED_DIRS:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
-        _require_dir(entry, "legacy private-state directory")
+        _require_legacy_dir(entry, "legacy private-state directory")
         for child in entry.iterdir():
             allow_fixed = entry.name == "automation-maintenance"
             if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
                 raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-            _require_regular(child, "legacy private-state record")
+            _require_legacy_record(child, "legacy private-state record")
+            if entry.name == "automation-maintenance":
+                content = read_bytes(child)
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                authority_admin = _validate_authority_topology(child, content, layout)
             if child.name in FIXED_AUTHORITY_FILES:
-                if layout.admin_is_common:
-                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
-                # In a linked worktree these belong to the main worktree admin.
+                if authority_admin not in {layout.common, layout.admin}:
+                    raise GitPrivateStateError(
+                        f"fixed authority belongs to a different worktree admin: {child}"
+                    )
+                pairs.append((child, authority_admin / NAMESPACE / entry.name / child.name))
             else:
                 pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs, legacy_lock
 
 
@@ -450,55 +650,211 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
     if not entries:
         return []
     maintenance = entries[0]
-    _require_dir(maintenance, "legacy maintenance authority directory")
+    _require_legacy_dir(maintenance, "legacy maintenance authority directory")
     pairs: list[tuple[Path, Path]] = []
     for child in maintenance.iterdir():
         if child.name not in FIXED_AUTHORITY_FILES:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-        _require_regular(child, "legacy private-state record")
+        _require_legacy_record(child, "legacy private-state record")
+        content = read_bytes(child)
+        _validate_legacy_content(child, content)
+        _validate_authority_filename(child, content)
+        if _validate_authority_topology(child, content, layout) != layout.admin:
+            raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs
 
 
-def _validate_canonical(layout: Topology) -> None:
+def _validate_legacy_relations(root: Path, canonical_roots: tuple[Path, Path]) -> None:
+    maintenance = root / "automation-maintenance"
+    if not maintenance.is_dir():
+        return
+    proof = maintenance / "source-recovery-proof.json"
+    authority = maintenance / "authority.json"
+    if authority.exists() and not proof.exists():
+        authority_value = _legacy_json(
+            read_bytes(authority, "legacy maintenance authority"), authority
+        )
+        if authority_value.get("kind") == "source-recovery-bridge":
+            canonical_proofs = [
+                candidate / "automation-maintenance" / "source-recovery-proof.json"
+                for candidate in canonical_roots
+            ]
+            canonical_proof = next((candidate for candidate in canonical_proofs
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        authority_value,
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                    )), None)
+            if canonical_proof is None:
+                raise GitPrivateStateError(
+                    f"legacy source-recovery bridge lacks its proof: {root}"
+                )
+            proof = canonical_proof
+        else:
+            return
+    if proof.exists() and not authority.exists():
+        canonical_authorities = [
+            candidate / "automation-maintenance" / "authority.json"
+            for candidate in canonical_roots
+        ]
+        proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+        canonical_authority = next((candidate for candidate in canonical_authorities
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                        proof_value,
+                                    )), None)
+        if canonical_authority is None:
+            raise GitPrivateStateError(
+                f"legacy source-recovery proof lacks its bridge: {root}"
+            )
+        authority = canonical_authority
+    if not proof.exists() or not authority.exists():
+        return
+    proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+    authority_value = _legacy_json(read_bytes(authority, "legacy maintenance authority"), authority)
+    if not _recovery_pair_matches(authority_value, proof_value):
+        raise GitPrivateStateError(f"conflicting legacy authority and proof identity: {root}")
+
+
+def _recovery_pair_matches(authority: dict, proof: dict) -> bool:
+    if authority.get("kind") != "source-recovery-bridge":
+        return False
+    if any(proof.get(field) != authority.get(field) for field in (
+        "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"
+    )):
+        return False
+    digest = hashlib.sha256(
+        json.dumps(proof, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return authority.get("proof_sha256") == digest
+
+
+def _validate_canonical(
+    layout: Topology, *, allow_incomplete_recovery: bool = False
+) -> None:
     shared = layout.common / NAMESPACE
     kind = _namespace_kind(shared, foreign_regular=False)
     if kind == "directory":
+        _require_canonical_dir(shared)
         for entry in shared.iterdir():
             if entry.name in LOCK_FILES:
-                _require_regular(entry, "canonical private-state lock")
+                _require_canonical_file(entry, "canonical private-state lock")
                 continue
             if entry.name not in SHARED_DIRS:
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
-            _require_dir(entry)
+            _require_canonical_dir(entry)
             for child in entry.iterdir():
+                if child.name.startswith("."):
+                    if TEMP_RE.fullmatch(child.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    temporary = _require_canonical_file(child, "canonical temporary")
+                    if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                    continue
                 # Fixed files in common are the main worktree's admin records.
                 if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
                     raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                _require_regular(child, "canonical private-state record")
+                _require_canonical_file(child, "canonical private-state record")
+                content = read_bytes(child, "canonical private-state record")
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                if entry.name == "automation-maintenance":
+                    authority_admin = _validate_authority_topology(child, content, layout)
+                    if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
     if not layout.admin_is_common:
         admin_root = layout.admin / NAMESPACE
         kind = _namespace_kind(admin_root, foreign_regular=False)
         if kind == "directory":
+            _require_canonical_dir(admin_root)
             entries = list(admin_root.iterdir())
-            if any(entry.name != "automation-maintenance" for entry in entries):
-                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+            if any(entry.name not in {"automation-maintenance", "migration.lock"} for entry in entries):
+                unknown = next(
+                    entry for entry in entries
+                    if entry.name not in {"automation-maintenance", "migration.lock"}
+                )
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
-            if entries:
-                maintenance = entries[0]
-                _require_dir(maintenance)
+            lock = admin_root / "migration.lock"
+            if lock.exists():
+                _require_canonical_file(lock, "canonical private-state lock")
+            maintenance = admin_root / "automation-maintenance"
+            if maintenance.exists():
+                _require_canonical_dir(maintenance)
                 for child in maintenance.iterdir():
+                    if child.name.startswith("."):
+                        if TEMP_RE.fullmatch(child.name) is None:
+                            raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                        temporary = _require_canonical_file(child, "canonical temporary")
+                        if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                            raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                        continue
                     if child.name not in FIXED_AUTHORITY_FILES:
                         raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                    _require_regular(child, "canonical private-state record")
+                    _require_canonical_file(child, "canonical private-state record")
+                    content = read_bytes(child, "canonical private-state record")
+                    _validate_legacy_content(child, content)
+                    _validate_authority_filename(child, content)
+                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
+
+    # Canonical maintenance authority is fixed to the administrative topology;
+    # a bridge, when present, must name the exact canonical proof bytes.
+    for namespace in {layout.common / NAMESPACE, layout.admin / NAMESPACE}:
+        proof = namespace / "automation-maintenance" / "source-recovery-proof.json"
+        bridge = namespace / "automation-maintenance" / "authority.json"
+        proof_exists = proof.is_file()
+        bridge_exists = bridge.is_file()
+        if proof_exists and not bridge_exists:
+            legacy_bridges = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+            }
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            if not allow_incomplete_recovery and not any(candidate.is_file() and _recovery_pair_matches(
+                _legacy_json(read_bytes(candidate), candidate), proof_value
+            ) for candidate in legacy_bridges):
+                raise GitPrivateStateError(f"source-recovery proof lacks bridge authority: {namespace}")
+        if bridge_exists:
+            bridge_value = _legacy_json(read_bytes(bridge), bridge)
+            is_bridge = bridge_value.get("kind") == "source-recovery-bridge"
+            legacy_proofs = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+            }
+            if is_bridge and not proof_exists and not any(
+                candidate.is_file() and _recovery_pair_matches(
+                    bridge_value, _legacy_json(read_bytes(candidate), candidate)
+                ) for candidate in legacy_proofs
+            ):
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+            if not is_bridge and proof_exists:
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+        if proof_exists and bridge_exists:
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            for field in ("task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"):
+                if proof_value.get(field) != bridge_value.get(field):
+                    raise GitPrivateStateError(f"conflicting authority and proof identity: {namespace}")
+            digest = hashlib.sha256(
+                json.dumps(proof_value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
+            if bridge_value.get("proof_sha256") != digest:
+                raise GitPrivateStateError(f"source-recovery proof digest mismatch: {namespace}")
 
 
 def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
     inspected: list[MigrationFile] = []
     for source, target in pairs:
-        metadata = _require_regular(source, "legacy private-state record")
+        metadata = _require_legacy_record(source, "legacy private-state record")
         content = read_bytes(source, "legacy private-state record")
         _validate_legacy_content(source, content)
+        _validate_authority_filename(source, content)
         try:
             target.lstat()
         except FileNotFoundError:
@@ -537,10 +893,15 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
                     follow_symlinks=False)
             os.fsync(parent_fd)
         except FileExistsError:
+            _require_canonical_file(path, "canonical private-state record")
             if read_bytes(path, "canonical private-state record") != content:
                 raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
         published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
-        if not stat.S_ISREG(published.st_mode):
+        if (
+            not stat.S_ISREG(published.st_mode)
+            or published.st_uid != os.geteuid()
+            or stat.S_IMODE(published.st_mode) != 0o600
+        ):
             raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         return published.st_dev, published.st_ino
     except GitPrivateStateError:
@@ -556,6 +917,36 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
             os.close(parent_fd)
 
 
+def _exclusive_publish_direct(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    """Restore an absent legacy record without a visible temporary artifact."""
+    parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            path.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            mode,
+            dir_fd=parent_fd,
+        )
+        os.fchmod(descriptor, mode)
+        view = memoryview(content)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short private-state write")
+            view = view[written:]
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        os.fsync(parent_fd)
+        return metadata.st_dev, metadata.st_ino
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot restore legacy private-state record: {path}") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
 def ensure_parent(path: Path) -> None:
     parts = path.parts
     indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
@@ -569,18 +960,53 @@ def ensure_parent(path: Path) -> None:
     _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
 
 
+def _state_namespace(path: Path) -> Path:
+    """Return the namespace containing a canonical state path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside canonical private-state namespace: {path}")
+    return Path(*path.parts[: indexes[-1] + 1])
+
+
+def _legacy_equivalent(path: Path) -> tuple[Path, Path]:
+    """Return the state root and canonical equivalent of one legacy path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == LEGACY_NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside legacy private-state namespace: {path}")
+    marker = indexes[-1]
+    state_root = Path(*path.parts[:marker])
+    relative = Path(*path.parts[marker + 1:])
+    return state_root, state_root / NAMESPACE / relative
+
+
 def exclusive_write_bytes(
-    path: Path, content: bytes, mode: int = 0o600
+    path: Path, content: bytes, mode: int = 0o600, *, _lock_held: bool = False
 ) -> tuple[int, int]:
     """Durably publish a new state record without replacing any existing object."""
+    if NAMESPACE not in path.parts:
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            if os.path.lexists(path):
+                raise GitPrivateStateError(f"legacy private-state record already exists: {path}")
+            target = canonical if not (state_root / LEGACY_NAMESPACE).exists() else path
+            ensure_parent(target)
+            if target == canonical:
+                return _exclusive_publish(target, content, 0o600)
+            return _exclusive_publish_direct(target, content, mode)
     ensure_parent(path)
-    return _exclusive_publish(path, content, mode)
+    namespace = _state_namespace(path)
+    if _lock_held:
+        return _exclusive_publish(path, content, 0o600)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        return _exclusive_publish(path, content, 0o600)
 
 
 def _identity_unlink(item: MigrationFile) -> None:
     if read_bytes(item.source, "legacy private-state record") != item.content:
         raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
-    metadata = _require_regular(item.source, "legacy private-state record")
+    metadata = _require_legacy_record(item.source, "legacy private-state record")
     if (metadata.st_dev, metadata.st_ino) != item.identity:
         raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
     parent_fd = _open_anchored_parent(item.source)
@@ -598,6 +1024,118 @@ def _identity_unlink(item: MigrationFile) -> None:
         os.close(parent_fd)
 
 
+def _unlink_identity_path(path: Path, identity: tuple[int, int], what: str) -> None:
+    parent_fd = _open_anchored_parent(path)
+    try:
+        metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if ((metadata.st_dev, metadata.st_ino) != identity or
+                not stat.S_ISREG(metadata.st_mode)):
+            raise GitPrivateStateError(f"{what} identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _handoff_cleanup_lock(
+    legacy: Path, canonical: Path, expected_identity: tuple[int, int]
+) -> tuple[int, int]:
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    if (legacy_meta.st_dev, legacy_meta.st_ino) != expected_identity:
+        raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+    legacy_parent_fd = _open_anchored_parent(legacy)
+    canonical_parent_fd = _open_anchored_parent(canonical)
+    try:
+        legacy_fd = os.open(
+            legacy.name,
+            os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=legacy_parent_fd,
+        )
+        try:
+            opened = os.fstat(legacy_fd)
+            if (opened.st_dev, opened.st_ino) != expected_identity:
+                raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+            os.fchmod(legacy_fd, 0o600)
+            os.fsync(legacy_fd)
+        finally:
+            os.close(legacy_fd)
+    finally:
+        os.close(legacy_parent_fd)
+    try:
+        try:
+            canonical_meta = os.stat(
+                canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+            )
+        except FileNotFoundError:
+            canonical_meta = None
+        if canonical_meta is not None:
+            if (
+                not stat.S_ISREG(canonical_meta.st_mode)
+                or canonical_meta.st_uid != os.geteuid()
+                or stat.S_IMODE(canonical_meta.st_mode) != 0o600
+            ):
+                raise GitPrivateStateError(f"unsafe canonical cleanup lock: {canonical}")
+            if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+                expected_identity
+            ):
+                raise GitPrivateStateError(
+                    "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+                    "automatic cutover cannot prove a single cleanup fence"
+                )
+        else:
+            try:
+                source_fd = _open_anchored_parent(legacy)
+                try:
+                    os.link(
+                        legacy.name,
+                        canonical.name,
+                        src_dir_fd=source_fd,
+                        dst_dir_fd=canonical_parent_fd,
+                        follow_symlinks=False,
+                    )
+                finally:
+                    os.close(source_fd)
+                os.fsync(canonical_parent_fd)
+                published = os.stat(
+                    canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+                )
+                if (published.st_dev, published.st_ino) != expected_identity:
+                    raise GitPrivateStateError(
+                        f"legacy cleanup lock identity changed during handoff: {legacy}"
+                    )
+            except OSError as exc:
+                raise GitPrivateStateError(
+                    f"cannot establish cleanup lock handoff: {canonical}"
+                ) from exc
+    finally:
+        os.close(canonical_parent_fd)
+    return expected_identity
+
+
+def _preflight_cleanup_lock_handoff(legacy: Path | None, canonical: Path) -> None:
+    if legacy is None:
+        return
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    try:
+        canonical_meta = canonical.lstat()
+    except FileNotFoundError:
+        return
+    _require_canonical_file(canonical, "canonical cleanup lock")
+    if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+        legacy_meta.st_dev, legacy_meta.st_ino
+    ):
+        raise GitPrivateStateError(
+            "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+            "automatic cutover cannot prove a single cleanup fence"
+        )
+
+
 def _remove_known_empty_legacy_directories(layout: Topology) -> None:
     roots = [layout.common / LEGACY_NAMESPACE]
     if not layout.admin_is_common:
@@ -608,7 +1146,7 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
         for name in SHARED_DIRS:
             child = root / name
             try:
-                _require_dir(child, "legacy private-state directory")
+                _require_legacy_dir(child, "legacy private-state directory")
             except GitPrivateStateError:
                 if child.exists() or child.is_symlink():
                     raise
@@ -620,7 +1158,6 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
                     os.fsync(descriptor)
                 finally:
                     os.close(descriptor)
-        # The shared root remains while its mixed-version cleanup lock exists.
         if not any(root.iterdir()):
             root.rmdir()
             descriptor = _open_dir(root.parent)
@@ -631,24 +1168,46 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
 
 
 @contextmanager
-def _file_lock(path: Path, *, create: bool):
+def _file_lock(path: Path, *, create: bool, nonblocking: bool = False, exact: bool = False):
     flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-    if create:
-        flags |= os.O_CREAT
     parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
     try:
-        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        if create:
+            try:
+                descriptor = os.open(path.name, flags | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=parent_fd)
+                os.fchmod(descriptor, 0o600)
+                os.fsync(parent_fd)
+            except FileExistsError:
+                descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        else:
+            descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise GitPrivateStateError(f"unsafe private-state lock: {path}")
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        yield
+        if metadata.st_uid != os.geteuid() or (exact and stat.S_IMODE(metadata.st_mode) != 0o600) or (
+                not exact and (stat.S_IMODE(metadata.st_mode) & 0o022 or metadata.st_mode & 0o111 or
+                               not (metadata.st_mode & 0o600))):
+            raise GitPrivateStateError(f"unsafe private-state lock mode or ownership: {path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0))
+        except BlockingIOError as exc:
+            raise GitPrivateStateError(f"BLOCKED: private-state lock is contended: {path}") from exc
     except GitPrivateStateError:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise
     except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    try:
+        locked = os.fstat(descriptor)
+        yield (locked.st_dev, locked.st_ino)
     finally:
-        if "descriptor" in locals():
+        if descriptor is not None:
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_UN)
             finally:
@@ -662,7 +1221,8 @@ def prepare(
     admin: bool = False,
     common_dir: Path | None = None,
     admin_dir: Path | None = None,
-    _legacy_lock_held: bool = False,
+    _legacy_lock_identity: tuple[int, int] | None = None,
+    _allow_incomplete_recovery: bool = False,
 ) -> None:
     """Validate and migrate known legacy state before a state mutation."""
     layout = (
@@ -670,25 +1230,38 @@ def prepare(
         if common_dir is not None
         else topology(root)
     )
-    _validate_canonical(layout)
+    _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
     shared_pairs, legacy_lock = _scan_shared_legacy(layout)
     pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
     _inspect_pairs(pairs)  # preflight before creating even the migration lock
-    if legacy_lock is not None and not _legacy_lock_held:
-        with _file_lock(legacy_lock, create=False):
+    if legacy_lock is not None and _legacy_lock_identity is None:
+        with _file_lock(legacy_lock, create=False, nonblocking=True) as lock_identity:
             prepare(
                 root,
                 admin=admin,
                 common_dir=layout.common,
                 admin_dir=layout.admin,
-                _legacy_lock_held=True,
+                _legacy_lock_identity=lock_identity,
+                _allow_incomplete_recovery=_allow_incomplete_recovery,
             )
         return
 
+    _preflight_cleanup_lock_handoff(
+        legacy_lock, layout.common / NAMESPACE / "cleanup.lock"
+    )
     _ensure_namespace(layout.common, ())
-    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+    admin_lock_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_lock_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_lock_context:
         # Repeat all classification under the migration lock.
-        _validate_canonical(layout)
+        _recover_canonical_temps(layout, include_admin=admin)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         shared_pairs, _ = _scan_shared_legacy(layout)
         pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
         inspected = _inspect_pairs(pairs)
@@ -696,28 +1269,67 @@ def prepare(
             _ensure_namespace(layout.common, (name,))
         if admin:
             _ensure_namespace(layout.admin, ("automation-maintenance",))
+        legacy_lock_identity = None
+        if legacy_lock is not None:
+            if _legacy_lock_identity is None:
+                raise GitPrivateStateError("legacy cleanup lock is not held for handoff")
+            legacy_lock_identity = _handoff_cleanup_lock(
+                legacy_lock,
+                layout.common / NAMESPACE / "cleanup.lock",
+                _legacy_lock_identity,
+            )
         for item in inspected:
             try:
                 item.target.lstat()
             except FileNotFoundError:
-                _exclusive_publish(item.target, item.content, item.mode)
+                _exclusive_publish(item.target, item.content, 0o600)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         # No source is removed until every destination is durable and equivalent.
         for item in inspected:
+            _require_canonical_file(item.target, "canonical private-state record")
             if read_bytes(item.target, "canonical private-state record") != item.content:
                 raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
         for item in inspected:
-            metadata = _require_regular(item.source, "legacy private-state record")
+            metadata = _require_legacy_record(item.source, "legacy private-state record")
             if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
                 item.source, "legacy private-state record"
             ) != item.content:
                 raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
         for item in inspected:
             _identity_unlink(item)
+        if legacy_lock is not None and legacy_lock_identity is not None:
+            _unlink_identity_path(legacy_lock, legacy_lock_identity, "legacy cleanup lock")
         _remove_known_empty_legacy_directories(layout)
 
 
 def write_bytes(path: Path, content: bytes) -> None:
     """Atomically and durably replace one prepared canonical regular file."""
+    namespace = _state_namespace(path)
+    ensure_parent(path)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _write_bytes_locked(path, content)
+
+
+@contextmanager
+def mutation_lock(root: Path, *, admin: bool = False):
+    """Fence a caller-managed canonical transaction in global lock order."""
+    layout = topology(root)
+    _ensure_namespace(layout.common, ())
+    admin_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_context:
+        _recover_canonical_temps(layout, include_admin=admin)
+        yield
+
+
+def _write_bytes_locked(path: Path, content: bytes) -> None:
     parent_fd = _open_anchored_parent(path)
     temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
@@ -731,6 +1343,7 @@ def write_bytes(path: Path, content: bytes) -> None:
                 raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
         try:
+            os.fchmod(descriptor, 0o600)
             view = memoryview(content)
             while view:
                 written = os.write(descriptor, view)
@@ -755,8 +1368,51 @@ def write_bytes(path: Path, content: bytes) -> None:
             os.close(parent_fd)
 
 
-def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+def unlink(
+    path: Path,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+    expected_content: bytes | None = None,
+    _lock_held: bool = False,
+) -> None:
     """Remove only a canonical regular file through its verified parent."""
+    if NAMESPACE not in path.parts:
+        # A pre-cutover consumer may need to consume or roll back a validated
+        # historical authority before the upgraded implementation is committed.
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            legacy_exists = os.path.lexists(path)
+            canonical_exists = os.path.lexists(canonical)
+            if legacy_exists and canonical_exists:
+                if expected_content is None:
+                    raise GitPrivateStateError(
+                        f"legacy and canonical private-state records both exist: {path}"
+                    )
+                if read_bytes(path) != expected_content or read_bytes(canonical) != expected_content:
+                    raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+                _unlink_locked(path, expected_identity=expected_identity)
+                _unlink_locked(canonical)
+                return
+            if legacy_exists:
+                _unlink_locked(path, expected_identity=expected_identity)
+                return
+            if not canonical_exists or expected_content is None:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            if read_bytes(canonical, "canonical private-state record") != expected_content:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            _unlink_locked(canonical)
+        return
+    namespace = _state_namespace(path)
+    if _lock_held:
+        _unlink_locked(path, expected_identity=expected_identity)
+        return
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _unlink_locked(path, expected_identity=expected_identity)
+
+
+def _unlink_locked(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
     parent_fd = _open_anchored_parent(path)
     try:
         try:
@@ -779,19 +1435,26 @@ def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> N
 
 @contextmanager
 def cleanup_lock(root: Path):
-    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    """Cut over legacy cleanup locking, then acquire only the canonical lock."""
     layout = topology(root)
     _validate_canonical(layout)
     _, legacy = _scan_shared_legacy(layout)
     # Lock old consumers out while migrating cleanup/discard evidence.
-    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
-    with legacy_context:
+    legacy_context = (_file_lock(legacy, create=False, nonblocking=True)
+                      if legacy is not None else nullcontext())
+    with legacy_context as legacy_identity:
         prepare(
             root,
             common_dir=layout.common,
             admin_dir=layout.admin,
-            _legacy_lock_held=legacy is not None,
+            _legacy_lock_identity=legacy_identity,
         )
-        _ensure_namespace(layout.common, ())
-        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+        if legacy is not None:
+            # The open legacy descriptor now names the same inode as the
+            # canonical path and remains held for the whole caller operation.
             yield
+        else:
+            with _file_lock(
+                layout.common / NAMESPACE / "cleanup.lock", create=True, exact=True
+            ):
+                yield

--- a/templates/agent-python/.automation/bin/git_private_state.py
+++ b/templates/agent-python/.automation/bin/git_private_state.py
@@ -1,0 +1,797 @@
+"""Owned, fail-closed storage for Agent Core's Git-private runtime state."""
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+import subprocess
+
+
+NAMESPACE = "agent-core"
+LEGACY_NAMESPACE = "opencode"
+TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+PR_RE = re.compile(r"[1-9][0-9]*")
+HASH_RE = re.compile(r"[0-9a-f]{64}")
+SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
+FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+LOCK_FILES = {"cleanup.lock", "migration.lock"}
+_GIT_EXECUTABLE = "git"
+
+
+class GitPrivateStateError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Topology:
+    common: Path
+    admin: Path
+
+    @property
+    def admin_is_common(self) -> bool:
+        return self.admin == self.common
+
+
+@dataclass(frozen=True)
+class MigrationFile:
+    source: Path
+    target: Path
+    identity: tuple[int, int]
+    mode: int
+    content: bytes
+
+
+def _git_path(root: Path, argument: str) -> Path:
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    environment.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    })
+    result = subprocess.run(
+        [_GIT_EXECUTABLE, "-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null",
+         "-c", "core.pager=", "rev-parse", argument],
+        cwd=root, text=True, capture_output=True, check=False, env=environment,
+    )
+    raw = result.stdout.strip()
+    if result.returncode != 0 or not raw:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}")
+    candidate = Path(raw)
+    try:
+        resolved = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+        metadata = resolved.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"Git private-state location is not a directory: {resolved}")
+    return resolved
+
+
+def topology(root: Path) -> Topology:
+    return Topology(_git_path(root, "--git-common-dir"), _git_path(root, "--absolute-git-dir"))
+
+
+def common_git_dir(root: Path) -> Path:
+    return topology(root).common
+
+
+def admin_git_dir(root: Path) -> Path:
+    return topology(root).admin
+
+
+def common_state(root: Path) -> Path:
+    return common_git_dir(root) / NAMESPACE
+
+
+def admin_maintenance(root: Path) -> Path:
+    return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def cleanup_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "cleanup" / f"{task}.json"
+
+
+def discard_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "discard-pristine" / f"{task}.json"
+
+
+def integration_checkpoint(root: Path, pr: str) -> Path:
+    if PR_RE.fullmatch(pr) is None:
+        raise GitPrivateStateError("invalid pull request number")
+    return common_state(root) / "integration" / f"pr-{pr}.head"
+
+
+def _lstat(path: Path, what: str) -> os.stat_result:
+    try:
+        return path.lstat()
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect {what}: {path}") from exc
+
+
+def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def _require_regular(path: Path, what: str) -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def safe_directory(path: Path) -> None:
+    _require_dir(path)
+
+
+def _open_dir(path: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot open private-state directory: {path}") from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise GitPrivateStateError(f"unsafe private-state directory: {path}")
+    return descriptor
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open a state parent without following namespace or descendant symlinks."""
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    descriptor = _open_dir(boundary)
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for component in parts[marker:-1]:
+            child = os.open(component, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except GitPrivateStateError:
+        os.close(descriptor)
+        raise
+    except OSError as exc:
+        os.close(descriptor)
+        raise GitPrivateStateError(f"cannot traverse private-state directory: {path.parent}") from exc
+
+
+def _ensure_child_directory(parent: Path, name: str) -> Path:
+    descriptor = _open_dir(parent)
+    try:
+        try:
+            os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.fsync(descriptor)
+        except FileExistsError:
+            pass
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        child = os.open(name, flags, dir_fd=descriptor)
+        try:
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+        finally:
+            os.close(child)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state directory: {parent / name}") from exc
+    finally:
+        os.close(descriptor)
+    return parent / name
+
+
+def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
+    _require_dir(base, "Git administrative directory")
+    descriptor = _open_dir(base)
+    current = base
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for name in (NAMESPACE, *subdirectories):
+            try:
+                os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.fsync(descriptor)
+            except FileExistsError:
+                pass
+            child = os.open(name, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            os.close(descriptor)
+            descriptor = child
+            current /= name
+        return current
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state namespace below: {base}") from exc
+    finally:
+        os.close(descriptor)
+
+
+def read_bytes_identity(
+    path: Path, what: str = "private-state record"
+) -> tuple[bytes, tuple[int, int]]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe {what}: {path}")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino, metadata.st_size) != (
+                after.st_dev, after.st_ino, after.st_size
+            ):
+                raise GitPrivateStateError(f"{what} changed while reading: {path}")
+            return b"".join(chunks), (metadata.st_dev, metadata.st_ino)
+        finally:
+            os.close(descriptor)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot read {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def read_bytes(path: Path, what: str = "private-state record") -> bytes:
+    return read_bytes_identity(path, what)[0]
+
+
+def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
+    if directory in {"cleanup", "discard-pristine"}:
+        return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
+    if directory == "integration":
+        return re.fullmatch(r"pr-[1-9][0-9]*\.head", name) is not None
+    if directory == "automation-maintenance":
+        return (
+            re.fullmatch(r"[0-9a-f]{64}\.json", name) is not None
+            or (allow_fixed and name in FIXED_AUTHORITY_FILES)
+        )
+    return False
+
+
+def _legacy_json(content: bytes, path: Path) -> dict:
+    try:
+        value = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}") from exc
+    if not isinstance(value, dict):
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+    return value
+
+
+def _valid_oid(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+
+
+def _valid_digest(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+def _valid_task_id(value: object) -> bool:
+    return isinstance(value, str) and TASK_RE.fullmatch(value) is not None
+
+
+def _valid_nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _valid_absolute_path(value: object) -> bool:
+    return _valid_nonempty(value) and Path(value).is_absolute()
+
+
+def _valid_authority_fields(value: dict) -> bool:
+    return (
+        _valid_task_id(value.get("task_id"))
+        and _valid_nonempty(value.get("branch"))
+        and _valid_absolute_path(value.get("worktree"))
+        and _valid_digest(value.get("authority_nonce"))
+        and _valid_digest(value.get("receipt_sha256"))
+    )
+
+
+def _validate_legacy_content(path: Path, content: bytes) -> None:
+    directory = path.parent.name
+    name = path.name
+    if directory == "integration":
+        try:
+            text = content.decode("ascii", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
+        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
+        return
+    value = _legacy_json(content, path)
+    if directory == "cleanup":
+        required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("task") == name[:-5]
+            and value.get("status") in {"merged", "cancelled"}
+            and isinstance(value.get("worktree"), str)
+            and isinstance(value.get("branch"), str)
+            and _valid_oid(value.get("local_head"))
+            and isinstance(value.get("evidence"), dict)
+        )
+    elif directory == "discard-pristine":
+        required = {
+            "schema_version", "operation", "task", "status", "worktree", "branch",
+            "base_branch", "base_revision", "local_head", "repository",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("operation") == "discard-pristine"
+            and value.get("task") == name[:-5]
+            and value.get("status") == "initialized"
+            and all(isinstance(value.get(field), str) for field in (
+                "worktree", "branch", "base_branch", "repository"
+            ))
+            and _valid_oid(value.get("base_revision"))
+            and value.get("local_head") == value.get("base_revision")
+        )
+    elif name == "source-recovery-proof.json":
+        required = {
+            "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+            "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+            "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+            "receipt_source", "receipt_source_revision",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "source-recovery-proof"
+            and _valid_authority_fields(value)
+            and _valid_oid(value.get("authority_head"))
+            and all(_valid_digest(value.get(field)) for field in (
+                "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256",
+            ))
+            and _valid_absolute_path(value.get("implementation_source"))
+            and _valid_oid(value.get("implementation_revision"))
+            and _valid_absolute_path(value.get("receipt_source"))
+            and _valid_oid(value.get("receipt_source_revision"))
+        )
+    else:
+        standard = {"schema_version", "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"}
+        bridge = standard | {"kind", "proof_sha256"}
+        valid = (
+            (set(value) == standard and value.get("schema_version") == 1
+             and _valid_authority_fields(value))
+            or (set(value) == bridge and value.get("schema_version") == 2
+                and value.get("kind") == "source-recovery-bridge"
+                and _valid_authority_fields(value)
+                and _valid_digest(value.get("proof_sha256")))
+        )
+    if not valid:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+
+
+def _namespace_kind(path: Path, *, foreign_regular: bool) -> str:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return "absent"
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect private-state namespace: {path}") from exc
+    if stat.S_ISREG(metadata.st_mode) and foreign_regular:
+        return "foreign"
+    if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+        return "directory"
+    raise GitPrivateStateError(f"unsafe private-state namespace: {path}")
+
+
+def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path | None]:
+    root = layout.common / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return [], None
+    pairs: list[tuple[Path, Path]] = []
+    legacy_lock: Path | None = None
+    for entry in root.iterdir():
+        if entry.name == "cleanup.lock":
+            _require_regular(entry, "legacy cleanup lock")
+            legacy_lock = entry
+            continue
+        if entry.name not in SHARED_DIRS:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
+        _require_dir(entry, "legacy private-state directory")
+        for child in entry.iterdir():
+            allow_fixed = entry.name == "automation-maintenance"
+            if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
+                raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+            _require_regular(child, "legacy private-state record")
+            if child.name in FIXED_AUTHORITY_FILES:
+                if layout.admin_is_common:
+                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
+                # In a linked worktree these belong to the main worktree admin.
+            else:
+                pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    return pairs, legacy_lock
+
+
+def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
+    if layout.admin_is_common:
+        return []
+    root = layout.admin / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return []
+    entries = list(root.iterdir())
+    if any(entry.name != "automation-maintenance" for entry in entries):
+        unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+        raise GitPrivateStateError(f"unknown legacy private-state entry: {unknown}")
+    if not entries:
+        return []
+    maintenance = entries[0]
+    _require_dir(maintenance, "legacy maintenance authority directory")
+    pairs: list[tuple[Path, Path]] = []
+    for child in maintenance.iterdir():
+        if child.name not in FIXED_AUTHORITY_FILES:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+        _require_regular(child, "legacy private-state record")
+        pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    return pairs
+
+
+def _validate_canonical(layout: Topology) -> None:
+    shared = layout.common / NAMESPACE
+    kind = _namespace_kind(shared, foreign_regular=False)
+    if kind == "directory":
+        for entry in shared.iterdir():
+            if entry.name in LOCK_FILES:
+                _require_regular(entry, "canonical private-state lock")
+                continue
+            if entry.name not in SHARED_DIRS:
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
+            _require_dir(entry)
+            for child in entry.iterdir():
+                # Fixed files in common are the main worktree's admin records.
+                if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
+                    raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                _require_regular(child, "canonical private-state record")
+    if not layout.admin_is_common:
+        admin_root = layout.admin / NAMESPACE
+        kind = _namespace_kind(admin_root, foreign_regular=False)
+        if kind == "directory":
+            entries = list(admin_root.iterdir())
+            if any(entry.name != "automation-maintenance" for entry in entries):
+                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
+            if entries:
+                maintenance = entries[0]
+                _require_dir(maintenance)
+                for child in maintenance.iterdir():
+                    if child.name not in FIXED_AUTHORITY_FILES:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    _require_regular(child, "canonical private-state record")
+
+
+def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
+    inspected: list[MigrationFile] = []
+    for source, target in pairs:
+        metadata = _require_regular(source, "legacy private-state record")
+        content = read_bytes(source, "legacy private-state record")
+        _validate_legacy_content(source, content)
+        try:
+            target.lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise GitPrivateStateError(f"cannot inspect canonical private-state record: {target}") from exc
+        else:
+            if read_bytes(target, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting private-state records: {source} and {target}")
+        inspected.append(MigrationFile(
+            source, target, (metadata.st_dev, metadata.st_ino),
+            stat.S_IMODE(metadata.st_mode), content,
+        ))
+    return inspected
+
+
+def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".migrate.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            os.link(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd,
+                    follow_symlinks=False)
+            os.fsync(parent_fd)
+        except FileExistsError:
+            if read_bytes(path, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
+        published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if not stat.S_ISREG(published.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        return published.st_dev, published.st_ino
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot publish private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def ensure_parent(path: Path) -> None:
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
+    if not indexes:
+        # Legacy restoration may use only an already-existing validated parent.
+        descriptor = _open_anchored_parent(path)
+        os.close(descriptor)
+        return
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
+
+
+def exclusive_write_bytes(
+    path: Path, content: bytes, mode: int = 0o600
+) -> tuple[int, int]:
+    """Durably publish a new state record without replacing any existing object."""
+    ensure_parent(path)
+    return _exclusive_publish(path, content, mode)
+
+
+def _identity_unlink(item: MigrationFile) -> None:
+    if read_bytes(item.source, "legacy private-state record") != item.content:
+        raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+    metadata = _require_regular(item.source, "legacy private-state record")
+    if (metadata.st_dev, metadata.st_ino) != item.identity:
+        raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+    parent_fd = _open_anchored_parent(item.source)
+    try:
+        current = os.stat(item.source.name, dir_fd=parent_fd, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) != item.identity or not stat.S_ISREG(current.st_mode):
+            raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+        os.unlink(item.source.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove legacy private-state record: {item.source}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _remove_known_empty_legacy_directories(layout: Topology) -> None:
+    roots = [layout.common / LEGACY_NAMESPACE]
+    if not layout.admin_is_common:
+        roots.append(layout.admin / LEGACY_NAMESPACE)
+    for root in roots:
+        if _namespace_kind(root, foreign_regular=True) != "directory":
+            continue
+        for name in SHARED_DIRS:
+            child = root / name
+            try:
+                _require_dir(child, "legacy private-state directory")
+            except GitPrivateStateError:
+                if child.exists() or child.is_symlink():
+                    raise
+                continue
+            if not any(child.iterdir()):
+                child.rmdir()
+                descriptor = _open_dir(root)
+                try:
+                    os.fsync(descriptor)
+                finally:
+                    os.close(descriptor)
+        # The shared root remains while its mixed-version cleanup lock exists.
+        if not any(root.iterdir()):
+            root.rmdir()
+            descriptor = _open_dir(root.parent)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+
+
+@contextmanager
+def _file_lock(path: Path, *, create: bool):
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    if create:
+        flags |= os.O_CREAT
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe private-state lock: {path}")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    finally:
+        if "descriptor" in locals():
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+        os.close(parent_fd)
+
+
+def prepare(
+    root: Path,
+    *,
+    admin: bool = False,
+    common_dir: Path | None = None,
+    admin_dir: Path | None = None,
+    _legacy_lock_held: bool = False,
+) -> None:
+    """Validate and migrate known legacy state before a state mutation."""
+    layout = (
+        Topology(common_dir.resolve(), (admin_dir or common_dir).resolve())
+        if common_dir is not None
+        else topology(root)
+    )
+    _validate_canonical(layout)
+    shared_pairs, legacy_lock = _scan_shared_legacy(layout)
+    pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+    _inspect_pairs(pairs)  # preflight before creating even the migration lock
+    if legacy_lock is not None and not _legacy_lock_held:
+        with _file_lock(legacy_lock, create=False):
+            prepare(
+                root,
+                admin=admin,
+                common_dir=layout.common,
+                admin_dir=layout.admin,
+                _legacy_lock_held=True,
+            )
+        return
+
+    _ensure_namespace(layout.common, ())
+    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+        # Repeat all classification under the migration lock.
+        _validate_canonical(layout)
+        shared_pairs, _ = _scan_shared_legacy(layout)
+        pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+        inspected = _inspect_pairs(pairs)
+        for name in SHARED_DIRS:
+            _ensure_namespace(layout.common, (name,))
+        if admin:
+            _ensure_namespace(layout.admin, ("automation-maintenance",))
+        for item in inspected:
+            try:
+                item.target.lstat()
+            except FileNotFoundError:
+                _exclusive_publish(item.target, item.content, item.mode)
+        # No source is removed until every destination is durable and equivalent.
+        for item in inspected:
+            if read_bytes(item.target, "canonical private-state record") != item.content:
+                raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
+        for item in inspected:
+            metadata = _require_regular(item.source, "legacy private-state record")
+            if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
+                item.source, "legacy private-state record"
+            ) != item.content:
+                raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+        for item in inspected:
+            _identity_unlink(item)
+        _remove_known_empty_legacy_directories(layout)
+
+
+def write_bytes(path: Path, content: bytes) -> None:
+    """Atomically and durably replace one prepared canonical regular file."""
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        try:
+            current = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            if not stat.S_ISREG(current.st_mode):
+                raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot write private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+    """Remove only a canonical regular file through its verified parent."""
+    parent_fd = _open_anchored_parent(path)
+    try:
+        try:
+            metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        if expected_identity is not None and (metadata.st_dev, metadata.st_ino) != expected_identity:
+            raise GitPrivateStateError(f"private-state record identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove private-state record: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    layout = topology(root)
+    _validate_canonical(layout)
+    _, legacy = _scan_shared_legacy(layout)
+    # Lock old consumers out while migrating cleanup/discard evidence.
+    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
+    with legacy_context:
+        prepare(
+            root,
+            common_dir=layout.common,
+            admin_dir=layout.admin,
+            _legacy_lock_held=legacy is not None,
+        )
+        _ensure_namespace(layout.common, ())
+        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+            yield

--- a/templates/agent-python/.automation/bin/task_lifecycle.py
+++ b/templates/agent-python/.automation/bin/task_lifecycle.py
@@ -15,6 +15,10 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 WORK_UNIT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -1053,19 +1057,19 @@ def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
     validate_task(task)
-    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+    try:
+        return private_state.cleanup_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 @contextmanager
 def cleanup_lock(root: Path):
-    path = common_git_dir(root) / "opencode" / "cleanup.lock"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        try:
+    try:
+        with private_state.cleanup_lock(root):
             yield
-        finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 def cleanup_repository(root: Path) -> str:
@@ -1230,8 +1234,8 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
     if path.is_symlink() or not path.is_file():
         raise LifecycleError("cleanup receipt is not a regular local file")
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "cleanup receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise LifecycleError("cleanup receipt is invalid") from exc
     required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
     if (
@@ -1317,7 +1321,10 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -1332,13 +1339,18 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
 
 def task_cleanup(root: Path, task: str) -> None:
     require_main_worktree(root)
-    receipt = cleanup_receipt_path(root, task)
     with cleanup_lock(root):
+        receipt = cleanup_receipt_path(root, task)
         if receipt.exists():
             finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
             return
         plan = cleanup_plan(root, task)
-        atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise LifecycleError(str(exc)) from exc
         finish_cleanup(root, plan, receipt)
 
 

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -184,5 +184,29 @@ upgrade with changes replaces the active receipt and removes the previous consum
 receipt. A no-change invocation returns `NO_CHANGES` without discarding existing
 receipt lifecycle evidence.
 
+## Git-private runtime state
+
+Agent Core owns only the `agent-core/` namespace beneath Git administrative
+directories. Shared cleanup receipts, pristine-discard receipts, integration
+checkpoints, the cleanup lock, the migration lock, and historical hashed
+maintenance authorities live beneath `<git-common-dir>/agent-core/`.
+Worktree-specific maintenance `authority.json` and
+`source-recovery-proof.json` live beneath
+`<absolute-git-dir>/agent-core/automation-maintenance/`. Repository Task State
+under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
+`opencode.json` configuration are separate ownership surfaces.
+
+The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
+file and Agent Core never changes its bytes, metadata, or identity. A legacy
+directory at that name is accepted only when every entry has an explicitly
+known historical Agent Core path and schema. Known regular records are copied byte for
+byte with durable no-overwrite publication, all conflicts are rejected before
+migration mutation, and legacy records are removed only after every canonical
+destination is verified equivalent. Equivalent dual state and partially
+completed migration are retryable. Unknown entries, unexpected nesting,
+symlinks, and special files fail closed. The historical `cleanup.lock` is
+retained as a mixed-version locking ABI and is acquired before the canonical
+lock; it is never renamed or unlinked automatically.
+
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -148,6 +148,12 @@ files unchanged. It reports `PROVENANCE_REBOUND` or idempotent
 `PROVENANCE_ALREADY_BOUND`; then run ordinary consumer verification and the
 existing `automation::commit`.
 
+Rebind is an operator-serialized maintenance transition: no commit or other
+authority mutation may run concurrently in the target worktree. Current Agent
+Core revisions additionally fence rebind and commit with the same ordered
+common/admin migration locks; the explicit quiescence requirement preserves the
+older pending consumer needed to finish an in-flight upgrade.
+
 Eligibility is exact: registered maintenance Task/worktree/branch/HEAD; one
 standard active receipt matching exactly one authority; safe pending Agent
 Core paths/fingerprints only; no consumed, source-recovery, or ambiguous state;
@@ -155,7 +161,8 @@ the old and expected revisions in the same Templates object database; and an
 identical expected canonical diff. Missing authority remains the Issue #85
 route. Committed or consumed state, including a crossed guarded publication
 boundary, is rejected. Handled
-failures roll back safely and concurrency fails closed. No cross-filesystem
+failures roll back safely; operations by current revisions fail closed under the
+shared fence. No cross-filesystem
 atomicity or hard-crash durability is claimed; that remains Issue #89 scope.
 
 The receipt is schema-1 JSON containing Task identity (`task_id`, `branch`, and
@@ -198,15 +205,36 @@ under `.task-state/`, Git's `info/exclude`, and committed `.opencode/` and
 
 The path `<git-common-dir>/opencode` is OpenCode-owned when it is a regular
 file and Agent Core never changes its bytes, metadata, or identity. A legacy
-directory at that name is accepted only when every entry has an explicitly
-known historical Agent Core path and schema. Known regular records are copied byte for
-byte with durable no-overwrite publication, all conflicts are rejected before
-migration mutation, and legacy records are removed only after every canonical
-destination is verified equivalent. Equivalent dual state and partially
-completed migration are retryable. Unknown entries, unexpected nesting,
-symlinks, and special files fail closed. The historical `cleanup.lock` is
-retained as a mixed-version locking ABI and is acquired before the canonical
-lock; it is never renamed or unlinked automatically.
+directory at that name is accepted only when every entry satisfies the exact
+historical path, schema, Task/branch/worktree identity, repository syntax, and
+authority/proof relationship that Agent Core produced. The legacy namespace,
+subdirectories, records, and lock must be owned by the current effective user.
+Directories require owner access and reject group/other mutation while retaining
+historically produced read/traverse modes such as `0755`; records and locks reject
+group/other mutation and executable bits. Canonical directories
+are exactly mode `0700`, and canonical records, locks, and publication
+artifacts are exactly mode `0600`.
+
+Known records are copied byte for byte with durable no-overwrite publication,
+all conflicts are rejected before migration mutation, and legacy records are
+removed only after every canonical destination is mode-, owner-, and
+content-equivalent. The legacy cleanup-lock inode is acquired nonblocking and
+hard-linked into the canonical cleanup-lock path before its legacy name is
+removed. Existing waiters therefore remain fenced on the same inode. A
+contended legacy lock, or distinct legacy and canonical lock inodes, reports a
+precise `BLOCKED` condition rather than claiming migration success. Successful
+cutover removes the legacy lock last and then removes the empty `opencode/`
+directory, leaving the path available to OpenCode.
+
+Canonical publication is serialized by `migration.lock`. Only exact owned
+`.migrate.<pid>.<16-lowercase-hex>` and
+`.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next
+operation they are validated and durably removed under that lock before the
+legacy source is retried or an already-durable destination is used. Equivalent
+dual state, partial legacy removal, and interruption before or after durable
+publication are therefore retryable. Unknown entries, malformed temporary
+names, unsafe modes/ownership, unexpected nesting, symlinks, and special files
+fail closed without promotion.
 
 Do not bypass these guards with raw Git/GitHub commands. Merge is not part of
 this workflow and remains the separately gated Main Orchestrator operation.

--- a/templates/agent-rust/.automation/bin/agent_core.py
+++ b/templates/agent-rust/.automation/bin/agent_core.py
@@ -17,6 +17,7 @@ if str(SCRIPT_DIR) not in sys.path:
 import task_lifecycle as lifecycle
 import publication_metadata as publication
 import task_contract
+import git_private_state as private_state
 
 try:
     import tomllib
@@ -527,22 +528,31 @@ def validate_integration(root: Path, pr: str) -> dict:
 
 
 def integration_checkpoint(root: Path, pr: str) -> Path:
-    path = common_git_dir(root) / "opencode" / "integration" / f"pr-{pr}.head"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    return path
+    try:
+        return private_state.integration_checkpoint(root, pr)
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
 
 
 def integrate_check(root: Path, pr: str) -> None:
     data = validate_integration(root, pr)
-    integration_checkpoint(root, pr).write_text(data["headRefOid"] + "\n", encoding="utf-8")
+    try:
+        private_state.prepare(root)
+        checkpoint = integration_checkpoint(root, pr)
+        private_state.write_bytes(checkpoint, (data["headRefOid"] + "\n").encode("utf-8"))
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
     print(json.dumps({"pr": data["number"], "head": data["headRefOid"], "status": "verified"}))
 
 
 def integrate_merge(root: Path, pr: str) -> None:
     checkpoint = integration_checkpoint(root, pr)
-    if not checkpoint.exists():
+    if not checkpoint.exists() or checkpoint.is_symlink() or not checkpoint.is_file():
         raise AutomationError("run integrate::check before merge")
-    expected = checkpoint.read_text(encoding="utf-8").strip()
+    try:
+        expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
+    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+        raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:
         raise AutomationError(f"PR head moved after integration check: expected {expected}, got {data['headRefOid']}")

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -16,6 +16,10 @@ import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path, PurePosixPath
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 
 class UpgradeError(RuntimeError):
     pass
@@ -120,16 +124,55 @@ def worktree_admin_dir(repo: Path) -> Path:
 
 def _authority_locations(repo: Path) -> tuple[Path, Path | None]:
     admin = worktree_admin_dir(repo)
-    new_parent = admin / "opencode" / "automation-maintenance"
+    new_parent = admin / private_state.NAMESPACE / "automation-maintenance"
+    if new_parent.exists() or new_parent.is_symlink():
+        try:
+            private_state.safe_directory(admin / private_state.NAMESPACE)
+            private_state.safe_directory(new_parent)
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError(str(exc)) from exc
     try:
         resolved_parent = new_parent.resolve()
     except (OSError, ValueError, RuntimeError) as exc:
         raise UpgradeError("cannot resolve authority directory") from exc
     if resolved_parent != admin and admin not in resolved_parent.parents:
         raise UpgradeError("authority directory escapes the worktree administrative directory")
-    legacy_location = _safe_legacy_location(repo)
-    legacy = legacy_location[0] if legacy_location is not None else None
+    common = common_git_dir(repo)
+    key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
+    migrated = common / private_state.NAMESPACE / "automation-maintenance" / f"{key}.json"
+    if os.path.lexists(migrated):
+        try:
+            private_state.safe_directory(common / private_state.NAMESPACE)
+            private_state.safe_directory(migrated.parent)
+            private_state.read_bytes(migrated, "migrated maintenance authority")
+        except private_state.GitPrivateStateError as exc:
+            raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
+        legacy = migrated
+    else:
+        old_admin = _safe_old_admin_authority(repo)
+        if old_admin is not None and os.path.lexists(old_admin[0]):
+            legacy = old_admin[0]
+        else:
+            legacy_location = _safe_legacy_location(repo)
+            legacy = legacy_location[0] if legacy_location is not None else None
     return new_parent / "authority.json", legacy
+
+
+def _safe_old_admin_authority(repo: Path) -> tuple[Path, Path] | None:
+    try:
+        admin = worktree_admin_dir(repo)
+        root = admin / "opencode"
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
+            return None
+        parent = root / "automation-maintenance"
+        if parent.is_symlink() or (parent.exists() and not parent.is_dir()):
+            return None
+        resolved = parent.resolve()
+        if resolved != admin and admin not in resolved.parents:
+            return None
+        return parent / "authority.json", admin
+    except (OSError, ValueError, RuntimeError, UpgradeError):
+        return None
 
 
 def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
@@ -144,7 +187,7 @@ def _safe_legacy_location(repo: Path) -> tuple[Path, Path] | None:
             return None
         key = hashlib.sha256(str(repo.resolve()).encode("utf-8")).hexdigest()
         return parent / f"{key}.json", common
-    except (OSError, ValueError, RuntimeError, UpgradeError):
+    except (OSError, ValueError, RuntimeError, UpgradeError, private_state.GitPrivateStateError):
         return None
 
 
@@ -167,6 +210,15 @@ def receipt_digest(receipt: dict) -> str:
 
 
 def write_authority(repo: Path, receipt: dict) -> None:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     _write_authority_at(
         authority_path(repo),
         {
@@ -187,33 +239,29 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
             parent_before = path.parent.resolve()
             if parent_before != admin and admin not in parent_before.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        path.parent.mkdir(parents=True, exist_ok=True)
+        private_state.ensure_parent(path)
         if admin is not None:
             parent_after = path.parent.resolve()
             if parent_after != admin and admin not in parent_after.parents:
                 raise UpgradeError("authority directory escapes the worktree administrative directory")
-        # The caller has validated the parent; do not replace an existing record.
-        fd, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.tmp.", dir=path.parent)
-        temporary = Path(temporary_name)
-        try:
-            with os.fdopen(fd, "wb") as stream:
-                stream.write(json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n")
-                stream.flush()
-                try:
-                    os.fsync(stream.fileno())
-                except OSError:
-                    pass
-            os.link(temporary, path)
-        finally:
-            temporary.unlink(missing_ok=True)
-    except (OSError, ValueError, RuntimeError) as exc:
+        private_state.exclusive_write_bytes(
+            path,
+            json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+        )
+    except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
 
 
 def _rollback_authority_guard(repo: Path, authority: Path) -> Path:
+    old_admin = _safe_old_admin_authority(repo)
+    if old_admin is not None and authority == old_admin[0]:
+        return old_admin[1]
     legacy = _safe_legacy_location(repo)
     if legacy is not None and authority == legacy[0]:
         return legacy[1]
+    common = common_git_dir(repo)
+    if authority.parent == common / private_state.NAMESPACE / "automation-maintenance":
+        return common
     if authority == authority_path(repo):
         return worktree_admin_dir(repo)
     raise UpgradeError("cannot safely resolve authority location for rollback")
@@ -227,11 +275,10 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError("missing or invalid successful-upgrade authority record")
-        authority = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        authority = json.loads(
+            private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError("missing or invalid successful-upgrade authority record") from exc
     expected = {
         "schema_version": 1,
@@ -253,12 +300,15 @@ def _read_json_record(path: Path, error: str) -> dict:
 
 def _read_json_record_bytes(path: Path, error: str) -> tuple[bytes, dict]:
     try:
-        metadata = path.lstat()
-        if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
-            raise UpgradeError(error)
-        raw = path.read_bytes()
+        if private_state.NAMESPACE in path.parts or "opencode" in path.parts:
+            raw = private_state.read_bytes(path, error)
+        else:
+            metadata = path.lstat()
+            if not stat.S_ISREG(metadata.st_mode) or path.is_symlink():
+                raise UpgradeError(error)
+            raw = path.read_bytes()
         value = json.loads(raw.decode("utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(error) from exc
     if not isinstance(value, dict):
         raise UpgradeError(error)
@@ -1795,7 +1845,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         raise UpgradeError("receipt source is not compatible with the current Templates source")
     old_revision = _validate_source_revision(source, old["source_revision"])
     authority = _standard_authority_only(repo, old)
-    old_authority_raw = authority.read_bytes()
+    old_authority_raw = private_state.read_bytes(authority, "maintenance authority")
     receipt_identity = (active.lstat().st_dev, active.lstat().st_ino)
     authority_identity = (authority.lstat().st_dev, authority.lstat().st_ino)
     authority_head = validate_commit_oid(repo, old["authority_head"], field="receipt authority HEAD")
@@ -1828,7 +1878,7 @@ def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_sourc
         current_source, current_revision = resolve_clean_source_worktree(source)
         if expected_implementation_revision is None or current_revision != expected_implementation_revision:
             raise UpgradeError("source implementation changed before provenance replacement")
-    if active.read_bytes() != raw_receipt or authority.read_bytes() != old_authority_raw or pending_paths(repo) != expected_paths \
+    if active.read_bytes() != raw_receipt or private_state.read_bytes(authority, "maintenance authority") != old_authority_raw or pending_paths(repo) != expected_paths \
             or git_head(repo) != authority_head or current_source != source \
             or (require_source_head and current_revision != expected_source_revision) \
             or (active.lstat().st_dev, active.lstat().st_ino) != receipt_identity \
@@ -2021,7 +2071,11 @@ def recover_maintenance_authority_from_source(
             if existing != proof:
                 raise UpgradeError("existing source-recovery proof does not match reconstruction")
         else:
-            created_proof = exclusive_json_write_contained(proof_path, proof, admin=proof_admin)
+            private_state.ensure_parent(proof_path)
+            created_proof = private_state.exclusive_write_bytes(
+                proof_path,
+                json.dumps(proof, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            )
         current_source, current_implementation_revision = resolve_clean_source_worktree(source)
         if (current_source != source
                 or current_implementation_revision != expected_implementation_revision):
@@ -2040,13 +2094,11 @@ def recover_maintenance_authority_from_source(
             raise UpgradeError("source-recovery proof changed before bridge publication")
         _write_authority_at(_bridge_authority_path(target_repo), _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest()),
                             admin=worktree_admin_dir(target_repo))
-    except (OSError, UpgradeError):
+    except (OSError, UpgradeError, private_state.GitPrivateStateError):
         if created_proof is not None:
             try:
-                metadata = proof_path.lstat()
-                if (metadata.st_dev, metadata.st_ino) == created_proof:
-                    proof_path.unlink()
-            except OSError as exc:
+                private_state.unlink(proof_path, expected_identity=created_proof)
+            except (OSError, private_state.GitPrivateStateError) as exc:
                 raise UpgradeError("source-recovery publication failed and proof rollback failed") from exc
         raise
     return {"status": "AUTHORITY_RECOVERED", "changedPaths": expected,
@@ -2209,7 +2261,13 @@ def _commit_mode(
         )
         proof_admin = worktree_admin_dir(repo)
         _validate_admin_record_parent(proof_path, proof_admin)
-        proof_raw, proof_record = _read_json_record_bytes(proof_path, "missing or invalid source-recovery proof")
+        try:
+            proof_raw, proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            proof_record = json.loads(proof_raw.decode("utf-8"))
+        except (private_state.GitPrivateStateError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise UpgradeError("missing or invalid source-recovery proof") from exc
         proof = _validate_recovery_proof(proof_record)
         source, current_revision = resolve_clean_source_worktree(Path(proof["implementation_source"]))
         if (proof["implementation_source"] != str(source)
@@ -2221,7 +2279,7 @@ def _commit_mode(
             raise UpgradeError("source-recovery receipt source is incompatible")
         _validate_source_revision(source, receipt["source_revision"])
         authority = _validate_recovery_records(repo, receipt, active.read_bytes(), proof)
-        if proof_path.read_bytes() != proof_raw:
+        if private_state.read_bytes(proof_path, "source-recovery proof") != proof_raw:
             raise UpgradeError("source-recovery proof changed before commit mutation")
     else:  # pragma: no cover
         raise UpgradeError("unsupported commit mode")
@@ -2249,10 +2307,29 @@ def _commit_mode(
         atomic_json_write(consumed, consumed_receipt)
         consumed_metadata = consumed.lstat()
         consumed_instances.add((consumed_metadata.st_dev, consumed_metadata.st_ino))
-        authority.unlink(missing_ok=True)
+        authority_raw, authority_identity = private_state.read_bytes_identity(
+            authority, "maintenance authority"
+        )
+        expected_authority = (
+            _bridge_authority(receipt, hashlib.sha256(canonical_json(proof)).hexdigest())
+            if mode == "source_recovery" and proof is not None
+            else {
+                "schema_version": 1, "task_id": receipt["task_id"], "branch": receipt["branch"],
+                "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
+                "receipt_sha256": receipt_digest(receipt),
+            }
+        )
+        if json.loads(authority_raw.decode("utf-8")) != expected_authority:
+            raise UpgradeError("authority changed before commit mutation")
+        private_state.unlink(authority, expected_identity=authority_identity)
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
-            proof_path.unlink()
+            current_proof, current_proof_identity = private_state.read_bytes_identity(
+                proof_path, "source-recovery proof"
+            )
+            if current_proof != proof_raw or current_proof_identity != proof_identity:
+                raise UpgradeError("source-recovery proof changed before removal")
+            private_state.unlink(proof_path, expected_identity=proof_identity)
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2304,7 +2381,7 @@ def _commit_mode(
         consumed_receipt["commit_sha"] = commit_sha
         atomic_json_write(consumed, consumed_receipt)
         run(["git", "reset", "-q", commit_sha, "--", *paths], cwd=repo)
-    except (UpgradeError, OSError) as failure:
+    except (UpgradeError, OSError, private_state.GitPrivateStateError) as failure:
         if committed:
             raise UpgradeError(
                 f"commit {commit_sha} was published but finalization failed"
@@ -2314,8 +2391,8 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                exclusive_bytes_write_contained(proof_path, proof_raw, admin=worktree_admin_dir(repo))
-        except (OSError, UpgradeError) as rollback_error:
+                private_state.exclusive_write_bytes(proof_path, proof_raw)
+        except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
             if authority_removed:

--- a/templates/agent-rust/.automation/bin/automation_upgrade.py
+++ b/templates/agent-rust/.automation/bin/automation_upgrade.py
@@ -233,7 +233,13 @@ def write_authority(repo: Path, receipt: dict) -> None:
     )
 
 
-def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -> None:
+def _write_authority_at(
+    path: Path,
+    value: dict,
+    *,
+    admin: Path | None = None,
+    lock_held: bool = False,
+) -> None:
     try:
         if admin is not None:
             parent_before = path.parent.resolve()
@@ -247,6 +253,7 @@ def _write_authority_at(path: Path, value: dict, *, admin: Path | None = None) -
         private_state.exclusive_write_bytes(
             path,
             json.dumps(value, indent=2, sort_keys=True).encode("utf-8") + b"\n",
+            _lock_held=lock_held,
         )
     except (OSError, ValueError, RuntimeError, private_state.GitPrivateStateError) as exc:
         raise UpgradeError(f"cannot publish authority record: {path}") from exc
@@ -275,6 +282,7 @@ def validate_authority(repo: Path, receipt: dict) -> Path:
             raise UpgradeError("missing or invalid successful-upgrade authority record")
         path = legacy_path
     try:
+        private_state.validate_record(path, "successful-upgrade authority record")
         authority = json.loads(
             private_state.read_bytes(path, "successful-upgrade authority record").decode("utf-8")
         )
@@ -1642,9 +1650,10 @@ def _rename_record_at(source: str, destination: str, *, source_dir_fd: int, dest
     )
 
 
-def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
-                           receipt: dict, authority_path_value: Path,
-                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+def _replace_standard_pair_locked(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                                  receipt: dict, authority_path_value: Path,
+                                  receipt_identity: tuple[int, int],
+                                  authority_identity: tuple[int, int]) -> None:
     active = receipt_path(repo)
     admin = _rollback_authority_guard(repo, authority_path_value)
     _validate_admin_record_parent(authority_path_value, admin)
@@ -1823,6 +1832,25 @@ def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw
                 pass
 
 
+def _replace_standard_pair(repo: Path, old_receipt_raw: bytes, old_authority_raw: bytes,
+                           receipt: dict, authority_path_value: Path,
+                           receipt_identity: tuple[int, int], authority_identity: tuple[int, int]) -> None:
+    """Replace a common/admin record pair under ordered namespace fences."""
+    try:
+        with private_state.mutation_lock(repo, admin=True):
+            _replace_standard_pair_locked(
+                repo,
+                old_receipt_raw,
+                old_authority_raw,
+                receipt,
+                authority_path_value,
+                receipt_identity,
+                authority_identity,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
+
+
 def _rebind_maintenance_provenance(repo: Path, source_path: Path, expected_source_revision: str,
                                    *, require_source_head: bool,
                                    expected_implementation_revision: str | None = None) -> dict:
@@ -1994,6 +2022,16 @@ def recover_maintenance_authority_from_source(
         expected_implementation_revision
     )
     task_id, branch, worktree = require_maintenance(target_repo)
+    try:
+        private_state.prepare(
+            target_repo,
+            admin=True,
+            common_dir=common_git_dir(target_repo),
+            admin_dir=worktree_admin_dir(target_repo),
+            _allow_incomplete_recovery=True,
+        )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
     source, implementation_revision = resolve_clean_source_worktree(templates_source_root)
     if implementation_revision != expected_implementation_revision:
         raise UpgradeError("source HEAD does not match the expected implementation revision")
@@ -2215,7 +2253,7 @@ def normalized_git_fingerprint(fingerprint: object) -> dict[str, object]:
     }
 
 
-def _commit_mode(
+def _commit_mode_locked(
     repo: Path,
     task: str,
     message: str,
@@ -2321,7 +2359,12 @@ def _commit_mode(
         )
         if json.loads(authority_raw.decode("utf-8")) != expected_authority:
             raise UpgradeError("authority changed before commit mutation")
-        private_state.unlink(authority, expected_identity=authority_identity)
+        private_state.unlink(
+            authority,
+            expected_identity=authority_identity,
+            expected_content=authority_raw,
+            _lock_held=True,
+        )
         authority_removed = True
         if mode == "source_recovery" and proof is not None:
             current_proof, current_proof_identity = private_state.read_bytes_identity(
@@ -2329,7 +2372,12 @@ def _commit_mode(
             )
             if current_proof != proof_raw or current_proof_identity != proof_identity:
                 raise UpgradeError("source-recovery proof changed before removal")
-            private_state.unlink(proof_path, expected_identity=proof_identity)
+            private_state.unlink(
+                proof_path,
+                expected_identity=proof_identity,
+                expected_content=proof_raw,
+                _lock_held=True,
+            )
             proof_removed = True
         task_state_dir(repo)
         private_index.unlink(missing_ok=True)
@@ -2391,7 +2439,9 @@ def _commit_mode(
             if proof_removed and proof is not None:
                 if proof_raw is None:
                     raise UpgradeError("source-recovery proof bytes were not captured")
-                private_state.exclusive_write_bytes(proof_path, proof_raw)
+                private_state.exclusive_write_bytes(
+                    proof_path, proof_raw, _lock_held=True
+                )
         except (OSError, UpgradeError, private_state.GitPrivateStateError) as rollback_error:
             rollback_errors.append(f"proof restore failed: {rollback_error}")
         try:
@@ -2401,7 +2451,12 @@ def _commit_mode(
                     "worktree": receipt["worktree"], "authority_nonce": receipt["authority_nonce"],
                     "receipt_sha256": receipt_digest(receipt),
                 }
-                _write_authority_at(authority, restored, admin=_rollback_authority_guard(repo, authority))
+                _write_authority_at(
+                    authority,
+                    restored,
+                    admin=_rollback_authority_guard(repo, authority),
+                    lock_held=True,
+                )
         except (OSError, UpgradeError) as rollback_error:
             rollback_errors.append(f"authority restore failed: {rollback_error}")
         try:
@@ -2446,6 +2501,35 @@ def _commit_mode(
             "mergePerformed": False,
         })
     return result
+
+
+def _commit_mode(
+    repo: Path,
+    task: str,
+    message: str,
+    mode: str,
+    *,
+    source_root: Path | None = None,
+    expected_implementation_revision: str | None = None,
+) -> dict[str, object]:
+    try:
+        private_state.prepare(
+            repo,
+            admin=True,
+            common_dir=common_git_dir(repo),
+            admin_dir=worktree_admin_dir(repo),
+        )
+        with private_state.mutation_lock(repo, admin=True):
+            return _commit_mode_locked(
+                repo,
+                task,
+                message,
+                mode,
+                source_root=source_root,
+                expected_implementation_revision=expected_implementation_revision,
+            )
+    except private_state.GitPrivateStateError as exc:
+        raise UpgradeError(str(exc)) from exc
 
 
 def commit(repo: Path, task: str, message: str) -> dict[str, object]:

--- a/templates/agent-rust/.automation/bin/discard_pristine.py
+++ b/templates/agent-rust/.automation/bin/discard_pristine.py
@@ -7,7 +7,10 @@ import re
 import sys
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
 import task_lifecycle as lifecycle
+import git_private_state as private_state
 
 
 RECEIPT_SCHEMA_VERSION = 1
@@ -18,12 +21,10 @@ REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 
 def discard_receipt_path(root: Path, task: str) -> Path:
     lifecycle.validate_task(task)
-    return (
-        lifecycle.common_git_dir(root)
-        / "opencode"
-        / "discard-pristine"
-        / f"{task}.json"
-    )
+    try:
+        return private_state.discard_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
 
 
 def _branch_publication_configuration(record: lifecycle.WorktreeRecord) -> list[str]:
@@ -255,8 +256,8 @@ def read_discard_receipt(root: Path, path: Path, task: str) -> dict:
             "discard-pristine receipt is not a regular local file"
         )
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "discard-pristine receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise lifecycle.LifecycleError("discard-pristine receipt is invalid") from exc
     required = {
         "schema_version",
@@ -394,7 +395,10 @@ def finish_pristine_discard(root: Path, plan: dict, receipt: Path) -> None:
             "discard-pristine failed to delete the expected local Task branch"
         )
 
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise lifecycle.LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -421,7 +425,12 @@ def task_discard_pristine(root: Path, task: str) -> None:
             )
             return
         plan = pristine_discard_plan(root, task)
-        lifecycle.atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise lifecycle.LifecycleError(str(exc)) from exc
         finish_pristine_discard(root, plan, receipt)
 
 

--- a/templates/agent-rust/.automation/bin/git_private_state.py
+++ b/templates/agent-rust/.automation/bin/git_private_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 import fcntl
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -18,9 +19,12 @@ LEGACY_NAMESPACE = "opencode"
 TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 PR_RE = re.compile(r"[1-9][0-9]*")
 HASH_RE = re.compile(r"[0-9a-f]{64}")
+OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
+REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
 FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
+TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
 
 
@@ -126,6 +130,43 @@ def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_r
     return metadata
 
 
+def _require_owned_mode(path: Path, metadata: os.stat_result, mode: int, what: str,
+                        *, exact: bool = False) -> None:
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    actual = stat.S_IMODE(metadata.st_mode)
+    unsafe = actual != mode if exact else (actual & mode) != mode
+    unsafe = unsafe or bool(actual & 0o022)
+    if unsafe:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+
+
+def _require_legacy_dir(path: Path, what: str) -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what)
+    return metadata
+
+
+def _require_legacy_record(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o400, what)
+    if metadata.st_mode & 0o111:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir(path: Path, what: str = "canonical private-state directory") -> os.stat_result:
+    metadata = _require_dir(path, what)
+    _require_owned_mode(path, metadata, 0o700, what, exact=True)
+    return metadata
+
+
+def _require_canonical_file(path: Path, what: str) -> os.stat_result:
+    metadata = _require_regular(path, what)
+    _require_owned_mode(path, metadata, 0o600, what, exact=True)
+    return metadata
+
+
 def _require_regular(path: Path, what: str) -> os.stat_result:
     metadata = _lstat(path, what)
     if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
@@ -134,7 +175,10 @@ def _require_regular(path: Path, what: str) -> os.stat_result:
 
 
 def safe_directory(path: Path) -> None:
-    _require_dir(path)
+    if NAMESPACE in path.parts:
+        _require_canonical_dir(path)
+    else:
+        _require_dir(path)
 
 
 def _open_dir(path: Path) -> int:
@@ -162,7 +206,8 @@ def _open_anchored_parent(path: Path) -> int:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
             os.close(descriptor)
@@ -179,15 +224,24 @@ def _open_anchored_parent(path: Path) -> int:
 def _ensure_child_directory(parent: Path, name: str) -> Path:
     descriptor = _open_dir(parent)
     try:
+        created = False
         try:
             os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
             os.fsync(descriptor)
+            created = True
         except FileExistsError:
             pass
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         child = os.open(name, flags, dir_fd=descriptor)
         try:
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            metadata = os.fstat(child)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+            if not created and (
+                metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o700
+            ):
                 raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
         finally:
             os.close(child)
@@ -205,15 +259,22 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
     try:
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
+            created = False
             try:
                 os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.chmod(name, 0o700, dir_fd=descriptor, follow_symlinks=False)
                 os.fsync(descriptor)
+                created = True
             except FileExistsError:
                 pass
             child = os.open(name, flags, dir_fd=descriptor)
-            if not stat.S_ISDIR(os.fstat(child).st_mode):
+            child_meta = os.fstat(child)
+            if not stat.S_ISDIR(child_meta.st_mode):
                 os.close(child)
                 raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            if child_meta.st_uid != os.geteuid() or stat.S_IMODE(child_meta.st_mode) != 0o700:
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe canonical private-state directory: {current / name}")
             os.close(descriptor)
             descriptor = child
             current /= name
@@ -263,6 +324,14 @@ def read_bytes(path: Path, what: str = "private-state record") -> bytes:
     return read_bytes_identity(path, what)[0]
 
 
+def validate_record(path: Path, what: str = "private-state record") -> None:
+    """Require the ownership and mode contract for a persisted state record."""
+    if NAMESPACE in path.parts:
+        _require_canonical_file(path, what)
+    else:
+        _require_legacy_record(path, what)
+
+
 def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     if directory in {"cleanup", "discard-pristine"}:
         return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
@@ -276,6 +345,34 @@ def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
     return False
 
 
+def _recover_canonical_temps(layout: Topology, *, include_admin: bool = True) -> None:
+    """Remove only our exact, owned publication artifacts while fenced."""
+    directories = [layout.common / NAMESPACE]
+    if include_admin and not layout.admin_is_common:
+        directories.append(layout.admin / NAMESPACE)
+    for namespace in directories:
+        if _namespace_kind(namespace, foreign_regular=False) != "directory":
+            continue
+        subdirs = [namespace / name for name in SHARED_DIRS]
+        for directory in subdirs:
+            if not directory.exists():
+                continue
+            _require_canonical_dir(directory)
+            for item in directory.iterdir():
+                if item.name.startswith("."):
+                    if TEMP_RE.fullmatch(item.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical temporary: {item}")
+                    metadata = _require_canonical_file(item, "canonical temporary")
+                    if metadata.st_nlink < 1 or metadata.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {item}")
+                    parent_fd = _open_anchored_parent(item)
+                    try:
+                        os.unlink(item.name, dir_fd=parent_fd)
+                        os.fsync(parent_fd)
+                    finally:
+                        os.close(parent_fd)
+
+
 def _legacy_json(content: bytes, path: Path) -> dict:
     try:
         value = json.loads(content.decode("utf-8"))
@@ -287,7 +384,7 @@ def _legacy_json(content: bytes, path: Path) -> dict:
 
 
 def _valid_oid(value: object) -> bool:
-    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+    return isinstance(value, str) and OID_RE.fullmatch(value) is not None
 
 
 def _valid_digest(value: object) -> bool:
@@ -306,14 +403,101 @@ def _valid_absolute_path(value: object) -> bool:
     return _valid_nonempty(value) and Path(value).is_absolute()
 
 
+def _valid_repository(value: object) -> bool:
+    return isinstance(value, str) and REPOSITORY_RE.fullmatch(value) is not None
+
+
+def _valid_branch_worktree(branch: object, task: object, worktree: object) -> bool:
+    if not (_valid_task_id(task) and isinstance(branch, str) and isinstance(worktree, str)):
+        return False
+    if not (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-")):
+        return False
+    path = Path(worktree)
+    return (path.is_absolute() and path.parent.name == ".worktrees" and
+            path.name == branch.split("/", 1)[1])
+
+
+def _valid_task_branch(branch: object, task: object) -> bool:
+    return (
+        _valid_task_id(task)
+        and isinstance(branch, str)
+        and (branch.startswith(f"task/{task}-") or branch.startswith(f"fix/{task}-"))
+    )
+
+
 def _valid_authority_fields(value: dict) -> bool:
     return (
         _valid_task_id(value.get("task_id"))
-        and _valid_nonempty(value.get("branch"))
+        and _valid_task_branch(value.get("branch"), value.get("task_id"))
         and _valid_absolute_path(value.get("worktree"))
         and _valid_digest(value.get("authority_nonce"))
         and _valid_digest(value.get("receipt_sha256"))
     )
+
+
+def _valid_cleanup_evidence(value: dict, status: str, local_head: str) -> bool:
+    if status == "merged":
+        return (set(value) == {"repository", "pr", "published_head", "upstream"}
+                and _valid_repository(value.get("repository"))
+                and isinstance(value.get("pr"), int) and not isinstance(value.get("pr"), bool)
+                and value["pr"] > 0 and _valid_oid(value.get("published_head"))
+                and value.get("published_head").casefold() == local_head.casefold()
+                and value.get("upstream") in {"live", "deleted"})
+    return (set(value) == {"repository", "upstream", "base_revision"}
+            and _valid_repository(value.get("repository"))
+            and value.get("upstream") == "cancelled-safe"
+            and _valid_oid(value.get("base_revision")))
+
+
+def _validate_authority_filename(path: Path, content: bytes) -> None:
+    if path.parent.name != "automation-maintenance" or path.name in FIXED_AUTHORITY_FILES:
+        return
+    value = _legacy_json(content, path)
+    expected = hashlib.sha256(str(Path(value["worktree"]).resolve()).encode()).hexdigest()
+    if path.name != expected + ".json":
+        raise GitPrivateStateError(f"invalid private-state authority filename: {path}")
+
+
+def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -> Path:
+    """Bind authority ownership to a worktree registered in this topology."""
+    if path.parent.name != "automation-maintenance":
+        raise GitPrivateStateError(f"authority has an invalid parent: {path}")
+    value = _legacy_json(content, path)
+    worktree = Path(value["worktree"])
+    dot_git = worktree / ".git"
+    try:
+        metadata = dot_git.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            raise ValueError
+        if stat.S_ISDIR(metadata.st_mode):
+            admin = dot_git.resolve(strict=True)
+        elif stat.S_ISREG(metadata.st_mode):
+            marker = dot_git.read_text(encoding="utf-8").strip()
+            if not marker.startswith("gitdir: "):
+                raise ValueError
+            target = Path(marker[8:])
+            admin = (target if target.is_absolute() else worktree / target).resolve(strict=True)
+        else:
+            raise ValueError
+    except (OSError, UnicodeDecodeError, ValueError, KeyError) as exc:
+        raise GitPrivateStateError(f"authority worktree is not registered: {path}") from exc
+    common = layout.common.resolve()
+    allowed = admin == common or admin == layout.admin.resolve()
+    if not allowed and admin.parent.name == "worktrees" and admin.parent.parent == common:
+        try:
+            registered_gitdir = (admin / "gitdir").read_text(encoding="utf-8").strip()
+            allowed = Path(registered_gitdir).resolve(strict=True) == dot_git.resolve(strict=True)
+        except (OSError, UnicodeDecodeError):
+            allowed = False
+    if not allowed:
+        raise GitPrivateStateError(f"authority worktree is outside Git topology: {path}")
+    try:
+        head = (admin / "HEAD").read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise GitPrivateStateError(f"authority worktree registration is unreadable: {path}") from exc
+    if head != f"ref: refs/heads/{value['branch']}":
+        raise GitPrivateStateError(f"authority branch does not match worktree registration: {path}")
+    return admin
 
 
 def _validate_legacy_content(path: Path, content: bytes) -> None:
@@ -324,7 +508,8 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             text = content.decode("ascii", errors="strict")
         except UnicodeDecodeError as exc:
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
-        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+        if (not text.endswith("\n") or not _valid_oid(text[:-1]) or
+                text[:-1] != text[:-1].lower()):
             raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
         return
     value = _legacy_json(content, path)
@@ -335,10 +520,10 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("schema_version") == 1
             and value.get("task") == name[:-5]
             and value.get("status") in {"merged", "cancelled"}
-            and isinstance(value.get("worktree"), str)
-            and isinstance(value.get("branch"), str)
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
             and _valid_oid(value.get("local_head"))
             and isinstance(value.get("evidence"), dict)
+            and _valid_cleanup_evidence(value["evidence"], value["status"], value["local_head"])
         )
     elif directory == "discard-pristine":
         required = {
@@ -351,11 +536,12 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and value.get("operation") == "discard-pristine"
             and value.get("task") == name[:-5]
             and value.get("status") == "initialized"
-            and all(isinstance(value.get(field), str) for field in (
-                "worktree", "branch", "base_branch", "repository"
-            ))
+            and _valid_branch_worktree(value.get("branch"), value.get("task"), value.get("worktree"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_repository(value.get("repository"))
             and _valid_oid(value.get("base_revision"))
-            and value.get("local_head") == value.get("base_revision")
+            and _valid_oid(value.get("local_head"))
+            and value.get("local_head").casefold() == value.get("base_revision").casefold()
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -413,26 +599,40 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
     if kind != "directory":
         return [], None
     pairs: list[tuple[Path, Path]] = []
+    _require_legacy_dir(root, "legacy private-state directory")
     legacy_lock: Path | None = None
     for entry in root.iterdir():
         if entry.name == "cleanup.lock":
-            _require_regular(entry, "legacy cleanup lock")
+            metadata = _require_regular(entry, "legacy cleanup lock")
+            _require_owned_mode(entry, metadata, 0o600, "legacy cleanup lock")
+            if metadata.st_mode & 0o111:
+                raise GitPrivateStateError(f"unsafe legacy cleanup lock mode: {entry}")
             legacy_lock = entry
             continue
         if entry.name not in SHARED_DIRS:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
-        _require_dir(entry, "legacy private-state directory")
+        _require_legacy_dir(entry, "legacy private-state directory")
         for child in entry.iterdir():
             allow_fixed = entry.name == "automation-maintenance"
             if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
                 raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-            _require_regular(child, "legacy private-state record")
+            _require_legacy_record(child, "legacy private-state record")
+            if entry.name == "automation-maintenance":
+                content = read_bytes(child)
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                authority_admin = _validate_authority_topology(child, content, layout)
             if child.name in FIXED_AUTHORITY_FILES:
-                if layout.admin_is_common:
-                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
-                # In a linked worktree these belong to the main worktree admin.
+                if authority_admin not in {layout.common, layout.admin}:
+                    raise GitPrivateStateError(
+                        f"fixed authority belongs to a different worktree admin: {child}"
+                    )
+                pairs.append((child, authority_admin / NAMESPACE / entry.name / child.name))
             else:
                 pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs, legacy_lock
 
 
@@ -450,55 +650,211 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
     if not entries:
         return []
     maintenance = entries[0]
-    _require_dir(maintenance, "legacy maintenance authority directory")
+    _require_legacy_dir(maintenance, "legacy maintenance authority directory")
     pairs: list[tuple[Path, Path]] = []
     for child in maintenance.iterdir():
         if child.name not in FIXED_AUTHORITY_FILES:
             raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
-        _require_regular(child, "legacy private-state record")
+        _require_legacy_record(child, "legacy private-state record")
+        content = read_bytes(child)
+        _validate_legacy_content(child, content)
+        _validate_authority_filename(child, content)
+        if _validate_authority_topology(child, content, layout) != layout.admin:
+            raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    _validate_legacy_relations(
+        root, (layout.common / NAMESPACE, layout.admin / NAMESPACE)
+    )
     return pairs
 
 
-def _validate_canonical(layout: Topology) -> None:
+def _validate_legacy_relations(root: Path, canonical_roots: tuple[Path, Path]) -> None:
+    maintenance = root / "automation-maintenance"
+    if not maintenance.is_dir():
+        return
+    proof = maintenance / "source-recovery-proof.json"
+    authority = maintenance / "authority.json"
+    if authority.exists() and not proof.exists():
+        authority_value = _legacy_json(
+            read_bytes(authority, "legacy maintenance authority"), authority
+        )
+        if authority_value.get("kind") == "source-recovery-bridge":
+            canonical_proofs = [
+                candidate / "automation-maintenance" / "source-recovery-proof.json"
+                for candidate in canonical_roots
+            ]
+            canonical_proof = next((candidate for candidate in canonical_proofs
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        authority_value,
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                    )), None)
+            if canonical_proof is None:
+                raise GitPrivateStateError(
+                    f"legacy source-recovery bridge lacks its proof: {root}"
+                )
+            proof = canonical_proof
+        else:
+            return
+    if proof.exists() and not authority.exists():
+        canonical_authorities = [
+            candidate / "automation-maintenance" / "authority.json"
+            for candidate in canonical_roots
+        ]
+        proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+        canonical_authority = next((candidate for candidate in canonical_authorities
+                                    if candidate.is_file() and _recovery_pair_matches(
+                                        _legacy_json(read_bytes(candidate), candidate),
+                                        proof_value,
+                                    )), None)
+        if canonical_authority is None:
+            raise GitPrivateStateError(
+                f"legacy source-recovery proof lacks its bridge: {root}"
+            )
+        authority = canonical_authority
+    if not proof.exists() or not authority.exists():
+        return
+    proof_value = _legacy_json(read_bytes(proof, "legacy source-recovery proof"), proof)
+    authority_value = _legacy_json(read_bytes(authority, "legacy maintenance authority"), authority)
+    if not _recovery_pair_matches(authority_value, proof_value):
+        raise GitPrivateStateError(f"conflicting legacy authority and proof identity: {root}")
+
+
+def _recovery_pair_matches(authority: dict, proof: dict) -> bool:
+    if authority.get("kind") != "source-recovery-bridge":
+        return False
+    if any(proof.get(field) != authority.get(field) for field in (
+        "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"
+    )):
+        return False
+    digest = hashlib.sha256(
+        json.dumps(proof, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return authority.get("proof_sha256") == digest
+
+
+def _validate_canonical(
+    layout: Topology, *, allow_incomplete_recovery: bool = False
+) -> None:
     shared = layout.common / NAMESPACE
     kind = _namespace_kind(shared, foreign_regular=False)
     if kind == "directory":
+        _require_canonical_dir(shared)
         for entry in shared.iterdir():
             if entry.name in LOCK_FILES:
-                _require_regular(entry, "canonical private-state lock")
+                _require_canonical_file(entry, "canonical private-state lock")
                 continue
             if entry.name not in SHARED_DIRS:
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
-            _require_dir(entry)
+            _require_canonical_dir(entry)
             for child in entry.iterdir():
+                if child.name.startswith("."):
+                    if TEMP_RE.fullmatch(child.name) is None:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    temporary = _require_canonical_file(child, "canonical temporary")
+                    if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                        raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                    continue
                 # Fixed files in common are the main worktree's admin records.
                 if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
                     raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                _require_regular(child, "canonical private-state record")
+                _require_canonical_file(child, "canonical private-state record")
+                content = read_bytes(child, "canonical private-state record")
+                _validate_legacy_content(child, content)
+                _validate_authority_filename(child, content)
+                if entry.name == "automation-maintenance":
+                    authority_admin = _validate_authority_topology(child, content, layout)
+                    if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
     if not layout.admin_is_common:
         admin_root = layout.admin / NAMESPACE
         kind = _namespace_kind(admin_root, foreign_regular=False)
         if kind == "directory":
+            _require_canonical_dir(admin_root)
             entries = list(admin_root.iterdir())
-            if any(entry.name != "automation-maintenance" for entry in entries):
-                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+            if any(entry.name not in {"automation-maintenance", "migration.lock"} for entry in entries):
+                unknown = next(
+                    entry for entry in entries
+                    if entry.name not in {"automation-maintenance", "migration.lock"}
+                )
                 raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
-            if entries:
-                maintenance = entries[0]
-                _require_dir(maintenance)
+            lock = admin_root / "migration.lock"
+            if lock.exists():
+                _require_canonical_file(lock, "canonical private-state lock")
+            maintenance = admin_root / "automation-maintenance"
+            if maintenance.exists():
+                _require_canonical_dir(maintenance)
                 for child in maintenance.iterdir():
+                    if child.name.startswith("."):
+                        if TEMP_RE.fullmatch(child.name) is None:
+                            raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                        temporary = _require_canonical_file(child, "canonical temporary")
+                        if temporary.st_nlink < 1 or temporary.st_nlink > 2:
+                            raise GitPrivateStateError(f"unsafe canonical temporary link count: {child}")
+                        continue
                     if child.name not in FIXED_AUTHORITY_FILES:
                         raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
-                    _require_regular(child, "canonical private-state record")
+                    _require_canonical_file(child, "canonical private-state record")
+                    content = read_bytes(child, "canonical private-state record")
+                    _validate_legacy_content(child, content)
+                    _validate_authority_filename(child, content)
+                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                        raise GitPrivateStateError(
+                            f"fixed authority is outside its worktree admin: {child}"
+                        )
+
+    # Canonical maintenance authority is fixed to the administrative topology;
+    # a bridge, when present, must name the exact canonical proof bytes.
+    for namespace in {layout.common / NAMESPACE, layout.admin / NAMESPACE}:
+        proof = namespace / "automation-maintenance" / "source-recovery-proof.json"
+        bridge = namespace / "automation-maintenance" / "authority.json"
+        proof_exists = proof.is_file()
+        bridge_exists = bridge.is_file()
+        if proof_exists and not bridge_exists:
+            legacy_bridges = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/authority.json",
+            }
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            if not allow_incomplete_recovery and not any(candidate.is_file() and _recovery_pair_matches(
+                _legacy_json(read_bytes(candidate), candidate), proof_value
+            ) for candidate in legacy_bridges):
+                raise GitPrivateStateError(f"source-recovery proof lacks bridge authority: {namespace}")
+        if bridge_exists:
+            bridge_value = _legacy_json(read_bytes(bridge), bridge)
+            is_bridge = bridge_value.get("kind") == "source-recovery-bridge"
+            legacy_proofs = {
+                layout.common / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+                layout.admin / LEGACY_NAMESPACE / "automation-maintenance/source-recovery-proof.json",
+            }
+            if is_bridge and not proof_exists and not any(
+                candidate.is_file() and _recovery_pair_matches(
+                    bridge_value, _legacy_json(read_bytes(candidate), candidate)
+                ) for candidate in legacy_proofs
+            ):
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+            if not is_bridge and proof_exists:
+                raise GitPrivateStateError(f"incomplete source-recovery authority pair: {namespace}")
+        if proof_exists and bridge_exists:
+            proof_value = _legacy_json(read_bytes(proof), proof)
+            for field in ("task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"):
+                if proof_value.get(field) != bridge_value.get(field):
+                    raise GitPrivateStateError(f"conflicting authority and proof identity: {namespace}")
+            digest = hashlib.sha256(
+                json.dumps(proof_value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
+            if bridge_value.get("proof_sha256") != digest:
+                raise GitPrivateStateError(f"source-recovery proof digest mismatch: {namespace}")
 
 
 def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
     inspected: list[MigrationFile] = []
     for source, target in pairs:
-        metadata = _require_regular(source, "legacy private-state record")
+        metadata = _require_legacy_record(source, "legacy private-state record")
         content = read_bytes(source, "legacy private-state record")
         _validate_legacy_content(source, content)
+        _validate_authority_filename(source, content)
         try:
             target.lstat()
         except FileNotFoundError:
@@ -537,10 +893,15 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
                     follow_symlinks=False)
             os.fsync(parent_fd)
         except FileExistsError:
+            _require_canonical_file(path, "canonical private-state record")
             if read_bytes(path, "canonical private-state record") != content:
                 raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
         published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
-        if not stat.S_ISREG(published.st_mode):
+        if (
+            not stat.S_ISREG(published.st_mode)
+            or published.st_uid != os.geteuid()
+            or stat.S_IMODE(published.st_mode) != 0o600
+        ):
             raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         return published.st_dev, published.st_ino
     except GitPrivateStateError:
@@ -556,6 +917,36 @@ def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]
             os.close(parent_fd)
 
 
+def _exclusive_publish_direct(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    """Restore an absent legacy record without a visible temporary artifact."""
+    parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
+    try:
+        descriptor = os.open(
+            path.name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            mode,
+            dir_fd=parent_fd,
+        )
+        os.fchmod(descriptor, mode)
+        view = memoryview(content)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("short private-state write")
+            view = view[written:]
+        os.fsync(descriptor)
+        metadata = os.fstat(descriptor)
+        os.fsync(parent_fd)
+        return metadata.st_dev, metadata.st_ino
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot restore legacy private-state record: {path}") from exc
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
+
+
 def ensure_parent(path: Path) -> None:
     parts = path.parts
     indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
@@ -569,18 +960,53 @@ def ensure_parent(path: Path) -> None:
     _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
 
 
+def _state_namespace(path: Path) -> Path:
+    """Return the namespace containing a canonical state path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside canonical private-state namespace: {path}")
+    return Path(*path.parts[: indexes[-1] + 1])
+
+
+def _legacy_equivalent(path: Path) -> tuple[Path, Path]:
+    """Return the state root and canonical equivalent of one legacy path."""
+    indexes = [i for i, part in enumerate(path.parts) if part == LEGACY_NAMESPACE]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside legacy private-state namespace: {path}")
+    marker = indexes[-1]
+    state_root = Path(*path.parts[:marker])
+    relative = Path(*path.parts[marker + 1:])
+    return state_root, state_root / NAMESPACE / relative
+
+
 def exclusive_write_bytes(
-    path: Path, content: bytes, mode: int = 0o600
+    path: Path, content: bytes, mode: int = 0o600, *, _lock_held: bool = False
 ) -> tuple[int, int]:
     """Durably publish a new state record without replacing any existing object."""
+    if NAMESPACE not in path.parts:
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            if os.path.lexists(path):
+                raise GitPrivateStateError(f"legacy private-state record already exists: {path}")
+            target = canonical if not (state_root / LEGACY_NAMESPACE).exists() else path
+            ensure_parent(target)
+            if target == canonical:
+                return _exclusive_publish(target, content, 0o600)
+            return _exclusive_publish_direct(target, content, mode)
     ensure_parent(path)
-    return _exclusive_publish(path, content, mode)
+    namespace = _state_namespace(path)
+    if _lock_held:
+        return _exclusive_publish(path, content, 0o600)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        return _exclusive_publish(path, content, 0o600)
 
 
 def _identity_unlink(item: MigrationFile) -> None:
     if read_bytes(item.source, "legacy private-state record") != item.content:
         raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
-    metadata = _require_regular(item.source, "legacy private-state record")
+    metadata = _require_legacy_record(item.source, "legacy private-state record")
     if (metadata.st_dev, metadata.st_ino) != item.identity:
         raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
     parent_fd = _open_anchored_parent(item.source)
@@ -598,6 +1024,118 @@ def _identity_unlink(item: MigrationFile) -> None:
         os.close(parent_fd)
 
 
+def _unlink_identity_path(path: Path, identity: tuple[int, int], what: str) -> None:
+    parent_fd = _open_anchored_parent(path)
+    try:
+        metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if ((metadata.st_dev, metadata.st_ino) != identity or
+                not stat.S_ISREG(metadata.st_mode)):
+            raise GitPrivateStateError(f"{what} identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _handoff_cleanup_lock(
+    legacy: Path, canonical: Path, expected_identity: tuple[int, int]
+) -> tuple[int, int]:
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    if (legacy_meta.st_dev, legacy_meta.st_ino) != expected_identity:
+        raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+    legacy_parent_fd = _open_anchored_parent(legacy)
+    canonical_parent_fd = _open_anchored_parent(canonical)
+    try:
+        legacy_fd = os.open(
+            legacy.name,
+            os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0),
+            dir_fd=legacy_parent_fd,
+        )
+        try:
+            opened = os.fstat(legacy_fd)
+            if (opened.st_dev, opened.st_ino) != expected_identity:
+                raise GitPrivateStateError(f"legacy cleanup lock identity changed: {legacy}")
+            os.fchmod(legacy_fd, 0o600)
+            os.fsync(legacy_fd)
+        finally:
+            os.close(legacy_fd)
+    finally:
+        os.close(legacy_parent_fd)
+    try:
+        try:
+            canonical_meta = os.stat(
+                canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+            )
+        except FileNotFoundError:
+            canonical_meta = None
+        if canonical_meta is not None:
+            if (
+                not stat.S_ISREG(canonical_meta.st_mode)
+                or canonical_meta.st_uid != os.geteuid()
+                or stat.S_IMODE(canonical_meta.st_mode) != 0o600
+            ):
+                raise GitPrivateStateError(f"unsafe canonical cleanup lock: {canonical}")
+            if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+                expected_identity
+            ):
+                raise GitPrivateStateError(
+                    "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+                    "automatic cutover cannot prove a single cleanup fence"
+                )
+        else:
+            try:
+                source_fd = _open_anchored_parent(legacy)
+                try:
+                    os.link(
+                        legacy.name,
+                        canonical.name,
+                        src_dir_fd=source_fd,
+                        dst_dir_fd=canonical_parent_fd,
+                        follow_symlinks=False,
+                    )
+                finally:
+                    os.close(source_fd)
+                os.fsync(canonical_parent_fd)
+                published = os.stat(
+                    canonical.name, dir_fd=canonical_parent_fd, follow_symlinks=False
+                )
+                if (published.st_dev, published.st_ino) != expected_identity:
+                    raise GitPrivateStateError(
+                        f"legacy cleanup lock identity changed during handoff: {legacy}"
+                    )
+            except OSError as exc:
+                raise GitPrivateStateError(
+                    f"cannot establish cleanup lock handoff: {canonical}"
+                ) from exc
+    finally:
+        os.close(canonical_parent_fd)
+    return expected_identity
+
+
+def _preflight_cleanup_lock_handoff(legacy: Path | None, canonical: Path) -> None:
+    if legacy is None:
+        return
+    legacy_meta = _require_regular(legacy, "legacy cleanup lock")
+    _require_owned_mode(legacy, legacy_meta, 0o600, "legacy cleanup lock")
+    try:
+        canonical_meta = canonical.lstat()
+    except FileNotFoundError:
+        return
+    _require_canonical_file(canonical, "canonical cleanup lock")
+    if (canonical_meta.st_dev, canonical_meta.st_ino) != (
+        legacy_meta.st_dev, legacy_meta.st_ino
+    ):
+        raise GitPrivateStateError(
+            "BLOCKED: legacy and canonical cleanup locks use different inodes; "
+            "automatic cutover cannot prove a single cleanup fence"
+        )
+
+
 def _remove_known_empty_legacy_directories(layout: Topology) -> None:
     roots = [layout.common / LEGACY_NAMESPACE]
     if not layout.admin_is_common:
@@ -608,7 +1146,7 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
         for name in SHARED_DIRS:
             child = root / name
             try:
-                _require_dir(child, "legacy private-state directory")
+                _require_legacy_dir(child, "legacy private-state directory")
             except GitPrivateStateError:
                 if child.exists() or child.is_symlink():
                     raise
@@ -620,7 +1158,6 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
                     os.fsync(descriptor)
                 finally:
                     os.close(descriptor)
-        # The shared root remains while its mixed-version cleanup lock exists.
         if not any(root.iterdir()):
             root.rmdir()
             descriptor = _open_dir(root.parent)
@@ -631,24 +1168,46 @@ def _remove_known_empty_legacy_directories(layout: Topology) -> None:
 
 
 @contextmanager
-def _file_lock(path: Path, *, create: bool):
+def _file_lock(path: Path, *, create: bool, nonblocking: bool = False, exact: bool = False):
     flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
-    if create:
-        flags |= os.O_CREAT
     parent_fd = _open_anchored_parent(path)
+    descriptor: int | None = None
     try:
-        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        if create:
+            try:
+                descriptor = os.open(path.name, flags | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=parent_fd)
+                os.fchmod(descriptor, 0o600)
+                os.fsync(parent_fd)
+            except FileExistsError:
+                descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        else:
+            descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         metadata = os.fstat(descriptor)
         if not stat.S_ISREG(metadata.st_mode):
             raise GitPrivateStateError(f"unsafe private-state lock: {path}")
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        yield
+        if metadata.st_uid != os.geteuid() or (exact and stat.S_IMODE(metadata.st_mode) != 0o600) or (
+                not exact and (stat.S_IMODE(metadata.st_mode) & 0o022 or metadata.st_mode & 0o111 or
+                               not (metadata.st_mode & 0o600))):
+            raise GitPrivateStateError(f"unsafe private-state lock mode or ownership: {path}")
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | (fcntl.LOCK_NB if nonblocking else 0))
+        except BlockingIOError as exc:
+            raise GitPrivateStateError(f"BLOCKED: private-state lock is contended: {path}") from exc
     except GitPrivateStateError:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise
     except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        os.close(parent_fd)
         raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    try:
+        locked = os.fstat(descriptor)
+        yield (locked.st_dev, locked.st_ino)
     finally:
-        if "descriptor" in locals():
+        if descriptor is not None:
             try:
                 fcntl.flock(descriptor, fcntl.LOCK_UN)
             finally:
@@ -662,7 +1221,8 @@ def prepare(
     admin: bool = False,
     common_dir: Path | None = None,
     admin_dir: Path | None = None,
-    _legacy_lock_held: bool = False,
+    _legacy_lock_identity: tuple[int, int] | None = None,
+    _allow_incomplete_recovery: bool = False,
 ) -> None:
     """Validate and migrate known legacy state before a state mutation."""
     layout = (
@@ -670,25 +1230,38 @@ def prepare(
         if common_dir is not None
         else topology(root)
     )
-    _validate_canonical(layout)
+    _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
     shared_pairs, legacy_lock = _scan_shared_legacy(layout)
     pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
     _inspect_pairs(pairs)  # preflight before creating even the migration lock
-    if legacy_lock is not None and not _legacy_lock_held:
-        with _file_lock(legacy_lock, create=False):
+    if legacy_lock is not None and _legacy_lock_identity is None:
+        with _file_lock(legacy_lock, create=False, nonblocking=True) as lock_identity:
             prepare(
                 root,
                 admin=admin,
                 common_dir=layout.common,
                 admin_dir=layout.admin,
-                _legacy_lock_held=True,
+                _legacy_lock_identity=lock_identity,
+                _allow_incomplete_recovery=_allow_incomplete_recovery,
             )
         return
 
+    _preflight_cleanup_lock_handoff(
+        legacy_lock, layout.common / NAMESPACE / "cleanup.lock"
+    )
     _ensure_namespace(layout.common, ())
-    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+    admin_lock_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_lock_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_lock_context:
         # Repeat all classification under the migration lock.
-        _validate_canonical(layout)
+        _recover_canonical_temps(layout, include_admin=admin)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         shared_pairs, _ = _scan_shared_legacy(layout)
         pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
         inspected = _inspect_pairs(pairs)
@@ -696,28 +1269,67 @@ def prepare(
             _ensure_namespace(layout.common, (name,))
         if admin:
             _ensure_namespace(layout.admin, ("automation-maintenance",))
+        legacy_lock_identity = None
+        if legacy_lock is not None:
+            if _legacy_lock_identity is None:
+                raise GitPrivateStateError("legacy cleanup lock is not held for handoff")
+            legacy_lock_identity = _handoff_cleanup_lock(
+                legacy_lock,
+                layout.common / NAMESPACE / "cleanup.lock",
+                _legacy_lock_identity,
+            )
         for item in inspected:
             try:
                 item.target.lstat()
             except FileNotFoundError:
-                _exclusive_publish(item.target, item.content, item.mode)
+                _exclusive_publish(item.target, item.content, 0o600)
+        _validate_canonical(layout, allow_incomplete_recovery=_allow_incomplete_recovery)
         # No source is removed until every destination is durable and equivalent.
         for item in inspected:
+            _require_canonical_file(item.target, "canonical private-state record")
             if read_bytes(item.target, "canonical private-state record") != item.content:
                 raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
         for item in inspected:
-            metadata = _require_regular(item.source, "legacy private-state record")
+            metadata = _require_legacy_record(item.source, "legacy private-state record")
             if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
                 item.source, "legacy private-state record"
             ) != item.content:
                 raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
         for item in inspected:
             _identity_unlink(item)
+        if legacy_lock is not None and legacy_lock_identity is not None:
+            _unlink_identity_path(legacy_lock, legacy_lock_identity, "legacy cleanup lock")
         _remove_known_empty_legacy_directories(layout)
 
 
 def write_bytes(path: Path, content: bytes) -> None:
     """Atomically and durably replace one prepared canonical regular file."""
+    namespace = _state_namespace(path)
+    ensure_parent(path)
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _write_bytes_locked(path, content)
+
+
+@contextmanager
+def mutation_lock(root: Path, *, admin: bool = False):
+    """Fence a caller-managed canonical transaction in global lock order."""
+    layout = topology(root)
+    _ensure_namespace(layout.common, ())
+    admin_context = nullcontext()
+    if admin and not layout.admin_is_common:
+        _ensure_namespace(layout.admin, ())
+        admin_context = _file_lock(
+            layout.admin / NAMESPACE / "migration.lock", create=True, exact=True
+        )
+    with _file_lock(
+        layout.common / NAMESPACE / "migration.lock", create=True, exact=True
+    ), admin_context:
+        _recover_canonical_temps(layout, include_admin=admin)
+        yield
+
+
+def _write_bytes_locked(path: Path, content: bytes) -> None:
     parent_fd = _open_anchored_parent(path)
     temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
     flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
@@ -731,6 +1343,7 @@ def write_bytes(path: Path, content: bytes) -> None:
                 raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
         descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
         try:
+            os.fchmod(descriptor, 0o600)
             view = memoryview(content)
             while view:
                 written = os.write(descriptor, view)
@@ -755,8 +1368,51 @@ def write_bytes(path: Path, content: bytes) -> None:
             os.close(parent_fd)
 
 
-def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+def unlink(
+    path: Path,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+    expected_content: bytes | None = None,
+    _lock_held: bool = False,
+) -> None:
     """Remove only a canonical regular file through its verified parent."""
+    if NAMESPACE not in path.parts:
+        # A pre-cutover consumer may need to consume or roll back a validated
+        # historical authority before the upgraded implementation is committed.
+        state_root, canonical = _legacy_equivalent(path)
+        _ensure_namespace(state_root, ())
+        with _file_lock(state_root / NAMESPACE / "migration.lock", create=True, exact=True):
+            legacy_exists = os.path.lexists(path)
+            canonical_exists = os.path.lexists(canonical)
+            if legacy_exists and canonical_exists:
+                if expected_content is None:
+                    raise GitPrivateStateError(
+                        f"legacy and canonical private-state records both exist: {path}"
+                    )
+                if read_bytes(path) != expected_content or read_bytes(canonical) != expected_content:
+                    raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+                _unlink_locked(path, expected_identity=expected_identity)
+                _unlink_locked(canonical)
+                return
+            if legacy_exists:
+                _unlink_locked(path, expected_identity=expected_identity)
+                return
+            if not canonical_exists or expected_content is None:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            if read_bytes(canonical, "canonical private-state record") != expected_content:
+                raise GitPrivateStateError(f"private-state record changed during migration: {path}")
+            _unlink_locked(canonical)
+        return
+    namespace = _state_namespace(path)
+    if _lock_held:
+        _unlink_locked(path, expected_identity=expected_identity)
+        return
+    with _file_lock(namespace / "migration.lock", create=True, exact=True):
+        _recover_canonical_temps(Topology(namespace.parent, namespace.parent))
+        _unlink_locked(path, expected_identity=expected_identity)
+
+
+def _unlink_locked(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
     parent_fd = _open_anchored_parent(path)
     try:
         try:
@@ -779,19 +1435,26 @@ def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> N
 
 @contextmanager
 def cleanup_lock(root: Path):
-    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    """Cut over legacy cleanup locking, then acquire only the canonical lock."""
     layout = topology(root)
     _validate_canonical(layout)
     _, legacy = _scan_shared_legacy(layout)
     # Lock old consumers out while migrating cleanup/discard evidence.
-    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
-    with legacy_context:
+    legacy_context = (_file_lock(legacy, create=False, nonblocking=True)
+                      if legacy is not None else nullcontext())
+    with legacy_context as legacy_identity:
         prepare(
             root,
             common_dir=layout.common,
             admin_dir=layout.admin,
-            _legacy_lock_held=legacy is not None,
+            _legacy_lock_identity=legacy_identity,
         )
-        _ensure_namespace(layout.common, ())
-        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+        if legacy is not None:
+            # The open legacy descriptor now names the same inode as the
+            # canonical path and remains held for the whole caller operation.
             yield
+        else:
+            with _file_lock(
+                layout.common / NAMESPACE / "cleanup.lock", create=True, exact=True
+            ):
+                yield

--- a/templates/agent-rust/.automation/bin/git_private_state.py
+++ b/templates/agent-rust/.automation/bin/git_private_state.py
@@ -1,0 +1,797 @@
+"""Owned, fail-closed storage for Agent Core's Git-private runtime state."""
+from __future__ import annotations
+
+from contextlib import contextmanager, nullcontext
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+import subprocess
+
+
+NAMESPACE = "agent-core"
+LEGACY_NAMESPACE = "opencode"
+TASK_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+PR_RE = re.compile(r"[1-9][0-9]*")
+HASH_RE = re.compile(r"[0-9a-f]{64}")
+SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
+FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+LOCK_FILES = {"cleanup.lock", "migration.lock"}
+_GIT_EXECUTABLE = "git"
+
+
+class GitPrivateStateError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Topology:
+    common: Path
+    admin: Path
+
+    @property
+    def admin_is_common(self) -> bool:
+        return self.admin == self.common
+
+
+@dataclass(frozen=True)
+class MigrationFile:
+    source: Path
+    target: Path
+    identity: tuple[int, int]
+    mode: int
+    content: bytes
+
+
+def _git_path(root: Path, argument: str) -> Path:
+    environment = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    environment.update({
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+    })
+    result = subprocess.run(
+        [_GIT_EXECUTABLE, "-c", "core.fsmonitor=false", "-c", "core.hooksPath=/dev/null",
+         "-c", "core.pager=", "rev-parse", argument],
+        cwd=root, text=True, capture_output=True, check=False, env=environment,
+    )
+    raw = result.stdout.strip()
+    if result.returncode != 0 or not raw:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}")
+    candidate = Path(raw)
+    try:
+        resolved = candidate.resolve() if candidate.is_absolute() else (root / candidate).resolve()
+        metadata = resolved.lstat()
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise GitPrivateStateError(f"cannot resolve Git private-state location: {argument}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"Git private-state location is not a directory: {resolved}")
+    return resolved
+
+
+def topology(root: Path) -> Topology:
+    return Topology(_git_path(root, "--git-common-dir"), _git_path(root, "--absolute-git-dir"))
+
+
+def common_git_dir(root: Path) -> Path:
+    return topology(root).common
+
+
+def admin_git_dir(root: Path) -> Path:
+    return topology(root).admin
+
+
+def common_state(root: Path) -> Path:
+    return common_git_dir(root) / NAMESPACE
+
+
+def admin_maintenance(root: Path) -> Path:
+    return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def cleanup_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "cleanup" / f"{task}.json"
+
+
+def discard_receipt(root: Path, task: str) -> Path:
+    if TASK_RE.fullmatch(task) is None:
+        raise GitPrivateStateError("invalid Task ID")
+    return common_state(root) / "discard-pristine" / f"{task}.json"
+
+
+def integration_checkpoint(root: Path, pr: str) -> Path:
+    if PR_RE.fullmatch(pr) is None:
+        raise GitPrivateStateError("invalid pull request number")
+    return common_state(root) / "integration" / f"pr-{pr}.head"
+
+
+def _lstat(path: Path, what: str) -> os.stat_result:
+    try:
+        return path.lstat()
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect {what}: {path}") from exc
+
+
+def _require_dir(path: Path, what: str = "private-state directory") -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def _require_regular(path: Path, what: str) -> os.stat_result:
+    metadata = _lstat(path, what)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    return metadata
+
+
+def safe_directory(path: Path) -> None:
+    _require_dir(path)
+
+
+def _open_dir(path: Path) -> int:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot open private-state directory: {path}") from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise GitPrivateStateError(f"unsafe private-state directory: {path}")
+    return descriptor
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open a state parent without following namespace or descendant symlinks."""
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+    if not indexes:
+        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    descriptor = _open_dir(boundary)
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for component in parts[marker:-1]:
+            child = os.open(component, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except GitPrivateStateError:
+        os.close(descriptor)
+        raise
+    except OSError as exc:
+        os.close(descriptor)
+        raise GitPrivateStateError(f"cannot traverse private-state directory: {path.parent}") from exc
+
+
+def _ensure_child_directory(parent: Path, name: str) -> Path:
+    descriptor = _open_dir(parent)
+    try:
+        try:
+            os.mkdir(name, 0o700, dir_fd=descriptor)
+            os.fsync(descriptor)
+        except FileExistsError:
+            pass
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        child = os.open(name, flags, dir_fd=descriptor)
+        try:
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                raise GitPrivateStateError(f"unsafe private-state directory: {parent / name}")
+        finally:
+            os.close(child)
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state directory: {parent / name}") from exc
+    finally:
+        os.close(descriptor)
+    return parent / name
+
+
+def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
+    _require_dir(base, "Git administrative directory")
+    descriptor = _open_dir(base)
+    current = base
+    try:
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        for name in (NAMESPACE, *subdirectories):
+            try:
+                os.mkdir(name, 0o700, dir_fd=descriptor)
+                os.fsync(descriptor)
+            except FileExistsError:
+                pass
+            child = os.open(name, flags, dir_fd=descriptor)
+            if not stat.S_ISDIR(os.fstat(child).st_mode):
+                os.close(child)
+                raise GitPrivateStateError(f"unsafe private-state directory: {current / name}")
+            os.close(descriptor)
+            descriptor = child
+            current /= name
+        return current
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot create private-state namespace below: {base}") from exc
+    finally:
+        os.close(descriptor)
+
+
+def read_bytes_identity(
+    path: Path, what: str = "private-state record"
+) -> tuple[bytes, tuple[int, int]]:
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, dir_fd=parent_fd)
+        try:
+            metadata = os.fstat(descriptor)
+            if not stat.S_ISREG(metadata.st_mode):
+                raise GitPrivateStateError(f"unsafe {what}: {path}")
+            chunks: list[bytes] = []
+            while True:
+                chunk = os.read(descriptor, 1024 * 1024)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            after = os.fstat(descriptor)
+            if (metadata.st_dev, metadata.st_ino, metadata.st_size) != (
+                after.st_dev, after.st_ino, after.st_size
+            ):
+                raise GitPrivateStateError(f"{what} changed while reading: {path}")
+            return b"".join(chunks), (metadata.st_dev, metadata.st_ino)
+        finally:
+            os.close(descriptor)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot read {what}: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def read_bytes(path: Path, what: str = "private-state record") -> bytes:
+    return read_bytes_identity(path, what)[0]
+
+
+def _valid_shared_file(directory: str, name: str, *, allow_fixed: bool) -> bool:
+    if directory in {"cleanup", "discard-pristine"}:
+        return name.endswith(".json") and TASK_RE.fullmatch(name[:-5]) is not None
+    if directory == "integration":
+        return re.fullmatch(r"pr-[1-9][0-9]*\.head", name) is not None
+    if directory == "automation-maintenance":
+        return (
+            re.fullmatch(r"[0-9a-f]{64}\.json", name) is not None
+            or (allow_fixed and name in FIXED_AUTHORITY_FILES)
+        )
+    return False
+
+
+def _legacy_json(content: bytes, path: Path) -> dict:
+    try:
+        value = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}") from exc
+    if not isinstance(value, dict):
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+    return value
+
+
+def _valid_oid(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", value) is not None
+
+
+def _valid_digest(value: object) -> bool:
+    return isinstance(value, str) and re.fullmatch(r"[0-9a-f]{64}", value) is not None
+
+
+def _valid_task_id(value: object) -> bool:
+    return isinstance(value, str) and TASK_RE.fullmatch(value) is not None
+
+
+def _valid_nonempty(value: object) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _valid_absolute_path(value: object) -> bool:
+    return _valid_nonempty(value) and Path(value).is_absolute()
+
+
+def _valid_authority_fields(value: dict) -> bool:
+    return (
+        _valid_task_id(value.get("task_id"))
+        and _valid_nonempty(value.get("branch"))
+        and _valid_absolute_path(value.get("worktree"))
+        and _valid_digest(value.get("authority_nonce"))
+        and _valid_digest(value.get("receipt_sha256"))
+    )
+
+
+def _validate_legacy_content(path: Path, content: bytes) -> None:
+    directory = path.parent.name
+    name = path.name
+    if directory == "integration":
+        try:
+            text = content.decode("ascii", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}") from exc
+        if not text.endswith("\n") or not _valid_oid(text[:-1]):
+            raise GitPrivateStateError(f"invalid legacy integration checkpoint: {path}")
+        return
+    value = _legacy_json(content, path)
+    if directory == "cleanup":
+        required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("task") == name[:-5]
+            and value.get("status") in {"merged", "cancelled"}
+            and isinstance(value.get("worktree"), str)
+            and isinstance(value.get("branch"), str)
+            and _valid_oid(value.get("local_head"))
+            and isinstance(value.get("evidence"), dict)
+        )
+    elif directory == "discard-pristine":
+        required = {
+            "schema_version", "operation", "task", "status", "worktree", "branch",
+            "base_branch", "base_revision", "local_head", "repository",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("operation") == "discard-pristine"
+            and value.get("task") == name[:-5]
+            and value.get("status") == "initialized"
+            and all(isinstance(value.get(field), str) for field in (
+                "worktree", "branch", "base_branch", "repository"
+            ))
+            and _valid_oid(value.get("base_revision"))
+            and value.get("local_head") == value.get("base_revision")
+        )
+    elif name == "source-recovery-proof.json":
+        required = {
+            "schema_version", "kind", "task_id", "branch", "worktree", "authority_head",
+            "authority_nonce", "receipt_sha256", "receipt_bytes_sha256", "changed_paths_sha256",
+            "path_fingerprints_sha256", "implementation_source", "implementation_revision",
+            "receipt_source", "receipt_source_revision",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "source-recovery-proof"
+            and _valid_authority_fields(value)
+            and _valid_oid(value.get("authority_head"))
+            and all(_valid_digest(value.get(field)) for field in (
+                "receipt_bytes_sha256", "changed_paths_sha256", "path_fingerprints_sha256",
+            ))
+            and _valid_absolute_path(value.get("implementation_source"))
+            and _valid_oid(value.get("implementation_revision"))
+            and _valid_absolute_path(value.get("receipt_source"))
+            and _valid_oid(value.get("receipt_source_revision"))
+        )
+    else:
+        standard = {"schema_version", "task_id", "branch", "worktree", "authority_nonce", "receipt_sha256"}
+        bridge = standard | {"kind", "proof_sha256"}
+        valid = (
+            (set(value) == standard and value.get("schema_version") == 1
+             and _valid_authority_fields(value))
+            or (set(value) == bridge and value.get("schema_version") == 2
+                and value.get("kind") == "source-recovery-bridge"
+                and _valid_authority_fields(value)
+                and _valid_digest(value.get("proof_sha256")))
+        )
+    if not valid:
+        raise GitPrivateStateError(f"invalid legacy private-state record: {path}")
+
+
+def _namespace_kind(path: Path, *, foreign_regular: bool) -> str:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return "absent"
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot inspect private-state namespace: {path}") from exc
+    if stat.S_ISREG(metadata.st_mode) and foreign_regular:
+        return "foreign"
+    if stat.S_ISDIR(metadata.st_mode) and not stat.S_ISLNK(metadata.st_mode):
+        return "directory"
+    raise GitPrivateStateError(f"unsafe private-state namespace: {path}")
+
+
+def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path | None]:
+    root = layout.common / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return [], None
+    pairs: list[tuple[Path, Path]] = []
+    legacy_lock: Path | None = None
+    for entry in root.iterdir():
+        if entry.name == "cleanup.lock":
+            _require_regular(entry, "legacy cleanup lock")
+            legacy_lock = entry
+            continue
+        if entry.name not in SHARED_DIRS:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {entry}")
+        _require_dir(entry, "legacy private-state directory")
+        for child in entry.iterdir():
+            allow_fixed = entry.name == "automation-maintenance"
+            if not _valid_shared_file(entry.name, child.name, allow_fixed=allow_fixed):
+                raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+            _require_regular(child, "legacy private-state record")
+            if child.name in FIXED_AUTHORITY_FILES:
+                if layout.admin_is_common:
+                    pairs.append((child, layout.admin / NAMESPACE / entry.name / child.name))
+                # In a linked worktree these belong to the main worktree admin.
+            else:
+                pairs.append((child, layout.common / NAMESPACE / entry.name / child.name))
+    return pairs, legacy_lock
+
+
+def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
+    if layout.admin_is_common:
+        return []
+    root = layout.admin / LEGACY_NAMESPACE
+    kind = _namespace_kind(root, foreign_regular=True)
+    if kind != "directory":
+        return []
+    entries = list(root.iterdir())
+    if any(entry.name != "automation-maintenance" for entry in entries):
+        unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+        raise GitPrivateStateError(f"unknown legacy private-state entry: {unknown}")
+    if not entries:
+        return []
+    maintenance = entries[0]
+    _require_dir(maintenance, "legacy maintenance authority directory")
+    pairs: list[tuple[Path, Path]] = []
+    for child in maintenance.iterdir():
+        if child.name not in FIXED_AUTHORITY_FILES:
+            raise GitPrivateStateError(f"unknown legacy private-state entry: {child}")
+        _require_regular(child, "legacy private-state record")
+        pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
+    return pairs
+
+
+def _validate_canonical(layout: Topology) -> None:
+    shared = layout.common / NAMESPACE
+    kind = _namespace_kind(shared, foreign_regular=False)
+    if kind == "directory":
+        for entry in shared.iterdir():
+            if entry.name in LOCK_FILES:
+                _require_regular(entry, "canonical private-state lock")
+                continue
+            if entry.name not in SHARED_DIRS:
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {entry}")
+            _require_dir(entry)
+            for child in entry.iterdir():
+                # Fixed files in common are the main worktree's admin records.
+                if not _valid_shared_file(entry.name, child.name, allow_fixed=True):
+                    raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                _require_regular(child, "canonical private-state record")
+    if not layout.admin_is_common:
+        admin_root = layout.admin / NAMESPACE
+        kind = _namespace_kind(admin_root, foreign_regular=False)
+        if kind == "directory":
+            entries = list(admin_root.iterdir())
+            if any(entry.name != "automation-maintenance" for entry in entries):
+                unknown = next(entry for entry in entries if entry.name != "automation-maintenance")
+                raise GitPrivateStateError(f"unknown canonical private-state entry: {unknown}")
+            if entries:
+                maintenance = entries[0]
+                _require_dir(maintenance)
+                for child in maintenance.iterdir():
+                    if child.name not in FIXED_AUTHORITY_FILES:
+                        raise GitPrivateStateError(f"unknown canonical private-state entry: {child}")
+                    _require_regular(child, "canonical private-state record")
+
+
+def _inspect_pairs(pairs: list[tuple[Path, Path]]) -> list[MigrationFile]:
+    inspected: list[MigrationFile] = []
+    for source, target in pairs:
+        metadata = _require_regular(source, "legacy private-state record")
+        content = read_bytes(source, "legacy private-state record")
+        _validate_legacy_content(source, content)
+        try:
+            target.lstat()
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            raise GitPrivateStateError(f"cannot inspect canonical private-state record: {target}") from exc
+        else:
+            if read_bytes(target, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting private-state records: {source} and {target}")
+        inspected.append(MigrationFile(
+            source, target, (metadata.st_dev, metadata.st_ino),
+            stat.S_IMODE(metadata.st_mode), content,
+        ))
+    return inspected
+
+
+def _exclusive_publish(path: Path, content: bytes, mode: int) -> tuple[int, int]:
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".migrate.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            os.link(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd,
+                    follow_symlinks=False)
+            os.fsync(parent_fd)
+        except FileExistsError:
+            if read_bytes(path, "canonical private-state record") != content:
+                raise GitPrivateStateError(f"conflicting canonical private-state record: {path}")
+        published = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        if not stat.S_ISREG(published.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        return published.st_dev, published.st_ino
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot publish private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def ensure_parent(path: Path) -> None:
+    parts = path.parts
+    indexes = [index for index, part in enumerate(parts) if part == NAMESPACE]
+    if not indexes:
+        # Legacy restoration may use only an already-existing validated parent.
+        descriptor = _open_anchored_parent(path)
+        os.close(descriptor)
+        return
+    marker = indexes[-1]
+    boundary = Path(*parts[:marker])
+    _ensure_namespace(boundary, tuple(parts[marker + 1:-1]))
+
+
+def exclusive_write_bytes(
+    path: Path, content: bytes, mode: int = 0o600
+) -> tuple[int, int]:
+    """Durably publish a new state record without replacing any existing object."""
+    ensure_parent(path)
+    return _exclusive_publish(path, content, mode)
+
+
+def _identity_unlink(item: MigrationFile) -> None:
+    if read_bytes(item.source, "legacy private-state record") != item.content:
+        raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+    metadata = _require_regular(item.source, "legacy private-state record")
+    if (metadata.st_dev, metadata.st_ino) != item.identity:
+        raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+    parent_fd = _open_anchored_parent(item.source)
+    try:
+        current = os.stat(item.source.name, dir_fd=parent_fd, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) != item.identity or not stat.S_ISREG(current.st_mode):
+            raise GitPrivateStateError(f"legacy private-state identity changed: {item.source}")
+        os.unlink(item.source.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove legacy private-state record: {item.source}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+def _remove_known_empty_legacy_directories(layout: Topology) -> None:
+    roots = [layout.common / LEGACY_NAMESPACE]
+    if not layout.admin_is_common:
+        roots.append(layout.admin / LEGACY_NAMESPACE)
+    for root in roots:
+        if _namespace_kind(root, foreign_regular=True) != "directory":
+            continue
+        for name in SHARED_DIRS:
+            child = root / name
+            try:
+                _require_dir(child, "legacy private-state directory")
+            except GitPrivateStateError:
+                if child.exists() or child.is_symlink():
+                    raise
+                continue
+            if not any(child.iterdir()):
+                child.rmdir()
+                descriptor = _open_dir(root)
+                try:
+                    os.fsync(descriptor)
+                finally:
+                    os.close(descriptor)
+        # The shared root remains while its mixed-version cleanup lock exists.
+        if not any(root.iterdir()):
+            root.rmdir()
+            descriptor = _open_dir(root.parent)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+
+
+@contextmanager
+def _file_lock(path: Path, *, create: bool):
+    flags = os.O_RDWR | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    if create:
+        flags |= os.O_CREAT
+    parent_fd = _open_anchored_parent(path)
+    try:
+        descriptor = os.open(path.name, flags, 0o600, dir_fd=parent_fd)
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe private-state lock: {path}")
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot acquire private-state lock: {path}") from exc
+    finally:
+        if "descriptor" in locals():
+            try:
+                fcntl.flock(descriptor, fcntl.LOCK_UN)
+            finally:
+                os.close(descriptor)
+        os.close(parent_fd)
+
+
+def prepare(
+    root: Path,
+    *,
+    admin: bool = False,
+    common_dir: Path | None = None,
+    admin_dir: Path | None = None,
+    _legacy_lock_held: bool = False,
+) -> None:
+    """Validate and migrate known legacy state before a state mutation."""
+    layout = (
+        Topology(common_dir.resolve(), (admin_dir or common_dir).resolve())
+        if common_dir is not None
+        else topology(root)
+    )
+    _validate_canonical(layout)
+    shared_pairs, legacy_lock = _scan_shared_legacy(layout)
+    pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+    _inspect_pairs(pairs)  # preflight before creating even the migration lock
+    if legacy_lock is not None and not _legacy_lock_held:
+        with _file_lock(legacy_lock, create=False):
+            prepare(
+                root,
+                admin=admin,
+                common_dir=layout.common,
+                admin_dir=layout.admin,
+                _legacy_lock_held=True,
+            )
+        return
+
+    _ensure_namespace(layout.common, ())
+    with _file_lock(layout.common / NAMESPACE / "migration.lock", create=True):
+        # Repeat all classification under the migration lock.
+        _validate_canonical(layout)
+        shared_pairs, _ = _scan_shared_legacy(layout)
+        pairs = shared_pairs + (_scan_admin_legacy(layout) if admin else [])
+        inspected = _inspect_pairs(pairs)
+        for name in SHARED_DIRS:
+            _ensure_namespace(layout.common, (name,))
+        if admin:
+            _ensure_namespace(layout.admin, ("automation-maintenance",))
+        for item in inspected:
+            try:
+                item.target.lstat()
+            except FileNotFoundError:
+                _exclusive_publish(item.target, item.content, item.mode)
+        # No source is removed until every destination is durable and equivalent.
+        for item in inspected:
+            if read_bytes(item.target, "canonical private-state record") != item.content:
+                raise GitPrivateStateError(f"canonical private-state record changed: {item.target}")
+        for item in inspected:
+            metadata = _require_regular(item.source, "legacy private-state record")
+            if (metadata.st_dev, metadata.st_ino) != item.identity or read_bytes(
+                item.source, "legacy private-state record"
+            ) != item.content:
+                raise GitPrivateStateError(f"legacy private-state record changed: {item.source}")
+        for item in inspected:
+            _identity_unlink(item)
+        _remove_known_empty_legacy_directories(layout)
+
+
+def write_bytes(path: Path, content: bytes) -> None:
+    """Atomically and durably replace one prepared canonical regular file."""
+    parent_fd = _open_anchored_parent(path)
+    temporary = f".record.{os.getpid()}.{secrets.token_hex(8)}"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        try:
+            current = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            pass
+        else:
+            if not stat.S_ISREG(current.st_mode):
+                raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        descriptor = os.open(temporary, flags, 0o600, dir_fd=parent_fd)
+        try:
+            view = memoryview(content)
+            while view:
+                written = os.write(descriptor, view)
+                if written <= 0:
+                    raise OSError("short private-state write")
+                view = view[written:]
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, path.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot write private-state record: {path}") from exc
+    finally:
+        try:
+            os.unlink(temporary, dir_fd=parent_fd)
+        except FileNotFoundError:
+            pass
+        finally:
+            os.close(parent_fd)
+
+
+def unlink(path: Path, *, expected_identity: tuple[int, int] | None = None) -> None:
+    """Remove only a canonical regular file through its verified parent."""
+    parent_fd = _open_anchored_parent(path)
+    try:
+        try:
+            metadata = os.stat(path.name, dir_fd=parent_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return
+        if not stat.S_ISREG(metadata.st_mode):
+            raise GitPrivateStateError(f"unsafe canonical private-state record: {path}")
+        if expected_identity is not None and (metadata.st_dev, metadata.st_ino) != expected_identity:
+            raise GitPrivateStateError(f"private-state record identity changed: {path}")
+        os.unlink(path.name, dir_fd=parent_fd)
+        os.fsync(parent_fd)
+    except GitPrivateStateError:
+        raise
+    except OSError as exc:
+        raise GitPrivateStateError(f"cannot remove private-state record: {path}") from exc
+    finally:
+        os.close(parent_fd)
+
+
+@contextmanager
+def cleanup_lock(root: Path):
+    """Acquire the retained legacy ABI lock first, then the canonical lock."""
+    layout = topology(root)
+    _validate_canonical(layout)
+    _, legacy = _scan_shared_legacy(layout)
+    # Lock old consumers out while migrating cleanup/discard evidence.
+    legacy_context = _file_lock(legacy, create=False) if legacy is not None else nullcontext()
+    with legacy_context:
+        prepare(
+            root,
+            common_dir=layout.common,
+            admin_dir=layout.admin,
+            _legacy_lock_held=legacy is not None,
+        )
+        _ensure_namespace(layout.common, ())
+        with _file_lock(layout.common / NAMESPACE / "cleanup.lock", create=True):
+            yield

--- a/templates/agent-rust/.automation/bin/task_lifecycle.py
+++ b/templates/agent-rust/.automation/bin/task_lifecycle.py
@@ -15,6 +15,10 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+import git_private_state as private_state
+
 TASK_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 WORK_UNIT_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
@@ -1053,19 +1057,19 @@ def require_cleanup_base_revision(root: Path, base_revision: str) -> None:
 
 def cleanup_receipt_path(root: Path, task: str) -> Path:
     validate_task(task)
-    return common_git_dir(root) / "opencode" / "cleanup" / f"{task}.json"
+    try:
+        return private_state.cleanup_receipt(root, task)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 @contextmanager
 def cleanup_lock(root: Path):
-    path = common_git_dir(root) / "opencode" / "cleanup.lock"
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
-        try:
+    try:
+        with private_state.cleanup_lock(root):
             yield
-        finally:
-            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
 
 
 def cleanup_repository(root: Path) -> str:
@@ -1230,8 +1234,8 @@ def read_cleanup_receipt(path: Path, task: str) -> dict:
     if path.is_symlink() or not path.is_file():
         raise LifecycleError("cleanup receipt is not a regular local file")
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        value = json.loads(private_state.read_bytes(path, "cleanup receipt").decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, private_state.GitPrivateStateError) as exc:
         raise LifecycleError("cleanup receipt is invalid") from exc
     required = {"schema_version", "task", "status", "worktree", "branch", "local_head", "evidence"}
     if (
@@ -1317,7 +1321,10 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
         run(["git", "update-ref", "-d", branch_ref, expected_head], cwd=root)
     if git("rev-parse", "--verify", branch_ref, cwd=root, check=False):
         raise LifecycleError("cleanup failed to delete the expected local Task branch")
-    receipt.unlink(missing_ok=True)
+    try:
+        private_state.unlink(receipt)
+    except private_state.GitPrivateStateError as exc:
+        raise LifecycleError(str(exc)) from exc
     print(
         json.dumps(
             {
@@ -1332,13 +1339,18 @@ def finish_cleanup(root: Path, plan: dict, receipt: Path) -> None:
 
 def task_cleanup(root: Path, task: str) -> None:
     require_main_worktree(root)
-    receipt = cleanup_receipt_path(root, task)
     with cleanup_lock(root):
+        receipt = cleanup_receipt_path(root, task)
         if receipt.exists():
             finish_cleanup(root, read_cleanup_receipt(receipt, task), receipt)
             return
         plan = cleanup_plan(root, task)
-        atomic_json(receipt, plan)
+        try:
+            private_state.write_bytes(
+                receipt, (json.dumps(plan, sort_keys=True) + "\n").encode("utf-8")
+            )
+        except private_state.GitPrivateStateError as exc:
+            raise LifecycleError(str(exc)) from exc
         finish_cleanup(root, plan, receipt)
 
 

--- a/tests/test_agent_core_automation.py
+++ b/tests/test_agent_core_automation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -22,6 +23,28 @@ spec.loader.exec_module(agent_core)
 
 
 class AgentCoreSafetyTest(unittest.TestCase):
+    def test_integration_checkpoint_preserves_opencode_project_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "-b", "main"], cwd=root, check=True,
+                           capture_output=True)
+            foreign = root / ".git/opencode"
+            foreign.write_bytes(b"0123456789abcdef0123456789abcdef01234567")
+            before = foreign.lstat()
+            details = {"number": 12, "headRefOid": "a" * 40}
+            with mock.patch.object(agent_core, "validate_integration", return_value=details):
+                agent_core.integrate_check(root, "12")
+            after = foreign.lstat()
+            self.assertEqual(foreign.read_bytes(), b"0123456789abcdef0123456789abcdef01234567")
+            self.assertEqual(
+                (before.st_dev, before.st_ino, before.st_mode, before.st_size, before.st_mtime_ns),
+                (after.st_dev, after.st_ino, after.st_mode, after.st_size, after.st_mtime_ns),
+            )
+            self.assertEqual(
+                (root / ".git/agent-core/integration/pr-12.head").read_bytes(),
+                b"a" * 40 + b"\n",
+            )
+
     def test_automation_core_change_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -59,7 +82,8 @@ class AgentCoreSafetyTest(unittest.TestCase):
     def test_integration_merge_rejects_head_drift(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            checkpoint = root / "checkpoint"
+            checkpoint = root / "agent-core" / "integration" / "checkpoint"
+            checkpoint.parent.mkdir(parents=True)
             checkpoint.write_text("old-head\n", encoding="utf-8")
             with (
                 mock.patch.object(agent_core, "integration_checkpoint", return_value=checkpoint),

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -312,6 +312,7 @@ mod project 'just/project/mod.just'
         self._git(["switch", "--detach", "HEAD"], bridge)
         implementation = (
             "components/agent-core/.automation/bin/automation_upgrade.py",
+            "components/agent-core/.automation/bin/git_private_state.py",
             "tools/automation_recovery_bridge.py",
             "just/agent-core.just",
         )
@@ -1316,14 +1317,14 @@ mod project 'just/project/mod.just'
             authority = upgrade.authority_path(repo)
             active_bytes = active.read_bytes()
             authority_bytes = authority.read_bytes()
-            original_unlink = Path.unlink
+            original_unlink = upgrade.private_state.unlink
 
             def fail_authority_unlink(path: Path, *args, **kwargs) -> None:
                 if path == authority:
                     raise OSError("injected authority consume failure")
                 original_unlink(path, *args, **kwargs)
 
-            with mock.patch.object(Path, "unlink", autospec=True, side_effect=fail_authority_unlink):
+            with mock.patch.object(upgrade.private_state, "unlink", side_effect=fail_authority_unlink):
                 with self.assertRaises(upgrade.UpgradeError):
                     upgrade.commit(repo, "TASK-78", "maintenance")
             self.assertEqual(active_bytes, active.read_bytes())
@@ -2080,6 +2081,7 @@ mod project 'just/project/mod.just'
             )
             implementation = (
                 "components/agent-core/.automation/bin/automation_upgrade.py",
+                "components/agent-core/.automation/bin/git_private_state.py",
                 "components/agent-core/.automation/bin/task_contract.py",
                 "components/agent-core/.automation/bin/task_lifecycle.py",
                 "tools/automation_recovery_bridge.py",
@@ -2179,7 +2181,10 @@ mod project 'just/project/mod.just'
             receipt_before = self._receipt(task)
             self.assertEqual(old_revision, receipt_before["source_revision"])
             self.assertEqual(local_baseline, receipt_before["authority_head"])
-            self.assertTrue(upgrade.authority_path(task).is_file())
+            _, installed_legacy_authority = upgrade._authority_locations(task)
+            self.assertIsNotNone(installed_legacy_authority)
+            assert installed_legacy_authority is not None
+            self.assertTrue(installed_legacy_authority.is_file())
             self.assertFalse(upgrade.consumed_receipt_path(task).exists())
             self.assertEqual(local_baseline, self._git(["rev-parse", "HEAD"], task))
 

--- a/tests/test_automation_upgrade.py
+++ b/tests/test_automation_upgrade.py
@@ -1435,6 +1435,13 @@ mod project 'just/project/mod.just'
             self.assertEqual("COMMITTED", upgrade.commit(repo, "TASK-78", "legacy maintenance")["status"])
             self.assertFalse(legacy_path.exists())
 
+    def test_commit_rejects_unsafe_canonical_authority_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, _ = self._apply_fixture(Path(directory))
+            authority = upgrade.authority_path(repo)
+            authority.chmod(0o666)
+            self.assertIn("unsafe canonical private-state record mode", self._commit_error(repo))
+
     def test_linked_worktree_ignores_legacy_authority_under_escaped_common_parent(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -1500,8 +1507,11 @@ mod project 'just/project/mod.just'
                 with self.assertRaisesRegex(upgrade.UpgradeError, "injected staging check failure"):
                     upgrade.commit(repo, "TASK-78", "legacy rollback")
             self.assertEqual(active_bytes, upgrade.receipt_path(repo).read_bytes())
-            self.assertEqual(authority_bytes, legacy_path.read_bytes())
-            self.assertFalse(new_path.exists())
+            current_new, current_fallback = upgrade._authority_locations(repo)
+            restored = current_new if current_new.exists() else current_fallback
+            self.assertIsNotNone(restored)
+            assert restored is not None
+            self.assertEqual(authority_bytes, restored.read_bytes())
             self.assertFalse(upgrade.consumed_receipt_path(repo).exists())
             self.assertEqual("COMMITTED", upgrade.commit(repo, "TASK-78", "legacy retry")["status"])
             self.assertFalse(legacy_path.exists())
@@ -1515,12 +1525,18 @@ mod project 'just/project/mod.just'
             legacy_path.parent.mkdir(parents=True, exist_ok=True)
             legacy_path.write_bytes(new_path.read_bytes())
             new_path.write_text("not json\n", encoding="utf-8")
-            self.assertIn("invalid successful-upgrade authority", self._commit_error(repo))
+            self.assertRegex(
+                self._commit_error(repo),
+                "invalid successful-upgrade authority|invalid legacy private-state record",
+            )
             new_path.unlink()
             common_file = root / "common-file"
             common_file.write_text("not a git directory\n", encoding="utf-8")
             with mock.patch.object(upgrade, "common_git_dir", return_value=common_file):
-                self.assertIn("missing or invalid successful-upgrade authority", self._commit_error(repo))
+                self.assertRegex(
+                    self._commit_error(repo),
+                    "missing or invalid successful-upgrade authority|cannot inspect private-state namespace",
+                )
 
     def test_no_change_upgrade_preserves_consumed_receipt(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -2308,6 +2324,12 @@ mod project 'just/project/mod.just'
             )["state"])
             self.assertEqual(local_baseline, self._git(["rev-parse", "HEAD"], task))
 
+            authority_locations = upgrade._authority_locations(task)
+            self.assertEqual(
+                1,
+                sum(path is not None and path.is_file() for path in authority_locations),
+                authority_locations,
+            )
             committed = json.loads(
                 self._cli(task, ["commit", fixture["task"], "fix: upgrade Agent Core v3.1.2"]).stdout
             )

--- a/tests/test_git_private_state.py
+++ b/tests/test_git_private_state.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BIN = ROOT / "components" / "agent-core" / ".automation" / "bin"
+sys.path.insert(0, str(BIN))
+import git_private_state as private_state
+
+
+def command(*arguments: str, cwd: Path) -> str:
+    result = subprocess.run(arguments, cwd=cwd, text=True, capture_output=True)
+    if result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    return result.stdout.strip()
+
+
+class GitPrivateStateTest(unittest.TestCase):
+    def repository(self, root: Path) -> Path:
+        repo = root / "repo"
+        repo.mkdir()
+        command("git", "init", "-b", "main", cwd=repo)
+        command("git", "config", "user.name", "Private State Test", cwd=repo)
+        command("git", "config", "user.email", "private-state@example.invalid", cwd=repo)
+        (repo / "seed").write_text("seed\n", encoding="utf-8")
+        command("git", "add", "seed", cwd=repo)
+        command("git", "commit", "-m", "seed", cwd=repo)
+        return repo
+
+    @staticmethod
+    def identity(path: Path) -> tuple[int, int, int, int, int]:
+        value = path.lstat()
+        return value.st_dev, value.st_ino, value.st_mode, value.st_size, value.st_mtime_ns
+
+    def test_paths_are_pure_before_namespace_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            self.assertEqual(
+                private_state.integration_checkpoint(repo, "12"),
+                common / "agent-core" / "integration" / "pr-12.head",
+            )
+            self.assertFalse((common / "agent-core").exists())
+
+    def test_regular_opencode_is_foreign_and_identity_is_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            foreign = private_state.common_git_dir(repo) / "opencode"
+            foreign.write_bytes(b"0123456789abcdef0123456789abcdef01234567")
+            before = self.identity(foreign)
+            private_state.prepare(repo, admin=True)
+            self.assertEqual(before, self.identity(foreign))
+            self.assertEqual(b"0123456789abcdef0123456789abcdef01234567", foreign.read_bytes())
+
+    def test_all_recognized_legacy_records_migrate_exactly(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            legacy = common / "opencode"
+            authority = {
+                "schema_version": 1,
+                "task_id": "TASK-1",
+                "branch": "task/TASK-1-test",
+                "worktree": "/tmp/worktree",
+                "authority_nonce": "9" * 64,
+                "receipt_sha256": "a" * 64,
+            }
+            proof = {
+                "schema_version": 1, "kind": "source-recovery-proof",
+                "task_id": "TASK-1", "branch": "task/TASK-1-test",
+                "worktree": "/tmp/worktree", "authority_head": "a" * 40,
+                "authority_nonce": "9" * 64, "receipt_sha256": "a" * 64,
+                "receipt_bytes_sha256": "b" * 64, "changed_paths_sha256": "c" * 64,
+                "path_fingerprints_sha256": "d" * 64,
+                "implementation_source": "/tmp/source", "implementation_revision": "e" * 40,
+                "receipt_source": "/tmp/source", "receipt_source_revision": "f" * 40,
+            }
+            records = {
+                "cleanup/TASK-1.json": json.dumps({
+                    "schema_version": 1, "task": "TASK-1", "status": "merged",
+                    "worktree": "/tmp/worktree", "branch": "task/TASK-1-test",
+                    "local_head": "a" * 40, "evidence": {},
+                }).encode(),
+                "integration/pr-12.head": b"a" * 40 + b"\n",
+                "discard-pristine/13.json": json.dumps({
+                    "schema_version": 1, "operation": "discard-pristine", "task": "13",
+                    "status": "initialized", "worktree": "/tmp/worktree",
+                    "branch": "task/13-test", "base_branch": "main",
+                    "base_revision": "b" * 40, "local_head": "b" * 40,
+                    "repository": "acme/widgets",
+                }).encode(),
+                f"automation-maintenance/{'b' * 64}.json": json.dumps(authority).encode(),
+                "automation-maintenance/authority.json": json.dumps(authority).encode(),
+                "automation-maintenance/source-recovery-proof.json": json.dumps(proof).encode(),
+            }
+            for relative, content in records.items():
+                path = legacy / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(content)
+            (legacy / "cleanup.lock").write_bytes(b"")
+
+            private_state.prepare(repo, admin=True)
+
+            for relative, content in records.items():
+                self.assertEqual(content, (common / "agent-core" / relative).read_bytes())
+                self.assertFalse((legacy / relative).exists())
+            self.assertTrue((legacy / "cleanup.lock").is_file())
+            private_state.prepare(repo, admin=True)
+
+    def test_conflict_fails_before_any_migration_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            first = common / "opencode/cleanup/1.json"
+            conflict = common / "opencode/integration/pr-2.head"
+            destination = common / "agent-core/integration/pr-2.head"
+            first.parent.mkdir(parents=True)
+            conflict.parent.mkdir(parents=True)
+            destination.parent.mkdir(parents=True)
+            first.write_bytes(json.dumps({
+                "schema_version": 1, "task": "1", "status": "merged",
+                "worktree": "/tmp/worktree", "branch": "task/1-test",
+                "local_head": "a" * 40, "evidence": {},
+            }).encode())
+            conflict.write_bytes(b"a" * 40 + b"\n")
+            destination.write_bytes(b"new")
+            with self.assertRaisesRegex(private_state.GitPrivateStateError, "conflicting"):
+                private_state.prepare(repo)
+            self.assertTrue(first.is_file())
+            self.assertEqual(b"a" * 40 + b"\n", conflict.read_bytes())
+            self.assertEqual(b"new", destination.read_bytes())
+            self.assertFalse((common / "agent-core/migration.lock").exists())
+
+    def test_unknown_legacy_entry_fails_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            unknown = common / "opencode/unexpected"
+            unknown.mkdir(parents=True)
+            (unknown / "data").write_bytes(b"x")
+            with self.assertRaisesRegex(private_state.GitPrivateStateError, "unknown legacy"):
+                private_state.prepare(repo)
+            self.assertFalse((common / "agent-core").exists())
+            self.assertEqual(b"x", (unknown / "data").read_bytes())
+
+    def test_matching_legacy_name_with_invalid_schema_is_not_claimed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            foreign = common / "opencode/cleanup/1.json"
+            foreign.parent.mkdir(parents=True)
+            foreign.write_bytes(b"arbitrary foreign bytes")
+            before = self.identity(foreign)
+            with self.assertRaisesRegex(private_state.GitPrivateStateError, "invalid legacy"):
+                private_state.prepare(repo)
+            self.assertEqual(before, self.identity(foreign))
+            self.assertEqual(b"arbitrary foreign bytes", foreign.read_bytes())
+            self.assertFalse((common / "agent-core").exists())
+
+    def test_schema_shaped_invalid_authority_and_proof_are_not_claimed(self) -> None:
+        authority = {
+            "schema_version": 1, "task_id": "TASK-1", "branch": "task/TASK-1-test",
+            "worktree": "/tmp/worktree", "authority_nonce": "9" * 64,
+            "receipt_sha256": "a" * 64,
+        }
+        proof = {
+            "schema_version": 1, "kind": "source-recovery-proof",
+            "task_id": "TASK-1", "branch": "task/TASK-1-test",
+            "worktree": "/tmp/worktree", "authority_head": "a" * 40,
+            "authority_nonce": "9" * 64, "receipt_sha256": "a" * 64,
+            "receipt_bytes_sha256": "b" * 64, "changed_paths_sha256": "c" * 64,
+            "path_fingerprints_sha256": "d" * 64,
+            "implementation_source": "/tmp/source", "implementation_revision": "e" * 40,
+            "receipt_source": "/tmp/source", "receipt_source_revision": "f" * 40,
+        }
+        cases = (
+            ("authority.json", dict(authority, authority_nonce="not-a-nonce")),
+            ("authority.json", dict(authority, worktree="relative/worktree")),
+            ("source-recovery-proof.json", dict(proof, authority_head="not-an-oid")),
+            ("source-recovery-proof.json", dict(proof, authority_head="a" * 41)),
+            ("source-recovery-proof.json", dict(proof, implementation_revision="e" * 63)),
+            ("source-recovery-proof.json", dict(proof, receipt_bytes_sha256="not-a-digest")),
+            ("source-recovery-proof.json", dict(proof, implementation_source="relative/source")),
+            ("source-recovery-proof.json", dict(proof, receipt_source_revision="not-an-oid")),
+        )
+        for name, record in cases:
+            with self.subTest(name=name, record=record), tempfile.TemporaryDirectory() as directory:
+                repo = self.repository(Path(directory))
+                common = private_state.common_git_dir(repo)
+                foreign = common / "opencode/automation-maintenance" / name
+                foreign.parent.mkdir(parents=True)
+                foreign.write_text(json.dumps(record), encoding="utf-8")
+                before = self.identity(foreign)
+                with self.assertRaisesRegex(private_state.GitPrivateStateError, "invalid legacy"):
+                    private_state.prepare(repo, admin=True)
+                self.assertEqual(before, self.identity(foreign))
+                self.assertEqual(record, json.loads(foreign.read_text(encoding="utf-8")))
+                self.assertFalse((common / "agent-core").exists())
+
+    def test_malformed_integration_oid_is_not_claimed(self) -> None:
+        for content in (b"a" * 41 + b"\n", b"a" * 63 + b"\n", b"A" * 40 + b"\n"):
+            with self.subTest(content=content), tempfile.TemporaryDirectory() as directory:
+                repo = self.repository(Path(directory))
+                common = private_state.common_git_dir(repo)
+                foreign = common / "opencode/integration/pr-1.head"
+                foreign.parent.mkdir(parents=True)
+                foreign.write_bytes(content)
+                before = self.identity(foreign)
+                with self.assertRaisesRegex(private_state.GitPrivateStateError, "invalid legacy"):
+                    private_state.prepare(repo)
+                self.assertEqual(before, self.identity(foreign))
+                self.assertEqual(content, foreign.read_bytes())
+                self.assertFalse((common / "agent-core").exists())
+
+    def test_legacy_symlink_and_special_file_fail_closed(self) -> None:
+        for kind in ("symlink", "fifo"):
+            with self.subTest(kind=kind), tempfile.TemporaryDirectory() as directory:
+                repo = self.repository(Path(directory))
+                common = private_state.common_git_dir(repo)
+                legacy = common / "opencode/cleanup"
+                legacy.mkdir(parents=True)
+                unsafe = legacy / "1.json"
+                if kind == "symlink":
+                    outside = Path(directory) / "outside"
+                    outside.write_bytes(b"outside")
+                    unsafe.symlink_to(outside)
+                else:
+                    os.mkfifo(unsafe)
+                with self.assertRaises(private_state.GitPrivateStateError):
+                    private_state.prepare(repo)
+                self.assertFalse((common / "agent-core").exists())
+
+    def test_equivalent_dual_state_retry_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            legacy = common / "opencode/cleanup/7.json"
+            current = common / "agent-core/cleanup/7.json"
+            legacy.parent.mkdir(parents=True)
+            current.parent.mkdir(parents=True)
+            content = json.dumps({
+                "schema_version": 1, "task": "7", "status": "merged",
+                "worktree": "/tmp/worktree", "branch": "task/7-test",
+                "local_head": "a" * 40, "evidence": {},
+            }).encode()
+            legacy.write_bytes(content)
+            current.write_bytes(content)
+            private_state.prepare(repo)
+            self.assertFalse(legacy.exists())
+            self.assertEqual(content, current.read_bytes())
+            private_state.prepare(repo)
+
+    def test_namespace_symlink_cannot_redirect_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            outside = Path(directory) / "outside"
+            outside.mkdir()
+            (common / "agent-core").symlink_to(outside, target_is_directory=True)
+            with self.assertRaises(private_state.GitPrivateStateError):
+                private_state.prepare(repo)
+            self.assertEqual([], list(outside.iterdir()))
+
+    def test_parent_replacement_after_open_cannot_redirect_write(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            private_state.prepare(repo)
+            namespace = common / "agent-core"
+            saved = common / "agent-core-saved"
+            outside = Path(directory) / "outside"
+            outside.mkdir()
+            target = private_state.integration_checkpoint(repo, "8")
+            real_replace = private_state.os.replace
+            replaced = False
+
+            def swap_then_replace(*args, **kwargs):
+                nonlocal replaced
+                if not replaced:
+                    replaced = True
+                    namespace.rename(saved)
+                    namespace.symlink_to(outside, target_is_directory=True)
+                return real_replace(*args, **kwargs)
+
+            with mock.patch.object(private_state.os, "replace", side_effect=swap_then_replace):
+                private_state.write_bytes(target, b"a" * 40 + b"\n")
+            self.assertEqual([], list(outside.iterdir()))
+            self.assertEqual(b"a" * 40 + b"\n", (saved / "integration/pr-8.head").read_bytes())
+
+    def test_opencode_symlink_cannot_redirect_migration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            outside = Path(directory) / "outside"
+            (outside / "cleanup").mkdir(parents=True)
+            (outside / "cleanup/1.json").write_bytes(b"outside")
+            (common / "opencode").symlink_to(outside, target_is_directory=True)
+            with self.assertRaises(private_state.GitPrivateStateError):
+                private_state.prepare(repo)
+            self.assertEqual(b"outside", (outside / "cleanup/1.json").read_bytes())
+            self.assertFalse((common / "agent-core").exists())
+
+    def test_linked_worktree_preserves_main_admin_fixed_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            linked = Path(directory) / "linked"
+            command("git", "worktree", "add", "-b", "task/1-test", str(linked), cwd=repo)
+            common = private_state.common_git_dir(linked)
+            authority = common / "opencode/automation-maintenance/authority.json"
+            authority.parent.mkdir(parents=True)
+            content = json.dumps({
+                "schema_version": 1, "task_id": "1", "branch": "task/1-test",
+                "worktree": str(repo), "authority_nonce": "nonce",
+                "receipt_sha256": "a" * 64,
+            }).encode()
+            authority.write_bytes(content)
+            before = self.identity(authority)
+            private_state.prepare(linked, admin=True)
+            self.assertEqual(before, self.identity(authority))
+            self.assertEqual(content, authority.read_bytes())
+            self.assertTrue((private_state.admin_git_dir(linked) / "agent-core/automation-maintenance").is_dir())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_git_private_state.py
+++ b/tests/test_git_private_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 from pathlib import Path
 import stat
@@ -25,6 +26,23 @@ def command(*arguments: str, cwd: Path) -> str:
 
 
 class GitPrivateStateTest(unittest.TestCase):
+    @staticmethod
+    def valid_worktree(root: Path, suffix: str) -> str:
+        path = root / ".worktrees" / suffix
+        path.parent.mkdir(exist_ok=True)
+        if (root / ".git").exists() and not path.exists():
+            command("git", "worktree", "add", "-b", f"task/{suffix}", str(path), cwd=root)
+        return str(path)
+
+    @staticmethod
+    def secure_canonical(path: Path, *, file: bool = False) -> None:
+        cursor = path.parent if file else path
+        while cursor.name != "agent-core":
+            cursor.chmod(0o700)
+            cursor = cursor.parent
+        cursor.chmod(0o700)
+        if file:
+            path.chmod(0o600)
     def repository(self, root: Path) -> Path:
         repo = root / "repo"
         repo.mkdir()
@@ -40,6 +58,68 @@ class GitPrivateStateTest(unittest.TestCase):
     def identity(path: Path) -> tuple[int, int, int, int, int]:
         value = path.lstat()
         return value.st_dev, value.st_ino, value.st_mode, value.st_size, value.st_mtime_ns
+
+    def cleanup_record(self, root: Path, task: str = "1") -> dict:
+        head = "a" * 40
+        return {
+            "schema_version": 1,
+            "task": task,
+            "status": "merged",
+            "worktree": self.valid_worktree(root, f"{task}-test"),
+            "branch": f"task/{task}-test",
+            "local_head": head,
+            "evidence": {
+                "repository": "acme/widgets",
+                "pr": 1,
+                "published_head": head,
+                "upstream": "deleted",
+            },
+        }
+
+    def discard_record(self, root: Path, task: str = "1") -> dict:
+        head = "b" * 40
+        return {
+            "schema_version": 1,
+            "operation": "discard-pristine",
+            "task": task,
+            "status": "initialized",
+            "worktree": self.valid_worktree(root, f"{task}-test"),
+            "branch": f"task/{task}-test",
+            "base_branch": "main",
+            "base_revision": head,
+            "local_head": head,
+            "repository": "acme/widgets",
+        }
+
+    def authority_record(self, root: Path, task: str = "1") -> dict:
+        return {
+            "schema_version": 1,
+            "task_id": task,
+            "branch": f"task/{task}-test",
+            "worktree": self.valid_worktree(root, f"{task}-test"),
+            "authority_nonce": "9" * 64,
+            "receipt_sha256": "a" * 64,
+        }
+
+    def proof_record(self, root: Path, task: str = "1") -> dict:
+        authority = self.authority_record(root, task)
+        return {
+            "schema_version": 1,
+            "kind": "source-recovery-proof",
+            "task_id": task,
+            "branch": authority["branch"],
+            "worktree": authority["worktree"],
+            "authority_head": "a" * 40,
+            "authority_nonce": authority["authority_nonce"],
+            "receipt_sha256": authority["receipt_sha256"],
+            "receipt_bytes_sha256": "b" * 64,
+            "changed_paths_sha256": "c" * 64,
+            "path_fingerprints_sha256": "d" * 64,
+            "implementation_source": "/tmp/source",
+            "implementation_revision": "e" * 40,
+            "receipt_source": "/tmp/source",
+            "receipt_source_revision": "f" * 40,
+        }
 
     def test_paths_are_pure_before_namespace_exists(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -66,55 +146,182 @@ class GitPrivateStateTest(unittest.TestCase):
             repo = self.repository(Path(directory))
             common = private_state.common_git_dir(repo)
             legacy = common / "opencode"
+            authority_worktree = Path(self.valid_worktree(repo, "TASK-1-test"))
             authority = {
                 "schema_version": 1,
                 "task_id": "TASK-1",
                 "branch": "task/TASK-1-test",
-                "worktree": "/tmp/worktree",
+                "worktree": str(authority_worktree),
                 "authority_nonce": "9" * 64,
                 "receipt_sha256": "a" * 64,
             }
             proof = {
                 "schema_version": 1, "kind": "source-recovery-proof",
                 "task_id": "TASK-1", "branch": "task/TASK-1-test",
-                "worktree": "/tmp/worktree", "authority_head": "a" * 40,
+                "worktree": str(authority_worktree), "authority_head": "a" * 40,
                 "authority_nonce": "9" * 64, "receipt_sha256": "a" * 64,
                 "receipt_bytes_sha256": "b" * 64, "changed_paths_sha256": "c" * 64,
                 "path_fingerprints_sha256": "d" * 64,
                 "implementation_source": "/tmp/source", "implementation_revision": "e" * 40,
                 "receipt_source": "/tmp/source", "receipt_source_revision": "f" * 40,
             }
+            bridge = {
+                "schema_version": 2, "kind": "source-recovery-bridge",
+                "task_id": authority["task_id"], "branch": authority["branch"],
+                "worktree": authority["worktree"],
+                "authority_nonce": authority["authority_nonce"],
+                "receipt_sha256": authority["receipt_sha256"],
+                "proof_sha256": hashlib.sha256(
+                    json.dumps(proof, sort_keys=True, separators=(",", ":")).encode()
+                ).hexdigest(),
+            }
             records = {
                 "cleanup/TASK-1.json": json.dumps({
                     "schema_version": 1, "task": "TASK-1", "status": "merged",
-                    "worktree": "/tmp/worktree", "branch": "task/TASK-1-test",
-                    "local_head": "a" * 40, "evidence": {},
+                    "worktree": self.valid_worktree(Path(directory), "TASK-1-test"), "branch": "task/TASK-1-test",
+                    "local_head": "a" * 40, "evidence": {"repository": "acme/widgets", "pr": 12, "published_head": "a" * 40, "upstream": "deleted"},
                 }).encode(),
                 "integration/pr-12.head": b"a" * 40 + b"\n",
                 "discard-pristine/13.json": json.dumps({
                     "schema_version": 1, "operation": "discard-pristine", "task": "13",
-                    "status": "initialized", "worktree": "/tmp/worktree",
+                    "status": "initialized", "worktree": self.valid_worktree(Path(directory), "13-test"),
                     "branch": "task/13-test", "base_branch": "main",
                     "base_revision": "b" * 40, "local_head": "b" * 40,
                     "repository": "acme/widgets",
                 }).encode(),
-                f"automation-maintenance/{'b' * 64}.json": json.dumps(authority).encode(),
-                "automation-maintenance/authority.json": json.dumps(authority).encode(),
+                f"automation-maintenance/{hashlib.sha256(str(Path(authority['worktree']).resolve()).encode()).hexdigest()}.json": json.dumps(authority).encode(),
+                "automation-maintenance/authority.json": json.dumps(bridge).encode(),
                 "automation-maintenance/source-recovery-proof.json": json.dumps(proof).encode(),
             }
             for relative, content in records.items():
                 path = legacy / relative
                 path.parent.mkdir(parents=True, exist_ok=True)
                 path.write_bytes(content)
-            (legacy / "cleanup.lock").write_bytes(b"")
+            legacy_lock = legacy / "cleanup.lock"
+            legacy_lock.write_bytes(b"")
+            legacy_lock_identity = self.identity(legacy_lock)
 
-            private_state.prepare(repo, admin=True)
+            private_state.prepare(authority_worktree, admin=True)
 
             for relative, content in records.items():
-                self.assertEqual(content, (common / "agent-core" / relative).read_bytes())
+                base = (
+                    private_state.admin_git_dir(authority_worktree) / "agent-core"
+                    if Path(relative).name in private_state.FIXED_AUTHORITY_FILES
+                    else common / "agent-core"
+                )
+                self.assertEqual(content, (base / relative).read_bytes())
                 self.assertFalse((legacy / relative).exists())
-            self.assertTrue((legacy / "cleanup.lock").is_file())
-            private_state.prepare(repo, admin=True)
+            self.assertFalse(legacy.exists())
+            canonical_lock = common / "agent-core/cleanup.lock"
+            self.assertEqual(legacy_lock_identity[0:2], self.identity(canonical_lock)[0:2])
+            self.assertEqual(0o600, stat.S_IMODE(canonical_lock.stat().st_mode))
+            private_state.prepare(authority_worktree, admin=True)
+
+    def test_contended_legacy_cleanup_lock_blocks_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            legacy_lock = common / "opencode/cleanup.lock"
+            legacy_lock.parent.mkdir()
+            legacy_lock.write_bytes(b"")
+            with legacy_lock.open("r+b") as handle:
+                import fcntl
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                with self.assertRaisesRegex(private_state.GitPrivateStateError, "BLOCKED.*contended"):
+                    private_state.prepare(repo)
+            self.assertTrue(legacy_lock.is_file())
+            self.assertFalse((common / "agent-core").exists())
+
+    def test_cleanup_operation_uses_handed_off_inode_without_relocking_itself(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            legacy_lock = common / "opencode/cleanup.lock"
+            legacy_lock.parent.mkdir()
+            legacy_lock.write_bytes(b"")
+            inode = legacy_lock.stat().st_ino
+            with private_state.cleanup_lock(repo):
+                self.assertFalse((common / "opencode").exists())
+                self.assertEqual(inode, (common / "agent-core/cleanup.lock").stat().st_ino)
+
+    def test_cleanup_handoff_rejects_legacy_path_inode_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            legacy_lock = common / "opencode/cleanup.lock"
+            legacy_lock.parent.mkdir()
+            legacy_lock.write_bytes(b"")
+            original = private_state._handoff_cleanup_lock
+
+            def replace_before_handoff(legacy, canonical, expected_identity):
+                legacy.unlink()
+                legacy.write_bytes(b"replacement")
+                return original(legacy, canonical, expected_identity)
+
+            with mock.patch.object(
+                private_state, "_handoff_cleanup_lock", side_effect=replace_before_handoff
+            ):
+                with self.assertRaisesRegex(
+                    private_state.GitPrivateStateError, "identity changed"
+                ):
+                    with private_state.cleanup_lock(repo):
+                        self.fail("unsafe cleanup lock handoff succeeded")
+            self.assertFalse((common / "agent-core/cleanup.lock").exists())
+            self.assertEqual(b"replacement", legacy_lock.read_bytes())
+
+    def test_cleanup_handoff_preserves_unknown_canonical_path_replacement(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            legacy_lock = common / "opencode/cleanup.lock"
+            canonical_lock = common / "agent-core/cleanup.lock"
+            legacy_lock.parent.mkdir()
+            legacy_lock.write_bytes(b"")
+            real_stat = os.stat
+            replaced = False
+
+            def replace_canonical_before_postlink_stat(path, *args, **kwargs):
+                nonlocal replaced
+                if (
+                    not replaced
+                    and path == canonical_lock.name
+                    and kwargs.get("dir_fd") is not None
+                    and os.path.lexists(canonical_lock)
+                ):
+                    replaced = True
+                    canonical_lock.unlink()
+                    canonical_lock.write_bytes(b"unknown")
+                    canonical_lock.chmod(0o600)
+                return real_stat(path, *args, **kwargs)
+
+            with mock.patch.object(os, "stat", side_effect=replace_canonical_before_postlink_stat):
+                with self.assertRaisesRegex(
+                    private_state.GitPrivateStateError, "identity changed during handoff"
+                ):
+                    with private_state.cleanup_lock(repo):
+                        self.fail("unsafe cleanup lock handoff succeeded")
+            self.assertTrue(replaced)
+            self.assertEqual(b"unknown", canonical_lock.read_bytes())
+
+    def test_distinct_dual_cleanup_locks_block_before_migration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            legacy = common / "opencode/cleanup.lock"
+            legacy.parent.mkdir()
+            legacy.write_bytes(b"")
+            canonical = common / "agent-core/cleanup.lock"
+            canonical.parent.mkdir()
+            canonical.parent.chmod(0o700)
+            canonical.write_bytes(b"")
+            canonical.chmod(0o600)
+            legacy_before = self.identity(legacy)
+            canonical_before = self.identity(canonical)
+            with self.assertRaisesRegex(private_state.GitPrivateStateError, "BLOCKED.*different inodes"):
+                private_state.prepare(repo)
+            self.assertEqual(legacy_before, self.identity(legacy))
+            self.assertEqual(canonical_before, self.identity(canonical))
+            self.assertFalse((common / "agent-core/migration.lock").exists())
 
     def test_conflict_fails_before_any_migration_mutation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -126,18 +333,20 @@ class GitPrivateStateTest(unittest.TestCase):
             first.parent.mkdir(parents=True)
             conflict.parent.mkdir(parents=True)
             destination.parent.mkdir(parents=True)
+            self.secure_canonical(destination.parent)
             first.write_bytes(json.dumps({
                 "schema_version": 1, "task": "1", "status": "merged",
-                "worktree": "/tmp/worktree", "branch": "task/1-test",
-                "local_head": "a" * 40, "evidence": {},
+                "worktree": self.valid_worktree(repo, "1-test"), "branch": "task/1-test",
+                "local_head": "a" * 40, "evidence": {"repository": "acme/widgets", "pr": 1, "published_head": "a" * 40, "upstream": "deleted"},
             }).encode())
             conflict.write_bytes(b"a" * 40 + b"\n")
-            destination.write_bytes(b"new")
+            destination.write_bytes(b"b" * 40 + b"\n")
+            destination.chmod(0o600)
             with self.assertRaisesRegex(private_state.GitPrivateStateError, "conflicting"):
                 private_state.prepare(repo)
             self.assertTrue(first.is_file())
             self.assertEqual(b"a" * 40 + b"\n", conflict.read_bytes())
-            self.assertEqual(b"new", destination.read_bytes())
+            self.assertEqual(b"b" * 40 + b"\n", destination.read_bytes())
             self.assertFalse((common / "agent-core/migration.lock").exists())
 
     def test_unknown_legacy_entry_fails_without_mutation(self) -> None:
@@ -247,17 +456,378 @@ class GitPrivateStateTest(unittest.TestCase):
             current = common / "agent-core/cleanup/7.json"
             legacy.parent.mkdir(parents=True)
             current.parent.mkdir(parents=True)
+            self.secure_canonical(current.parent)
             content = json.dumps({
                 "schema_version": 1, "task": "7", "status": "merged",
-                "worktree": "/tmp/worktree", "branch": "task/7-test",
-                "local_head": "a" * 40, "evidence": {},
+                "worktree": self.valid_worktree(repo, "7-test"), "branch": "task/7-test",
+                "local_head": "a" * 40, "evidence": {"repository": "acme/widgets", "pr": 7, "published_head": "a" * 40, "upstream": "deleted"},
             }).encode()
             legacy.write_bytes(content)
             current.write_bytes(content)
+            current.chmod(0o600)
             private_state.prepare(repo)
             self.assertFalse(legacy.exists())
             self.assertEqual(content, current.read_bytes())
             private_state.prepare(repo)
+
+    def test_owned_crash_temporaries_are_recovered_and_migration_resumes(self) -> None:
+        for temporary_content in (b"partial", json.dumps(self.cleanup_record(Path("/tmp"))).encode()):
+            with self.subTest(size=len(temporary_content)), tempfile.TemporaryDirectory() as directory:
+                repo = self.repository(Path(directory))
+                common = private_state.common_git_dir(repo)
+                record = self.cleanup_record(repo)
+                content = json.dumps(record).encode()
+                source = common / "opencode/cleanup/1.json"
+                source.parent.mkdir(parents=True)
+                source.write_bytes(content)
+                temporary = common / "agent-core/cleanup/.migrate.123.0123456789abcdef"
+                temporary.parent.mkdir(parents=True)
+                self.secure_canonical(temporary.parent)
+                temporary.write_bytes(temporary_content)
+                temporary.chmod(0o600)
+
+                private_state.prepare(repo)
+
+                self.assertFalse(temporary.exists())
+                self.assertFalse((common / "opencode").exists())
+                self.assertEqual(content, (common / "agent-core/cleanup/1.json").read_bytes())
+
+    def test_durable_destination_with_leftover_temp_is_recovered(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            destination = common / "agent-core/cleanup/1.json"
+            destination.parent.mkdir(parents=True)
+            self.secure_canonical(destination.parent)
+            destination.write_text(json.dumps(self.cleanup_record(repo)), encoding="utf-8")
+            destination.chmod(0o600)
+            temporary = destination.parent / ".record.123.0123456789abcdef"
+            temporary.write_bytes(b"complete but stale")
+            temporary.chmod(0o600)
+
+            private_state.prepare(repo)
+
+            self.assertFalse(temporary.exists())
+            self.assertTrue(destination.is_file())
+
+    def test_partial_legacy_removal_resumes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            canonical = common / "agent-core/cleanup/1.json"
+            canonical.parent.mkdir(parents=True)
+            self.secure_canonical(canonical.parent)
+            first = json.dumps(self.cleanup_record(repo, "1")).encode()
+            second = json.dumps(self.cleanup_record(repo, "2")).encode()
+            canonical.write_bytes(first)
+            canonical.chmod(0o600)
+            remaining = common / "opencode/cleanup/2.json"
+            remaining.parent.mkdir(parents=True)
+            remaining.write_bytes(second)
+
+            private_state.prepare(repo)
+
+            self.assertEqual(first, canonical.read_bytes())
+            self.assertEqual(second, (canonical.parent / "2.json").read_bytes())
+            self.assertFalse((common / "opencode").exists())
+
+    def test_malformed_or_unsafe_canonical_temp_fails_closed(self) -> None:
+        for name, mode in ((".migrate.bad", 0o600), (".record.1.0123456789abcdef", 0o666)):
+            with self.subTest(name=name, mode=mode), tempfile.TemporaryDirectory() as directory:
+                repo = self.repository(Path(directory))
+                common = private_state.common_git_dir(repo)
+                temporary = common / "agent-core/cleanup" / name
+                temporary.parent.mkdir(parents=True)
+                self.secure_canonical(temporary.parent)
+                temporary.write_bytes(b"stale")
+                temporary.chmod(mode)
+                before = self.identity(temporary)
+                with self.assertRaises(private_state.GitPrivateStateError):
+                    private_state.prepare(repo)
+                self.assertEqual(before, self.identity(temporary))
+
+    def test_unsafe_legacy_modes_are_not_promoted(self) -> None:
+        cases = ("receipt", "authority", "namespace", "subdirectory")
+        for case in cases:
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                repo = self.repository(Path(directory))
+                common = private_state.common_git_dir(repo)
+                if case == "authority":
+                    value = self.authority_record(repo)
+                    key = hashlib.sha256(str(Path(value["worktree"]).resolve()).encode()).hexdigest()
+                    source = common / "opencode/automation-maintenance" / f"{key}.json"
+                else:
+                    value = self.cleanup_record(repo)
+                    source = common / "opencode/cleanup/1.json"
+                source.parent.mkdir(parents=True)
+                source.write_text(json.dumps(value), encoding="utf-8")
+                unsafe = source
+                if case == "namespace":
+                    unsafe = common / "opencode"
+                elif case == "subdirectory":
+                    unsafe = source.parent
+                unsafe.chmod(0o777 if unsafe.is_dir() else 0o666)
+                before = self.identity(source)
+                with self.assertRaisesRegex(private_state.GitPrivateStateError, "unsafe"):
+                    private_state.prepare(repo)
+                self.assertEqual(before, self.identity(source))
+                self.assertFalse((common / "agent-core").exists())
+
+    def test_unsafe_canonical_directory_or_record_fails_closed(self) -> None:
+        for case in ("directory", "record"):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                repo = self.repository(Path(directory))
+                common = private_state.common_git_dir(repo)
+                record = common / "agent-core/cleanup/1.json"
+                record.parent.mkdir(parents=True)
+                self.secure_canonical(record.parent)
+                record.write_text(json.dumps(self.cleanup_record(repo)), encoding="utf-8")
+                record.chmod(0o600)
+                (record.parent if case == "directory" else record).chmod(0o777 if case == "directory" else 0o666)
+                with self.assertRaisesRegex(private_state.GitPrivateStateError, "unsafe"):
+                    private_state.prepare(repo)
+
+    def test_historical_semantic_violations_are_not_claimed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cleanup = self.cleanup_record(root)
+            discard = self.discard_record(root)
+            cases = (
+                ("cleanup/1.json", dict(cleanup, branch="task/2-foreign")),
+                ("cleanup/1.json", dict(cleanup, evidence={"repository": "acme/widgets"})),
+                ("discard-pristine/1.json", dict(discard, branch="fix/2-foreign")),
+                ("discard-pristine/1.json", dict(discard, worktree="/tmp/foreign")),
+                ("discard-pristine/1.json", dict(discard, base_branch="")),
+                ("discard-pristine/1.json", dict(discard, repository="invalid")),
+            )
+            for relative, record in cases:
+                with self.subTest(relative=relative, record=record), tempfile.TemporaryDirectory() as repo_dir:
+                    repo = self.repository(Path(repo_dir))
+                    common = private_state.common_git_dir(repo)
+                    source = common / "opencode" / relative
+                    source.parent.mkdir(parents=True)
+                    raw = json.dumps(record).encode()
+                    source.write_bytes(raw)
+                    before = self.identity(source)
+                    with self.assertRaisesRegex(private_state.GitPrivateStateError, "invalid legacy"):
+                        private_state.prepare(repo)
+                    self.assertEqual(before, self.identity(source))
+                    self.assertEqual(raw, source.read_bytes())
+                    self.assertFalse((common / "agent-core").exists())
+
+    def test_wrong_hashed_authority_filename_is_not_claimed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            source = common / "opencode/automation-maintenance" / f"{'0' * 64}.json"
+            source.parent.mkdir(parents=True)
+            raw = json.dumps(self.authority_record(repo)).encode()
+            source.write_bytes(raw)
+            before = self.identity(source)
+            with self.assertRaisesRegex(private_state.GitPrivateStateError, "filename"):
+                private_state.prepare(repo)
+            self.assertEqual(before, self.identity(source))
+            self.assertFalse((common / "agent-core").exists())
+
+    def test_mismatched_legacy_proof_and_bridge_are_not_claimed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            proof = self.proof_record(repo, "1")
+            other = self.authority_record(repo, "2")
+            bridge = {
+                **other,
+                "schema_version": 2,
+                "kind": "source-recovery-bridge",
+                "proof_sha256": hashlib.sha256(
+                    json.dumps(proof, sort_keys=True, separators=(",", ":")).encode()
+                ).hexdigest(),
+            }
+            maintenance = common / "opencode/automation-maintenance"
+            maintenance.mkdir(parents=True)
+            proof_path = maintenance / "source-recovery-proof.json"
+            authority_path = maintenance / "authority.json"
+            proof_path.write_text(json.dumps(proof), encoding="utf-8")
+            authority_path.write_text(json.dumps(bridge), encoding="utf-8")
+            before = (self.identity(proof_path), self.identity(authority_path))
+            with self.assertRaisesRegex(
+                private_state.GitPrivateStateError,
+                "conflicting legacy|different worktree admin",
+            ):
+                private_state.prepare(repo, admin=True)
+            self.assertEqual(before, (self.identity(proof_path), self.identity(authority_path)))
+            self.assertFalse((common / "agent-core").exists())
+
+    def test_legacy_bridge_without_proof_is_not_claimed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            authority = self.authority_record(repo)
+            bridge = {
+                **authority,
+                "schema_version": 2,
+                "kind": "source-recovery-bridge",
+                "proof_sha256": "f" * 64,
+            }
+            source = common / "opencode/automation-maintenance/authority.json"
+            source.parent.mkdir(parents=True)
+            source.write_text(json.dumps(bridge), encoding="utf-8")
+            before = self.identity(source)
+            linked = Path(bridge["worktree"])
+            with self.assertRaisesRegex(private_state.GitPrivateStateError, "lacks its proof"):
+                private_state.prepare(linked, admin=True)
+            self.assertEqual(before, self.identity(source))
+            self.assertFalse((common / "agent-core").exists())
+
+    def test_legacy_bridge_recovers_after_proof_was_already_migrated(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            proof = self.proof_record(repo)
+            linked = Path(proof["worktree"])
+            bridge = {
+                **self.authority_record(repo),
+                "schema_version": 2,
+                "kind": "source-recovery-bridge",
+                "proof_sha256": hashlib.sha256(
+                    json.dumps(proof, sort_keys=True, separators=(",", ":")).encode()
+                ).hexdigest(),
+            }
+            legacy = common / "opencode/automation-maintenance"
+            canonical = (
+                private_state.admin_git_dir(linked)
+                / "agent-core/automation-maintenance"
+            )
+            legacy.mkdir(parents=True)
+            canonical.mkdir(parents=True)
+            canonical.parent.chmod(0o700)
+            canonical.chmod(0o700)
+            (legacy / "authority.json").write_text(json.dumps(bridge), encoding="utf-8")
+            (canonical / "source-recovery-proof.json").write_text(
+                json.dumps(proof), encoding="utf-8"
+            )
+            (canonical / "source-recovery-proof.json").chmod(0o600)
+            private_state.prepare(linked, admin=True)
+            self.assertFalse((common / "opencode").exists())
+            self.assertTrue((canonical / "authority.json").is_file())
+
+    def test_unrelated_absolute_authority_worktree_is_not_claimed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            authority = self.authority_record(repo)
+            authority["worktree"] = str(Path(directory) / "unrelated")
+            source = common / "opencode/automation-maintenance/authority.json"
+            source.parent.mkdir(parents=True)
+            source.write_text(json.dumps(authority), encoding="utf-8")
+            with self.assertRaisesRegex(private_state.GitPrivateStateError, "not registered"):
+                private_state.prepare(repo, admin=True)
+            self.assertTrue(source.is_file())
+
+    def test_incomplete_or_nonbridge_canonical_recovery_pair_is_rejected(self) -> None:
+        for case in ("proof-only", "bridge-only", "standard-with-proof"):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                repo = self.repository(Path(directory))
+                proof = self.proof_record(repo)
+                linked = Path(proof["worktree"])
+                authority = self.authority_record(repo)
+                bridge = {
+                    **authority,
+                    "schema_version": 2,
+                    "kind": "source-recovery-bridge",
+                    "proof_sha256": hashlib.sha256(
+                        json.dumps(proof, sort_keys=True, separators=(",", ":")).encode()
+                    ).hexdigest(),
+                }
+                maintenance = (
+                    private_state.admin_git_dir(linked)
+                    / "agent-core/automation-maintenance"
+                )
+                maintenance.mkdir(parents=True)
+                maintenance.parent.chmod(0o700)
+                maintenance.chmod(0o700)
+                records = (
+                    {"source-recovery-proof.json": proof}
+                    if case == "proof-only"
+                    else {"authority.json": bridge}
+                    if case == "bridge-only"
+                    else {
+                        "authority.json": authority,
+                        "source-recovery-proof.json": proof,
+                    }
+                )
+                for name, value in records.items():
+                    record = maintenance / name
+                    record.write_text(json.dumps(value), encoding="utf-8")
+                    record.chmod(0o600)
+                with self.assertRaises(private_state.GitPrivateStateError):
+                    private_state.prepare(linked, admin=True)
+
+    def test_legacy_unlink_consumes_equivalent_migrated_record(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            content = (json.dumps(self.authority_record(repo)) + "\n").encode()
+            value = json.loads(content)
+            name = hashlib.sha256(
+                str(Path(value["worktree"]).resolve()).encode()
+            ).hexdigest() + ".json"
+            legacy = common / "opencode/automation-maintenance" / name
+            legacy.parent.mkdir(parents=True)
+            legacy.write_bytes(content)
+            identity = self.identity(legacy)[:2]
+            private_state.prepare(repo, admin=True)
+            canonical = common / "agent-core/automation-maintenance" / name
+            self.assertTrue(canonical.is_file())
+            private_state.unlink(
+                legacy, expected_identity=identity, expected_content=content
+            )
+            self.assertFalse(canonical.exists())
+
+    def test_legacy_unlink_consumes_equivalent_dual_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            content = (json.dumps(self.cleanup_record(Path(directory))) + "\n").encode()
+            legacy = common / "opencode/cleanup/1.json"
+            canonical = common / "agent-core/cleanup/1.json"
+            legacy.parent.mkdir(parents=True)
+            canonical.parent.mkdir(parents=True)
+            canonical.parent.parent.chmod(0o700)
+            canonical.parent.chmod(0o700)
+            legacy.write_bytes(content)
+            canonical.write_bytes(content)
+            canonical.chmod(0o600)
+            identity = self.identity(legacy)[:2]
+            private_state.unlink(
+                legacy, expected_identity=identity, expected_content=content
+            )
+            self.assertFalse(legacy.exists())
+            self.assertFalse(canonical.exists())
+
+    def test_unsafe_matching_target_race_does_not_consume_legacy(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            common = private_state.common_git_dir(repo)
+            source = common / "opencode/cleanup/1.json"
+            source.parent.mkdir(parents=True)
+            raw = json.dumps(self.cleanup_record(repo)).encode()
+            source.write_bytes(raw)
+            before = self.identity(source)
+            target = common / "agent-core/cleanup/1.json"
+            original = private_state._exclusive_publish
+
+            def inject_unsafe(path: Path, content: bytes, mode: int):
+                if path == target and not path.exists():
+                    path.write_bytes(content)
+                    path.chmod(0o666)
+                return original(path, content, mode)
+
+            with mock.patch.object(private_state, "_exclusive_publish", side_effect=inject_unsafe):
+                with self.assertRaisesRegex(private_state.GitPrivateStateError, "unsafe canonical"):
+                    private_state.prepare(repo)
+            self.assertEqual(before, self.identity(source))
+            self.assertEqual(raw, source.read_bytes())
 
     def test_namespace_symlink_cannot_redirect_writes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -309,25 +879,43 @@ class GitPrivateStateTest(unittest.TestCase):
             self.assertEqual(b"outside", (outside / "cleanup/1.json").read_bytes())
             self.assertFalse((common / "agent-core").exists())
 
-    def test_linked_worktree_preserves_main_admin_fixed_authority(self) -> None:
+    def test_linked_worktree_routes_fixed_authority_to_its_admin(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repo = self.repository(Path(directory))
-            linked = Path(directory) / "linked"
+            linked = repo / ".worktrees" / "1-test"
             command("git", "worktree", "add", "-b", "task/1-test", str(linked), cwd=repo)
             common = private_state.common_git_dir(linked)
             authority = common / "opencode/automation-maintenance/authority.json"
             authority.parent.mkdir(parents=True)
             content = json.dumps({
                 "schema_version": 1, "task_id": "1", "branch": "task/1-test",
-                "worktree": str(repo), "authority_nonce": "nonce",
+                "worktree": str(linked), "authority_nonce": "a" * 64,
                 "receipt_sha256": "a" * 64,
             }).encode()
             authority.write_bytes(content)
             before = self.identity(authority)
             private_state.prepare(linked, admin=True)
-            self.assertEqual(before, self.identity(authority))
-            self.assertEqual(content, authority.read_bytes())
+            self.assertFalse(authority.exists())
+            migrated = private_state.admin_git_dir(linked) / "agent-core/automation-maintenance/authority.json"
+            self.assertEqual(content, migrated.read_bytes())
+            self.assertNotEqual(before, self.identity(migrated))
             self.assertTrue((private_state.admin_git_dir(linked) / "agent-core/automation-maintenance").is_dir())
+
+    def test_common_prepare_does_not_recover_unlocked_admin_temporary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            linked = repo / ".worktrees" / "1-test"
+            command("git", "worktree", "add", "-b", "task/1-test", str(linked), cwd=repo)
+            admin = private_state.admin_git_dir(linked)
+            maintenance = admin / "agent-core/automation-maintenance"
+            maintenance.mkdir(parents=True)
+            (admin / "agent-core").chmod(0o700)
+            maintenance.chmod(0o700)
+            temporary = maintenance / (".record.1." + "a" * 16)
+            temporary.write_bytes(b"active")
+            temporary.chmod(0o600)
+            private_state.prepare(linked, admin=False)
+            self.assertEqual(b"active", temporary.read_bytes())
 
 
 if __name__ == "__main__":

--- a/tests/test_post_merge_finalization.py
+++ b/tests/test_post_merge_finalization.py
@@ -178,6 +178,23 @@ class DefaultBranchSynchronizationTest(RepositoryFixture):
 
 
 class PostMergeFinalizationTest(RepositoryFixture):
+    def test_cleanup_preserves_opencode_project_file(self) -> None:
+        task_worktree, _, evidence = self.merged_cleanup_fixture(delete_remote=True)
+        foreign = Path(command("git", "rev-parse", "--git-common-dir", cwd=self.repo)) / "opencode"
+        if not foreign.is_absolute():
+            foreign = self.repo / foreign
+        foreign.write_bytes(b"0123456789abcdef0123456789abcdef01234567")
+        before = foreign.lstat()
+        with self.cleanup_run(evidence):
+            lifecycle.task_cleanup(self.repo, "TASK-1")
+        after = foreign.lstat()
+        self.assertFalse(task_worktree.exists())
+        self.assertEqual(foreign.read_bytes(), b"0123456789abcdef0123456789abcdef01234567")
+        self.assertEqual(
+            (before.st_dev, before.st_ino, before.st_mode, before.st_size, before.st_mtime_ns),
+            (after.st_dev, after.st_ino, after.st_mode, after.st_size, after.st_mtime_ns),
+        )
+
     def merged_evidence(self, task_worktree: Path, merge_oid: str, **changes: object) -> dict:
         value = {
             "number": 93,

--- a/tests/test_pristine_discard.py
+++ b/tests/test_pristine_discard.py
@@ -180,6 +180,23 @@ class PristineDiscardTest(unittest.TestCase):
         state = lifecycle.state_path(restarted.path).read_text(encoding="utf-8")
         self.assertIn(f"- Base revision: {current_main}", state)
 
+    def test_discard_preserves_opencode_project_file(self) -> None:
+        task_worktree = self.start()
+        foreign = Path(command("git", "rev-parse", "--git-common-dir", cwd=self.repo)) / "opencode"
+        if not foreign.is_absolute():
+            foreign = self.repo / foreign
+        foreign.write_bytes(b"0123456789abcdef0123456789abcdef01234567")
+        before = foreign.lstat()
+        with self.github():
+            discard.task_discard_pristine(self.repo, "13")
+        after = foreign.lstat()
+        self.assertFalse(task_worktree.exists())
+        self.assertEqual(foreign.read_bytes(), b"0123456789abcdef0123456789abcdef01234567")
+        self.assertEqual(
+            (before.st_dev, before.st_ino, before.st_mode, before.st_size, before.st_mtime_ns),
+            (after.st_dev, after.st_ino, after.st_mode, after.st_size, after.st_mtime_ns),
+        )
+
     def test_dirty_worktree_is_rejected(self) -> None:
         task_worktree = self.start()
         (task_worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")

--- a/tests/test_source_maintenance_finalize_bridge.py
+++ b/tests/test_source_maintenance_finalize_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -42,6 +43,24 @@ class FirstAdoptionFinalizeBridgeTest(unittest.TestCase):
     def configure(self, repo: Path) -> None:
         self.git(repo, "config", "user.name", "Bootstrap Finalize Test")
         self.git(repo, "config", "user.email", "bootstrap@example.invalid")
+
+    def test_verified_module_bundle_loads_actual_private_state_dependency(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source = Path(directory) / "source"
+            source.mkdir()
+            self.git(source, "init", "-b", "main")
+            self.configure(source)
+            for _, relative in bridge.CANONICAL_MODULES:
+                destination = source / relative
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(ROOT / relative, destination)
+            self.git(source, "add", ".")
+            self.git(source, "commit", "-m", "verified module fixture")
+            revision = self.git(source, "rev-parse", "HEAD")
+            with bridge._verified_modules(source, revision) as loaded:
+                self.assertIn("git_private_state", loaded)
+                self.assertIn("maintenance_lifecycle", loaded)
+                self.assertTrue(callable(loaded["maintenance_lifecycle"].maintenance_finalize))
 
     def test_stale_main_bootstraps_fast_forward_and_exact_idempotent_transition(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/automation_recovery_bridge.py
+++ b/tools/automation_recovery_bridge.py
@@ -27,6 +27,7 @@ PUBLICATION_PATH = ROOT / "components" / "agent-core" / ".automation" / "bin" / 
 AGENT_CORE_PATH = ROOT / "components" / "agent-core" / ".automation" / "bin" / "agent_core.py"
 MAINTENANCE_PATH = ROOT / "components" / "agent-core" / ".automation" / "bin" / "maintenance_lifecycle.py"
 CANONICAL_MODULES = (
+    ("git_private_state", "components/agent-core/.automation/bin/git_private_state.py"),
     ("task_lifecycle", "components/agent-core/.automation/bin/task_lifecycle.py"),
     ("task_contract", "components/agent-core/.automation/bin/task_contract.py"),
     ("publication_metadata", "components/agent-core/.automation/bin/publication_metadata.py"),
@@ -270,6 +271,7 @@ def _verified_modules(root: Path, revision: str):
                 module.run = _pinned_run
             loaded["automation_upgrade"]._GIT_EXECUTABLE = git
             loaded["automation_upgrade"].git_executable = lambda: git
+            loaded["git_private_state"]._GIT_EXECUTABLE = str(git)
             loaded["task_lifecycle"].gh = lambda *args, cwd, check=True: _pinned_run(
                 ["gh", *args], cwd=cwd, check=check)
             loaded["agent_core"].gh = lambda *args, cwd=None: _pinned_run(
@@ -294,22 +296,31 @@ def _verified_task_contract(root: Path, revision: str):
     """Load the contract and its dependency exclusively from HEAD Git blobs."""
     contract_oid, contract_mode = _tree_blob(root, revision, "components/agent-core/.automation/bin/task_contract.py")
     lifecycle_oid, lifecycle_mode = _tree_blob(root, revision, "components/agent-core/.automation/bin/task_lifecycle.py")
+    private_state_oid, private_state_mode = _tree_blob(
+        root, revision, "components/agent-core/.automation/bin/git_private_state.py"
+    )
     with tempfile.TemporaryDirectory(prefix="automation-contract-") as directory:
         directory_path = Path(directory)
         lifecycle_path = directory_path / "task_lifecycle.py"
         contract_path = directory_path / "task_contract.py"
+        private_state_path = directory_path / "git_private_state.py"
+        private_state_path.write_bytes(_blob(root, private_state_oid))
         lifecycle_path.write_bytes(_blob(root, lifecycle_oid))
         contract_path.write_bytes(_blob(root, contract_oid))
         # The Git modes are validated by _tree_blob; the private copies need
         # not retain executable bits and must not be writable by other users.
         os.chmod(lifecycle_path, 0o600)
         os.chmod(contract_path, 0o600)
+        os.chmod(private_state_path, 0o600)
         lifecycle_name = f"_templates_verified_lifecycle_{secrets.token_hex(16)}"
         contract_name = f"_templates_verified_contract_{secrets.token_hex(16)}"
         previous_lifecycle = sys.modules.get("task_lifecycle")
+        previous_private_state = sys.modules.get("git_private_state")
+        old_path = list(sys.path)
         previous_bytecode = sys.dont_write_bytecode
         sys.dont_write_bytecode = True
         try:
+            sys.path.insert(0, str(directory_path))
             lifecycle_spec = importlib.util.spec_from_file_location(lifecycle_name, lifecycle_path)
             if lifecycle_spec is None or lifecycle_spec.loader is None:
                 raise BridgeError("cannot create specification for verified Task Contract dependency")
@@ -317,6 +328,7 @@ def _verified_task_contract(root: Path, revision: str):
             sys.modules[lifecycle_name] = lifecycle
             sys.modules["task_lifecycle"] = lifecycle
             lifecycle_spec.loader.exec_module(lifecycle)
+            sys.modules["git_private_state"]._GIT_EXECUTABLE = str(trusted_git())
 
             def trusted_lifecycle_run(command, *, cwd=None, check=True):
                 if not command or command[0] != "git":
@@ -352,6 +364,11 @@ def _verified_task_contract(root: Path, revision: str):
                 sys.modules.pop("task_lifecycle", None)
             else:
                 sys.modules["task_lifecycle"] = previous_lifecycle
+            if previous_private_state is None:
+                sys.modules.pop("git_private_state", None)
+            else:
+                sys.modules["git_private_state"] = previous_private_state
+            sys.path[:] = old_path
             sys.dont_write_bytecode = previous_bytecode
 
 
@@ -359,9 +376,16 @@ def _verified_task_contract(root: Path, revision: str):
 def _verified_engine(root: Path, revision: str):
     oid, mode = _tree_blob(root, revision, "components/agent-core/.automation/bin/automation_upgrade.py")
     engine_bytes = _blob(root, oid)
+    private_oid, private_mode = _tree_blob(
+        root, revision, "components/agent-core/.automation/bin/git_private_state.py"
+    )
+    private_bytes = _blob(root, private_oid)
     _clean_root(root, revision)
     with tempfile.TemporaryDirectory(prefix="automation-bridge-") as directory:
         path = Path(directory) / "engine.py"
+        private_path = Path(directory) / "git_private_state.py"
+        private_path.write_bytes(private_bytes)
+        os.chmod(private_path, 0o600)
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         if hasattr(os, "O_NOFOLLOW"):
             flags |= os.O_NOFOLLOW
@@ -378,15 +402,20 @@ def _verified_engine(root: Path, revision: str):
             raise
         name = f"_templates_verified_engine_{secrets.token_hex(16)}"
         previous = sys.dont_write_bytecode
+        previous_private_state = sys.modules.get("git_private_state")
+        old_path = list(sys.path)
         sys.dont_write_bytecode = True
         spec = None
         try:
+            sys.path.insert(0, directory)
+            sys.modules.pop("git_private_state", None)
             spec = importlib.util.spec_from_file_location(name, path)
             if spec is None or spec.loader is None:
                 raise BridgeError("cannot create specification for verified recovery engine")
             engine = importlib.util.module_from_spec(spec)
             sys.modules[name] = engine
             spec.loader.exec_module(engine)
+            sys.modules["git_private_state"]._GIT_EXECUTABLE = str(trusted_git())
             yield engine
         except BridgeError:
             raise
@@ -394,6 +423,11 @@ def _verified_engine(root: Path, revision: str):
             raise BridgeError(f"cannot load verified recovery engine: {exc}") from exc
         finally:
             sys.modules.pop(name, None)
+            if previous_private_state is None:
+                sys.modules.pop("git_private_state", None)
+            else:
+                sys.modules["git_private_state"] = previous_private_state
+            sys.path[:] = old_path
             sys.dont_write_bytecode = previous
 
 


### PR DESCRIPTION
## Summary

- move Agent Core runtime state from the OpenCode-owned Git namespace into `<git-common-dir>/agent-core`
- migrate only recognized legacy records with durable, idempotent, fail-closed semantics
- preserve cleanup locking across cutover with verified same-inode handoff
- serialize common/admin migration, rebind, commit, recovery, and rollback mutations
- enforce strict ownership, modes, topology, historical schemas, and authority/proof relations
- regenerate all distributed Agent Core templates

## State inventory

- cleanup lock and receipts: Git common directory
- integration checkpoints: Git common directory
- pristine-discard receipts: Git common directory
- hashed historical maintenance authority: Git common directory
- fixed maintenance authority and recovery proof: exact worktree administrative directory
- migration serialization: ordered common then worktree-admin `agent-core/migration.lock` fences
- Git `info/exclude`, Task State, `.opencode/`, and `opencode.json` remain separate ownership surfaces

## Validation

- `python -m unittest discover -s tests`: PASS (537 tests)
- `just template::check`: PASS
- `just template::distribution-verify`: PASS
- `nix flake check --all-systems --no-update-lock-file`: PASS, including OpenCode policy
- `git diff --check`: PASS
- correctness review: no blocking findings
- security review: no blocking findings
- architecture review: implementation findings resolved; final documentation-only quiescence finding corrected
- Template CI contracts: PASS for exact head `93830eb30c930bd7bc33c13dd552408cbf17fd29`
- generated-template smoke: PASS for C++/CMake, Nix, Python, and Rust
- GitGuardian Security Checks: PASS

## Downstream dogfood

### Repaired merged-Task cleanup path

- exact candidate HEAD: `93830eb30c930bd7bc33c13dd552408cbf17fd29`
- exact candidate tree: `fc6963dfa130f85337f8ca91e49e76124e1c8cee`
- fixture: isolated AKV-shaped bare-remote clone with a linked `task/12-semantic-candidate-expansion` worktree; repository identity `upiscium/AgentKnowledgeVault`; terminal Task status `merged`; exact merged PR evidence bound published head `d935ab45f071ac15bae7ca8636dd5bd8ef3029a9`; remote Task branch absent
- cleanup operation: `task_lifecycle.task_cleanup` through the same implementation path as `just agent::cleanup 12`
- cleanup result: PASS; worktree removed, local Task branch removed, and Task State discarded
- legitimate OpenCode project-ID file: `<git-common-dir>/opencode`, regular file owned by UID 1000, 40 bytes, mode `0644`
- OpenCode bytes: unchanged; pre/post SHA-256 `deb87fabd17715bb31ad4cf4ffb9494eeb15f8d33d85b031a301c64ab3417eaa`
- OpenCode identity: device `2049` → `2049`; inode `7654342` → `7654342`
- OpenCode metadata: mode `0644` → `0644`; size `40` → `40`; mtime-ns `1788433275681555065` → `1788433275681555065`
- canonical result: `<git-common-dir>/agent-core` exists at mode `0700`; canonical `cleanup.lock` exists at mode `0600`; no Agent-Core-created `<git-common-dir>/opencode/` directory remains
- canonical AgentKnowledgeVault Task #12 was never accessed or modified; Task #12 above existed only inside the disposable isolated fixture

### Maintenance/source-bridge path

- exact candidate HEAD: `93830eb30c930bd7bc33c13dd552408cbf17fd29`
- exact candidate tree: `fc6963dfa130f85337f8ca91e49e76124e1c8cee`
- isolated AKV Issue #19-shaped source-bridge rebind, resume, and standard commit fixture: PASS
- OpenCode-owned Git state remains outside Agent Core ownership; migration reaches canonical terminal state
- canonical AKV Task #12 was not touched

Closes #121