### PR TITLE
Require pre-merge release evidence before candidate merge

### DIFF
--- a/docs/agent-core-release-gate.md
+++ b/docs/agent-core-release-gate.md
@@ -5,13 +5,14 @@ affect downstream repositories. It is a gate and evidence protocol, not a
 merge or release publisher. The canonical path is:
 
 ```text
-Issue -> Draft PR -> full Templates CI/review/security
-      -> freeze exact PR head
-      -> detached, clean release-candidate worktree
-      -> exact-revision AKV downstream dogfood
-      -> PASS evidence
-      -> human merge
-      -> merge-tree equality
+Issue -> Draft PR -> full CI/review/security
+      -> release-candidate-check
+      -> detached exact candidate
+      -> exact downstream dogfood
+      -> dogfood-evidence-record
+      -> release-ready-check
+      -> human Ready/Merge
+      -> release-gate-check
       -> release
 ```
 
@@ -53,6 +54,7 @@ These are the narrow operator surfaces for the release gate:
 just agent-core::release-candidate-check <pr>
 just agent-core::release-candidate-worktree <pr> <path>
 just agent-core::dogfood-evidence-record <pr> <operation> [task] [downstream_pr]
+just agent-core::release-ready-check <pr>
 just agent-core::release-gate-check <pr> <merge-commit> <dogfood-head> <dogfood-tree> [version]
 ```
 
@@ -96,6 +98,17 @@ operation identifier names the overall externally executed dogfood run. When a
 run has several required guarded steps, complete or safely resume all of them
 and record the aggregate PASS only after every applicable step has passed.
 
+`release-ready-check` is a read-only pre-merge assertion. It requires the PR to
+be open and bound to the exact current candidate, an exact successful canonical
+Template CI workflow/run/attempt and complete status rollup, and exactly one
+strict schema-v2 PASS evidence record matching the current PR, head, tree,
+downstream repository, and the same Template CI workflow/run/attempt identity.
+It revalidates those bindings immediately before the operator marks the PR
+`READY_FOR_MERGE`; it does not mark the PR ready, merge it, or publish a
+release. Dogfood described only in a PR body is not canonical release-gate
+evidence. For downstream-sensitive changes, human Ready/Merge must not occur
+before this check is PASS.
+
 `release-gate-check` is the final read-only assertion. It requires the recorded
 evidence, supplied merge commit, exact dogfooded **Templates** PR head/tree,
 and (when supplied) the intended version. It independently verifies the merged
@@ -135,7 +148,10 @@ tag. It must never reuse a tag that appeared after the gate check.
 6. Require every applicable dogfood operation to PASS. A blocked, skipped, or
    unexecuted operation is not PASS. Preserve and resume partial guarded
    downstream progress rather than resetting it or launching duplicate work.
-7. After a human merges the PR, obtain the actual merge commit and run
+7. Run `release-ready-check <pr>` immediately before the human marks the PR
+   `READY_FOR_MERGE`. This must be PASS for downstream-sensitive changes;
+   dogfood claims in the PR body alone do not satisfy the evidence gate.
+8. After the human marks the PR ready and merges it, obtain the actual merge commit and run
    `release-gate-check <pr> <merge-commit> <dogfood-head> <dogfood-tree>
    [version]`. Release only after this check is PASS and the operator has
    retained the evidence.

--- a/just/agent-core.just
+++ b/just/agent-core.just
@@ -17,6 +17,10 @@ release-candidate-check pr:
     /bin/sh {{quote(release_gate_launcher)}} {{quote(release_gate)}} release-candidate-check {{quote(pr)}}
 
 [working-directory: root]
+release-ready-check pr:
+    /bin/sh {{quote(release_gate_launcher)}} {{quote(release_gate)}} release-ready-check {{quote(pr)}}
+
+[working-directory: root]
 release-candidate-worktree pr path:
     /bin/sh {{quote(release_gate_launcher)}} {{quote(release_gate)}} release-candidate-worktree {{quote(pr)}} {{quote(path)}}
 

--- a/tests/test_agent_core_release_gate.py
+++ b/tests/test_agent_core_release_gate.py
@@ -379,6 +379,136 @@ class ReleaseGateTest(unittest.TestCase):
             target.write_text(content, encoding="utf-8")
             os.chmod(target, 0o600)
 
+    def test_release_ready_accepts_exact_open_candidate_and_v2_evidence(self) -> None:
+        record = self.evidence()
+        self.write_evidence(record, canonical_bytes=True)
+        target = gate.evidence_root(self.root, create=False) / gate.evidence_filename(record)
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            result = gate.release_ready_check(self.root, "115")
+        self.assertEqual(result["status"], "READY_FOR_MERGE")
+        self.assertEqual((result["pr"], result["head"], result["tree"]),
+                         (115, self.head, self.tree))
+        self.assertEqual(result["evidenceSha256"], hashlib.sha256(target.read_bytes()).hexdigest())
+
+    def test_release_ready_rejects_absent_evidence_root(self) -> None:
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "required directory is missing"):
+                gate.release_ready_check(self.root, "115")
+
+    def test_release_ready_rejects_previous_head_evidence(self) -> None:
+        self.write_evidence(self.evidence(head="a" * 40))
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "missing, duplicated, or stale"):
+                gate.release_ready_check(self.root, "115")
+
+    def test_release_ready_rejects_each_recorded_ci_identity_mismatch(self) -> None:
+        for field, value, message in (
+            ("workflowId", 601, "workflowId"),
+            ("workflowPath", ".github/workflows/other.yml", "workflow path"),
+            ("runId", 701, "runId"),
+            ("runAttempt", 2, "runAttempt"),
+        ):
+            with self.subTest(field=field):
+                record = self.evidence(**{field: value})
+                self.write_evidence(record)
+                target = gate.evidence_root(self.root, create=False) / gate.evidence_filename(record)
+                try:
+                    with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+                        with self.assertRaisesRegex(gate.GateError, message):
+                            gate.release_ready_check(self.root, "115")
+                finally:
+                    target.unlink()
+
+    def test_release_ready_rejects_duplicate_matching_records(self) -> None:
+        checked = {"pr": 115, "head": self.head, "tree": self.tree,
+                   "base": "main", "workflowId": 600,
+                   "workflowPath": gate.CANONICAL_WORKFLOW_PATH,
+                   "runId": 700, "runAttempt": 1, "ci": "PASS",
+                   "status": "READY_FOR_DOGFOOD"}
+        record = self.evidence()
+        with mock.patch.object(gate, "candidate", return_value=checked), mock.patch.object(
+            gate, "load_evidence_records", return_value=[(record, "a" * 64), (record, "b" * 64)]
+        ):
+            with self.assertRaisesRegex(gate.GateError, "duplicated"):
+                gate.release_ready_check(self.root, "115")
+
+    def test_release_ready_rejects_non_pass_and_legacy_evidence(self) -> None:
+        for record, message in (
+            (dict(self.evidence(), outcome="FAIL"), "outcome is not PASS"),
+            (self.evidence(version=1), "schema version 2"),
+        ):
+            with self.subTest(message=message):
+                self.write_evidence(record)
+                with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+                    with self.assertRaisesRegex(gate.GateError, message):
+                        gate.release_ready_check(self.root, "115")
+                (gate.evidence_root(self.root, create=False) / gate.evidence_filename(record)).unlink()
+
+    def test_schema_v2_requires_non_null_ci_identity(self) -> None:
+        for field in ("workflowId", "runId", "runAttempt"):
+            with self.subTest(field=field):
+                record = self.evidence(**{field: None})
+                self.write_evidence(record)
+                target = gate.evidence_root(self.root, create=False) / gate.evidence_filename(record)
+                try:
+                    with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+                        with self.assertRaisesRegex(gate.GateError, "is invalid"):
+                            gate.release_ready_check(self.root, "115")
+                finally:
+                    target.unlink()
+
+    def test_release_ready_uses_strict_evidence_file_safety(self) -> None:
+        record = self.evidence()
+        directory = gate.evidence_root(self.root, create=True)
+        target = directory / gate.evidence_filename(record)
+        content = json.dumps(record) + "\n"
+        outside = self.root / "outside.json"
+        outside.write_text(content, encoding="utf-8")
+        outside.chmod(0o600)
+
+        target.symlink_to(outside)
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "unsafe or unexpected"):
+                gate.release_ready_check(self.root, "115")
+        target.unlink()
+
+        target.write_text(content, encoding="utf-8")
+        target.chmod(0o644)
+        with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
+            with self.assertRaisesRegex(gate.GateError, "unsafe or unexpected"):
+                gate.release_ready_check(self.root, "115")
+        target.chmod(0o600)
+
+        with mock.patch.object(gate.os, "geteuid", return_value=os.geteuid() + 1), mock.patch.object(
+            gate, "gh", side_effect=self.gh_candidate()
+        ):
+            with self.assertRaisesRegex(gate.GateError, "directory is unsafe"):
+                gate.release_ready_check(self.root, "115")
+
+    def test_release_ready_rejects_closed_or_merged_pr(self) -> None:
+        for pr in (
+            self.pr(state="closed"),
+            self.pr(state="closed", merged=True, merge="c" * 40),
+        ):
+            with self.subTest(merged=pr["merged"]), mock.patch.object(
+                gate, "gh", side_effect=self.gh_candidate(pr_values=[pr])
+            ):
+                with self.assertRaisesRegex(gate.GateError, "not open"):
+                    gate.release_ready_check(self.root, "115")
+
+    def test_release_ready_rejects_candidate_change_during_final_recheck(self) -> None:
+        checked = {"pr": 115, "head": self.head, "tree": self.tree,
+                   "base": "main", "workflowId": 600,
+                   "workflowPath": gate.CANONICAL_WORKFLOW_PATH,
+                   "runId": 700, "runAttempt": 1, "ci": "PASS",
+                   "status": "READY_FOR_DOGFOOD"}
+        changed = dict(checked, head="b" * 40, tree="c" * 40)
+        with mock.patch.object(gate, "candidate", side_effect=[checked, changed]), mock.patch.object(
+            gate, "load_evidence_records", return_value=[(self.evidence(), "a" * 64)]
+        ):
+            with self.assertRaisesRegex(gate.GateError, "candidate changed"):
+                gate.release_ready_check(self.root, "115")
+
     def test_recorded_pass_evidence_contains_all_identity_bindings(self) -> None:
         with mock.patch.object(gate, "gh", side_effect=self.gh_candidate()):
             record = gate.record_evidence(self.root, "115", "dogfood-run", "116", "7")

--- a/tools/agent_core_release_gate.py
+++ b/tools/agent_core_release_gate.py
@@ -526,6 +526,36 @@ def candidate(root: Path, number: str, *, require_open: bool = True) -> dict[str
     }
 
 
+def release_ready_check(root: Path, number: str) -> dict[str, Any]:
+    """Assert that the open candidate has exactly one current v2 dogfood receipt."""
+    checked = candidate(root, number)
+    records = load_evidence_records(root, create=False)
+    matching = [
+        (record, digest)
+        for record, digest in records
+        if record["pr"] == checked["pr"]
+        and record["head"] == checked["head"]
+        and record["tree"] == checked["tree"]
+    ]
+    if len(matching) != 1:
+        raise GateError("exact current dogfood evidence is missing, duplicated, or stale")
+    evidence, evidence_digest = matching[0]
+    if evidence["version"] != 2:
+        raise GateError("release-ready evidence must use schema version 2")
+    for field in ("workflowId", "workflowPath", "runId", "runAttempt"):
+        if evidence[field] != checked[field]:
+            raise GateError(f"release-ready evidence {field} does not match the candidate")
+
+    final = candidate(root, number)
+    if final != checked:
+        raise GateError("candidate changed during release-ready validation")
+    return {
+        **checked,
+        "status": "READY_FOR_MERGE",
+        "evidenceSha256": evidence_digest,
+    }
+
+
 def validate_git_execution_configuration(root: Path) -> None:
     raw_names = git(
         ["config", "--local", "--no-includes", "--null", "--name-only", "--list"],
@@ -684,6 +714,13 @@ def positive_optional_integer(value: Any, name: str) -> int | None:
     return value
 
 
+def positive_integer(value: Any, name: str) -> int:
+    checked = positive_optional_integer(value, name)
+    if checked is None:
+        raise GateError(f"evidence {name} is invalid")
+    return checked
+
+
 def validate_timestamp(value: Any) -> str:
     if not isinstance(value, str) or not value.endswith("Z"):
         raise GateError("evidence timestamp is invalid")
@@ -734,11 +771,11 @@ def validate_evidence_payload(value: Any) -> dict[str, Any]:
     valid_sha(value["head"], "evidence head")
     valid_sha(value["tree"], "evidence tree")
     if version == 2:
-        positive_optional_integer(value["workflowId"], "workflow ID")
+        positive_integer(value["workflowId"], "workflow ID")
         if value["workflowPath"] != CANONICAL_WORKFLOW_PATH:
             raise GateError("evidence workflow path is invalid")
-        positive_optional_integer(value["runId"], "run ID")
-        positive_optional_integer(value["runAttempt"], "run attempt")
+        positive_integer(value["runId"], "run ID")
+        positive_integer(value["runAttempt"], "run attempt")
     positive_optional_integer(value["task"], "Task ID")
     positive_optional_integer(value["downstreamPr"], "downstream PR")
     if value["outcome"] != "PASS":
@@ -1118,6 +1155,8 @@ def parser() -> argparse.ArgumentParser:
     commands = result.add_subparsers(dest="command", required=True)
     candidate_parser = commands.add_parser("release-candidate-check")
     candidate_parser.add_argument("pr")
+    ready_parser = commands.add_parser("release-ready-check")
+    ready_parser.add_argument("pr")
     worktree_parser = commands.add_parser("release-candidate-worktree")
     worktree_parser.add_argument("pr")
     worktree_parser.add_argument("path")
@@ -1140,6 +1179,8 @@ def main() -> int:
     root, implementation_head = source_root()
     if arguments.command == "release-candidate-check":
         output = candidate(root, arguments.pr)
+    elif arguments.command == "release-ready-check":
+        output = release_ready_check(root, arguments.pr)
     elif arguments.command == "release-candidate-worktree":
         output = create_or_verify_worktree(root, arguments.pr, arguments.path)
     elif arguments.command == "dogfood-evidence-record":


### PR DESCRIPTION
Closes #125

## Summary
- add a read-only `agent-core::release-ready-check <pr>` boundary between evidence recording and human Ready/Merge
- require an open canonical PR, exact current head/tree, successful immutable Template CI identity and rollup, and exactly one strict schema-v2 PASS dogfood record
- re-read the complete candidate and CI identity before returning `READY_FOR_MERGE`
- document that PR-body dogfood claims are not canonical release-gate evidence and cannot replace the pre-merge check

## Verification
- `nix develop --no-update-lock-file --command python3 -m unittest tests.test_agent_core_release_gate -v` (57 tests, PASS)
- `nix develop --no-update-lock-file --command python3 -m unittest discover -s tests -v` (547 tests, PASS)
- `nix develop --no-update-lock-file --command just template::check` (PASS)
- `nix develop --no-update-lock-file --command just template::distribution-verify` (PASS)
- `nix flake check --all-systems --no-update-lock-file` (PASS)
- `nix build .#checks.x86_64-linux.opencode-policy --no-link --no-update-lock-file` (PASS)
- `git diff --check` (PASS)

## Reviews
- correctness review: PASS after tightening schema-v2 CI identity fields to required positive integers
- security review: PASS, no findings

## Risks and boundaries
- evidence remains local operator-owned state under the existing filesystem trust model
- this Draft has not been dogfooded or evidenced yet; human Ready/Merge remains blocked pending exact-head CI/review/security, downstream dogfood, `dogfood-evidence-record`, and `release-ready-check` PASS
- no merge, tag, release, AKV upgrade/cleanup, or #119/#122 work is included