### PR TITLE
Harden canonical Git-private reads at integration merge boundary

### DIFF
--- a/components/agent-core/.automation/README.md
+++ b/components/agent-core/.automation/README.md
@@ -226,6 +226,17 @@ precise `BLOCKED` condition rather than claiming migration success. Successful
 cutover removes the legacy lock last and then removes the empty `opencode/`
 directory, leaving the path available to OpenCode.
 
+Canonical reads and writes validate the actual descriptor chain. The opened Git
+administrative boundary must be owned by the effective user and must not be
+group- or world-writable; ordinary non-writable modes such as `0755` remain
+valid. Every opened directory below `agent-core/` must be owned by that user at
+exact mode `0700`, and every opened authority record must be a regular file
+owned by that user at exact mode `0600`. Traversal and record access remain
+descriptor-anchored with `O_NOFOLLOW`, and reads retain device, inode, and size
+stability checks. Recognized legacy `opencode/` state keeps its separate bounded
+migration mode policy. Hostile processes running as the same effective user are
+outside this local-filesystem trust boundary.
+
 Canonical publication is serialized by `migration.lock`. Only exact owned
 `.migrate.<pid>.<16-lowercase-hex>` and
 `.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next

--- a/components/agent-core/.automation/bin/agent_core.py
+++ b/components/agent-core/.automation/bin/agent_core.py
@@ -551,7 +551,9 @@ def integrate_merge(root: Path, pr: str) -> None:
         raise AutomationError("run integrate::check before merge")
     try:
         expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
-    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
+    except UnicodeDecodeError as exc:
         raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:

--- a/components/agent-core/.automation/bin/git_private_state.py
+++ b/components/agent-core/.automation/bin/git_private_state.py
@@ -193,23 +193,84 @@ def _open_dir(path: Path) -> int:
     return descriptor
 
 
-def _open_anchored_parent(path: Path) -> int:
-    """Open a state parent without following namespace or descendant symlinks."""
-    parts = path.parts
-    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+def _require_git_admin_descriptor(
+    descriptor: int, path: Path, what: str = "Git administrative directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir_descriptor(
+    descriptor: int, path: Path, what: str = "canonical private-state directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_file_descriptor(
+    descriptor: int, path: Path, what: str
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _namespace_marker(path: Path) -> tuple[int, str]:
+    indexes = [
+        index for index, part in enumerate(path.parts)
+        if part in {NAMESPACE, LEGACY_NAMESPACE}
+    ]
     if not indexes:
-        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+        raise GitPrivateStateError(
+            f"path is outside a recognized private-state namespace: {path}"
+        )
     marker = indexes[-1]
+    return marker, path.parts[marker]
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open and validate the descriptors that anchor a private-state parent."""
+    parts = path.parts
+    marker, namespace = _namespace_marker(path)
+    canonical = namespace == NAMESPACE
     boundary = Path(*parts[:marker])
     descriptor = _open_dir(boundary)
     try:
+        if canonical:
+            _require_git_admin_descriptor(descriptor, boundary)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        current = boundary
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            child_meta = os.fstat(child)
-            if not stat.S_ISDIR(child_meta.st_mode):
+            current /= component
+            try:
+                child_meta = os.fstat(child)
+                if not stat.S_ISDIR(child_meta.st_mode):
+                    raise GitPrivateStateError(
+                        f"unsafe private-state directory component: {current}"
+                    )
+                if canonical:
+                    _require_canonical_dir_descriptor(child, current)
+            except (GitPrivateStateError, OSError):
                 os.close(child)
-                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+                raise
             os.close(descriptor)
             descriptor = child
         return descriptor
@@ -253,10 +314,10 @@ def _ensure_child_directory(parent: Path, name: str) -> Path:
 
 
 def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
-    _require_dir(base, "Git administrative directory")
     descriptor = _open_dir(base)
     current = base
     try:
+        _require_git_admin_descriptor(descriptor, base)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
             created = False
@@ -290,13 +351,16 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
 def read_bytes_identity(
     path: Path, what: str = "private-state record"
 ) -> tuple[bytes, tuple[int, int]]:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags = (os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) |
+             getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0))
     parent_fd = _open_anchored_parent(path)
     try:
         descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         try:
             metadata = os.fstat(descriptor)
-            if not stat.S_ISREG(metadata.st_mode):
+            if _namespace_marker(path)[1] == NAMESPACE:
+                metadata = _require_canonical_file_descriptor(descriptor, path, what)
+            elif not stat.S_ISREG(metadata.st_mode):
                 raise GitPrivateStateError(f"unsafe {what}: {path}")
             chunks: list[bytes] = []
             while True:

--- a/templates/agent-base/.automation/README.md
+++ b/templates/agent-base/.automation/README.md
@@ -226,6 +226,17 @@ precise `BLOCKED` condition rather than claiming migration success. Successful
 cutover removes the legacy lock last and then removes the empty `opencode/`
 directory, leaving the path available to OpenCode.
 
+Canonical reads and writes validate the actual descriptor chain. The opened Git
+administrative boundary must be owned by the effective user and must not be
+group- or world-writable; ordinary non-writable modes such as `0755` remain
+valid. Every opened directory below `agent-core/` must be owned by that user at
+exact mode `0700`, and every opened authority record must be a regular file
+owned by that user at exact mode `0600`. Traversal and record access remain
+descriptor-anchored with `O_NOFOLLOW`, and reads retain device, inode, and size
+stability checks. Recognized legacy `opencode/` state keeps its separate bounded
+migration mode policy. Hostile processes running as the same effective user are
+outside this local-filesystem trust boundary.
+
 Canonical publication is serialized by `migration.lock`. Only exact owned
 `.migrate.<pid>.<16-lowercase-hex>` and
 `.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next

--- a/templates/agent-base/.automation/bin/agent_core.py
+++ b/templates/agent-base/.automation/bin/agent_core.py
@@ -551,7 +551,9 @@ def integrate_merge(root: Path, pr: str) -> None:
         raise AutomationError("run integrate::check before merge")
     try:
         expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
-    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
+    except UnicodeDecodeError as exc:
         raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:

--- a/templates/agent-base/.automation/bin/git_private_state.py
+++ b/templates/agent-base/.automation/bin/git_private_state.py
@@ -193,23 +193,84 @@ def _open_dir(path: Path) -> int:
     return descriptor
 
 
-def _open_anchored_parent(path: Path) -> int:
-    """Open a state parent without following namespace or descendant symlinks."""
-    parts = path.parts
-    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+def _require_git_admin_descriptor(
+    descriptor: int, path: Path, what: str = "Git administrative directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir_descriptor(
+    descriptor: int, path: Path, what: str = "canonical private-state directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_file_descriptor(
+    descriptor: int, path: Path, what: str
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _namespace_marker(path: Path) -> tuple[int, str]:
+    indexes = [
+        index for index, part in enumerate(path.parts)
+        if part in {NAMESPACE, LEGACY_NAMESPACE}
+    ]
     if not indexes:
-        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+        raise GitPrivateStateError(
+            f"path is outside a recognized private-state namespace: {path}"
+        )
     marker = indexes[-1]
+    return marker, path.parts[marker]
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open and validate the descriptors that anchor a private-state parent."""
+    parts = path.parts
+    marker, namespace = _namespace_marker(path)
+    canonical = namespace == NAMESPACE
     boundary = Path(*parts[:marker])
     descriptor = _open_dir(boundary)
     try:
+        if canonical:
+            _require_git_admin_descriptor(descriptor, boundary)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        current = boundary
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            child_meta = os.fstat(child)
-            if not stat.S_ISDIR(child_meta.st_mode):
+            current /= component
+            try:
+                child_meta = os.fstat(child)
+                if not stat.S_ISDIR(child_meta.st_mode):
+                    raise GitPrivateStateError(
+                        f"unsafe private-state directory component: {current}"
+                    )
+                if canonical:
+                    _require_canonical_dir_descriptor(child, current)
+            except (GitPrivateStateError, OSError):
                 os.close(child)
-                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+                raise
             os.close(descriptor)
             descriptor = child
         return descriptor
@@ -253,10 +314,10 @@ def _ensure_child_directory(parent: Path, name: str) -> Path:
 
 
 def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
-    _require_dir(base, "Git administrative directory")
     descriptor = _open_dir(base)
     current = base
     try:
+        _require_git_admin_descriptor(descriptor, base)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
             created = False
@@ -290,13 +351,16 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
 def read_bytes_identity(
     path: Path, what: str = "private-state record"
 ) -> tuple[bytes, tuple[int, int]]:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags = (os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) |
+             getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0))
     parent_fd = _open_anchored_parent(path)
     try:
         descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         try:
             metadata = os.fstat(descriptor)
-            if not stat.S_ISREG(metadata.st_mode):
+            if _namespace_marker(path)[1] == NAMESPACE:
+                metadata = _require_canonical_file_descriptor(descriptor, path, what)
+            elif not stat.S_ISREG(metadata.st_mode):
                 raise GitPrivateStateError(f"unsafe {what}: {path}")
             chunks: list[bytes] = []
             while True:

--- a/templates/agent-cpp-cmake/.automation/README.md
+++ b/templates/agent-cpp-cmake/.automation/README.md
@@ -226,6 +226,17 @@ precise `BLOCKED` condition rather than claiming migration success. Successful
 cutover removes the legacy lock last and then removes the empty `opencode/`
 directory, leaving the path available to OpenCode.
 
+Canonical reads and writes validate the actual descriptor chain. The opened Git
+administrative boundary must be owned by the effective user and must not be
+group- or world-writable; ordinary non-writable modes such as `0755` remain
+valid. Every opened directory below `agent-core/` must be owned by that user at
+exact mode `0700`, and every opened authority record must be a regular file
+owned by that user at exact mode `0600`. Traversal and record access remain
+descriptor-anchored with `O_NOFOLLOW`, and reads retain device, inode, and size
+stability checks. Recognized legacy `opencode/` state keeps its separate bounded
+migration mode policy. Hostile processes running as the same effective user are
+outside this local-filesystem trust boundary.
+
 Canonical publication is serialized by `migration.lock`. Only exact owned
 `.migrate.<pid>.<16-lowercase-hex>` and
 `.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next

--- a/templates/agent-cpp-cmake/.automation/bin/agent_core.py
+++ b/templates/agent-cpp-cmake/.automation/bin/agent_core.py
@@ -551,7 +551,9 @@ def integrate_merge(root: Path, pr: str) -> None:
         raise AutomationError("run integrate::check before merge")
     try:
         expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
-    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
+    except UnicodeDecodeError as exc:
         raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:

--- a/templates/agent-cpp-cmake/.automation/bin/git_private_state.py
+++ b/templates/agent-cpp-cmake/.automation/bin/git_private_state.py
@@ -193,23 +193,84 @@ def _open_dir(path: Path) -> int:
     return descriptor
 
 
-def _open_anchored_parent(path: Path) -> int:
-    """Open a state parent without following namespace or descendant symlinks."""
-    parts = path.parts
-    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+def _require_git_admin_descriptor(
+    descriptor: int, path: Path, what: str = "Git administrative directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir_descriptor(
+    descriptor: int, path: Path, what: str = "canonical private-state directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_file_descriptor(
+    descriptor: int, path: Path, what: str
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _namespace_marker(path: Path) -> tuple[int, str]:
+    indexes = [
+        index for index, part in enumerate(path.parts)
+        if part in {NAMESPACE, LEGACY_NAMESPACE}
+    ]
     if not indexes:
-        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+        raise GitPrivateStateError(
+            f"path is outside a recognized private-state namespace: {path}"
+        )
     marker = indexes[-1]
+    return marker, path.parts[marker]
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open and validate the descriptors that anchor a private-state parent."""
+    parts = path.parts
+    marker, namespace = _namespace_marker(path)
+    canonical = namespace == NAMESPACE
     boundary = Path(*parts[:marker])
     descriptor = _open_dir(boundary)
     try:
+        if canonical:
+            _require_git_admin_descriptor(descriptor, boundary)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        current = boundary
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            child_meta = os.fstat(child)
-            if not stat.S_ISDIR(child_meta.st_mode):
+            current /= component
+            try:
+                child_meta = os.fstat(child)
+                if not stat.S_ISDIR(child_meta.st_mode):
+                    raise GitPrivateStateError(
+                        f"unsafe private-state directory component: {current}"
+                    )
+                if canonical:
+                    _require_canonical_dir_descriptor(child, current)
+            except (GitPrivateStateError, OSError):
                 os.close(child)
-                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+                raise
             os.close(descriptor)
             descriptor = child
         return descriptor
@@ -253,10 +314,10 @@ def _ensure_child_directory(parent: Path, name: str) -> Path:
 
 
 def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
-    _require_dir(base, "Git administrative directory")
     descriptor = _open_dir(base)
     current = base
     try:
+        _require_git_admin_descriptor(descriptor, base)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
             created = False
@@ -290,13 +351,16 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
 def read_bytes_identity(
     path: Path, what: str = "private-state record"
 ) -> tuple[bytes, tuple[int, int]]:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags = (os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) |
+             getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0))
     parent_fd = _open_anchored_parent(path)
     try:
         descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         try:
             metadata = os.fstat(descriptor)
-            if not stat.S_ISREG(metadata.st_mode):
+            if _namespace_marker(path)[1] == NAMESPACE:
+                metadata = _require_canonical_file_descriptor(descriptor, path, what)
+            elif not stat.S_ISREG(metadata.st_mode):
                 raise GitPrivateStateError(f"unsafe {what}: {path}")
             chunks: list[bytes] = []
             while True:

--- a/templates/agent-nix/.automation/README.md
+++ b/templates/agent-nix/.automation/README.md
@@ -226,6 +226,17 @@ precise `BLOCKED` condition rather than claiming migration success. Successful
 cutover removes the legacy lock last and then removes the empty `opencode/`
 directory, leaving the path available to OpenCode.
 
+Canonical reads and writes validate the actual descriptor chain. The opened Git
+administrative boundary must be owned by the effective user and must not be
+group- or world-writable; ordinary non-writable modes such as `0755` remain
+valid. Every opened directory below `agent-core/` must be owned by that user at
+exact mode `0700`, and every opened authority record must be a regular file
+owned by that user at exact mode `0600`. Traversal and record access remain
+descriptor-anchored with `O_NOFOLLOW`, and reads retain device, inode, and size
+stability checks. Recognized legacy `opencode/` state keeps its separate bounded
+migration mode policy. Hostile processes running as the same effective user are
+outside this local-filesystem trust boundary.
+
 Canonical publication is serialized by `migration.lock`. Only exact owned
 `.migrate.<pid>.<16-lowercase-hex>` and
 `.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next

--- a/templates/agent-nix/.automation/bin/agent_core.py
+++ b/templates/agent-nix/.automation/bin/agent_core.py
@@ -551,7 +551,9 @@ def integrate_merge(root: Path, pr: str) -> None:
         raise AutomationError("run integrate::check before merge")
     try:
         expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
-    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
+    except UnicodeDecodeError as exc:
         raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:

--- a/templates/agent-nix/.automation/bin/git_private_state.py
+++ b/templates/agent-nix/.automation/bin/git_private_state.py
@@ -193,23 +193,84 @@ def _open_dir(path: Path) -> int:
     return descriptor
 
 
-def _open_anchored_parent(path: Path) -> int:
-    """Open a state parent without following namespace or descendant symlinks."""
-    parts = path.parts
-    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+def _require_git_admin_descriptor(
+    descriptor: int, path: Path, what: str = "Git administrative directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir_descriptor(
+    descriptor: int, path: Path, what: str = "canonical private-state directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_file_descriptor(
+    descriptor: int, path: Path, what: str
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _namespace_marker(path: Path) -> tuple[int, str]:
+    indexes = [
+        index for index, part in enumerate(path.parts)
+        if part in {NAMESPACE, LEGACY_NAMESPACE}
+    ]
     if not indexes:
-        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+        raise GitPrivateStateError(
+            f"path is outside a recognized private-state namespace: {path}"
+        )
     marker = indexes[-1]
+    return marker, path.parts[marker]
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open and validate the descriptors that anchor a private-state parent."""
+    parts = path.parts
+    marker, namespace = _namespace_marker(path)
+    canonical = namespace == NAMESPACE
     boundary = Path(*parts[:marker])
     descriptor = _open_dir(boundary)
     try:
+        if canonical:
+            _require_git_admin_descriptor(descriptor, boundary)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        current = boundary
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            child_meta = os.fstat(child)
-            if not stat.S_ISDIR(child_meta.st_mode):
+            current /= component
+            try:
+                child_meta = os.fstat(child)
+                if not stat.S_ISDIR(child_meta.st_mode):
+                    raise GitPrivateStateError(
+                        f"unsafe private-state directory component: {current}"
+                    )
+                if canonical:
+                    _require_canonical_dir_descriptor(child, current)
+            except (GitPrivateStateError, OSError):
                 os.close(child)
-                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+                raise
             os.close(descriptor)
             descriptor = child
         return descriptor
@@ -253,10 +314,10 @@ def _ensure_child_directory(parent: Path, name: str) -> Path:
 
 
 def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
-    _require_dir(base, "Git administrative directory")
     descriptor = _open_dir(base)
     current = base
     try:
+        _require_git_admin_descriptor(descriptor, base)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
             created = False
@@ -290,13 +351,16 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
 def read_bytes_identity(
     path: Path, what: str = "private-state record"
 ) -> tuple[bytes, tuple[int, int]]:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags = (os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) |
+             getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0))
     parent_fd = _open_anchored_parent(path)
     try:
         descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         try:
             metadata = os.fstat(descriptor)
-            if not stat.S_ISREG(metadata.st_mode):
+            if _namespace_marker(path)[1] == NAMESPACE:
+                metadata = _require_canonical_file_descriptor(descriptor, path, what)
+            elif not stat.S_ISREG(metadata.st_mode):
                 raise GitPrivateStateError(f"unsafe {what}: {path}")
             chunks: list[bytes] = []
             while True:

--- a/templates/agent-python/.automation/README.md
+++ b/templates/agent-python/.automation/README.md
@@ -226,6 +226,17 @@ precise `BLOCKED` condition rather than claiming migration success. Successful
 cutover removes the legacy lock last and then removes the empty `opencode/`
 directory, leaving the path available to OpenCode.
 
+Canonical reads and writes validate the actual descriptor chain. The opened Git
+administrative boundary must be owned by the effective user and must not be
+group- or world-writable; ordinary non-writable modes such as `0755` remain
+valid. Every opened directory below `agent-core/` must be owned by that user at
+exact mode `0700`, and every opened authority record must be a regular file
+owned by that user at exact mode `0600`. Traversal and record access remain
+descriptor-anchored with `O_NOFOLLOW`, and reads retain device, inode, and size
+stability checks. Recognized legacy `opencode/` state keeps its separate bounded
+migration mode policy. Hostile processes running as the same effective user are
+outside this local-filesystem trust boundary.
+
 Canonical publication is serialized by `migration.lock`. Only exact owned
 `.migrate.<pid>.<16-lowercase-hex>` and
 `.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next

--- a/templates/agent-python/.automation/bin/agent_core.py
+++ b/templates/agent-python/.automation/bin/agent_core.py
@@ -551,7 +551,9 @@ def integrate_merge(root: Path, pr: str) -> None:
         raise AutomationError("run integrate::check before merge")
     try:
         expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
-    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
+    except UnicodeDecodeError as exc:
         raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:

--- a/templates/agent-python/.automation/bin/git_private_state.py
+++ b/templates/agent-python/.automation/bin/git_private_state.py
@@ -193,23 +193,84 @@ def _open_dir(path: Path) -> int:
     return descriptor
 
 
-def _open_anchored_parent(path: Path) -> int:
-    """Open a state parent without following namespace or descendant symlinks."""
-    parts = path.parts
-    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+def _require_git_admin_descriptor(
+    descriptor: int, path: Path, what: str = "Git administrative directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir_descriptor(
+    descriptor: int, path: Path, what: str = "canonical private-state directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_file_descriptor(
+    descriptor: int, path: Path, what: str
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _namespace_marker(path: Path) -> tuple[int, str]:
+    indexes = [
+        index for index, part in enumerate(path.parts)
+        if part in {NAMESPACE, LEGACY_NAMESPACE}
+    ]
     if not indexes:
-        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+        raise GitPrivateStateError(
+            f"path is outside a recognized private-state namespace: {path}"
+        )
     marker = indexes[-1]
+    return marker, path.parts[marker]
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open and validate the descriptors that anchor a private-state parent."""
+    parts = path.parts
+    marker, namespace = _namespace_marker(path)
+    canonical = namespace == NAMESPACE
     boundary = Path(*parts[:marker])
     descriptor = _open_dir(boundary)
     try:
+        if canonical:
+            _require_git_admin_descriptor(descriptor, boundary)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        current = boundary
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            child_meta = os.fstat(child)
-            if not stat.S_ISDIR(child_meta.st_mode):
+            current /= component
+            try:
+                child_meta = os.fstat(child)
+                if not stat.S_ISDIR(child_meta.st_mode):
+                    raise GitPrivateStateError(
+                        f"unsafe private-state directory component: {current}"
+                    )
+                if canonical:
+                    _require_canonical_dir_descriptor(child, current)
+            except (GitPrivateStateError, OSError):
                 os.close(child)
-                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+                raise
             os.close(descriptor)
             descriptor = child
         return descriptor
@@ -253,10 +314,10 @@ def _ensure_child_directory(parent: Path, name: str) -> Path:
 
 
 def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
-    _require_dir(base, "Git administrative directory")
     descriptor = _open_dir(base)
     current = base
     try:
+        _require_git_admin_descriptor(descriptor, base)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
             created = False
@@ -290,13 +351,16 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
 def read_bytes_identity(
     path: Path, what: str = "private-state record"
 ) -> tuple[bytes, tuple[int, int]]:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags = (os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) |
+             getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0))
     parent_fd = _open_anchored_parent(path)
     try:
         descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         try:
             metadata = os.fstat(descriptor)
-            if not stat.S_ISREG(metadata.st_mode):
+            if _namespace_marker(path)[1] == NAMESPACE:
+                metadata = _require_canonical_file_descriptor(descriptor, path, what)
+            elif not stat.S_ISREG(metadata.st_mode):
                 raise GitPrivateStateError(f"unsafe {what}: {path}")
             chunks: list[bytes] = []
             while True:

--- a/templates/agent-rust/.automation/README.md
+++ b/templates/agent-rust/.automation/README.md
@@ -226,6 +226,17 @@ precise `BLOCKED` condition rather than claiming migration success. Successful
 cutover removes the legacy lock last and then removes the empty `opencode/`
 directory, leaving the path available to OpenCode.
 
+Canonical reads and writes validate the actual descriptor chain. The opened Git
+administrative boundary must be owned by the effective user and must not be
+group- or world-writable; ordinary non-writable modes such as `0755` remain
+valid. Every opened directory below `agent-core/` must be owned by that user at
+exact mode `0700`, and every opened authority record must be a regular file
+owned by that user at exact mode `0600`. Traversal and record access remain
+descriptor-anchored with `O_NOFOLLOW`, and reads retain device, inode, and size
+stability checks. Recognized legacy `opencode/` state keeps its separate bounded
+migration mode policy. Hostile processes running as the same effective user are
+outside this local-filesystem trust boundary.
+
 Canonical publication is serialized by `migration.lock`. Only exact owned
 `.migrate.<pid>.<16-lowercase-hex>` and
 `.record.<pid>.<16-lowercase-hex>` artifacts are recoverable. On the next

--- a/templates/agent-rust/.automation/bin/agent_core.py
+++ b/templates/agent-rust/.automation/bin/agent_core.py
@@ -551,7 +551,9 @@ def integrate_merge(root: Path, pr: str) -> None:
         raise AutomationError("run integrate::check before merge")
     try:
         expected = private_state.read_bytes(checkpoint, "integration checkpoint").decode("utf-8").strip()
-    except (private_state.GitPrivateStateError, UnicodeDecodeError) as exc:
+    except private_state.GitPrivateStateError as exc:
+        raise AutomationError(str(exc)) from exc
+    except UnicodeDecodeError as exc:
         raise AutomationError("integration checkpoint is invalid") from exc
     data = validate_integration(root, pr)
     if data["headRefOid"] != expected:

--- a/templates/agent-rust/.automation/bin/git_private_state.py
+++ b/templates/agent-rust/.automation/bin/git_private_state.py
@@ -193,23 +193,84 @@ def _open_dir(path: Path) -> int:
     return descriptor
 
 
-def _open_anchored_parent(path: Path) -> int:
-    """Open a state parent without following namespace or descendant symlinks."""
-    parts = path.parts
-    indexes = [index for index, part in enumerate(parts) if part in {NAMESPACE, LEGACY_NAMESPACE}]
+def _require_git_admin_descriptor(
+    descriptor: int, path: Path, what: str = "Git administrative directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_dir_descriptor(
+    descriptor: int, path: Path, what: str = "canonical private-state directory"
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _require_canonical_file_descriptor(
+    descriptor: int, path: Path, what: str
+) -> os.stat_result:
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(metadata.st_mode):
+        raise GitPrivateStateError(f"unsafe {what}: {path}")
+    if metadata.st_uid != os.geteuid():
+        raise GitPrivateStateError(f"unsafe {what} ownership: {path}")
+    if stat.S_IMODE(metadata.st_mode) != 0o600:
+        raise GitPrivateStateError(f"unsafe {what} mode: {path}")
+    return metadata
+
+
+def _namespace_marker(path: Path) -> tuple[int, str]:
+    indexes = [
+        index for index, part in enumerate(path.parts)
+        if part in {NAMESPACE, LEGACY_NAMESPACE}
+    ]
     if not indexes:
-        raise GitPrivateStateError(f"path is outside a recognized private-state namespace: {path}")
+        raise GitPrivateStateError(
+            f"path is outside a recognized private-state namespace: {path}"
+        )
     marker = indexes[-1]
+    return marker, path.parts[marker]
+
+
+def _open_anchored_parent(path: Path) -> int:
+    """Open and validate the descriptors that anchor a private-state parent."""
+    parts = path.parts
+    marker, namespace = _namespace_marker(path)
+    canonical = namespace == NAMESPACE
     boundary = Path(*parts[:marker])
     descriptor = _open_dir(boundary)
     try:
+        if canonical:
+            _require_git_admin_descriptor(descriptor, boundary)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        current = boundary
         for component in parts[marker:-1]:
             child = os.open(component, flags, dir_fd=descriptor)
-            child_meta = os.fstat(child)
-            if not stat.S_ISDIR(child_meta.st_mode):
+            current /= component
+            try:
+                child_meta = os.fstat(child)
+                if not stat.S_ISDIR(child_meta.st_mode):
+                    raise GitPrivateStateError(
+                        f"unsafe private-state directory component: {current}"
+                    )
+                if canonical:
+                    _require_canonical_dir_descriptor(child, current)
+            except (GitPrivateStateError, OSError):
                 os.close(child)
-                raise GitPrivateStateError(f"unsafe private-state directory component: {component}")
+                raise
             os.close(descriptor)
             descriptor = child
         return descriptor
@@ -253,10 +314,10 @@ def _ensure_child_directory(parent: Path, name: str) -> Path:
 
 
 def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
-    _require_dir(base, "Git administrative directory")
     descriptor = _open_dir(base)
     current = base
     try:
+        _require_git_admin_descriptor(descriptor, base)
         flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
         for name in (NAMESPACE, *subdirectories):
             created = False
@@ -290,13 +351,16 @@ def _ensure_namespace(base: Path, subdirectories: tuple[str, ...]) -> Path:
 def read_bytes_identity(
     path: Path, what: str = "private-state record"
 ) -> tuple[bytes, tuple[int, int]]:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags = (os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0) |
+             getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NONBLOCK", 0))
     parent_fd = _open_anchored_parent(path)
     try:
         descriptor = os.open(path.name, flags, dir_fd=parent_fd)
         try:
             metadata = os.fstat(descriptor)
-            if not stat.S_ISREG(metadata.st_mode):
+            if _namespace_marker(path)[1] == NAMESPACE:
+                metadata = _require_canonical_file_descriptor(descriptor, path, what)
+            elif not stat.S_ISREG(metadata.st_mode):
                 raise GitPrivateStateError(f"unsafe {what}: {path}")
             chunks: list[bytes] = []
             while True:

--- a/tests/test_agent_core_automation.py
+++ b/tests/test_agent_core_automation.py
@@ -84,7 +84,10 @@ class AgentCoreSafetyTest(unittest.TestCase):
             root = Path(directory)
             checkpoint = root / "agent-core" / "integration" / "checkpoint"
             checkpoint.parent.mkdir(parents=True)
+            checkpoint.parent.parent.chmod(0o700)
+            checkpoint.parent.chmod(0o700)
             checkpoint.write_text("old-head\n", encoding="utf-8")
+            checkpoint.chmod(0o600)
             with (
                 mock.patch.object(agent_core, "integration_checkpoint", return_value=checkpoint),
                 mock.patch.object(
@@ -95,6 +98,56 @@ class AgentCoreSafetyTest(unittest.TestCase):
                 self.assertRaisesRegex(agent_core.AutomationError, "head moved"),
             ):
                 agent_core.integrate_merge(root, "10")
+
+    def test_integration_merge_accepts_valid_unchanged_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoint = root / "agent-core/integration/checkpoint"
+            checkpoint.parent.mkdir(parents=True)
+            checkpoint.parent.parent.chmod(0o700)
+            checkpoint.parent.chmod(0o700)
+            checkpoint.write_text("current-head\n", encoding="utf-8")
+            checkpoint.chmod(0o600)
+            with (
+                mock.patch.object(
+                    agent_core, "integration_checkpoint", return_value=checkpoint
+                ),
+                mock.patch.object(
+                    agent_core,
+                    "validate_integration",
+                    return_value={"headRefOid": "current-head", "number": 10},
+                ),
+                mock.patch.object(agent_core, "gh") as merge,
+            ):
+                agent_core.integrate_merge(root, "10")
+            merge.assert_called_once_with(
+                "pr", "merge", "10", "--squash", "--match-head-commit",
+                "current-head", cwd=root
+            )
+
+    def test_integration_merge_rejects_unsafe_canonical_checkpoint_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(
+                ["git", "init", "-b", "main"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+            )
+            details = {"number": 12, "headRefOid": "a" * 40}
+            with mock.patch.object(agent_core, "validate_integration", return_value=details):
+                agent_core.integrate_check(root, "12")
+            checkpoint = root / ".git/agent-core/integration/pr-12.head"
+            checkpoint.chmod(0o644)
+
+            with (
+                mock.patch.object(agent_core, "validate_integration") as validate,
+                mock.patch.object(agent_core, "gh") as merge,
+                self.assertRaisesRegex(agent_core.AutomationError, "unsafe integration checkpoint"),
+            ):
+                agent_core.integrate_merge(root, "12")
+            validate.assert_not_called()
+            merge.assert_not_called()
 
 
 class PublicationMetadataTest(unittest.TestCase):

--- a/tests/test_git_private_state.py
+++ b/tests/test_git_private_state.py
@@ -141,6 +141,248 @@ class GitPrivateStateTest(unittest.TestCase):
             self.assertEqual(before, self.identity(foreign))
             self.assertEqual(b"0123456789abcdef0123456789abcdef01234567", foreign.read_bytes())
 
+    def canonical_checkpoint(self, root: Path) -> tuple[Path, Path]:
+        repo = self.repository(root)
+        private_state.prepare(repo)
+        checkpoint = private_state.integration_checkpoint(repo, "12")
+        private_state.write_bytes(checkpoint, b"a" * 40 + b"\n")
+        return repo, checkpoint
+
+    def test_canonical_read_validates_opened_descriptors(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo, checkpoint = self.canonical_checkpoint(Path(directory))
+            common = private_state.common_git_dir(repo)
+            common.chmod(0o755)
+            self.assertEqual(0o700, stat.S_IMODE((common / "agent-core").stat().st_mode))
+            self.assertEqual(
+                0o700, stat.S_IMODE((common / "agent-core/integration").stat().st_mode)
+            )
+            self.assertEqual(0o600, stat.S_IMODE(checkpoint.stat().st_mode))
+            self.assertEqual(b"a" * 40 + b"\n", private_state.read_bytes(checkpoint))
+
+    def test_canonical_read_rejects_unsafe_directory_and_record_modes(self) -> None:
+        cases = (
+            ("namespace", "agent-core", 0o755),
+            ("subdirectory", "agent-core/integration", 0o755),
+            ("record", "agent-core/integration/pr-12.head", 0o644),
+        )
+        for case, relative, mode in cases:
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                repo, checkpoint = self.canonical_checkpoint(Path(directory))
+                common = private_state.common_git_dir(repo)
+                (common / relative).chmod(mode)
+                with self.assertRaisesRegex(private_state.GitPrivateStateError, "unsafe.*mode"):
+                    private_state.read_bytes(checkpoint, "integration checkpoint")
+
+    def test_canonical_read_rejects_writable_git_admin_boundary(self) -> None:
+        for mode in (0o775, 0o757):
+            with self.subTest(mode=oct(mode)), tempfile.TemporaryDirectory() as directory:
+                repo, checkpoint = self.canonical_checkpoint(Path(directory))
+                private_state.common_git_dir(repo).chmod(mode)
+                with self.assertRaisesRegex(
+                    private_state.GitPrivateStateError,
+                    "unsafe Git administrative directory mode",
+                ):
+                    private_state.read_bytes(checkpoint)
+
+    def test_canonical_write_rejects_writable_git_admin_boundary(self) -> None:
+        for mode in (0o775, 0o757):
+            with self.subTest(mode=oct(mode)), tempfile.TemporaryDirectory() as directory:
+                repo = self.repository(Path(directory))
+                common = private_state.common_git_dir(repo)
+                common.chmod(mode)
+                with self.assertRaisesRegex(
+                    private_state.GitPrivateStateError,
+                    "unsafe Git administrative directory mode",
+                ):
+                    private_state.prepare(repo)
+                self.assertFalse((common / "agent-core").exists())
+
+    def test_canonical_read_rejects_invalid_descriptor_ownership(self) -> None:
+        cases = (
+            ("admin", "_require_git_admin_descriptor", ".git"),
+            ("namespace", "_require_canonical_dir_descriptor", ".git/agent-core"),
+            ("subdirectory", "_require_canonical_dir_descriptor",
+             ".git/agent-core/integration"),
+            ("record", "_require_canonical_file_descriptor",
+             ".git/agent-core/integration/pr-12.head"),
+        )
+        for case, helper_name, suffix in cases:
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                repo, checkpoint = self.canonical_checkpoint(Path(directory))
+                expected = (repo / suffix).resolve()
+                original = getattr(private_state, helper_name)
+                effective_uid = private_state.os.geteuid()
+
+                def require_wrong_owner(descriptor, path, *args, **kwargs):
+                    if path.resolve() == expected:
+                        with mock.patch.object(
+                            private_state.os, "geteuid", return_value=effective_uid + 1
+                        ):
+                            return original(descriptor, path, *args, **kwargs)
+                    return original(descriptor, path, *args, **kwargs)
+
+                with (
+                    mock.patch.object(
+                        private_state, helper_name, side_effect=require_wrong_owner
+                    ),
+                    self.assertRaisesRegex(
+                        private_state.GitPrivateStateError, "unsafe.*ownership"
+                    ),
+                ):
+                    private_state.read_bytes(checkpoint)
+
+    def test_canonical_read_rejects_symlinks_and_special_record(self) -> None:
+        cases = ("namespace", "subdirectory", "record", "fifo")
+        for case in cases:
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                repo, checkpoint = self.canonical_checkpoint(root)
+                common = private_state.common_git_dir(repo)
+                outside = root / "outside"
+                outside.mkdir(mode=0o700)
+                if case == "namespace":
+                    namespace = common / "agent-core"
+                    namespace.rename(common / "agent-core-saved")
+                    namespace.symlink_to(outside, target_is_directory=True)
+                elif case == "subdirectory":
+                    integration = common / "agent-core/integration"
+                    integration.rename(common / "agent-core/integration-saved")
+                    integration.symlink_to(outside, target_is_directory=True)
+                else:
+                    checkpoint.unlink()
+                    if case == "record":
+                        target = outside / "checkpoint"
+                        target.write_bytes(b"a" * 40 + b"\n")
+                        target.chmod(0o600)
+                        checkpoint.symlink_to(target)
+                    else:
+                        os.mkfifo(checkpoint, 0o600)
+                with self.assertRaises(private_state.GitPrivateStateError):
+                    private_state.read_bytes(checkpoint)
+
+    def test_canonical_directory_replacement_during_traversal_is_revalidated(self) -> None:
+        for case in ("namespace", "subdirectory"):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                repo, checkpoint = self.canonical_checkpoint(root)
+                common = private_state.common_git_dir(repo)
+                replacement = root / "replacement"
+                if case == "namespace":
+                    (replacement / "integration").mkdir(parents=True, mode=0o700)
+                    alternate = replacement / "integration/pr-12.head"
+                    trigger = "agent-core"
+                    destination = common / "agent-core"
+                else:
+                    replacement.mkdir(mode=0o755)
+                    alternate = replacement / "pr-12.head"
+                    trigger = "integration"
+                    destination = common / "agent-core/integration"
+                alternate.write_bytes(b"b" * 40 + b"\n")
+                alternate.chmod(0o600)
+                if case == "namespace":
+                    replacement.chmod(0o755)
+                real_open = private_state.os.open
+                replaced = False
+
+                def replace_then_open(path, flags, *args, **kwargs):
+                    nonlocal replaced
+                    if path == trigger and kwargs.get("dir_fd") is not None and not replaced:
+                        replaced = True
+                        destination.rename(destination.with_name(destination.name + "-saved"))
+                        replacement.rename(destination)
+                    return real_open(path, flags, *args, **kwargs)
+
+                with (
+                    mock.patch.object(
+                        private_state.os, "open", side_effect=replace_then_open
+                    ),
+                    self.assertRaisesRegex(
+                        private_state.GitPrivateStateError, "unsafe.*mode"
+                    ),
+                ):
+                    private_state.read_bytes(checkpoint)
+
+    def test_checkpoint_replacement_before_open_is_revalidated(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            _, checkpoint = self.canonical_checkpoint(Path(directory))
+            real_open = private_state.os.open
+            replaced = False
+
+            def replace_then_open(path, flags, *args, **kwargs):
+                nonlocal replaced
+                if path == checkpoint.name and kwargs.get("dir_fd") is not None and not replaced:
+                    replaced = True
+                    checkpoint.unlink()
+                    checkpoint.write_bytes(b"b" * 40 + b"\n")
+                    checkpoint.chmod(0o644)
+                return real_open(path, flags, *args, **kwargs)
+
+            with (
+                mock.patch.object(private_state.os, "open", side_effect=replace_then_open),
+                self.assertRaisesRegex(private_state.GitPrivateStateError, "unsafe.*mode"),
+            ):
+                private_state.read_bytes(checkpoint)
+
+    def test_canonical_read_rejects_size_change_during_read(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            _, checkpoint = self.canonical_checkpoint(Path(directory))
+            real_read = private_state.os.read
+            changed = False
+
+            def mutate_then_read(descriptor, size):
+                nonlocal changed
+                chunk = real_read(descriptor, size)
+                if not changed:
+                    changed = True
+                    with checkpoint.open("ab") as handle:
+                        handle.write(b"changed")
+                return chunk
+
+            with (
+                mock.patch.object(private_state.os, "read", side_effect=mutate_then_read),
+                self.assertRaisesRegex(
+                    private_state.GitPrivateStateError, "changed while reading"
+                ),
+            ):
+                private_state.read_bytes(checkpoint)
+
+    def test_all_canonical_authority_record_kinds_share_strict_read(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            private_state.prepare(repo, admin=True)
+            paths = (
+                private_state.cleanup_receipt(repo, "1"),
+                private_state.discard_receipt(repo, "1"),
+                private_state.integration_checkpoint(repo, "1"),
+                private_state.admin_maintenance(repo) / "authority.json",
+                private_state.admin_maintenance(repo) / "source-recovery-proof.json",
+            )
+            for path in paths:
+                private_state.write_bytes(path, b"authority")
+                path.chmod(0o644)
+                with self.subTest(path=path), self.assertRaisesRegex(
+                    private_state.GitPrivateStateError, "unsafe.*mode"
+                ):
+                    private_state.read_bytes(path)
+                path.chmod(0o600)
+
+    def test_legacy_namespace_is_not_confused_by_agent_core_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            parent = Path(directory) / "agent-core"
+            parent.mkdir()
+            repo = self.repository(parent)
+            common = private_state.common_git_dir(repo)
+            legacy = common / "opencode/integration/pr-12.head"
+            legacy.parent.mkdir(parents=True)
+            legacy.write_bytes(b"a" * 40 + b"\n")
+
+            private_state.prepare(repo)
+
+            self.assertFalse((common / "opencode").exists())
+            canonical = common / "agent-core/integration/pr-12.head"
+            self.assertEqual(b"a" * 40 + b"\n", private_state.read_bytes(canonical))
+
     def test_all_recognized_legacy_records_migrate_exactly(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             repo = self.repository(Path(directory))


### PR DESCRIPTION
## Summary

- validate the opened Git administrative directory, canonical namespace directories, and authority records through descriptor-bound ownership and mode checks
- make canonical reads and writes fail closed for writable administrative boundaries, unsafe topology, and invalid record types while preserving legacy `opencode` migration semantics
- keep integration merge freshness checks and `--match-head-commit`, with precise private-state integrity failures
- regenerate all distributed templates from Agent Core source

## Validation

- focused private-state tests: 47 passed
- focused integration boundary tests: 8 passed
- full Python unittest suite: 560 passed
- `just template::check`
- `just template::distribution-verify`
- `nix flake check --all-systems --no-update-lock-file`
- OpenCodePolicy derivation
- `git diff --check`
- correctness review: PASS
- security review: PASS, no High/Medium findings

## Known limitation

Hostile processes running as the same effective UID remain outside the documented local-filesystem trust boundary.

## Release boundary

Release-candidate checks and downstream-shaped dogfood are intentionally deferred until this exact Draft PR head has received human review.

Closes #127