### PR TITLE
Fix publication review supersession after blocked Work Units

### DIFF
--- a/components/agent-core/.automation/bin/publication_metadata.py
+++ b/components/agent-core/.automation/bin/publication_metadata.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 
 import task_contract
+import task_lifecycle
 
 
 class PublicationMetadataError(RuntimeError):
@@ -103,18 +104,36 @@ def completed_reviews(root: Path, task: str) -> list[str]:
         return []
     if value.get("task_id") != task or not isinstance(value.get("units"), dict):
         raise PublicationMetadataError("Work Unit evidence does not match the Task")
-    reviews = []
+    effective: dict[str, tuple[int, str, dict]] = {}
     for identifier, unit in value["units"].items():
         if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
             continue
+        sequence = (
+            task_lifecycle.canonical_work_unit_sequence(task, identifier)
+            if isinstance(identifier, str)
+            else None
+        )
+        if sequence is None:
+            raise PublicationMetadataError(
+                f"review Work Unit has no canonical sequence: {identifier}"
+            )
+        role = unit["requested_role"]
+        if role not in effective or sequence > effective[role][0]:
+            effective[role] = (sequence, identifier, unit)
+
+    reviews = []
+    for role in ("reviewer", "security-reviewer"):
+        if role not in effective:
+            continue
+        _, identifier, unit = effective[role]
         if unit.get("state") != "completed":
             raise PublicationMetadataError(
-                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+                f"required {role} Work Unit is not completed: {identifier}"
             )
         transitions = unit.get("transitions")
         digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
-        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
-            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{role}` — completed — evidence `{digest}`")
     return reviews
 
 

--- a/templates/agent-base/.automation/bin/publication_metadata.py
+++ b/templates/agent-base/.automation/bin/publication_metadata.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 
 import task_contract
+import task_lifecycle
 
 
 class PublicationMetadataError(RuntimeError):
@@ -103,18 +104,36 @@ def completed_reviews(root: Path, task: str) -> list[str]:
         return []
     if value.get("task_id") != task or not isinstance(value.get("units"), dict):
         raise PublicationMetadataError("Work Unit evidence does not match the Task")
-    reviews = []
+    effective: dict[str, tuple[int, str, dict]] = {}
     for identifier, unit in value["units"].items():
         if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
             continue
+        sequence = (
+            task_lifecycle.canonical_work_unit_sequence(task, identifier)
+            if isinstance(identifier, str)
+            else None
+        )
+        if sequence is None:
+            raise PublicationMetadataError(
+                f"review Work Unit has no canonical sequence: {identifier}"
+            )
+        role = unit["requested_role"]
+        if role not in effective or sequence > effective[role][0]:
+            effective[role] = (sequence, identifier, unit)
+
+    reviews = []
+    for role in ("reviewer", "security-reviewer"):
+        if role not in effective:
+            continue
+        _, identifier, unit = effective[role]
         if unit.get("state") != "completed":
             raise PublicationMetadataError(
-                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+                f"required {role} Work Unit is not completed: {identifier}"
             )
         transitions = unit.get("transitions")
         digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
-        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
-            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{role}` — completed — evidence `{digest}`")
     return reviews
 
 

--- a/templates/agent-cpp-cmake/.automation/bin/publication_metadata.py
+++ b/templates/agent-cpp-cmake/.automation/bin/publication_metadata.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 
 import task_contract
+import task_lifecycle
 
 
 class PublicationMetadataError(RuntimeError):
@@ -103,18 +104,36 @@ def completed_reviews(root: Path, task: str) -> list[str]:
         return []
     if value.get("task_id") != task or not isinstance(value.get("units"), dict):
         raise PublicationMetadataError("Work Unit evidence does not match the Task")
-    reviews = []
+    effective: dict[str, tuple[int, str, dict]] = {}
     for identifier, unit in value["units"].items():
         if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
             continue
+        sequence = (
+            task_lifecycle.canonical_work_unit_sequence(task, identifier)
+            if isinstance(identifier, str)
+            else None
+        )
+        if sequence is None:
+            raise PublicationMetadataError(
+                f"review Work Unit has no canonical sequence: {identifier}"
+            )
+        role = unit["requested_role"]
+        if role not in effective or sequence > effective[role][0]:
+            effective[role] = (sequence, identifier, unit)
+
+    reviews = []
+    for role in ("reviewer", "security-reviewer"):
+        if role not in effective:
+            continue
+        _, identifier, unit = effective[role]
         if unit.get("state") != "completed":
             raise PublicationMetadataError(
-                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+                f"required {role} Work Unit is not completed: {identifier}"
             )
         transitions = unit.get("transitions")
         digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
-        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
-            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{role}` — completed — evidence `{digest}`")
     return reviews
 
 

--- a/templates/agent-nix/.automation/bin/publication_metadata.py
+++ b/templates/agent-nix/.automation/bin/publication_metadata.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 
 import task_contract
+import task_lifecycle
 
 
 class PublicationMetadataError(RuntimeError):
@@ -103,18 +104,36 @@ def completed_reviews(root: Path, task: str) -> list[str]:
         return []
     if value.get("task_id") != task or not isinstance(value.get("units"), dict):
         raise PublicationMetadataError("Work Unit evidence does not match the Task")
-    reviews = []
+    effective: dict[str, tuple[int, str, dict]] = {}
     for identifier, unit in value["units"].items():
         if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
             continue
+        sequence = (
+            task_lifecycle.canonical_work_unit_sequence(task, identifier)
+            if isinstance(identifier, str)
+            else None
+        )
+        if sequence is None:
+            raise PublicationMetadataError(
+                f"review Work Unit has no canonical sequence: {identifier}"
+            )
+        role = unit["requested_role"]
+        if role not in effective or sequence > effective[role][0]:
+            effective[role] = (sequence, identifier, unit)
+
+    reviews = []
+    for role in ("reviewer", "security-reviewer"):
+        if role not in effective:
+            continue
+        _, identifier, unit = effective[role]
         if unit.get("state") != "completed":
             raise PublicationMetadataError(
-                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+                f"required {role} Work Unit is not completed: {identifier}"
             )
         transitions = unit.get("transitions")
         digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
-        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
-            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{role}` — completed — evidence `{digest}`")
     return reviews
 
 

--- a/templates/agent-python/.automation/bin/publication_metadata.py
+++ b/templates/agent-python/.automation/bin/publication_metadata.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 
 import task_contract
+import task_lifecycle
 
 
 class PublicationMetadataError(RuntimeError):
@@ -103,18 +104,36 @@ def completed_reviews(root: Path, task: str) -> list[str]:
         return []
     if value.get("task_id") != task or not isinstance(value.get("units"), dict):
         raise PublicationMetadataError("Work Unit evidence does not match the Task")
-    reviews = []
+    effective: dict[str, tuple[int, str, dict]] = {}
     for identifier, unit in value["units"].items():
         if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
             continue
+        sequence = (
+            task_lifecycle.canonical_work_unit_sequence(task, identifier)
+            if isinstance(identifier, str)
+            else None
+        )
+        if sequence is None:
+            raise PublicationMetadataError(
+                f"review Work Unit has no canonical sequence: {identifier}"
+            )
+        role = unit["requested_role"]
+        if role not in effective or sequence > effective[role][0]:
+            effective[role] = (sequence, identifier, unit)
+
+    reviews = []
+    for role in ("reviewer", "security-reviewer"):
+        if role not in effective:
+            continue
+        _, identifier, unit = effective[role]
         if unit.get("state") != "completed":
             raise PublicationMetadataError(
-                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+                f"required {role} Work Unit is not completed: {identifier}"
             )
         transitions = unit.get("transitions")
         digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
-        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
-            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{role}` — completed — evidence `{digest}`")
     return reviews
 
 

--- a/templates/agent-rust/.automation/bin/publication_metadata.py
+++ b/templates/agent-rust/.automation/bin/publication_metadata.py
@@ -8,6 +8,7 @@ import re
 from pathlib import Path
 
 import task_contract
+import task_lifecycle
 
 
 class PublicationMetadataError(RuntimeError):
@@ -103,18 +104,36 @@ def completed_reviews(root: Path, task: str) -> list[str]:
         return []
     if value.get("task_id") != task or not isinstance(value.get("units"), dict):
         raise PublicationMetadataError("Work Unit evidence does not match the Task")
-    reviews = []
+    effective: dict[str, tuple[int, str, dict]] = {}
     for identifier, unit in value["units"].items():
         if not isinstance(unit, dict) or unit.get("requested_role") not in {"reviewer", "security-reviewer"}:
             continue
+        sequence = (
+            task_lifecycle.canonical_work_unit_sequence(task, identifier)
+            if isinstance(identifier, str)
+            else None
+        )
+        if sequence is None:
+            raise PublicationMetadataError(
+                f"review Work Unit has no canonical sequence: {identifier}"
+            )
+        role = unit["requested_role"]
+        if role not in effective or sequence > effective[role][0]:
+            effective[role] = (sequence, identifier, unit)
+
+    reviews = []
+    for role in ("reviewer", "security-reviewer"):
+        if role not in effective:
+            continue
+        _, identifier, unit = effective[role]
         if unit.get("state") != "completed":
             raise PublicationMetadataError(
-                f"required {unit.get('requested_role')} Work Unit is not completed: {identifier}"
+                f"required {role} Work Unit is not completed: {identifier}"
             )
         transitions = unit.get("transitions")
         digest = transitions[-1].get("evidence_sha256") if isinstance(transitions, list) and transitions else None
-        if isinstance(identifier, str) and isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
-            reviews.append(f"- `{identifier}` — `{unit['requested_role']}` — completed — evidence `{digest}`")
+        if isinstance(digest, str) and re.fullmatch(r"[0-9a-f]{64}", digest):
+            reviews.append(f"- `{identifier}` — `{role}` — completed — evidence `{digest}`")
     return reviews
 
 

--- a/tests/test_agent_core_automation.py
+++ b/tests/test_agent_core_automation.py
@@ -153,6 +153,26 @@ class AgentCoreSafetyTest(unittest.TestCase):
 class PublicationMetadataTest(unittest.TestCase):
     HEAD = "a" * 40
 
+    @staticmethod
+    def unit(role: str, state: str, digest: str = "c") -> dict:
+        return {
+            "requested_role": role,
+            "state": state,
+            "transitions": [{"evidence_sha256": digest * 64}],
+        }
+
+    def write_work_units(self, root: Path, units: list[tuple[str, dict]]) -> None:
+        (root / ".task-state" / "work-units.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "task_id": "19",
+                    "units": dict(units),
+                }
+            ),
+            encoding="utf-8",
+        )
+
     def test_canonical_pr_body_matches_allows_only_one_terminal_lf(self) -> None:
         matches = agent_core.publication.canonical_pr_body_matches
         self.assertTrue(matches("canonical body", "canonical body"))
@@ -237,22 +257,9 @@ None yet.
             encoding="utf-8",
         )
         if reviews:
-            digest = "c" * 64
-            (state / "work-units.json").write_text(
-                json.dumps(
-                    {
-                        "schema_version": 1,
-                        "task_id": "19",
-                        "units": {
-                            "WU-19-04": {
-                                "requested_role": "reviewer",
-                                "state": "completed",
-                                "transitions": [{"evidence_sha256": digest}],
-                            },
-                        },
-                    }
-                ),
-                encoding="utf-8",
+            self.write_work_units(
+                root,
+                [("WU-19-04", self.unit("reviewer", "completed"))],
             )
 
     def test_untouched_default_template_is_rejected(self) -> None:
@@ -348,6 +355,172 @@ None yet.
             root = Path(directory)
             self.fixture(root, reviews=False)
             with self.assertRaisesRegex(agent_core.publication.PublicationMetadataError, "completed reviewer"):
+                agent_core.publication.canonical_metadata(
+                    root, "19", head=self.HEAD, changed_paths=["one"]
+                )
+
+    def test_blocked_reviewer_is_superseded_by_later_completed_reviewer(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            self.write_work_units(
+                root,
+                [
+                    ("WU-19-04", self.unit("reviewer", "blocked", "b")),
+                    ("WU-19-05", self.unit("reviewer", "completed", "c")),
+                ],
+            )
+            _, body = agent_core.publication.canonical_metadata(
+                root, "19", head=self.HEAD, changed_paths=["one"]
+            )
+            self.assertIn("`WU-19-05` — `reviewer` — completed", body)
+            self.assertNotIn("WU-19-04", body)
+
+    def test_later_blocked_reviewer_supersedes_completed_reviewer(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            self.write_work_units(
+                root,
+                [
+                    ("WU-19-04", self.unit("reviewer", "completed")),
+                    ("WU-19-05", self.unit("reviewer", "blocked")),
+                ],
+            )
+            with self.assertRaisesRegex(
+                agent_core.publication.PublicationMetadataError,
+                "reviewer Work Unit is not completed: WU-19-05",
+            ):
+                agent_core.publication.canonical_metadata(
+                    root, "19", head=self.HEAD, changed_paths=["one"]
+                )
+
+    def test_blocked_security_review_is_superseded_by_later_completed_review(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            self.write_work_units(
+                root,
+                [
+                    ("WU-19-04", self.unit("reviewer", "completed")),
+                    ("WU-19-05", self.unit("security-reviewer", "blocked", "b")),
+                    ("WU-19-06", self.unit("security-reviewer", "completed", "d")),
+                ],
+            )
+            _, body = agent_core.publication.canonical_metadata(
+                root, "19", head=self.HEAD, changed_paths=["one"]
+            )
+            self.assertIn("`WU-19-06` — `security-reviewer` — completed", body)
+            self.assertNotIn("WU-19-05", body)
+
+    def test_later_blocked_security_review_supersedes_completed_review(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            self.write_work_units(
+                root,
+                [
+                    ("WU-19-04", self.unit("reviewer", "completed")),
+                    ("WU-19-05", self.unit("security-reviewer", "completed")),
+                    ("WU-19-06", self.unit("security-reviewer", "blocked")),
+                ],
+            )
+            with self.assertRaisesRegex(
+                agent_core.publication.PublicationMetadataError,
+                "security-reviewer Work Unit is not completed: WU-19-06",
+            ):
+                agent_core.publication.canonical_metadata(
+                    root, "19", head=self.HEAD, changed_paths=["one"]
+                )
+
+    def test_failed_non_review_work_units_do_not_gate_publication(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            self.write_work_units(
+                root,
+                [
+                    ("WU-19-04", self.unit("reviewer", "completed")),
+                    ("WU-19-05", self.unit("general", "blocked")),
+                    ("WU-19-06", self.unit("verifier", "failed")),
+                ],
+            )
+            _, body = agent_core.publication.canonical_metadata(
+                root, "19", head=self.HEAD, changed_paths=["one"]
+            )
+            self.assertIn("`WU-19-04` — `reviewer` — completed", body)
+
+    def test_only_highest_reviewer_sequence_is_authoritative(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            self.write_work_units(
+                root,
+                [
+                    ("WU-19-05", self.unit("reviewer", "failed")),
+                    ("WU-19-04", self.unit("reviewer", "blocked")),
+                    ("WU-19-06", self.unit("reviewer", "completed", "d")),
+                ],
+            )
+            _, body = agent_core.publication.canonical_metadata(
+                root, "19", head=self.HEAD, changed_paths=["one"]
+            )
+            self.assertIn("`WU-19-06` — `reviewer` — completed", body)
+            self.assertNotIn("WU-19-04", body)
+            self.assertNotIn("WU-19-05", body)
+
+    def test_only_highest_security_review_sequence_is_authoritative(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            self.write_work_units(
+                root,
+                [
+                    ("WU-19-04", self.unit("reviewer", "completed")),
+                    ("WU-19-06", self.unit("security-reviewer", "completed", "d")),
+                    ("WU-19-05", self.unit("security-reviewer", "failed")),
+                ],
+            )
+            _, body = agent_core.publication.canonical_metadata(
+                root, "19", head=self.HEAD, changed_paths=["one"]
+            )
+            self.assertIn("`WU-19-06` — `security-reviewer` — completed", body)
+            self.assertNotIn("WU-19-05", body)
+
+    def test_canonical_sequence_wins_over_json_insertion_order(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            self.write_work_units(
+                root,
+                [
+                    ("WU-19-05", self.unit("reviewer", "blocked")),
+                    ("WU-19-04", self.unit("reviewer", "completed")),
+                ],
+            )
+            with self.assertRaisesRegex(
+                agent_core.publication.PublicationMetadataError,
+                "reviewer Work Unit is not completed: WU-19-05",
+            ):
+                agent_core.publication.canonical_metadata(
+                    root, "19", head=self.HEAD, changed_paths=["one"]
+                )
+
+    def test_noncanonical_review_work_unit_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(root)
+            self.write_work_units(
+                root,
+                [
+                    ("WU-19-04", self.unit("reviewer", "completed")),
+                    ("WU-19-5", self.unit("reviewer", "completed")),
+                ],
+            )
+            with self.assertRaisesRegex(
+                agent_core.publication.PublicationMetadataError,
+                "no canonical sequence: WU-19-5",
+            ):
                 agent_core.publication.canonical_metadata(
                     root, "19", head=self.HEAD, changed_paths=["one"]
                 )


### PR DESCRIPTION
## 概要

Issue #129 を修正します。過去の reviewer / security-reviewer Work Unit が `blocked` または `failed` で終端していると、後続の corrective review が成功しても publication が永久に拒否される問題を解消します。

## 原因

`publication_metadata.completed_reviews()` が review Work Unit の履歴をすべて同時に authoritative と扱い、1件でも `state != completed` があれば拒否していました。これは terminal evidence を保持したまま fresh corrective Work Unit を作る lifecycle contract と矛盾していました。

## 変更内容

- `reviewer` と `security-reviewer` を role ごとに独立して評価
- `task_lifecycle.canonical_work_unit_sequence(task, identifier)` の最大 sequence を current/effective review として選択
- effective review が `completed` 以外なら、その Work Unit ID を示して fail closed
- noncanonical review Work Unit ID は deterministic authority を確立できないため fail closed
- reviewer 必須、security-reviewer は存在する場合のみ必須という既存条件を維持
- PR body の `## Reviews` には role ごとの effective completed review だけを表示
- historical Work Unit evidence、terminal state、transition rules は変更しない

## 回帰ケース

- blocked reviewer → later completed reviewer: PASS
- completed reviewer → later blocked reviewer: FAIL
- blocked security-reviewer → later completed security-reviewer: PASS
- completed security-reviewer → later blocked security-reviewer: FAIL
- reviewer 不在: FAIL
- blocked/failed non-review Work Unit: 影響なし
- reviewer / security-reviewer の複数 corrective attempts: canonical sequence 最大のみ authoritative
- JSON insertion order と canonical sequence が異なる場合: canonical sequence を使用
- noncanonical review Work Unit ID: fail closed
- successful supersession の PR body は effective review のみを表示

## 検証

- focused `PublicationMetadataTest`: PASS (26 tests)
- full Python suite: PASS (569 tests)
- `git diff --check`: PASS
- `just template::check`: PASS (5 templates)
- `just template::distribution-verify`: PASS (4 published templates、agent-base は想定どおり除外)
- `nix flake check --no-update-lock-file`: PASS
- `nix flake check --all-systems --no-build --no-update-lock-file`: PASS
- `nix build .#checks.x86_64-linux.opencode-policy --no-link --no-update-lock-file`: PASS
- independent reviewer: findings なし

## 影響範囲

canonical Agent Core source、PublicationMetadata tests、render 生成された各 template の同一ファイルだけを変更しています。Product / Adapter / Task State schema / Automation Maintenance routing / publication bypass に変更はありません。

## Downstream motivation

AgentKnowledgeVault Task #13 は product implementation と verification が完了しており、この不具合により publication-only で blocked です。本PRでは AKV の変更や consumer recovery は行いません。

Closes #129