### PR TITLE
Recover publication-only blocked Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ or arbitrary consumer mutation surface. AKV #22/#23 are the motivating example
 for this first-adoption path; that example is not claimed as executed. Agent
 Core VERSION remains 3.
 
-### Issue #131: source-side publication recovery
+### Issues #131 and #148: source-side publication recovery
 
 An already-complete in-flight Task can be publication-blocked when its installed
 Agent Core predates a correction to canonical publication semantics. After that
@@ -220,14 +220,23 @@ just agent-core::publication-recover <consumer-task-worktree> <task> <expected-i
 
 This is not a normal publication route. Ordinary Tasks continue to use
 `just agent::pr-prepare` followed by `just agent::pr-create`. Recovery requires
-an exact registered non-default Task worktree already in `publication-ready` or
-`draft-pr-created`, a clean product tree, identical local and remote Task HEADs,
+an exact registered non-default Task worktree in `publication-ready`,
+`draft-pr-created`, or a narrowly recoverable publication-only `blocked` state,
+a clean product tree, identical local and remote Task HEADs,
 a resolved canonical Task Contract, fresh persisted verification for that HEAD,
 and effective completed review evidence. It executes canonical `pr_prepare`,
 then routes to canonical `pr_create` only for `publication-ready` with no PR, or
 canonical `pr_edit` when the exact Task PR already exists. A
 `draft-pr-created` Task without its existing Draft fails closed and never
-recreates a PR. Canonical modules are loaded only from verified immutable
+recreates a PR. A `blocked` Task is not generally publishable: recovery first
+requires an existing exact same-repository OPEN Draft for the Task branch,
+default base, and current head, plus current canonical verification and
+effective completed review evidence. The bridge captures and revalidates that
+Draft before a dedicated locked compare-and-swap changes only `blocked ->
+publication-ready`; a missing or changed Draft fails before that state mutation.
+It then uses canonical `pr_prepare` and number-bound `pr_edit`. It never creates
+a PR for a `blocked` Task, and the generic lifecycle/state-set transition table
+does not gain a bypass. Canonical modules are loaded only from verified immutable
 Templates commit blobs; consumer `.automation/bin` files are not publication
 authority.
 
@@ -235,7 +244,11 @@ The operation never upgrades the consumer or changes its product HEAD. Work
 Unit, verification, and contract evidence remain byte-identical. Starting from
 `publication-ready`, only ignored publication metadata and the guarded
 `publication-ready -> draft-pr-created` transition may change; starting from
-`draft-pr-created`, Task State remains byte-identical. Existing-PR repair
+`draft-pr-created`, Task State remains byte-identical. Starting from qualifying
+`blocked`, only the status transitions through `publication-ready` to
+`draft-pr-created`; all other Task State bytes and optional Issue evidence remain
+unchanged. An interruption after the first transition can safely retry through
+the existing publication-ready path. Existing-PR repair
 delegates the mutation boundary to canonical `pr_edit`, which requires the
 exact same-repository OPEN Draft at the
 captured branch, base, and current head and binds its internal lookup to the

--- a/README.md
+++ b/README.md
@@ -234,7 +234,12 @@ default base, and current head, plus current canonical verification and
 effective completed review evidence. The bridge captures and revalidates that
 Draft before a dedicated locked compare-and-swap changes only `blocked ->
 publication-ready`; a missing or changed Draft fails before that state mutation.
-It then uses canonical `pr_prepare` and number-bound `pr_edit`. It never creates
+Before that durable transition, it publishes a protected Git-private recovery
+receipt bound to repository, Task/worktree, branch, exact HEAD, base, original
+PR number, Task State, and evidence digests. Retries from `blocked`,
+`publication-ready`, or `draft-pr-created` must resolve that same receipt-bound
+Draft; absence or replacement fails closed and cannot select `pr_create`. It
+then uses canonical `pr_prepare` and number-bound `pr_edit`. It never creates
 a PR for a `blocked` Task, and the generic lifecycle/state-set transition table
 does not gain a bypass. Canonical modules are loaded only from verified immutable
 Templates commit blobs; consumer `.automation/bin` files are not publication
@@ -248,7 +253,11 @@ Unit, verification, and contract evidence remain byte-identical. Starting from
 `blocked`, only the status transitions through `publication-ready` to
 `draft-pr-created`; all other Task State bytes and optional Issue evidence remain
 unchanged. An interruption after the first transition can safely retry through
-the existing publication-ready path. Existing-PR repair
+the receipt-bound publication-ready path. The receipt is consumed only after
+exact Draft validation and convergence to `draft-pr-created`, so successful
+recovery leaves no stale authority. The exact receipt-bound canonical Draft is
+re-read immediately before consumption; replacement retains the receipt and
+fails closed. Existing-PR repair
 delegates the mutation boundary to canonical `pr_edit`, which requires the
 exact same-repository OPEN Draft at the
 captured branch, base, and current head and binds its internal lookup to the

--- a/components/agent-core/.automation/bin/git_private_state.py
+++ b/components/agent-core/.automation/bin/git_private_state.py
@@ -22,7 +22,11 @@ HASH_RE = re.compile(r"[0-9a-f]{64}")
 OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
 REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
-FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+FIXED_AUTHORITY_FILES = {
+    "authority.json",
+    "source-recovery-proof.json",
+    "publication-recovery.json",
+}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
 TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
@@ -96,6 +100,11 @@ def common_state(root: Path) -> Path:
 
 def admin_maintenance(root: Path) -> Path:
     return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def publication_recovery_receipt(root: Path) -> Path:
+    """Return the protected receipt path in this worktree's Git admin dir."""
+    return admin_maintenance(root) / "publication-recovery.json"
 
 
 def cleanup_receipt(root: Path, task: str) -> Path:
@@ -564,6 +573,41 @@ def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -
     return admin
 
 
+def _validate_publication_recovery_topology(
+    path: Path, value: dict, layout: Topology
+) -> Path:
+    """Bind a publication recovery receipt to its exact worktree and HEAD."""
+    admin = _validate_authority_topology(path, json.dumps(value).encode(), layout)
+    worktree = Path(value["worktree"])
+    try:
+        result = subprocess.run(
+            [_GIT_EXECUTABLE, "-C", str(worktree), "rev-parse", "--verify", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("GIT_")
+            } | {
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+            },
+        )
+        actual_head = result.stdout.strip()
+    except OSError as exc:
+        raise GitPrivateStateError(
+            f"publication recovery worktree HEAD is unreadable: {path}"
+        ) from exc
+    if result.returncode != 0 or not _valid_oid(actual_head):
+        raise GitPrivateStateError(f"publication recovery worktree HEAD is unreadable: {path}")
+    if value["head"] != actual_head:
+        raise GitPrivateStateError(f"publication recovery HEAD does not match worktree: {path}")
+    return admin
+
+
 def _validate_legacy_content(path: Path, content: bytes) -> None:
     directory = path.parent.name
     name = path.name
@@ -606,6 +650,35 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and _valid_oid(value.get("base_revision"))
             and _valid_oid(value.get("local_head"))
             and value.get("local_head").casefold() == value.get("base_revision").casefold()
+        )
+    elif name == "publication-recovery.json":
+        required = {
+            "schema_version", "kind", "repository", "task_id", "worktree", "branch",
+            "head", "base_branch", "base_revision", "pr_number",
+            "blocked_state_sha256", "publication_ready_state_sha256",
+            "draft_pr_created_state_sha256", "work_units_sha256", "verification_sha256",
+            "contract_sha256", "issue_sha256",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "blocked-publication-recovery"
+            and _valid_repository(value.get("repository"))
+            and _valid_task_id(value.get("task_id"))
+            and _valid_absolute_path(value.get("worktree"))
+            and _valid_task_branch(value.get("branch"), value.get("task_id"))
+            and _valid_oid(value.get("head"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_oid(value.get("base_revision"))
+            and isinstance(value.get("pr_number"), int)
+            and not isinstance(value.get("pr_number"), bool)
+            and value.get("pr_number") > 0
+            and all(_valid_digest(value.get(field)) for field in (
+                "blocked_state_sha256", "publication_ready_state_sha256",
+                "draft_pr_created_state_sha256", "work_units_sha256",
+                "verification_sha256", "contract_sha256",
+            ))
+            and (value.get("issue_sha256") is None or _valid_digest(value.get("issue_sha256")))
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -685,7 +758,12 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
                 content = read_bytes(child)
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
-                authority_admin = _validate_authority_topology(child, content, layout)
+                authority_value = _legacy_json(content, child)
+                authority_admin = (
+                    _validate_publication_recovery_topology(child, authority_value, layout)
+                    if child.name == "publication-recovery.json"
+                    else _validate_authority_topology(child, content, layout)
+                )
             if child.name in FIXED_AUTHORITY_FILES:
                 if authority_admin not in {layout.common, layout.admin}:
                     raise GitPrivateStateError(
@@ -723,7 +801,13 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
         content = read_bytes(child)
         _validate_legacy_content(child, content)
         _validate_authority_filename(child, content)
-        if _validate_authority_topology(child, content, layout) != layout.admin:
+        authority_value = _legacy_json(content, child)
+        owner = (
+            _validate_publication_recovery_topology(child, authority_value, layout)
+            if child.name == "publication-recovery.json"
+            else _validate_authority_topology(child, content, layout)
+        )
+        if owner != layout.admin:
             raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
     _validate_legacy_relations(
@@ -826,7 +910,12 @@ def _validate_canonical(
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
                 if entry.name == "automation-maintenance":
-                    authority_admin = _validate_authority_topology(child, content, layout)
+                    authority_value = _legacy_json(content, child)
+                    authority_admin = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
                     if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
@@ -863,7 +952,13 @@ def _validate_canonical(
                     content = read_bytes(child, "canonical private-state record")
                     _validate_legacy_content(child, content)
                     _validate_authority_filename(child, content)
-                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                    authority_value = _legacy_json(content, child)
+                    owner = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
+                    if owner != layout.admin:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
                         )

--- a/components/agent-core/.automation/bin/task_lifecycle.py
+++ b/components/agent-core/.automation/bin/task_lifecycle.py
@@ -959,6 +959,74 @@ def mark_task_publication_state(
     return "transitioned"
 
 
+def recover_blocked_publication_ready(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+) -> str:
+    """CAS a proven publication-only blocked Task to publication-ready.
+
+    This deliberately is not part of the general transition table: recovery
+    may use it only after its external publication evidence has been checked.
+    """
+    validate_task(task)
+    if not isinstance(expected_state, bytes):
+        raise LifecycleError("expected Task State CAS value must be bytes")
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if set(expected_evidence) != evidence_names or any(
+        value is not None and not isinstance(value, bytes)
+        for value in expected_evidence.values()
+    ):
+        raise LifecycleError("expected publication evidence CAS values are invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    try:
+        state_lock = task_contract.contract_state_lock(record.path)
+    except AttributeError as exc:  # pragma: no cover - verified module contract
+        raise LifecycleError("canonical Task State lock is unavailable") from exc
+    with state_lock as directory_fd:
+        current = current_worktree(record.path)
+        if current != record:
+            raise LifecycleError("local Task worktree identity changed")
+        registered = worktree_for_task(record.path, task)
+        if registered != record:
+            raise LifecycleError("Task worktree registration identity changed")
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        try:
+            actual = task_contract._read_state_file(directory_fd, "task.md")
+            actual_evidence = {
+                name: task_contract._read_state_file(directory_fd, name)
+                for name in evidence_names
+            }
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot read Task State for guarded recovery: {path}") from exc
+        if actual != expected_state:
+            raise LifecycleError("Task State changed before guarded blocked recovery")
+        if actual_evidence != expected_evidence:
+            raise LifecycleError("publication evidence changed before guarded blocked recovery")
+        try:
+            text = actual.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise LifecycleError("Task State is not valid UTF-8") from exc
+        updated, count = re.subn(
+            r"(?m)^- Status: blocked$", "- Status: publication-ready", text, count=1
+        )
+        if count != 1:
+            raise LifecycleError("cannot update blocked Task State status")
+        try:
+            task_contract._write_state_file(
+                directory_fd, "task.md", updated.encode("utf-8")
+            )
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
+    return "transitioned"
+
+
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:
     """Dedicated terminal transition used only after guarded merge reconciliation."""
     validate_task(task)

--- a/components/agent-core/.automation/bin/task_lifecycle.py
+++ b/components/agent-core/.automation/bin/task_lifecycle.py
@@ -964,6 +964,7 @@ def recover_blocked_publication_ready(
     task: str,
     expected_state: bytes,
     expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
 ) -> str:
     """CAS a proven publication-only blocked Task to publication-ready.
 
@@ -981,6 +982,34 @@ def recover_blocked_publication_ready(
         raise LifecycleError("expected publication evidence CAS values are invalid")
     require_resolved_contract(record, task)
     import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        receipt_value = json.loads(recovery_receipt.decode("utf-8"))
+        private_state._validate_legacy_content(receipt_path, recovery_receipt)
+        private_state._validate_publication_recovery_topology(
+            receipt_path, receipt_value, private_state.topology(record.path)
+        )
+        with private_state.mutation_lock(record.path, admin=True):
+            try:
+                receipt_path.lstat()
+            except FileNotFoundError:
+                private_state.exclusive_write_bytes(
+                    receipt_path, recovery_receipt, _lock_held=True
+                )
+            else:
+                existing = private_state.read_bytes(
+                    receipt_path, "publication recovery receipt"
+                )
+                if existing != recovery_receipt:
+                    raise LifecycleError(
+                        "conflicting publication recovery receipt already exists"
+                    )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot durably bind blocked publication recovery") from exc
 
     try:
         state_lock = task_contract.contract_state_lock(record.path)
@@ -1025,6 +1054,59 @@ def recover_blocked_publication_ready(
         except Exception as exc:
             raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
     return "transitioned"
+
+
+def complete_blocked_publication_recovery(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
+) -> str:
+    """Consume the exact recovery receipt only after Draft convergence."""
+    validate_task(task)
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if not isinstance(expected_state, bytes) or set(expected_evidence) != evidence_names:
+        raise LifecycleError("expected recovered publication subject is invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        with private_state.mutation_lock(record.path, admin=True):
+            receipt_content, receipt_identity = private_state.read_bytes_identity(
+                receipt_path, "publication recovery receipt"
+            )
+            if receipt_content != recovery_receipt:
+                raise LifecycleError("publication recovery receipt changed before consumption")
+            with task_contract.contract_state_lock(record.path) as directory_fd:
+                current = current_worktree(record.path)
+                registered = worktree_for_task(record.path, task)
+                if current != record or registered != record:
+                    raise LifecycleError("Task worktree identity changed before receipt consumption")
+                assert_task_identity(record, task)
+                actual_state = task_contract._read_state_file(directory_fd, "task.md")
+                actual_evidence = {
+                    name: task_contract._read_state_file(directory_fd, name)
+                    for name in evidence_names
+                }
+                task_contract._assert_state_dir_binding(record.path, directory_fd)
+                if actual_state != expected_state or actual_evidence != expected_evidence:
+                    raise LifecycleError(
+                        "recovered publication subject changed before receipt consumption"
+                    )
+                private_state.unlink(
+                    receipt_path,
+                    expected_identity=receipt_identity,
+                    expected_content=recovery_receipt,
+                    _lock_held=True,
+                )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot consume blocked publication recovery receipt") from exc
+    return "consumed"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -749,7 +749,7 @@ generic authority-expansion or arbitrary consumer-mutation primitive. AKV
 #22/#23 motivate this first-adoption example, but their execution is not
 claimed. Agent Core VERSION remains 3.
 
-#### Issue #131 source-side publication recovery
+#### Issues #131 and #148 source-side publication recovery
 
 `agent-core::publication-recover` is a bounded recovery boundary for an
 already-complete in-flight consumer Task whose installed publication tooling is
@@ -768,7 +768,8 @@ execution is pinned and environment-sanitized. Consumer-local Agent Core code
 never becomes publication authority.
 
 The bridge binds the exact registered non-default worktree, Task/branch/contract
-identity, initial `publication-ready` or `draft-pr-created` state, local
+identity, initial `publication-ready`, `draft-pr-created`, or narrowly
+recoverable publication-only `blocked` state, local
 worktree and branch HEAD, GitHub remote branch OID, canonical repository, clean
 product status, fresh head-bound verification receipt, and effective review
 evidence. It uses the verified source implementation's canonical preparation,
@@ -778,6 +779,21 @@ Task without that existing Draft fails closed. Product HEAD and tracked bytes
 remain unchanged; Work Unit, verification, and contract evidence remain
 byte-identical. Task State may perform only the guarded `publication-ready ->
 draft-pr-created` transition; from `draft-pr-created` it remains byte-identical.
+
+`blocked` is only a recovery candidate, never ordinary publication authority.
+Before any lifecycle or GitHub mutation, the bridge requires and captures an
+existing positive-numbered exact same-repository OPEN Draft at the Task branch,
+default base, and current head; regenerates canonical metadata from fresh
+current-head verification and effective reviews; then rechecks Task, product,
+remote, repository, evidence, and the same PR identity. A dedicated internal
+lifecycle helper performs a locked byte-CAS that changes only `blocked ->
+publication-ready`; it is not exposed through Just/CLI and does not alter the
+generic transition table. The bridge then uses canonical preparation and
+number-bound edit to reach `draft-pr-created`. A blocked Task without a PR fails
+before state mutation and never selects PR creation. Work Unit, verification,
+contract, optional Issue, historical failure, product, and non-status Task State
+bytes remain unchanged. If interrupted after the CAS, retry continues through
+the existing publication-ready path on the same Draft.
 
 Canonical `pr_create` remains strict and reconciles only an already-canonical
 existing Draft. The bridge does not broaden it: after preparation, absence of a

--- a/docs/agent-template-architecture.md
+++ b/docs/agent-template-architecture.md
@@ -788,12 +788,24 @@ current-head verification and effective reviews; then rechecks Task, product,
 remote, repository, evidence, and the same PR identity. A dedicated internal
 lifecycle helper performs a locked byte-CAS that changes only `blocked ->
 publication-ready`; it is not exposed through Just/CLI and does not alter the
-generic transition table. The bridge then uses canonical preparation and
+generic transition table. Before that CAS it durably publishes a strict
+Git-private receipt binding the exact repository, Task/worktree, branch, HEAD,
+base, original PR number, Task State variants, and immutable evidence digests.
+Any retry while the receipt exists must resolve that original PR; a missing or
+replacement PR fails before GitHub mutation and never selects creation. The
+bridge then uses canonical preparation and
 number-bound edit to reach `draft-pr-created`. A blocked Task without a PR fails
 before state mutation and never selects PR creation. Work Unit, verification,
 contract, optional Issue, historical failure, product, and non-status Task State
 bytes remain unchanged. If interrupted after the CAS, retry continues through
-the existing publication-ready path on the same Draft.
+the receipt-bound publication-ready path on the same Draft. The exact receipt
+remains across edit/state interruption and is consumed only after final
+postconditions prove `draft-pr-created`; completed recovery leaves no stale
+authority. The bridge re-reads and validates the receipt-bound canonical Draft
+immediately before receipt consumption. GitHub does not provide an atomic
+compare-and-edit precondition for title/body updates, so canonical `pr_edit`
+minimizes that remote race with identity validation immediately before and
+after its mutation and fails if either observation differs.
 
 Canonical `pr_create` remains strict and reconciles only an already-canonical
 existing Draft. The bridge does not broaden it: after preparation, absence of a

--- a/templates/agent-base/.automation/bin/git_private_state.py
+++ b/templates/agent-base/.automation/bin/git_private_state.py
@@ -22,7 +22,11 @@ HASH_RE = re.compile(r"[0-9a-f]{64}")
 OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
 REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
-FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+FIXED_AUTHORITY_FILES = {
+    "authority.json",
+    "source-recovery-proof.json",
+    "publication-recovery.json",
+}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
 TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
@@ -96,6 +100,11 @@ def common_state(root: Path) -> Path:
 
 def admin_maintenance(root: Path) -> Path:
     return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def publication_recovery_receipt(root: Path) -> Path:
+    """Return the protected receipt path in this worktree's Git admin dir."""
+    return admin_maintenance(root) / "publication-recovery.json"
 
 
 def cleanup_receipt(root: Path, task: str) -> Path:
@@ -564,6 +573,41 @@ def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -
     return admin
 
 
+def _validate_publication_recovery_topology(
+    path: Path, value: dict, layout: Topology
+) -> Path:
+    """Bind a publication recovery receipt to its exact worktree and HEAD."""
+    admin = _validate_authority_topology(path, json.dumps(value).encode(), layout)
+    worktree = Path(value["worktree"])
+    try:
+        result = subprocess.run(
+            [_GIT_EXECUTABLE, "-C", str(worktree), "rev-parse", "--verify", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("GIT_")
+            } | {
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+            },
+        )
+        actual_head = result.stdout.strip()
+    except OSError as exc:
+        raise GitPrivateStateError(
+            f"publication recovery worktree HEAD is unreadable: {path}"
+        ) from exc
+    if result.returncode != 0 or not _valid_oid(actual_head):
+        raise GitPrivateStateError(f"publication recovery worktree HEAD is unreadable: {path}")
+    if value["head"] != actual_head:
+        raise GitPrivateStateError(f"publication recovery HEAD does not match worktree: {path}")
+    return admin
+
+
 def _validate_legacy_content(path: Path, content: bytes) -> None:
     directory = path.parent.name
     name = path.name
@@ -606,6 +650,35 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and _valid_oid(value.get("base_revision"))
             and _valid_oid(value.get("local_head"))
             and value.get("local_head").casefold() == value.get("base_revision").casefold()
+        )
+    elif name == "publication-recovery.json":
+        required = {
+            "schema_version", "kind", "repository", "task_id", "worktree", "branch",
+            "head", "base_branch", "base_revision", "pr_number",
+            "blocked_state_sha256", "publication_ready_state_sha256",
+            "draft_pr_created_state_sha256", "work_units_sha256", "verification_sha256",
+            "contract_sha256", "issue_sha256",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "blocked-publication-recovery"
+            and _valid_repository(value.get("repository"))
+            and _valid_task_id(value.get("task_id"))
+            and _valid_absolute_path(value.get("worktree"))
+            and _valid_task_branch(value.get("branch"), value.get("task_id"))
+            and _valid_oid(value.get("head"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_oid(value.get("base_revision"))
+            and isinstance(value.get("pr_number"), int)
+            and not isinstance(value.get("pr_number"), bool)
+            and value.get("pr_number") > 0
+            and all(_valid_digest(value.get(field)) for field in (
+                "blocked_state_sha256", "publication_ready_state_sha256",
+                "draft_pr_created_state_sha256", "work_units_sha256",
+                "verification_sha256", "contract_sha256",
+            ))
+            and (value.get("issue_sha256") is None or _valid_digest(value.get("issue_sha256")))
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -685,7 +758,12 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
                 content = read_bytes(child)
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
-                authority_admin = _validate_authority_topology(child, content, layout)
+                authority_value = _legacy_json(content, child)
+                authority_admin = (
+                    _validate_publication_recovery_topology(child, authority_value, layout)
+                    if child.name == "publication-recovery.json"
+                    else _validate_authority_topology(child, content, layout)
+                )
             if child.name in FIXED_AUTHORITY_FILES:
                 if authority_admin not in {layout.common, layout.admin}:
                     raise GitPrivateStateError(
@@ -723,7 +801,13 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
         content = read_bytes(child)
         _validate_legacy_content(child, content)
         _validate_authority_filename(child, content)
-        if _validate_authority_topology(child, content, layout) != layout.admin:
+        authority_value = _legacy_json(content, child)
+        owner = (
+            _validate_publication_recovery_topology(child, authority_value, layout)
+            if child.name == "publication-recovery.json"
+            else _validate_authority_topology(child, content, layout)
+        )
+        if owner != layout.admin:
             raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
     _validate_legacy_relations(
@@ -826,7 +910,12 @@ def _validate_canonical(
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
                 if entry.name == "automation-maintenance":
-                    authority_admin = _validate_authority_topology(child, content, layout)
+                    authority_value = _legacy_json(content, child)
+                    authority_admin = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
                     if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
@@ -863,7 +952,13 @@ def _validate_canonical(
                     content = read_bytes(child, "canonical private-state record")
                     _validate_legacy_content(child, content)
                     _validate_authority_filename(child, content)
-                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                    authority_value = _legacy_json(content, child)
+                    owner = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
+                    if owner != layout.admin:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
                         )

--- a/templates/agent-base/.automation/bin/task_lifecycle.py
+++ b/templates/agent-base/.automation/bin/task_lifecycle.py
@@ -959,6 +959,74 @@ def mark_task_publication_state(
     return "transitioned"
 
 
+def recover_blocked_publication_ready(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+) -> str:
+    """CAS a proven publication-only blocked Task to publication-ready.
+
+    This deliberately is not part of the general transition table: recovery
+    may use it only after its external publication evidence has been checked.
+    """
+    validate_task(task)
+    if not isinstance(expected_state, bytes):
+        raise LifecycleError("expected Task State CAS value must be bytes")
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if set(expected_evidence) != evidence_names or any(
+        value is not None and not isinstance(value, bytes)
+        for value in expected_evidence.values()
+    ):
+        raise LifecycleError("expected publication evidence CAS values are invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    try:
+        state_lock = task_contract.contract_state_lock(record.path)
+    except AttributeError as exc:  # pragma: no cover - verified module contract
+        raise LifecycleError("canonical Task State lock is unavailable") from exc
+    with state_lock as directory_fd:
+        current = current_worktree(record.path)
+        if current != record:
+            raise LifecycleError("local Task worktree identity changed")
+        registered = worktree_for_task(record.path, task)
+        if registered != record:
+            raise LifecycleError("Task worktree registration identity changed")
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        try:
+            actual = task_contract._read_state_file(directory_fd, "task.md")
+            actual_evidence = {
+                name: task_contract._read_state_file(directory_fd, name)
+                for name in evidence_names
+            }
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot read Task State for guarded recovery: {path}") from exc
+        if actual != expected_state:
+            raise LifecycleError("Task State changed before guarded blocked recovery")
+        if actual_evidence != expected_evidence:
+            raise LifecycleError("publication evidence changed before guarded blocked recovery")
+        try:
+            text = actual.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise LifecycleError("Task State is not valid UTF-8") from exc
+        updated, count = re.subn(
+            r"(?m)^- Status: blocked$", "- Status: publication-ready", text, count=1
+        )
+        if count != 1:
+            raise LifecycleError("cannot update blocked Task State status")
+        try:
+            task_contract._write_state_file(
+                directory_fd, "task.md", updated.encode("utf-8")
+            )
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
+    return "transitioned"
+
+
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:
     """Dedicated terminal transition used only after guarded merge reconciliation."""
     validate_task(task)

--- a/templates/agent-base/.automation/bin/task_lifecycle.py
+++ b/templates/agent-base/.automation/bin/task_lifecycle.py
@@ -964,6 +964,7 @@ def recover_blocked_publication_ready(
     task: str,
     expected_state: bytes,
     expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
 ) -> str:
     """CAS a proven publication-only blocked Task to publication-ready.
 
@@ -981,6 +982,34 @@ def recover_blocked_publication_ready(
         raise LifecycleError("expected publication evidence CAS values are invalid")
     require_resolved_contract(record, task)
     import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        receipt_value = json.loads(recovery_receipt.decode("utf-8"))
+        private_state._validate_legacy_content(receipt_path, recovery_receipt)
+        private_state._validate_publication_recovery_topology(
+            receipt_path, receipt_value, private_state.topology(record.path)
+        )
+        with private_state.mutation_lock(record.path, admin=True):
+            try:
+                receipt_path.lstat()
+            except FileNotFoundError:
+                private_state.exclusive_write_bytes(
+                    receipt_path, recovery_receipt, _lock_held=True
+                )
+            else:
+                existing = private_state.read_bytes(
+                    receipt_path, "publication recovery receipt"
+                )
+                if existing != recovery_receipt:
+                    raise LifecycleError(
+                        "conflicting publication recovery receipt already exists"
+                    )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot durably bind blocked publication recovery") from exc
 
     try:
         state_lock = task_contract.contract_state_lock(record.path)
@@ -1025,6 +1054,59 @@ def recover_blocked_publication_ready(
         except Exception as exc:
             raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
     return "transitioned"
+
+
+def complete_blocked_publication_recovery(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
+) -> str:
+    """Consume the exact recovery receipt only after Draft convergence."""
+    validate_task(task)
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if not isinstance(expected_state, bytes) or set(expected_evidence) != evidence_names:
+        raise LifecycleError("expected recovered publication subject is invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        with private_state.mutation_lock(record.path, admin=True):
+            receipt_content, receipt_identity = private_state.read_bytes_identity(
+                receipt_path, "publication recovery receipt"
+            )
+            if receipt_content != recovery_receipt:
+                raise LifecycleError("publication recovery receipt changed before consumption")
+            with task_contract.contract_state_lock(record.path) as directory_fd:
+                current = current_worktree(record.path)
+                registered = worktree_for_task(record.path, task)
+                if current != record or registered != record:
+                    raise LifecycleError("Task worktree identity changed before receipt consumption")
+                assert_task_identity(record, task)
+                actual_state = task_contract._read_state_file(directory_fd, "task.md")
+                actual_evidence = {
+                    name: task_contract._read_state_file(directory_fd, name)
+                    for name in evidence_names
+                }
+                task_contract._assert_state_dir_binding(record.path, directory_fd)
+                if actual_state != expected_state or actual_evidence != expected_evidence:
+                    raise LifecycleError(
+                        "recovered publication subject changed before receipt consumption"
+                    )
+                private_state.unlink(
+                    receipt_path,
+                    expected_identity=receipt_identity,
+                    expected_content=recovery_receipt,
+                    _lock_held=True,
+                )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot consume blocked publication recovery receipt") from exc
+    return "consumed"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/templates/agent-cpp-cmake/.automation/bin/git_private_state.py
+++ b/templates/agent-cpp-cmake/.automation/bin/git_private_state.py
@@ -22,7 +22,11 @@ HASH_RE = re.compile(r"[0-9a-f]{64}")
 OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
 REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
-FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+FIXED_AUTHORITY_FILES = {
+    "authority.json",
+    "source-recovery-proof.json",
+    "publication-recovery.json",
+}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
 TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
@@ -96,6 +100,11 @@ def common_state(root: Path) -> Path:
 
 def admin_maintenance(root: Path) -> Path:
     return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def publication_recovery_receipt(root: Path) -> Path:
+    """Return the protected receipt path in this worktree's Git admin dir."""
+    return admin_maintenance(root) / "publication-recovery.json"
 
 
 def cleanup_receipt(root: Path, task: str) -> Path:
@@ -564,6 +573,41 @@ def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -
     return admin
 
 
+def _validate_publication_recovery_topology(
+    path: Path, value: dict, layout: Topology
+) -> Path:
+    """Bind a publication recovery receipt to its exact worktree and HEAD."""
+    admin = _validate_authority_topology(path, json.dumps(value).encode(), layout)
+    worktree = Path(value["worktree"])
+    try:
+        result = subprocess.run(
+            [_GIT_EXECUTABLE, "-C", str(worktree), "rev-parse", "--verify", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("GIT_")
+            } | {
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+            },
+        )
+        actual_head = result.stdout.strip()
+    except OSError as exc:
+        raise GitPrivateStateError(
+            f"publication recovery worktree HEAD is unreadable: {path}"
+        ) from exc
+    if result.returncode != 0 or not _valid_oid(actual_head):
+        raise GitPrivateStateError(f"publication recovery worktree HEAD is unreadable: {path}")
+    if value["head"] != actual_head:
+        raise GitPrivateStateError(f"publication recovery HEAD does not match worktree: {path}")
+    return admin
+
+
 def _validate_legacy_content(path: Path, content: bytes) -> None:
     directory = path.parent.name
     name = path.name
@@ -606,6 +650,35 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and _valid_oid(value.get("base_revision"))
             and _valid_oid(value.get("local_head"))
             and value.get("local_head").casefold() == value.get("base_revision").casefold()
+        )
+    elif name == "publication-recovery.json":
+        required = {
+            "schema_version", "kind", "repository", "task_id", "worktree", "branch",
+            "head", "base_branch", "base_revision", "pr_number",
+            "blocked_state_sha256", "publication_ready_state_sha256",
+            "draft_pr_created_state_sha256", "work_units_sha256", "verification_sha256",
+            "contract_sha256", "issue_sha256",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "blocked-publication-recovery"
+            and _valid_repository(value.get("repository"))
+            and _valid_task_id(value.get("task_id"))
+            and _valid_absolute_path(value.get("worktree"))
+            and _valid_task_branch(value.get("branch"), value.get("task_id"))
+            and _valid_oid(value.get("head"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_oid(value.get("base_revision"))
+            and isinstance(value.get("pr_number"), int)
+            and not isinstance(value.get("pr_number"), bool)
+            and value.get("pr_number") > 0
+            and all(_valid_digest(value.get(field)) for field in (
+                "blocked_state_sha256", "publication_ready_state_sha256",
+                "draft_pr_created_state_sha256", "work_units_sha256",
+                "verification_sha256", "contract_sha256",
+            ))
+            and (value.get("issue_sha256") is None or _valid_digest(value.get("issue_sha256")))
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -685,7 +758,12 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
                 content = read_bytes(child)
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
-                authority_admin = _validate_authority_topology(child, content, layout)
+                authority_value = _legacy_json(content, child)
+                authority_admin = (
+                    _validate_publication_recovery_topology(child, authority_value, layout)
+                    if child.name == "publication-recovery.json"
+                    else _validate_authority_topology(child, content, layout)
+                )
             if child.name in FIXED_AUTHORITY_FILES:
                 if authority_admin not in {layout.common, layout.admin}:
                     raise GitPrivateStateError(
@@ -723,7 +801,13 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
         content = read_bytes(child)
         _validate_legacy_content(child, content)
         _validate_authority_filename(child, content)
-        if _validate_authority_topology(child, content, layout) != layout.admin:
+        authority_value = _legacy_json(content, child)
+        owner = (
+            _validate_publication_recovery_topology(child, authority_value, layout)
+            if child.name == "publication-recovery.json"
+            else _validate_authority_topology(child, content, layout)
+        )
+        if owner != layout.admin:
             raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
     _validate_legacy_relations(
@@ -826,7 +910,12 @@ def _validate_canonical(
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
                 if entry.name == "automation-maintenance":
-                    authority_admin = _validate_authority_topology(child, content, layout)
+                    authority_value = _legacy_json(content, child)
+                    authority_admin = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
                     if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
@@ -863,7 +952,13 @@ def _validate_canonical(
                     content = read_bytes(child, "canonical private-state record")
                     _validate_legacy_content(child, content)
                     _validate_authority_filename(child, content)
-                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                    authority_value = _legacy_json(content, child)
+                    owner = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
+                    if owner != layout.admin:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
                         )

--- a/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
+++ b/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
@@ -959,6 +959,74 @@ def mark_task_publication_state(
     return "transitioned"
 
 
+def recover_blocked_publication_ready(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+) -> str:
+    """CAS a proven publication-only blocked Task to publication-ready.
+
+    This deliberately is not part of the general transition table: recovery
+    may use it only after its external publication evidence has been checked.
+    """
+    validate_task(task)
+    if not isinstance(expected_state, bytes):
+        raise LifecycleError("expected Task State CAS value must be bytes")
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if set(expected_evidence) != evidence_names or any(
+        value is not None and not isinstance(value, bytes)
+        for value in expected_evidence.values()
+    ):
+        raise LifecycleError("expected publication evidence CAS values are invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    try:
+        state_lock = task_contract.contract_state_lock(record.path)
+    except AttributeError as exc:  # pragma: no cover - verified module contract
+        raise LifecycleError("canonical Task State lock is unavailable") from exc
+    with state_lock as directory_fd:
+        current = current_worktree(record.path)
+        if current != record:
+            raise LifecycleError("local Task worktree identity changed")
+        registered = worktree_for_task(record.path, task)
+        if registered != record:
+            raise LifecycleError("Task worktree registration identity changed")
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        try:
+            actual = task_contract._read_state_file(directory_fd, "task.md")
+            actual_evidence = {
+                name: task_contract._read_state_file(directory_fd, name)
+                for name in evidence_names
+            }
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot read Task State for guarded recovery: {path}") from exc
+        if actual != expected_state:
+            raise LifecycleError("Task State changed before guarded blocked recovery")
+        if actual_evidence != expected_evidence:
+            raise LifecycleError("publication evidence changed before guarded blocked recovery")
+        try:
+            text = actual.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise LifecycleError("Task State is not valid UTF-8") from exc
+        updated, count = re.subn(
+            r"(?m)^- Status: blocked$", "- Status: publication-ready", text, count=1
+        )
+        if count != 1:
+            raise LifecycleError("cannot update blocked Task State status")
+        try:
+            task_contract._write_state_file(
+                directory_fd, "task.md", updated.encode("utf-8")
+            )
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
+    return "transitioned"
+
+
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:
     """Dedicated terminal transition used only after guarded merge reconciliation."""
     validate_task(task)

--- a/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
+++ b/templates/agent-cpp-cmake/.automation/bin/task_lifecycle.py
@@ -964,6 +964,7 @@ def recover_blocked_publication_ready(
     task: str,
     expected_state: bytes,
     expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
 ) -> str:
     """CAS a proven publication-only blocked Task to publication-ready.
 
@@ -981,6 +982,34 @@ def recover_blocked_publication_ready(
         raise LifecycleError("expected publication evidence CAS values are invalid")
     require_resolved_contract(record, task)
     import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        receipt_value = json.loads(recovery_receipt.decode("utf-8"))
+        private_state._validate_legacy_content(receipt_path, recovery_receipt)
+        private_state._validate_publication_recovery_topology(
+            receipt_path, receipt_value, private_state.topology(record.path)
+        )
+        with private_state.mutation_lock(record.path, admin=True):
+            try:
+                receipt_path.lstat()
+            except FileNotFoundError:
+                private_state.exclusive_write_bytes(
+                    receipt_path, recovery_receipt, _lock_held=True
+                )
+            else:
+                existing = private_state.read_bytes(
+                    receipt_path, "publication recovery receipt"
+                )
+                if existing != recovery_receipt:
+                    raise LifecycleError(
+                        "conflicting publication recovery receipt already exists"
+                    )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot durably bind blocked publication recovery") from exc
 
     try:
         state_lock = task_contract.contract_state_lock(record.path)
@@ -1025,6 +1054,59 @@ def recover_blocked_publication_ready(
         except Exception as exc:
             raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
     return "transitioned"
+
+
+def complete_blocked_publication_recovery(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
+) -> str:
+    """Consume the exact recovery receipt only after Draft convergence."""
+    validate_task(task)
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if not isinstance(expected_state, bytes) or set(expected_evidence) != evidence_names:
+        raise LifecycleError("expected recovered publication subject is invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        with private_state.mutation_lock(record.path, admin=True):
+            receipt_content, receipt_identity = private_state.read_bytes_identity(
+                receipt_path, "publication recovery receipt"
+            )
+            if receipt_content != recovery_receipt:
+                raise LifecycleError("publication recovery receipt changed before consumption")
+            with task_contract.contract_state_lock(record.path) as directory_fd:
+                current = current_worktree(record.path)
+                registered = worktree_for_task(record.path, task)
+                if current != record or registered != record:
+                    raise LifecycleError("Task worktree identity changed before receipt consumption")
+                assert_task_identity(record, task)
+                actual_state = task_contract._read_state_file(directory_fd, "task.md")
+                actual_evidence = {
+                    name: task_contract._read_state_file(directory_fd, name)
+                    for name in evidence_names
+                }
+                task_contract._assert_state_dir_binding(record.path, directory_fd)
+                if actual_state != expected_state or actual_evidence != expected_evidence:
+                    raise LifecycleError(
+                        "recovered publication subject changed before receipt consumption"
+                    )
+                private_state.unlink(
+                    receipt_path,
+                    expected_identity=receipt_identity,
+                    expected_content=recovery_receipt,
+                    _lock_held=True,
+                )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot consume blocked publication recovery receipt") from exc
+    return "consumed"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/templates/agent-nix/.automation/bin/git_private_state.py
+++ b/templates/agent-nix/.automation/bin/git_private_state.py
@@ -22,7 +22,11 @@ HASH_RE = re.compile(r"[0-9a-f]{64}")
 OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
 REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
-FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+FIXED_AUTHORITY_FILES = {
+    "authority.json",
+    "source-recovery-proof.json",
+    "publication-recovery.json",
+}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
 TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
@@ -96,6 +100,11 @@ def common_state(root: Path) -> Path:
 
 def admin_maintenance(root: Path) -> Path:
     return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def publication_recovery_receipt(root: Path) -> Path:
+    """Return the protected receipt path in this worktree's Git admin dir."""
+    return admin_maintenance(root) / "publication-recovery.json"
 
 
 def cleanup_receipt(root: Path, task: str) -> Path:
@@ -564,6 +573,41 @@ def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -
     return admin
 
 
+def _validate_publication_recovery_topology(
+    path: Path, value: dict, layout: Topology
+) -> Path:
+    """Bind a publication recovery receipt to its exact worktree and HEAD."""
+    admin = _validate_authority_topology(path, json.dumps(value).encode(), layout)
+    worktree = Path(value["worktree"])
+    try:
+        result = subprocess.run(
+            [_GIT_EXECUTABLE, "-C", str(worktree), "rev-parse", "--verify", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("GIT_")
+            } | {
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+            },
+        )
+        actual_head = result.stdout.strip()
+    except OSError as exc:
+        raise GitPrivateStateError(
+            f"publication recovery worktree HEAD is unreadable: {path}"
+        ) from exc
+    if result.returncode != 0 or not _valid_oid(actual_head):
+        raise GitPrivateStateError(f"publication recovery worktree HEAD is unreadable: {path}")
+    if value["head"] != actual_head:
+        raise GitPrivateStateError(f"publication recovery HEAD does not match worktree: {path}")
+    return admin
+
+
 def _validate_legacy_content(path: Path, content: bytes) -> None:
     directory = path.parent.name
     name = path.name
@@ -606,6 +650,35 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and _valid_oid(value.get("base_revision"))
             and _valid_oid(value.get("local_head"))
             and value.get("local_head").casefold() == value.get("base_revision").casefold()
+        )
+    elif name == "publication-recovery.json":
+        required = {
+            "schema_version", "kind", "repository", "task_id", "worktree", "branch",
+            "head", "base_branch", "base_revision", "pr_number",
+            "blocked_state_sha256", "publication_ready_state_sha256",
+            "draft_pr_created_state_sha256", "work_units_sha256", "verification_sha256",
+            "contract_sha256", "issue_sha256",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "blocked-publication-recovery"
+            and _valid_repository(value.get("repository"))
+            and _valid_task_id(value.get("task_id"))
+            and _valid_absolute_path(value.get("worktree"))
+            and _valid_task_branch(value.get("branch"), value.get("task_id"))
+            and _valid_oid(value.get("head"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_oid(value.get("base_revision"))
+            and isinstance(value.get("pr_number"), int)
+            and not isinstance(value.get("pr_number"), bool)
+            and value.get("pr_number") > 0
+            and all(_valid_digest(value.get(field)) for field in (
+                "blocked_state_sha256", "publication_ready_state_sha256",
+                "draft_pr_created_state_sha256", "work_units_sha256",
+                "verification_sha256", "contract_sha256",
+            ))
+            and (value.get("issue_sha256") is None or _valid_digest(value.get("issue_sha256")))
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -685,7 +758,12 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
                 content = read_bytes(child)
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
-                authority_admin = _validate_authority_topology(child, content, layout)
+                authority_value = _legacy_json(content, child)
+                authority_admin = (
+                    _validate_publication_recovery_topology(child, authority_value, layout)
+                    if child.name == "publication-recovery.json"
+                    else _validate_authority_topology(child, content, layout)
+                )
             if child.name in FIXED_AUTHORITY_FILES:
                 if authority_admin not in {layout.common, layout.admin}:
                     raise GitPrivateStateError(
@@ -723,7 +801,13 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
         content = read_bytes(child)
         _validate_legacy_content(child, content)
         _validate_authority_filename(child, content)
-        if _validate_authority_topology(child, content, layout) != layout.admin:
+        authority_value = _legacy_json(content, child)
+        owner = (
+            _validate_publication_recovery_topology(child, authority_value, layout)
+            if child.name == "publication-recovery.json"
+            else _validate_authority_topology(child, content, layout)
+        )
+        if owner != layout.admin:
             raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
     _validate_legacy_relations(
@@ -826,7 +910,12 @@ def _validate_canonical(
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
                 if entry.name == "automation-maintenance":
-                    authority_admin = _validate_authority_topology(child, content, layout)
+                    authority_value = _legacy_json(content, child)
+                    authority_admin = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
                     if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
@@ -863,7 +952,13 @@ def _validate_canonical(
                     content = read_bytes(child, "canonical private-state record")
                     _validate_legacy_content(child, content)
                     _validate_authority_filename(child, content)
-                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                    authority_value = _legacy_json(content, child)
+                    owner = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
+                    if owner != layout.admin:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
                         )

--- a/templates/agent-nix/.automation/bin/task_lifecycle.py
+++ b/templates/agent-nix/.automation/bin/task_lifecycle.py
@@ -959,6 +959,74 @@ def mark_task_publication_state(
     return "transitioned"
 
 
+def recover_blocked_publication_ready(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+) -> str:
+    """CAS a proven publication-only blocked Task to publication-ready.
+
+    This deliberately is not part of the general transition table: recovery
+    may use it only after its external publication evidence has been checked.
+    """
+    validate_task(task)
+    if not isinstance(expected_state, bytes):
+        raise LifecycleError("expected Task State CAS value must be bytes")
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if set(expected_evidence) != evidence_names or any(
+        value is not None and not isinstance(value, bytes)
+        for value in expected_evidence.values()
+    ):
+        raise LifecycleError("expected publication evidence CAS values are invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    try:
+        state_lock = task_contract.contract_state_lock(record.path)
+    except AttributeError as exc:  # pragma: no cover - verified module contract
+        raise LifecycleError("canonical Task State lock is unavailable") from exc
+    with state_lock as directory_fd:
+        current = current_worktree(record.path)
+        if current != record:
+            raise LifecycleError("local Task worktree identity changed")
+        registered = worktree_for_task(record.path, task)
+        if registered != record:
+            raise LifecycleError("Task worktree registration identity changed")
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        try:
+            actual = task_contract._read_state_file(directory_fd, "task.md")
+            actual_evidence = {
+                name: task_contract._read_state_file(directory_fd, name)
+                for name in evidence_names
+            }
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot read Task State for guarded recovery: {path}") from exc
+        if actual != expected_state:
+            raise LifecycleError("Task State changed before guarded blocked recovery")
+        if actual_evidence != expected_evidence:
+            raise LifecycleError("publication evidence changed before guarded blocked recovery")
+        try:
+            text = actual.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise LifecycleError("Task State is not valid UTF-8") from exc
+        updated, count = re.subn(
+            r"(?m)^- Status: blocked$", "- Status: publication-ready", text, count=1
+        )
+        if count != 1:
+            raise LifecycleError("cannot update blocked Task State status")
+        try:
+            task_contract._write_state_file(
+                directory_fd, "task.md", updated.encode("utf-8")
+            )
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
+    return "transitioned"
+
+
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:
     """Dedicated terminal transition used only after guarded merge reconciliation."""
     validate_task(task)

--- a/templates/agent-nix/.automation/bin/task_lifecycle.py
+++ b/templates/agent-nix/.automation/bin/task_lifecycle.py
@@ -964,6 +964,7 @@ def recover_blocked_publication_ready(
     task: str,
     expected_state: bytes,
     expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
 ) -> str:
     """CAS a proven publication-only blocked Task to publication-ready.
 
@@ -981,6 +982,34 @@ def recover_blocked_publication_ready(
         raise LifecycleError("expected publication evidence CAS values are invalid")
     require_resolved_contract(record, task)
     import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        receipt_value = json.loads(recovery_receipt.decode("utf-8"))
+        private_state._validate_legacy_content(receipt_path, recovery_receipt)
+        private_state._validate_publication_recovery_topology(
+            receipt_path, receipt_value, private_state.topology(record.path)
+        )
+        with private_state.mutation_lock(record.path, admin=True):
+            try:
+                receipt_path.lstat()
+            except FileNotFoundError:
+                private_state.exclusive_write_bytes(
+                    receipt_path, recovery_receipt, _lock_held=True
+                )
+            else:
+                existing = private_state.read_bytes(
+                    receipt_path, "publication recovery receipt"
+                )
+                if existing != recovery_receipt:
+                    raise LifecycleError(
+                        "conflicting publication recovery receipt already exists"
+                    )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot durably bind blocked publication recovery") from exc
 
     try:
         state_lock = task_contract.contract_state_lock(record.path)
@@ -1025,6 +1054,59 @@ def recover_blocked_publication_ready(
         except Exception as exc:
             raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
     return "transitioned"
+
+
+def complete_blocked_publication_recovery(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
+) -> str:
+    """Consume the exact recovery receipt only after Draft convergence."""
+    validate_task(task)
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if not isinstance(expected_state, bytes) or set(expected_evidence) != evidence_names:
+        raise LifecycleError("expected recovered publication subject is invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        with private_state.mutation_lock(record.path, admin=True):
+            receipt_content, receipt_identity = private_state.read_bytes_identity(
+                receipt_path, "publication recovery receipt"
+            )
+            if receipt_content != recovery_receipt:
+                raise LifecycleError("publication recovery receipt changed before consumption")
+            with task_contract.contract_state_lock(record.path) as directory_fd:
+                current = current_worktree(record.path)
+                registered = worktree_for_task(record.path, task)
+                if current != record or registered != record:
+                    raise LifecycleError("Task worktree identity changed before receipt consumption")
+                assert_task_identity(record, task)
+                actual_state = task_contract._read_state_file(directory_fd, "task.md")
+                actual_evidence = {
+                    name: task_contract._read_state_file(directory_fd, name)
+                    for name in evidence_names
+                }
+                task_contract._assert_state_dir_binding(record.path, directory_fd)
+                if actual_state != expected_state or actual_evidence != expected_evidence:
+                    raise LifecycleError(
+                        "recovered publication subject changed before receipt consumption"
+                    )
+                private_state.unlink(
+                    receipt_path,
+                    expected_identity=receipt_identity,
+                    expected_content=recovery_receipt,
+                    _lock_held=True,
+                )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot consume blocked publication recovery receipt") from exc
+    return "consumed"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/templates/agent-python/.automation/bin/git_private_state.py
+++ b/templates/agent-python/.automation/bin/git_private_state.py
@@ -22,7 +22,11 @@ HASH_RE = re.compile(r"[0-9a-f]{64}")
 OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
 REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
-FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+FIXED_AUTHORITY_FILES = {
+    "authority.json",
+    "source-recovery-proof.json",
+    "publication-recovery.json",
+}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
 TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
@@ -96,6 +100,11 @@ def common_state(root: Path) -> Path:
 
 def admin_maintenance(root: Path) -> Path:
     return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def publication_recovery_receipt(root: Path) -> Path:
+    """Return the protected receipt path in this worktree's Git admin dir."""
+    return admin_maintenance(root) / "publication-recovery.json"
 
 
 def cleanup_receipt(root: Path, task: str) -> Path:
@@ -564,6 +573,41 @@ def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -
     return admin
 
 
+def _validate_publication_recovery_topology(
+    path: Path, value: dict, layout: Topology
+) -> Path:
+    """Bind a publication recovery receipt to its exact worktree and HEAD."""
+    admin = _validate_authority_topology(path, json.dumps(value).encode(), layout)
+    worktree = Path(value["worktree"])
+    try:
+        result = subprocess.run(
+            [_GIT_EXECUTABLE, "-C", str(worktree), "rev-parse", "--verify", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("GIT_")
+            } | {
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+            },
+        )
+        actual_head = result.stdout.strip()
+    except OSError as exc:
+        raise GitPrivateStateError(
+            f"publication recovery worktree HEAD is unreadable: {path}"
+        ) from exc
+    if result.returncode != 0 or not _valid_oid(actual_head):
+        raise GitPrivateStateError(f"publication recovery worktree HEAD is unreadable: {path}")
+    if value["head"] != actual_head:
+        raise GitPrivateStateError(f"publication recovery HEAD does not match worktree: {path}")
+    return admin
+
+
 def _validate_legacy_content(path: Path, content: bytes) -> None:
     directory = path.parent.name
     name = path.name
@@ -606,6 +650,35 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and _valid_oid(value.get("base_revision"))
             and _valid_oid(value.get("local_head"))
             and value.get("local_head").casefold() == value.get("base_revision").casefold()
+        )
+    elif name == "publication-recovery.json":
+        required = {
+            "schema_version", "kind", "repository", "task_id", "worktree", "branch",
+            "head", "base_branch", "base_revision", "pr_number",
+            "blocked_state_sha256", "publication_ready_state_sha256",
+            "draft_pr_created_state_sha256", "work_units_sha256", "verification_sha256",
+            "contract_sha256", "issue_sha256",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "blocked-publication-recovery"
+            and _valid_repository(value.get("repository"))
+            and _valid_task_id(value.get("task_id"))
+            and _valid_absolute_path(value.get("worktree"))
+            and _valid_task_branch(value.get("branch"), value.get("task_id"))
+            and _valid_oid(value.get("head"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_oid(value.get("base_revision"))
+            and isinstance(value.get("pr_number"), int)
+            and not isinstance(value.get("pr_number"), bool)
+            and value.get("pr_number") > 0
+            and all(_valid_digest(value.get(field)) for field in (
+                "blocked_state_sha256", "publication_ready_state_sha256",
+                "draft_pr_created_state_sha256", "work_units_sha256",
+                "verification_sha256", "contract_sha256",
+            ))
+            and (value.get("issue_sha256") is None or _valid_digest(value.get("issue_sha256")))
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -685,7 +758,12 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
                 content = read_bytes(child)
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
-                authority_admin = _validate_authority_topology(child, content, layout)
+                authority_value = _legacy_json(content, child)
+                authority_admin = (
+                    _validate_publication_recovery_topology(child, authority_value, layout)
+                    if child.name == "publication-recovery.json"
+                    else _validate_authority_topology(child, content, layout)
+                )
             if child.name in FIXED_AUTHORITY_FILES:
                 if authority_admin not in {layout.common, layout.admin}:
                     raise GitPrivateStateError(
@@ -723,7 +801,13 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
         content = read_bytes(child)
         _validate_legacy_content(child, content)
         _validate_authority_filename(child, content)
-        if _validate_authority_topology(child, content, layout) != layout.admin:
+        authority_value = _legacy_json(content, child)
+        owner = (
+            _validate_publication_recovery_topology(child, authority_value, layout)
+            if child.name == "publication-recovery.json"
+            else _validate_authority_topology(child, content, layout)
+        )
+        if owner != layout.admin:
             raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
     _validate_legacy_relations(
@@ -826,7 +910,12 @@ def _validate_canonical(
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
                 if entry.name == "automation-maintenance":
-                    authority_admin = _validate_authority_topology(child, content, layout)
+                    authority_value = _legacy_json(content, child)
+                    authority_admin = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
                     if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
@@ -863,7 +952,13 @@ def _validate_canonical(
                     content = read_bytes(child, "canonical private-state record")
                     _validate_legacy_content(child, content)
                     _validate_authority_filename(child, content)
-                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                    authority_value = _legacy_json(content, child)
+                    owner = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
+                    if owner != layout.admin:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
                         )

--- a/templates/agent-python/.automation/bin/task_lifecycle.py
+++ b/templates/agent-python/.automation/bin/task_lifecycle.py
@@ -959,6 +959,74 @@ def mark_task_publication_state(
     return "transitioned"
 
 
+def recover_blocked_publication_ready(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+) -> str:
+    """CAS a proven publication-only blocked Task to publication-ready.
+
+    This deliberately is not part of the general transition table: recovery
+    may use it only after its external publication evidence has been checked.
+    """
+    validate_task(task)
+    if not isinstance(expected_state, bytes):
+        raise LifecycleError("expected Task State CAS value must be bytes")
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if set(expected_evidence) != evidence_names or any(
+        value is not None and not isinstance(value, bytes)
+        for value in expected_evidence.values()
+    ):
+        raise LifecycleError("expected publication evidence CAS values are invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    try:
+        state_lock = task_contract.contract_state_lock(record.path)
+    except AttributeError as exc:  # pragma: no cover - verified module contract
+        raise LifecycleError("canonical Task State lock is unavailable") from exc
+    with state_lock as directory_fd:
+        current = current_worktree(record.path)
+        if current != record:
+            raise LifecycleError("local Task worktree identity changed")
+        registered = worktree_for_task(record.path, task)
+        if registered != record:
+            raise LifecycleError("Task worktree registration identity changed")
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        try:
+            actual = task_contract._read_state_file(directory_fd, "task.md")
+            actual_evidence = {
+                name: task_contract._read_state_file(directory_fd, name)
+                for name in evidence_names
+            }
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot read Task State for guarded recovery: {path}") from exc
+        if actual != expected_state:
+            raise LifecycleError("Task State changed before guarded blocked recovery")
+        if actual_evidence != expected_evidence:
+            raise LifecycleError("publication evidence changed before guarded blocked recovery")
+        try:
+            text = actual.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise LifecycleError("Task State is not valid UTF-8") from exc
+        updated, count = re.subn(
+            r"(?m)^- Status: blocked$", "- Status: publication-ready", text, count=1
+        )
+        if count != 1:
+            raise LifecycleError("cannot update blocked Task State status")
+        try:
+            task_contract._write_state_file(
+                directory_fd, "task.md", updated.encode("utf-8")
+            )
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
+    return "transitioned"
+
+
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:
     """Dedicated terminal transition used only after guarded merge reconciliation."""
     validate_task(task)

--- a/templates/agent-python/.automation/bin/task_lifecycle.py
+++ b/templates/agent-python/.automation/bin/task_lifecycle.py
@@ -964,6 +964,7 @@ def recover_blocked_publication_ready(
     task: str,
     expected_state: bytes,
     expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
 ) -> str:
     """CAS a proven publication-only blocked Task to publication-ready.
 
@@ -981,6 +982,34 @@ def recover_blocked_publication_ready(
         raise LifecycleError("expected publication evidence CAS values are invalid")
     require_resolved_contract(record, task)
     import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        receipt_value = json.loads(recovery_receipt.decode("utf-8"))
+        private_state._validate_legacy_content(receipt_path, recovery_receipt)
+        private_state._validate_publication_recovery_topology(
+            receipt_path, receipt_value, private_state.topology(record.path)
+        )
+        with private_state.mutation_lock(record.path, admin=True):
+            try:
+                receipt_path.lstat()
+            except FileNotFoundError:
+                private_state.exclusive_write_bytes(
+                    receipt_path, recovery_receipt, _lock_held=True
+                )
+            else:
+                existing = private_state.read_bytes(
+                    receipt_path, "publication recovery receipt"
+                )
+                if existing != recovery_receipt:
+                    raise LifecycleError(
+                        "conflicting publication recovery receipt already exists"
+                    )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot durably bind blocked publication recovery") from exc
 
     try:
         state_lock = task_contract.contract_state_lock(record.path)
@@ -1025,6 +1054,59 @@ def recover_blocked_publication_ready(
         except Exception as exc:
             raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
     return "transitioned"
+
+
+def complete_blocked_publication_recovery(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
+) -> str:
+    """Consume the exact recovery receipt only after Draft convergence."""
+    validate_task(task)
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if not isinstance(expected_state, bytes) or set(expected_evidence) != evidence_names:
+        raise LifecycleError("expected recovered publication subject is invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        with private_state.mutation_lock(record.path, admin=True):
+            receipt_content, receipt_identity = private_state.read_bytes_identity(
+                receipt_path, "publication recovery receipt"
+            )
+            if receipt_content != recovery_receipt:
+                raise LifecycleError("publication recovery receipt changed before consumption")
+            with task_contract.contract_state_lock(record.path) as directory_fd:
+                current = current_worktree(record.path)
+                registered = worktree_for_task(record.path, task)
+                if current != record or registered != record:
+                    raise LifecycleError("Task worktree identity changed before receipt consumption")
+                assert_task_identity(record, task)
+                actual_state = task_contract._read_state_file(directory_fd, "task.md")
+                actual_evidence = {
+                    name: task_contract._read_state_file(directory_fd, name)
+                    for name in evidence_names
+                }
+                task_contract._assert_state_dir_binding(record.path, directory_fd)
+                if actual_state != expected_state or actual_evidence != expected_evidence:
+                    raise LifecycleError(
+                        "recovered publication subject changed before receipt consumption"
+                    )
+                private_state.unlink(
+                    receipt_path,
+                    expected_identity=receipt_identity,
+                    expected_content=recovery_receipt,
+                    _lock_held=True,
+                )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot consume blocked publication recovery receipt") from exc
+    return "consumed"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/templates/agent-rust/.automation/bin/git_private_state.py
+++ b/templates/agent-rust/.automation/bin/git_private_state.py
@@ -22,7 +22,11 @@ HASH_RE = re.compile(r"[0-9a-f]{64}")
 OID_RE = re.compile(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}")
 REPOSITORY_RE = re.compile(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
 SHARED_DIRS = ("cleanup", "integration", "discard-pristine", "automation-maintenance")
-FIXED_AUTHORITY_FILES = {"authority.json", "source-recovery-proof.json"}
+FIXED_AUTHORITY_FILES = {
+    "authority.json",
+    "source-recovery-proof.json",
+    "publication-recovery.json",
+}
 LOCK_FILES = {"cleanup.lock", "migration.lock"}
 TEMP_RE = re.compile(r"\.(?:migrate|record)\.[0-9]+\.[0-9a-f]{16}")
 _GIT_EXECUTABLE = "git"
@@ -96,6 +100,11 @@ def common_state(root: Path) -> Path:
 
 def admin_maintenance(root: Path) -> Path:
     return admin_git_dir(root) / NAMESPACE / "automation-maintenance"
+
+
+def publication_recovery_receipt(root: Path) -> Path:
+    """Return the protected receipt path in this worktree's Git admin dir."""
+    return admin_maintenance(root) / "publication-recovery.json"
 
 
 def cleanup_receipt(root: Path, task: str) -> Path:
@@ -564,6 +573,41 @@ def _validate_authority_topology(path: Path, content: bytes, layout: Topology) -
     return admin
 
 
+def _validate_publication_recovery_topology(
+    path: Path, value: dict, layout: Topology
+) -> Path:
+    """Bind a publication recovery receipt to its exact worktree and HEAD."""
+    admin = _validate_authority_topology(path, json.dumps(value).encode(), layout)
+    worktree = Path(value["worktree"])
+    try:
+        result = subprocess.run(
+            [_GIT_EXECUTABLE, "-C", str(worktree), "rev-parse", "--verify", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if not key.startswith("GIT_")
+            } | {
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+            },
+        )
+        actual_head = result.stdout.strip()
+    except OSError as exc:
+        raise GitPrivateStateError(
+            f"publication recovery worktree HEAD is unreadable: {path}"
+        ) from exc
+    if result.returncode != 0 or not _valid_oid(actual_head):
+        raise GitPrivateStateError(f"publication recovery worktree HEAD is unreadable: {path}")
+    if value["head"] != actual_head:
+        raise GitPrivateStateError(f"publication recovery HEAD does not match worktree: {path}")
+    return admin
+
+
 def _validate_legacy_content(path: Path, content: bytes) -> None:
     directory = path.parent.name
     name = path.name
@@ -606,6 +650,35 @@ def _validate_legacy_content(path: Path, content: bytes) -> None:
             and _valid_oid(value.get("base_revision"))
             and _valid_oid(value.get("local_head"))
             and value.get("local_head").casefold() == value.get("base_revision").casefold()
+        )
+    elif name == "publication-recovery.json":
+        required = {
+            "schema_version", "kind", "repository", "task_id", "worktree", "branch",
+            "head", "base_branch", "base_revision", "pr_number",
+            "blocked_state_sha256", "publication_ready_state_sha256",
+            "draft_pr_created_state_sha256", "work_units_sha256", "verification_sha256",
+            "contract_sha256", "issue_sha256",
+        }
+        valid = (
+            set(value) == required
+            and value.get("schema_version") == 1
+            and value.get("kind") == "blocked-publication-recovery"
+            and _valid_repository(value.get("repository"))
+            and _valid_task_id(value.get("task_id"))
+            and _valid_absolute_path(value.get("worktree"))
+            and _valid_task_branch(value.get("branch"), value.get("task_id"))
+            and _valid_oid(value.get("head"))
+            and _valid_nonempty(value.get("base_branch"))
+            and _valid_oid(value.get("base_revision"))
+            and isinstance(value.get("pr_number"), int)
+            and not isinstance(value.get("pr_number"), bool)
+            and value.get("pr_number") > 0
+            and all(_valid_digest(value.get(field)) for field in (
+                "blocked_state_sha256", "publication_ready_state_sha256",
+                "draft_pr_created_state_sha256", "work_units_sha256",
+                "verification_sha256", "contract_sha256",
+            ))
+            and (value.get("issue_sha256") is None or _valid_digest(value.get("issue_sha256")))
         )
     elif name == "source-recovery-proof.json":
         required = {
@@ -685,7 +758,12 @@ def _scan_shared_legacy(layout: Topology) -> tuple[list[tuple[Path, Path]], Path
                 content = read_bytes(child)
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
-                authority_admin = _validate_authority_topology(child, content, layout)
+                authority_value = _legacy_json(content, child)
+                authority_admin = (
+                    _validate_publication_recovery_topology(child, authority_value, layout)
+                    if child.name == "publication-recovery.json"
+                    else _validate_authority_topology(child, content, layout)
+                )
             if child.name in FIXED_AUTHORITY_FILES:
                 if authority_admin not in {layout.common, layout.admin}:
                     raise GitPrivateStateError(
@@ -723,7 +801,13 @@ def _scan_admin_legacy(layout: Topology) -> list[tuple[Path, Path]]:
         content = read_bytes(child)
         _validate_legacy_content(child, content)
         _validate_authority_filename(child, content)
-        if _validate_authority_topology(child, content, layout) != layout.admin:
+        authority_value = _legacy_json(content, child)
+        owner = (
+            _validate_publication_recovery_topology(child, authority_value, layout)
+            if child.name == "publication-recovery.json"
+            else _validate_authority_topology(child, content, layout)
+        )
+        if owner != layout.admin:
             raise GitPrivateStateError(f"fixed authority is outside its worktree admin: {child}")
         pairs.append((child, layout.admin / NAMESPACE / "automation-maintenance" / child.name))
     _validate_legacy_relations(
@@ -826,7 +910,12 @@ def _validate_canonical(
                 _validate_legacy_content(child, content)
                 _validate_authority_filename(child, content)
                 if entry.name == "automation-maintenance":
-                    authority_admin = _validate_authority_topology(child, content, layout)
+                    authority_value = _legacy_json(content, child)
+                    authority_admin = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
                     if child.name in FIXED_AUTHORITY_FILES and authority_admin != layout.common:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
@@ -863,7 +952,13 @@ def _validate_canonical(
                     content = read_bytes(child, "canonical private-state record")
                     _validate_legacy_content(child, content)
                     _validate_authority_filename(child, content)
-                    if _validate_authority_topology(child, content, layout) != layout.admin:
+                    authority_value = _legacy_json(content, child)
+                    owner = (
+                        _validate_publication_recovery_topology(child, authority_value, layout)
+                        if child.name == "publication-recovery.json"
+                        else _validate_authority_topology(child, content, layout)
+                    )
+                    if owner != layout.admin:
                         raise GitPrivateStateError(
                             f"fixed authority is outside its worktree admin: {child}"
                         )

--- a/templates/agent-rust/.automation/bin/task_lifecycle.py
+++ b/templates/agent-rust/.automation/bin/task_lifecycle.py
@@ -959,6 +959,74 @@ def mark_task_publication_state(
     return "transitioned"
 
 
+def recover_blocked_publication_ready(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+) -> str:
+    """CAS a proven publication-only blocked Task to publication-ready.
+
+    This deliberately is not part of the general transition table: recovery
+    may use it only after its external publication evidence has been checked.
+    """
+    validate_task(task)
+    if not isinstance(expected_state, bytes):
+        raise LifecycleError("expected Task State CAS value must be bytes")
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if set(expected_evidence) != evidence_names or any(
+        value is not None and not isinstance(value, bytes)
+        for value in expected_evidence.values()
+    ):
+        raise LifecycleError("expected publication evidence CAS values are invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    try:
+        state_lock = task_contract.contract_state_lock(record.path)
+    except AttributeError as exc:  # pragma: no cover - verified module contract
+        raise LifecycleError("canonical Task State lock is unavailable") from exc
+    with state_lock as directory_fd:
+        current = current_worktree(record.path)
+        if current != record:
+            raise LifecycleError("local Task worktree identity changed")
+        registered = worktree_for_task(record.path, task)
+        if registered != record:
+            raise LifecycleError("Task worktree registration identity changed")
+        assert_task_identity(record, task)
+        path = state_path(record.path)
+        try:
+            actual = task_contract._read_state_file(directory_fd, "task.md")
+            actual_evidence = {
+                name: task_contract._read_state_file(directory_fd, name)
+                for name in evidence_names
+            }
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot read Task State for guarded recovery: {path}") from exc
+        if actual != expected_state:
+            raise LifecycleError("Task State changed before guarded blocked recovery")
+        if actual_evidence != expected_evidence:
+            raise LifecycleError("publication evidence changed before guarded blocked recovery")
+        try:
+            text = actual.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise LifecycleError("Task State is not valid UTF-8") from exc
+        updated, count = re.subn(
+            r"(?m)^- Status: blocked$", "- Status: publication-ready", text, count=1
+        )
+        if count != 1:
+            raise LifecycleError("cannot update blocked Task State status")
+        try:
+            task_contract._write_state_file(
+                directory_fd, "task.md", updated.encode("utf-8")
+            )
+            task_contract._assert_state_dir_binding(record.path, directory_fd)
+        except Exception as exc:
+            raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
+    return "transitioned"
+
+
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:
     """Dedicated terminal transition used only after guarded merge reconciliation."""
     validate_task(task)

--- a/templates/agent-rust/.automation/bin/task_lifecycle.py
+++ b/templates/agent-rust/.automation/bin/task_lifecycle.py
@@ -964,6 +964,7 @@ def recover_blocked_publication_ready(
     task: str,
     expected_state: bytes,
     expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
 ) -> str:
     """CAS a proven publication-only blocked Task to publication-ready.
 
@@ -981,6 +982,34 @@ def recover_blocked_publication_ready(
         raise LifecycleError("expected publication evidence CAS values are invalid")
     require_resolved_contract(record, task)
     import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        receipt_value = json.loads(recovery_receipt.decode("utf-8"))
+        private_state._validate_legacy_content(receipt_path, recovery_receipt)
+        private_state._validate_publication_recovery_topology(
+            receipt_path, receipt_value, private_state.topology(record.path)
+        )
+        with private_state.mutation_lock(record.path, admin=True):
+            try:
+                receipt_path.lstat()
+            except FileNotFoundError:
+                private_state.exclusive_write_bytes(
+                    receipt_path, recovery_receipt, _lock_held=True
+                )
+            else:
+                existing = private_state.read_bytes(
+                    receipt_path, "publication recovery receipt"
+                )
+                if existing != recovery_receipt:
+                    raise LifecycleError(
+                        "conflicting publication recovery receipt already exists"
+                    )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot durably bind blocked publication recovery") from exc
 
     try:
         state_lock = task_contract.contract_state_lock(record.path)
@@ -1025,6 +1054,59 @@ def recover_blocked_publication_ready(
         except Exception as exc:
             raise LifecycleError(f"cannot update Task State for guarded recovery: {path}") from exc
     return "transitioned"
+
+
+def complete_blocked_publication_recovery(
+    record: WorktreeRecord,
+    task: str,
+    expected_state: bytes,
+    expected_evidence: dict[str, bytes | None],
+    recovery_receipt: bytes,
+) -> str:
+    """Consume the exact recovery receipt only after Draft convergence."""
+    validate_task(task)
+    evidence_names = {"work-units.json", "verification.json", "contract.json", "issue.json"}
+    if not isinstance(expected_state, bytes) or set(expected_evidence) != evidence_names:
+        raise LifecycleError("expected recovered publication subject is invalid")
+    require_resolved_contract(record, task)
+    import task_contract
+
+    receipt_path = private_state.publication_recovery_receipt(record.path)
+    try:
+        private_state.prepare(record.path, admin=True)
+        with private_state.mutation_lock(record.path, admin=True):
+            receipt_content, receipt_identity = private_state.read_bytes_identity(
+                receipt_path, "publication recovery receipt"
+            )
+            if receipt_content != recovery_receipt:
+                raise LifecycleError("publication recovery receipt changed before consumption")
+            with task_contract.contract_state_lock(record.path) as directory_fd:
+                current = current_worktree(record.path)
+                registered = worktree_for_task(record.path, task)
+                if current != record or registered != record:
+                    raise LifecycleError("Task worktree identity changed before receipt consumption")
+                assert_task_identity(record, task)
+                actual_state = task_contract._read_state_file(directory_fd, "task.md")
+                actual_evidence = {
+                    name: task_contract._read_state_file(directory_fd, name)
+                    for name in evidence_names
+                }
+                task_contract._assert_state_dir_binding(record.path, directory_fd)
+                if actual_state != expected_state or actual_evidence != expected_evidence:
+                    raise LifecycleError(
+                        "recovered publication subject changed before receipt consumption"
+                    )
+                private_state.unlink(
+                    receipt_path,
+                    expected_identity=receipt_identity,
+                    expected_content=recovery_receipt,
+                    _lock_held=True,
+                )
+    except LifecycleError:
+        raise
+    except Exception as exc:
+        raise LifecycleError("cannot consume blocked publication recovery receipt") from exc
+    return "consumed"
 
 
 def mark_task_merged_from_integration(record: WorktreeRecord, task: str) -> str:

--- a/tests/test_git_private_state.py
+++ b/tests/test_git_private_state.py
@@ -101,6 +101,29 @@ class GitPrivateStateTest(unittest.TestCase):
             "receipt_sha256": "a" * 64,
         }
 
+    def publication_recovery_record(self, root: Path, task: str = "1") -> dict:
+        worktree = Path(self.valid_worktree(root, f"{task}-test"))
+        head = command("git", "rev-parse", "HEAD", cwd=worktree)
+        return {
+            "schema_version": 1,
+            "kind": "blocked-publication-recovery",
+            "repository": "acme/widgets",
+            "task_id": task,
+            "worktree": str(worktree),
+            "branch": f"task/{task}-test",
+            "head": head,
+            "base_branch": "main",
+            "base_revision": head,
+            "pr_number": 149,
+            "blocked_state_sha256": "a" * 64,
+            "publication_ready_state_sha256": "b" * 64,
+            "draft_pr_created_state_sha256": "c" * 64,
+            "work_units_sha256": "d" * 64,
+            "verification_sha256": "e" * 64,
+            "contract_sha256": "f" * 64,
+            "issue_sha256": None,
+        }
+
     def proof_record(self, root: Path, task: str = "1") -> dict:
         authority = self.authority_record(root, task)
         return {
@@ -130,6 +153,40 @@ class GitPrivateStateTest(unittest.TestCase):
                 common / "agent-core" / "integration" / "pr-12.head",
             )
             self.assertFalse((common / "agent-core").exists())
+
+    def test_publication_recovery_path_is_worktree_admin_private(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = self.repository(Path(directory))
+            self.assertEqual(
+                private_state.admin_git_dir(repo) / "agent-core/automation-maintenance/publication-recovery.json",
+                private_state.publication_recovery_receipt(repo),
+            )
+
+    def test_publication_recovery_receipt_is_validated_in_canonical_topology(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repo = self.repository(root)
+            linked = Path(self.valid_worktree(repo, "1-test"))
+            receipt = private_state.publication_recovery_receipt(linked)
+            private_state.prepare(linked, admin=True)
+            content = json.dumps(self.publication_recovery_record(repo)).encode()
+            private_state.exclusive_write_bytes(receipt, content)
+            private_state.prepare(linked, admin=True)
+            self.assertEqual(content, private_state.read_bytes(receipt))
+
+    def test_publication_recovery_rejects_tampered_head_and_boolean_pr_number(self) -> None:
+        for field, replacement in (("head", "a" * 40), ("pr_number", True)):
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                repo = self.repository(root)
+                linked = Path(self.valid_worktree(repo, "1-test"))
+                private_state.prepare(linked, admin=True)
+                value = self.publication_recovery_record(repo)
+                value[field] = replacement
+                path = private_state.publication_recovery_receipt(linked)
+                private_state.write_bytes(path, json.dumps(value).encode())
+                with self.assertRaises(private_state.GitPrivateStateError):
+                    private_state.prepare(linked, admin=True)
 
     def test_regular_opencode_is_foreign_and_identity_is_unchanged(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_source_publication_recovery_bridge.py
+++ b/tests/test_source_publication_recovery_bridge.py
@@ -49,7 +49,12 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
         self.publication.completed_reviews.return_value = ["- `review` — `reviewer` — completed"]
         self.contract = mock.MagicMock()
         self.contract._read_state_file.return_value = None
+        self.private = mock.Mock()
+        self.private.publication_recovery_receipt.return_value = Path(
+            "/tmp/nonexistent-publication-recovery-receipt"
+        )
         self.modules = {
+            "git_private_state": self.private,
             "task_lifecycle": self.lifecycle,
             "agent_core": self.agent,
             "publication_metadata": self.publication,
@@ -130,6 +135,7 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
         self.agent.pr_prepare.assert_called_once_with(self.target, "131")
         self.agent.pr_create.assert_called_once_with(self.target, "131")
         self.agent.pr_edit.assert_not_called()
+        self.lifecycle.complete_blocked_publication_recovery.assert_not_called()
         self.assertIs(self.agent.verify, original_verify)
 
     def test_draft_pr_created_without_existing_pr_fails_closed_before_mutation(self) -> None:
@@ -213,7 +219,7 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
             "body": "Validation at 97dbf03607d8eaabfc76104be2722d89aa6ddf2d",
         }
         repaired = {**stale, "body": f"Validation at {current_head}"}
-        self.agent.pr_for_branch.side_effect = [stale, stale, stale, repaired, repaired]
+        self.agent.pr_for_branch.side_effect = [stale, stale, stale, repaired, repaired, repaired]
         self.agent.default_branch.return_value = "main"
         self.publication.canonical_metadata.return_value = ("13: canonical", repaired["body"])
         self.agent._validated_local_metadata.return_value = (
@@ -234,11 +240,13 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
                 "contract.json": before["contract"],
                 "issue.json": before["issue"],
             },
+            mock.ANY,
         )
         self.agent.pr_edit.assert_called_once_with(self.target, "13", expected_pr_number=29)
         self.agent.pr_create.assert_not_called()
         self.assertEqual(after["work_units"], before["work_units"])
         self.assertIn(b"WU-13-28", after["work_units"])
+        self.lifecycle.complete_blocked_publication_recovery.assert_called_once()
 
     def test_blocked_invalid_or_moved_pr_fails_before_state_mutation(self) -> None:
         before = {
@@ -359,6 +367,168 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
                      self.assertRaisesRegex(bridge.BridgeError, "authority changed"):
                     bridge._publication_recover(self.modules, self.target, "131")
                 self.lifecycle.recover_blocked_publication_ready.assert_not_called()
+
+    def test_interrupted_blocked_recovery_retry_without_bound_pr_fails_closed(self) -> None:
+        ready = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue",
+            "state": b"- Base revision: " + b"b" * 40 + b"\n- Status: publication-ready\n",
+            "status": "publication-ready",
+        }
+        receipt = bridge._publication_recovery_receipt(
+            self.target, "131", ready, "main", 29
+        )
+        self.agent.default_branch.return_value = "main"
+        self.agent.pr_for_branch.return_value = None
+        with mock.patch.object(bridge, "_publication_snapshot", return_value=ready), \
+             mock.patch.object(bridge, "_read_publication_recovery_receipt", return_value=receipt), \
+             self.assertRaisesRegex(bridge.BridgeError, "receipt-bound Draft PR"):
+            bridge._publication_recover(self.modules, self.target, "131")
+        self.agent.pr_create.assert_not_called()
+        self.agent.pr_edit.assert_not_called()
+        self.agent.gh.assert_not_called()
+
+    def test_interrupted_blocked_recovery_retry_rejects_replacement_pr(self) -> None:
+        ready = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue",
+            "state": b"- Base revision: " + b"b" * 40 + b"\n- Status: publication-ready\n",
+            "status": "publication-ready",
+        }
+        receipt = bridge._publication_recovery_receipt(
+            self.target, "131", ready, "main", 29
+        )
+        replacement = {
+            "number": 30, "headRefName": self.branch, "baseRefName": "main",
+            "headRefOid": self.head, "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN",
+        }
+        self.agent.default_branch.return_value = "main"
+        self.agent.pr_for_branch.return_value = replacement
+        with mock.patch.object(bridge, "_publication_snapshot", return_value=ready), \
+             mock.patch.object(bridge, "_read_publication_recovery_receipt", return_value=receipt), \
+             self.assertRaisesRegex(bridge.BridgeError, "differs from recovery receipt"):
+            bridge._publication_recover(self.modules, self.target, "131")
+        self.agent.pr_create.assert_not_called()
+        self.agent.pr_edit.assert_not_called()
+
+    def test_interrupted_blocked_recovery_retry_converges_same_pr_and_consumes_receipt(self) -> None:
+        ready = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue",
+            "state": b"- Base revision: " + b"b" * 40 + b"\n- Status: publication-ready\n",
+            "status": "publication-ready",
+        }
+        blocked = {
+            **ready,
+            "state": ready["state"].replace(b"publication-ready", b"blocked"),
+            "status": "blocked",
+        }
+        final = {
+            **ready,
+            "state": ready["state"].replace(b"publication-ready", b"draft-pr-created"),
+            "status": "draft-pr-created",
+        }
+        exact = {
+            "number": 29, "headRefName": self.branch, "baseRefName": "main",
+            "headRefOid": self.head, "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN", "body": "canonical",
+        }
+        self.agent.default_branch.return_value = "main"
+        self.agent.pr_for_branch.return_value = exact
+        self.publication.canonical_metadata.return_value = ("title", "canonical")
+        captured_receipts: list[bytes] = []
+
+        def interrupt_after_cas(
+            _record: object,
+            _task: str,
+            _state: bytes,
+            _evidence: dict,
+            receipt: bytes,
+        ) -> None:
+            captured_receipts.append(receipt)
+            raise RuntimeError("interrupted after durable publication-ready CAS")
+
+        self.lifecycle.recover_blocked_publication_ready.side_effect = interrupt_after_cas
+        with mock.patch.object(bridge, "_publication_snapshot", side_effect=[blocked, blocked]), \
+             mock.patch.object(bridge, "_read_publication_recovery_receipt", return_value=None), \
+             mock.patch.object(bridge, "_target_git", return_value=""), \
+             self.assertRaisesRegex(bridge.BridgeError, "interrupted after durable"):
+            bridge._publication_recover(self.modules, self.target, "131")
+        self.agent.pr_prepare.assert_not_called()
+        self.agent.pr_edit.assert_not_called()
+        self.agent.pr_create.assert_not_called()
+        self.assertEqual(len(captured_receipts), 1)
+
+        receipt = captured_receipts[0]
+        self.agent.reset_mock()
+        self.lifecycle.reset_mock()
+        self.lifecycle.recover_blocked_publication_ready.side_effect = None
+        self.agent.default_branch.return_value = "main"
+        self.agent.pr_for_branch.return_value = exact
+        self.agent._validated_local_metadata.return_value = (
+            "title", Path("/tmp/body"), "canonical"
+        )
+        with mock.patch.object(bridge, "_publication_snapshot", side_effect=[ready, ready]), \
+             mock.patch.object(bridge, "_publication_snapshot_for_post", return_value=final), \
+             mock.patch.object(bridge, "_read_publication_recovery_receipt", return_value=receipt), \
+             mock.patch.object(bridge, "_target_git", return_value=""):
+            result = bridge._publication_recover(self.modules, self.target, "131")
+        self.assertEqual(result["pullRequest"]["number"], 29)
+        self.agent.pr_edit.assert_called_once_with(
+            self.target, "131", expected_pr_number=29
+        )
+        self.agent.pr_create.assert_not_called()
+        self.lifecycle.complete_blocked_publication_recovery.assert_called_once_with(
+            self.record,
+            "131",
+            final["state"],
+            {
+                "work-units.json": ready["work_units"],
+                "verification.json": ready["verification"],
+                "contract.json": ready["contract"],
+                "issue.json": ready["issue"],
+            },
+            receipt,
+        )
+
+    def test_receipt_is_retained_when_pr_changes_before_consumption(self) -> None:
+        ready = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue",
+            "state": b"- Base revision: " + b"b" * 40 + b"\n- Status: publication-ready\n",
+            "status": "publication-ready",
+        }
+        final = {
+            **ready,
+            "state": ready["state"].replace(b"publication-ready", b"draft-pr-created"),
+            "status": "draft-pr-created",
+        }
+        receipt = bridge._publication_recovery_receipt(
+            self.target, "131", ready, "main", 29
+        )
+        exact = {
+            "number": 29, "headRefName": self.branch, "baseRefName": "main",
+            "headRefOid": self.head, "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN", "body": "canonical",
+        }
+        replacement = {**exact, "number": 30}
+        self.agent.default_branch.return_value = "main"
+        self.agent.pr_for_branch.side_effect = [exact, exact, exact, exact, replacement]
+        self.agent._validated_local_metadata.return_value = (
+            "title", Path("/tmp/body"), "canonical"
+        )
+        with mock.patch.object(bridge, "_publication_snapshot", side_effect=[ready, ready]), \
+             mock.patch.object(bridge, "_publication_snapshot_for_post", return_value=final), \
+             mock.patch.object(bridge, "_read_publication_recovery_receipt", return_value=receipt), \
+             mock.patch.object(bridge, "_target_git", return_value=""), \
+             self.assertRaisesRegex(bridge.BridgeError, "changed before receipt consumption"):
+            bridge._publication_recover(self.modules, self.target, "131")
+        self.lifecycle.complete_blocked_publication_recovery.assert_not_called()
 
     def test_stale_verification_and_effective_reviewer_fail_before_create(self) -> None:
         self.lifecycle.state_status.return_value = "blocked"

--- a/tests/test_source_publication_recovery_bridge.py
+++ b/tests/test_source_publication_recovery_bridge.py
@@ -47,11 +47,13 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
         self.publication = mock.Mock()
         self.publication.verification_evidence.return_value = {"head": self.head}
         self.publication.completed_reviews.return_value = ["- `review` — `reviewer` — completed"]
+        self.contract = mock.MagicMock()
+        self.contract._read_state_file.return_value = None
         self.modules = {
             "task_lifecycle": self.lifecycle,
             "agent_core": self.agent,
             "publication_metadata": self.publication,
-            "task_contract": mock.Mock(),
+            "task_contract": self.contract,
         }
 
     def snapshot_git(self, *args: str, **_: object) -> str:
@@ -91,11 +93,16 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
         before = self.snapshot()
         self.assertEqual(before["status"], "draft-pr-created")
 
+    def test_snapshot_accepts_blocked_only_as_a_recovery_candidate(self) -> None:
+        self.lifecycle.state_status.return_value = "blocked"
+        before = self.snapshot()
+        self.assertEqual(before["status"], "blocked")
+
     def test_snapshot_rejects_other_lifecycle_states(self) -> None:
         self.lifecycle.state_status.return_value = "implementing"
         with self.assertRaisesRegex(
             bridge.BridgeError,
-            "requires publication-ready or draft-pr-created",
+            "requires blocked, publication-ready, or draft-pr-created",
         ):
             self.snapshot()
 
@@ -165,7 +172,196 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
         self.agent.pr_create.assert_not_called()
         self.agent.pr_edit.assert_not_called()
 
+    def test_blocked_without_existing_pr_fails_before_state_or_github_mutation(self) -> None:
+        before = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue", "state": b"- Status: blocked\n",
+            "status": "blocked",
+        }
+        self.agent.pr_for_branch.return_value = None
+        with mock.patch.object(bridge, "_publication_snapshot", return_value=before), \
+             self.assertRaisesRegex(bridge.BridgeError, "blocked publication recovery requires the existing Draft PR"):
+            bridge._publication_recover(self.modules, self.target, "131")
+        self.lifecycle.recover_blocked_publication_ready.assert_not_called()
+        self.agent.pr_prepare.assert_not_called()
+        self.agent.pr_create.assert_not_called()
+        self.agent.pr_edit.assert_not_called()
+
+    def test_blocked_akv_shaped_stale_draft_recovers_same_pr_and_preserves_subject(self) -> None:
+        current_head = "8313bcfcfdee4a3985f8b5dd48861b2b2bcb69a4"
+        branch = "task/13-hybrid-level1-reranking"
+        repository = "upiscium/AgentKnowledgeVault"
+        original_state = (
+            b"prefix\n- Base revision: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+            b"- Status: blocked\n- Blockers: publication-only failure\nsuffix\n"
+        )
+        ready_state = original_state.replace(b"- Status: blocked", b"- Status: publication-ready")
+        final_state = original_state.replace(b"- Status: blocked", b"- Status: draft-pr-created")
+        before = {
+            "head": current_head, "branch": branch, "repository": repository,
+            "record": self.record, "work_units": b'history including WU-13-28',
+            "verification": b"current verification", "contract": b"contract",
+            "issue": b"issue", "state": original_state, "status": "blocked",
+        }
+        ready = {**before, "state": ready_state, "status": "publication-ready"}
+        after = {**before, "state": final_state, "status": "draft-pr-created"}
+        stale = {
+            "number": 29, "headRefName": branch, "baseRefName": "main",
+            "headRefOid": current_head, "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN",
+            "body": "Validation at 97dbf03607d8eaabfc76104be2722d89aa6ddf2d",
+        }
+        repaired = {**stale, "body": f"Validation at {current_head}"}
+        self.agent.pr_for_branch.side_effect = [stale, stale, stale, repaired, repaired]
+        self.agent.default_branch.return_value = "main"
+        self.publication.canonical_metadata.return_value = ("13: canonical", repaired["body"])
+        self.agent._validated_local_metadata.return_value = (
+            "13: canonical", Path("/tmp/body"), repaired["body"]
+        )
+        with mock.patch.object(bridge, "_publication_snapshot", side_effect=[before, before, ready, ready]), \
+             mock.patch.object(bridge, "_publication_snapshot_for_post", return_value=after), \
+             mock.patch.object(bridge, "_target_git", return_value=""):
+            result = bridge._publication_recover(self.modules, self.target, "13")
+        self.assertEqual(result["pullRequest"]["number"], 29)
+        self.lifecycle.recover_blocked_publication_ready.assert_called_once_with(
+            self.record,
+            "13",
+            original_state,
+            {
+                "work-units.json": before["work_units"],
+                "verification.json": before["verification"],
+                "contract.json": before["contract"],
+                "issue.json": before["issue"],
+            },
+        )
+        self.agent.pr_edit.assert_called_once_with(self.target, "13", expected_pr_number=29)
+        self.agent.pr_create.assert_not_called()
+        self.assertEqual(after["work_units"], before["work_units"])
+        self.assertIn(b"WU-13-28", after["work_units"])
+
+    def test_blocked_invalid_or_moved_pr_fails_before_state_mutation(self) -> None:
+        before = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue",
+            "state": b"- Base revision: " + b"b" * 40 + b"\n- Status: blocked\n",
+            "status": "blocked",
+        }
+        exact = {
+            "number": 29, "headRefName": self.branch, "baseRefName": "main",
+            "headRefOid": self.head, "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN",
+        }
+        cases = [
+            ("number", {**exact, "number": 0}),
+            ("bool number", {**exact, "number": True}),
+            ("branch", {**exact, "headRefName": "task/other"}),
+            ("base", {**exact, "baseRefName": "other"}),
+            ("head", {**exact, "headRefOid": "c" * 40}),
+            ("ready", {**exact, "isDraft": False}),
+            ("closed", {**exact, "state": "CLOSED"}),
+            ("cross repository", {**exact, "isCrossRepository": True}),
+        ]
+        self.agent.default_branch.return_value = "main"
+        for name, candidate in cases:
+            with self.subTest(name=name):
+                self.agent.reset_mock()
+                self.agent.default_branch.return_value = "main"
+                self.agent.pr_for_branch.return_value = candidate
+                with mock.patch.object(bridge, "_publication_snapshot", return_value=before), \
+                     self.assertRaises(bridge.BridgeError):
+                    bridge._publication_recover(self.modules, self.target, "131")
+                self.lifecycle.recover_blocked_publication_ready.assert_not_called()
+                self.agent.pr_edit.assert_not_called()
+
+    def test_blocked_pr_replacement_before_state_mutation_fails_closed(self) -> None:
+        before = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue",
+            "state": b"- Base revision: " + b"b" * 40 + b"\n- Status: blocked\n",
+            "status": "blocked",
+        }
+        exact = {
+            "number": 29, "headRefName": self.branch, "baseRefName": "main",
+            "headRefOid": self.head, "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN",
+        }
+        self.publication.canonical_metadata.return_value = ("title", "body")
+        for field, changed in (
+            ("number", 30), ("headRefName", "task/other"),
+            ("baseRefName", "other"), ("headRefOid", "c" * 40),
+            ("isDraft", False), ("state", "CLOSED"),
+        ):
+            with self.subTest(field=field):
+                self.agent.reset_mock()
+                self.agent.default_branch.return_value = "main"
+                self.agent.pr_for_branch.side_effect = [exact, {**exact, field: changed}]
+                with mock.patch.object(bridge, "_publication_snapshot", side_effect=[before, before]), \
+                     mock.patch.object(bridge, "_target_git", return_value=""), \
+                     self.assertRaises(bridge.BridgeError):
+                    bridge._publication_recover(self.modules, self.target, "131")
+                self.lifecycle.recover_blocked_publication_ready.assert_not_called()
+                self.agent.pr_edit.assert_not_called()
+
+    def test_blocked_default_branch_move_before_state_mutation_fails_closed(self) -> None:
+        before = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue",
+            "state": b"- Base revision: " + b"b" * 40 + b"\n- Status: blocked\n",
+            "status": "blocked",
+        }
+        exact = {
+            "number": 29, "headRefName": self.branch, "baseRefName": "main",
+            "headRefOid": self.head, "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN",
+        }
+        self.agent.default_branch.side_effect = ["main", "moved"]
+        self.agent.pr_for_branch.return_value = exact
+        self.publication.canonical_metadata.return_value = ("title", "body")
+        with mock.patch.object(bridge, "_publication_snapshot", side_effect=[before, before]), \
+             mock.patch.object(bridge, "_target_git", return_value=""), \
+             self.assertRaisesRegex(bridge.BridgeError, "default branch changed"):
+            bridge._publication_recover(self.modules, self.target, "131")
+        self.lifecycle.recover_blocked_publication_ready.assert_not_called()
+
+    def test_blocked_authority_change_before_state_mutation_fails_closed(self) -> None:
+        before = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue",
+            "state": b"- Base revision: " + b"b" * 40 + b"\n- Status: blocked\n",
+            "status": "blocked",
+        }
+        exact = {
+            "number": 29, "headRefName": self.branch, "baseRefName": "main",
+            "headRefOid": self.head, "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN",
+        }
+        self.agent.default_branch.return_value = "main"
+        self.agent.pr_for_branch.return_value = exact
+        self.publication.canonical_metadata.return_value = ("title", "body")
+        for field, changed in (
+            ("status", "planning"), ("head", "c" * 40),
+            ("branch", "task/other"), ("repository", "other/repository"),
+            ("work_units", b"changed"), ("verification", b"changed"),
+            ("contract", b"changed"), ("issue", b"changed"),
+        ):
+            with self.subTest(field=field):
+                self.agent.reset_mock()
+                self.agent.default_branch.return_value = "main"
+                self.agent.pr_for_branch.return_value = exact
+                moved = {**before, field: changed}
+                with mock.patch.object(bridge, "_publication_snapshot", side_effect=[before, moved]), \
+                     mock.patch.object(bridge, "_target_git", return_value=""), \
+                     self.assertRaisesRegex(bridge.BridgeError, "authority changed"):
+                    bridge._publication_recover(self.modules, self.target, "131")
+                self.lifecycle.recover_blocked_publication_ready.assert_not_called()
+
     def test_stale_verification_and_effective_reviewer_fail_before_create(self) -> None:
+        self.lifecycle.state_status.return_value = "blocked"
         for failure in (
             "project verification evidence is stale",
             "required reviewer Work Unit is not completed",
@@ -203,6 +399,7 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
         for name, mutate in cases.items():
             with self.subTest(name=name):
                 self.setUp()
+                self.lifecycle.state_status.return_value = "blocked"
                 mutate()
                 git = (lambda *args, **kwargs: "tracked\n") if name == "dirty target" else self.snapshot_git
                 with mock.patch.object(bridge, "_target_git", side_effect=git), \
@@ -210,6 +407,57 @@ class PublicationRecoveryBridgeTest(unittest.TestCase):
                       mock.patch.object(bridge, "_state_bytes", side_effect=lambda _root, n, *_: n.encode()), \
                      self.assertRaises(bridge.BridgeError):
                     bridge._publication_snapshot(self.modules, self.target, "131")
+
+    def test_blocked_local_or_remote_head_mismatch_is_rejected(self) -> None:
+        self.lifecycle.state_status.return_value = "blocked"
+
+        def local_mismatch(*args: str, **_: object) -> str:
+            if args[:2] == ("rev-parse", "--verify"):
+                return self.head if args[2] == "HEAD^{commit}" else "c" * 40
+            return ""
+
+        with mock.patch.object(bridge, "_target_git", side_effect=local_mismatch), \
+             mock.patch.object(bridge, "_optional_state_bytes", return_value=None), \
+             self.assertRaisesRegex(bridge.BridgeError, "HEAD.*differ"):
+            bridge._publication_snapshot(self.modules, self.target, "131")
+        with mock.patch.object(bridge, "_target_git", side_effect=self.snapshot_git), \
+             mock.patch.object(bridge, "_remote_branch_head", return_value="c" * 40), \
+             mock.patch.object(bridge, "_optional_state_bytes", return_value=None), \
+             self.assertRaisesRegex(bridge.BridgeError, "remote Task branch"):
+            bridge._publication_snapshot(self.modules, self.target, "131")
+
+    def test_blocked_unresolved_contract_is_rejected_before_evidence_or_pr(self) -> None:
+        self.lifecycle.state_status.return_value = "blocked"
+        self.lifecycle.require_resolved_contract.side_effect = RuntimeError("contract mismatch")
+        with mock.patch.object(bridge, "_target_git", side_effect=self.snapshot_git), \
+             self.assertRaisesRegex(bridge.BridgeError, "contract mismatch"):
+            bridge._publication_snapshot(self.modules, self.target, "131")
+        self.publication.verification_evidence.assert_not_called()
+        self.agent.pr_for_branch.assert_not_called()
+
+    def test_blocked_missing_current_reviewer_metadata_rejects_before_state_mutation(self) -> None:
+        before = {
+            "head": self.head, "branch": self.branch, "repository": self.repository,
+            "record": self.record, "work_units": b"units", "verification": b"verification",
+            "contract": b"contract", "issue": b"issue",
+            "state": b"- Base revision: " + b"b" * 40 + b"\n- Status: blocked\n",
+            "status": "blocked",
+        }
+        exact = {
+            "number": 29, "headRefName": self.branch, "baseRefName": "main",
+            "headRefOid": self.head, "isDraft": True,
+            "isCrossRepository": False, "state": "OPEN",
+        }
+        self.agent.default_branch.return_value = "main"
+        self.agent.pr_for_branch.return_value = exact
+        self.publication.canonical_metadata.side_effect = RuntimeError(
+            "publication requires a completed reviewer Work Unit"
+        )
+        with mock.patch.object(bridge, "_publication_snapshot", return_value=before), \
+             mock.patch.object(bridge, "_target_git", return_value=""), \
+             self.assertRaisesRegex(bridge.BridgeError, "completed reviewer"):
+            bridge._publication_recover(self.modules, self.target, "131")
+        self.lifecycle.recover_blocked_publication_ready.assert_not_called()
 
     def test_unsafe_config_is_rejected(self) -> None:
         with mock.patch.object(bridge, "_pinned_run", return_value=mock.Mock(stdout="core.sshCommand\0")):
@@ -254,7 +502,7 @@ Repair AgentKnowledgeVault PR #29 publication metadata.
 
 ## Current state
 
-- Status: publication-ready
+- Status: blocked
 - Blockers: none
 - Unverified: none
 

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 import tempfile
 import unittest
+from contextlib import nullcontext
 from pathlib import Path
 from unittest import mock
 
@@ -77,9 +78,16 @@ class TaskLifecycleTest(unittest.TestCase):
             with mock.patch.object(lifecycle, "current_worktree", return_value=record), \
                  mock.patch.object(lifecycle, "worktree_for_task", return_value=record), \
                  mock.patch.object(lifecycle, "require_resolved_contract"), \
-                 mock.patch.object(lifecycle, "assert_task_identity"):
+                 mock.patch.object(lifecycle, "assert_task_identity"), \
+                 mock.patch.object(lifecycle.private_state, "prepare"), \
+                 mock.patch.object(lifecycle.private_state, "publication_recovery_receipt", return_value=root / "receipt"), \
+                 mock.patch.object(lifecycle.private_state, "_validate_legacy_content"), \
+                 mock.patch.object(lifecycle.private_state, "_validate_publication_recovery_topology"), \
+                 mock.patch.object(lifecycle.private_state, "topology"), \
+                 mock.patch.object(lifecycle.private_state, "mutation_lock", return_value=nullcontext()), \
+                 mock.patch.object(lifecycle.private_state, "exclusive_write_bytes", side_effect=lambda path, content, **_: path.write_bytes(content)):
                 result = lifecycle.recover_blocked_publication_ready(
-                    record, "148", original, evidence
+                    record, "148", original, evidence, b"{}"
                 )
             self.assertEqual(result, "transitioned")
             self.assertEqual(
@@ -104,11 +112,19 @@ class TaskLifecycleTest(unittest.TestCase):
                  mock.patch.object(lifecycle, "worktree_for_task", return_value=record), \
                  mock.patch.object(lifecycle, "require_resolved_contract"), \
                  mock.patch.object(lifecycle, "assert_task_identity"), \
+                 mock.patch.object(lifecycle.private_state, "prepare"), \
+                 mock.patch.object(lifecycle.private_state, "publication_recovery_receipt", return_value=root / "receipt"), \
+                 mock.patch.object(lifecycle.private_state, "_validate_legacy_content"), \
+                 mock.patch.object(lifecycle.private_state, "_validate_publication_recovery_topology"), \
+                 mock.patch.object(lifecycle.private_state, "topology"), \
+                 mock.patch.object(lifecycle.private_state, "mutation_lock", return_value=nullcontext()), \
+                 mock.patch.object(lifecycle.private_state, "exclusive_write_bytes", side_effect=lambda path, content, **_: path.write_bytes(content)), \
                  self.assertRaisesRegex(lifecycle.LifecycleError, "Task State changed"):
                 lifecycle.recover_blocked_publication_ready(
-                    record, "148", b"stale", evidence
+                    record, "148", b"stale", evidence, b"{}"
                 )
             self.assertEqual(lifecycle.state_status(state), "blocked")
+            self.assertEqual((root / "receipt").read_bytes(), b"{}")
 
     def test_guarded_blocked_publication_recovery_rejects_any_evidence_change(self) -> None:
         for case in (
@@ -140,11 +156,57 @@ class TaskLifecycleTest(unittest.TestCase):
                      mock.patch.object(lifecycle, "worktree_for_task", return_value=record), \
                      mock.patch.object(lifecycle, "require_resolved_contract"), \
                      mock.patch.object(lifecycle, "assert_task_identity"), \
+                     mock.patch.object(lifecycle.private_state, "prepare"), \
+                     mock.patch.object(lifecycle.private_state, "publication_recovery_receipt", return_value=root / "receipt"), \
+                     mock.patch.object(lifecycle.private_state, "_validate_legacy_content"), \
+                     mock.patch.object(lifecycle.private_state, "_validate_publication_recovery_topology"), \
+                     mock.patch.object(lifecycle.private_state, "topology"), \
+                     mock.patch.object(lifecycle.private_state, "mutation_lock", return_value=nullcontext()), \
+                     mock.patch.object(lifecycle.private_state, "exclusive_write_bytes", side_effect=lambda path, content, **_: path.write_bytes(content)), \
                      self.assertRaisesRegex(lifecycle.LifecycleError, "publication evidence changed"):
                     lifecycle.recover_blocked_publication_ready(
-                        record, "148", original, evidence
+                        record, "148", original, evidence, b"{}"
                     )
                 self.assertEqual(state.read_bytes(), original)
+
+    def test_completed_blocked_recovery_consumes_exact_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = root / ".task-state/task.md"
+            state.parent.mkdir()
+            final = b"## Current state\n\n- Status: draft-pr-created\n"
+            state.write_bytes(final)
+            evidence = {
+                "work-units.json": b"units",
+                "verification.json": b"verification",
+                "contract.json": b"contract",
+                "issue.json": None,
+            }
+            for name, content in evidence.items():
+                if content is not None:
+                    (state.parent / name).write_bytes(content)
+            receipt = root / "receipt"
+            receipt.write_bytes(b"receipt")
+            record = lifecycle.WorktreeRecord(root, "task/148-recovery", "a" * 40)
+
+            def consume(path: Path, **_: object) -> None:
+                path.unlink()
+
+            with mock.patch.object(lifecycle, "current_worktree", return_value=record), \
+                 mock.patch.object(lifecycle, "worktree_for_task", return_value=record), \
+                 mock.patch.object(lifecycle, "require_resolved_contract"), \
+                 mock.patch.object(lifecycle, "assert_task_identity"), \
+                 mock.patch.object(lifecycle.private_state, "prepare"), \
+                 mock.patch.object(lifecycle.private_state, "publication_recovery_receipt", return_value=receipt), \
+                 mock.patch.object(lifecycle.private_state, "mutation_lock", return_value=nullcontext()), \
+                 mock.patch.object(lifecycle.private_state, "read_bytes_identity", return_value=(b"receipt", (1, 2))), \
+                 mock.patch.object(lifecycle.private_state, "unlink", side_effect=consume) as unlink:
+                result = lifecycle.complete_blocked_publication_recovery(
+                    record, "148", final, evidence, b"receipt"
+                )
+            self.assertEqual(result, "consumed")
+            self.assertFalse(receipt.exists())
+            unlink.assert_called_once()
 
     def test_batch_conflict_detects_dependency_and_shared_resources(self) -> None:
         summaries = [

--- a/tests/test_task_lifecycle.py
+++ b/tests/test_task_lifecycle.py
@@ -40,6 +40,112 @@ class TaskLifecycleTest(unittest.TestCase):
             lifecycle.set_state_status(path, "planning")
             self.assertEqual(lifecycle.state_status(path), "planning")
 
+    def test_generic_state_set_cannot_recover_blocked_to_publication_ready(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = root / ".task-state/task.md"
+            state.parent.mkdir()
+            state.write_text("## Current state\n\n- Status: blocked\n", encoding="utf-8")
+            record = lifecycle.WorktreeRecord(root, "task/148-recovery", "a" * 40)
+            with mock.patch.object(lifecycle, "require_local_task", return_value=record), \
+                 mock.patch.object(lifecycle, "require_resolved_contract"), \
+                 mock.patch.object(lifecycle, "assert_task_identity"), \
+                 mock.patch.object(lifecycle, "work_units_lock", return_value=mock.MagicMock(
+                     __enter__=mock.Mock(return_value=None), __exit__=mock.Mock(return_value=False)
+                 )), \
+                 self.assertRaisesRegex(lifecycle.LifecycleError, "invalid Task State transition"):
+                lifecycle.task_state_set(root, "148", "publication-ready")
+            self.assertEqual(lifecycle.state_status(state), "blocked")
+
+    def test_guarded_blocked_publication_recovery_is_exact_locked_status_cas(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = root / ".task-state/task.md"
+            state.parent.mkdir()
+            original = b"prefix\n## Current state\n\n- Status: blocked\n- Blockers: publication only\nsuffix\n"
+            state.write_bytes(original)
+            evidence = {
+                "work-units.json": b"units",
+                "verification.json": b"verification",
+                "contract.json": b"contract",
+                "issue.json": None,
+            }
+            for name, content in evidence.items():
+                if content is not None:
+                    (state.parent / name).write_bytes(content)
+            record = lifecycle.WorktreeRecord(root, "task/148-recovery", "a" * 40)
+            with mock.patch.object(lifecycle, "current_worktree", return_value=record), \
+                 mock.patch.object(lifecycle, "worktree_for_task", return_value=record), \
+                 mock.patch.object(lifecycle, "require_resolved_contract"), \
+                 mock.patch.object(lifecycle, "assert_task_identity"):
+                result = lifecycle.recover_blocked_publication_ready(
+                    record, "148", original, evidence
+                )
+            self.assertEqual(result, "transitioned")
+            self.assertEqual(
+                state.read_bytes(),
+                original.replace(b"- Status: blocked", b"- Status: publication-ready"),
+            )
+
+    def test_guarded_blocked_publication_recovery_rejects_stale_state_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = root / ".task-state/task.md"
+            state.parent.mkdir()
+            state.write_text("## Current state\n\n- Status: blocked\n", encoding="utf-8")
+            record = lifecycle.WorktreeRecord(root, "task/148-recovery", "a" * 40)
+            evidence = {
+                "work-units.json": None,
+                "verification.json": None,
+                "contract.json": None,
+                "issue.json": None,
+            }
+            with mock.patch.object(lifecycle, "current_worktree", return_value=record), \
+                 mock.patch.object(lifecycle, "worktree_for_task", return_value=record), \
+                 mock.patch.object(lifecycle, "require_resolved_contract"), \
+                 mock.patch.object(lifecycle, "assert_task_identity"), \
+                 self.assertRaisesRegex(lifecycle.LifecycleError, "Task State changed"):
+                lifecycle.recover_blocked_publication_ready(
+                    record, "148", b"stale", evidence
+                )
+            self.assertEqual(lifecycle.state_status(state), "blocked")
+
+    def test_guarded_blocked_publication_recovery_rejects_any_evidence_change(self) -> None:
+        for case in (
+            "work-units.json",
+            "verification.json",
+            "contract.json",
+            "issue.json",
+            "issue-value",
+        ):
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                state = root / ".task-state/task.md"
+                state.parent.mkdir()
+                original = b"## Current state\n\n- Status: blocked\n"
+                state.write_bytes(original)
+                evidence = {
+                    "work-units.json": b"units",
+                    "verification.json": b"verification",
+                    "contract.json": b"contract",
+                    "issue.json": b"issue" if case == "issue-value" else None,
+                }
+                for name, content in evidence.items():
+                    if content is not None:
+                        (state.parent / name).write_bytes(content)
+                changed_name = "issue.json" if case == "issue-value" else case
+                (state.parent / changed_name).write_bytes(b"changed")
+                record = lifecycle.WorktreeRecord(root, "task/148-recovery", "a" * 40)
+                with mock.patch.object(lifecycle, "current_worktree", return_value=record), \
+                     mock.patch.object(lifecycle, "worktree_for_task", return_value=record), \
+                     mock.patch.object(lifecycle, "require_resolved_contract"), \
+                     mock.patch.object(lifecycle, "assert_task_identity"), \
+                     self.assertRaisesRegex(lifecycle.LifecycleError, "publication evidence changed"):
+                    lifecycle.recover_blocked_publication_ready(
+                        record, "148", original, evidence
+                    )
+                self.assertEqual(state.read_bytes(), original)
+
     def test_batch_conflict_detects_dependency_and_shared_resources(self) -> None:
         summaries = [
             {

--- a/tools/automation_recovery_bridge.py
+++ b/tools/automation_recovery_bridge.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 import io
 import json
@@ -725,11 +726,147 @@ def _publication_snapshot_for_post(modules: dict, target: Path, task: str) -> di
     }
 
 
+def _replace_publication_status(state: bytes, expected: bytes, target: bytes) -> bytes:
+    updated, count = re.subn(
+        rb"(?m)^- Status: " + re.escape(expected) + rb"$",
+        b"- Status: " + target,
+        state,
+        count=1,
+    )
+    if count != 1:
+        raise BridgeError(
+            f"cannot derive recovery Task State transition {expected.decode()} -> {target.decode()}"
+        )
+    return updated
+
+
+def _recovery_states(snapshot: dict) -> tuple[bytes, bytes, bytes]:
+    state = snapshot["state"]
+    if snapshot["status"] == "blocked":
+        blocked = state
+        ready = _replace_publication_status(blocked, b"blocked", b"publication-ready")
+        draft = _replace_publication_status(ready, b"publication-ready", b"draft-pr-created")
+    elif snapshot["status"] == "publication-ready":
+        ready = state
+        blocked = _replace_publication_status(ready, b"publication-ready", b"blocked")
+        draft = _replace_publication_status(ready, b"publication-ready", b"draft-pr-created")
+    elif snapshot["status"] == "draft-pr-created":
+        draft = state
+        ready = _replace_publication_status(draft, b"draft-pr-created", b"publication-ready")
+        blocked = _replace_publication_status(ready, b"publication-ready", b"blocked")
+    else:  # pragma: no cover - snapshots reject all other states
+        raise BridgeError("unsupported publication recovery status")
+    return blocked, ready, draft
+
+
+def _publication_recovery_receipt(
+    target: Path, task: str, snapshot: dict, base: str, pr_number: int
+) -> bytes:
+    blocked, ready, draft = _recovery_states(snapshot)
+    base_match = re.search(
+        rb"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", snapshot["state"]
+    )
+    if base_match is None:
+        raise BridgeError("Task State has no valid Base revision")
+
+    def digest(content: bytes | None) -> str | None:
+        return hashlib.sha256(content).hexdigest() if content is not None else None
+
+    value = {
+        "schema_version": 1,
+        "kind": "blocked-publication-recovery",
+        "repository": snapshot["repository"],
+        "task_id": task,
+        "worktree": str(target),
+        "branch": snapshot["branch"],
+        "head": snapshot["head"],
+        "base_branch": base,
+        "base_revision": base_match.group(1).decode("ascii").lower(),
+        "pr_number": pr_number,
+        "blocked_state_sha256": digest(blocked),
+        "publication_ready_state_sha256": digest(ready),
+        "draft_pr_created_state_sha256": digest(draft),
+        "work_units_sha256": digest(snapshot["work_units"]),
+        "verification_sha256": digest(snapshot["verification"]),
+        "contract_sha256": digest(snapshot["contract"]),
+        "issue_sha256": digest(snapshot["issue"]),
+    }
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def _read_publication_recovery_receipt(modules: dict, target: Path) -> bytes | None:
+    private = modules["git_private_state"]
+    try:
+        private.prepare(target, admin=True)
+        path = private.publication_recovery_receipt(target)
+        try:
+            path.lstat()
+        except FileNotFoundError:
+            return None
+        return private.read_bytes(path, "publication recovery receipt")
+    except Exception as exc:
+        raise BridgeError(str(exc)) from exc
+
+
+def _validate_publication_recovery_receipt(
+    receipt: bytes, target: Path, task: str, snapshot: dict, base: str
+) -> dict:
+    try:
+        value = json.loads(receipt.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BridgeError("publication recovery receipt is invalid") from exc
+    if not isinstance(value, dict):
+        raise BridgeError("publication recovery receipt is invalid")
+    blocked, ready, draft = _recovery_states(snapshot)
+
+    def digest(content: bytes | None) -> str | None:
+        return hashlib.sha256(content).hexdigest() if content is not None else None
+
+    expected = {
+        "repository": snapshot["repository"],
+        "task_id": task,
+        "worktree": str(target),
+        "branch": snapshot["branch"],
+        "head": snapshot["head"],
+        "base_branch": base,
+        "blocked_state_sha256": digest(blocked),
+        "publication_ready_state_sha256": digest(ready),
+        "draft_pr_created_state_sha256": digest(draft),
+        "work_units_sha256": digest(snapshot["work_units"]),
+        "verification_sha256": digest(snapshot["verification"]),
+        "contract_sha256": digest(snapshot["contract"]),
+        "issue_sha256": digest(snapshot["issue"]),
+    }
+    mismatches = [name for name, expected_value in expected.items() if value.get(name) != expected_value]
+    base_match = re.search(
+        rb"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", snapshot["state"]
+    )
+    if base_match is None or value.get("base_revision") != base_match.group(1).decode("ascii").lower():
+        mismatches.append("base_revision")
+    number = value.get("pr_number")
+    if not isinstance(number, int) or isinstance(number, bool) or number < 1:
+        mismatches.append("pr_number")
+    if mismatches:
+        raise BridgeError(
+            "publication recovery receipt does not match the exact current subject: "
+            + ", ".join(sorted(set(mismatches)))
+        )
+    return value
+
+
 def _publication_recover(modules: dict, target: Path, task: str) -> dict:
     before = _publication_snapshot(modules, target, task)
     lifecycle = modules["task_lifecycle"]
     agent_core = modules["agent_core"]
     publication = modules["publication_metadata"]
+    recovery_receipt = _read_publication_recovery_receipt(modules, target)
+    receipt_value = None
+    receipt_base = None
+    if recovery_receipt is not None:
+        receipt_base = agent_core.default_branch(target)
+        receipt_value = _validate_publication_recovery_receipt(
+            recovery_receipt, target, task, before, receipt_base
+        )
 
     def existing_pr_number(existing: object) -> int:
         if (
@@ -801,6 +938,10 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
                     )
                 blocked_base = agent_core.default_branch(target)
                 initial_pr_number = validate_blocked_pr(initial_pr, blocked_base)
+                if receipt_value is not None and receipt_value["pr_number"] != initial_pr_number:
+                    raise BridgeError(
+                        "existing Draft PR identity differs from recovery receipt"
+                    )
                 prove_canonical_metadata()
                 immediately_before = _publication_snapshot(modules, target, task)
                 for name in (
@@ -821,6 +962,10 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
                     or validate_blocked_pr(confirmed, blocked_base) != initial_pr_number
                 ):
                     raise BridgeError("existing Draft PR identity changed before blocked recovery")
+                if recovery_receipt is None:
+                    recovery_receipt = _publication_recovery_receipt(
+                        target, task, before, blocked_base, initial_pr_number
+                    )
                 try:
                     lifecycle.recover_blocked_publication_ready(
                         before["record"],
@@ -832,6 +977,7 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
                             "contract.json": before["contract"],
                             "issue.json": before["issue"],
                         },
+                        recovery_receipt,
                     )
                 except Exception as exc:
                     raise BridgeError(str(exc)) from exc
@@ -854,7 +1000,20 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
                         raise BridgeError(
                             f"blocked publication recovery changed unexpected authority: {name}"
                         )
-            if before["status"] == "draft-pr-created":
+            if before["status"] in {"publication-ready", "draft-pr-created"} and receipt_value is not None:
+                initial_pr = agent_core.pr_for_branch(
+                    target, before["branch"], before["repository"]
+                )
+                if initial_pr is None:
+                    raise BridgeError(
+                        f"{before['status']} blocked-recovery retry requires the receipt-bound Draft PR"
+                    )
+                initial_pr_number = validate_blocked_pr(initial_pr, receipt_base)
+                if initial_pr_number != receipt_value["pr_number"]:
+                    raise BridgeError(
+                        "existing Draft PR identity differs from recovery receipt"
+                    )
+            elif before["status"] == "draft-pr-created":
                 initial_pr = agent_core.pr_for_branch(
                     target, before["branch"], before["repository"]
                 )
@@ -876,7 +1035,11 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
                     raise BridgeError(f"publication authority changed before GitHub write: {name}")
             existing = agent_core.pr_for_branch(target, before["branch"], before["repository"])
             if existing is None:
-                if before["status"] != "publication-ready" or initial_pr_number is not None:
+                if (
+                    before["status"] != "publication-ready"
+                    or initial_pr_number is not None
+                    or recovery_receipt is not None
+                ):
                     raise BridgeError(
                         f"{before['status']} recovery requires the existing Draft PR"
                     )
@@ -887,6 +1050,8 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
                     raise BridgeError(
                         "existing Draft PR identity changed before canonical repair"
                     )
+                if receipt_value is not None:
+                    validate_blocked_pr(existing, receipt_base)
                 agent_core.pr_edit(
                     target,
                     task,
@@ -919,6 +1084,42 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
         draft=True,
     )
     _assert_publication_postconditions(modules, target, task, before)
+    if recovery_receipt is not None:
+        receipt_live = agent_core.pr_for_branch(
+            target, before["branch"], before["repository"]
+        )
+        if (
+            not receipt_live
+            or receipt_live.get("number") != json.loads(recovery_receipt)["pr_number"]
+        ):
+            raise BridgeError(
+                "receipt-bound Draft PR identity changed before receipt consumption"
+            )
+        agent_core._validate_live_pr(
+            receipt_live,
+            branch=before["branch"],
+            base=agent_core.default_branch(target),
+            head=before["head"],
+            title=title,
+            body=body,
+            draft=True,
+        )
+        _, _, final_state = _recovery_states(before)
+        try:
+            lifecycle.complete_blocked_publication_recovery(
+                before["record"],
+                task,
+                final_state,
+                {
+                    "work-units.json": before["work_units"],
+                    "verification.json": before["verification"],
+                    "contract.json": before["contract"],
+                    "issue.json": before["issue"],
+                },
+                recovery_receipt,
+            )
+        except Exception as exc:
+            raise BridgeError(str(exc)) from exc
     return {
         "status": "DRAFT_PR_CREATED",
         "task": task,

--- a/tools/automation_recovery_bridge.py
+++ b/tools/automation_recovery_bridge.py
@@ -557,6 +557,17 @@ def _state_bytes(target: Path, name: str, contract=None) -> bytes:
         raise BridgeError(f"cannot read required Task evidence: {path}") from exc
 
 
+def _optional_state_bytes(target: Path, name: str, contract) -> bytes | None:
+    path = target / ".task-state" / name
+    try:
+        with contract.contract_state_lock(target) as directory_fd:
+            content = contract._read_state_file(directory_fd, name)
+            contract._assert_state_dir_binding(target, directory_fd)
+        return content
+    except Exception as exc:
+        raise BridgeError(f"cannot read optional Task evidence: {path}") from exc
+
+
 def _remote_branch_head(target: Path, repository: str, branch: str) -> str:
     result = _pinned_run(
         ["gh", "api", "--hostname", "github.com", f"repos/{repository}/git/ref/heads/{quote(branch, safe='')}", "--jq", ".object.sha"],
@@ -584,9 +595,9 @@ def _publication_snapshot(modules: dict, target: Path, task: str) -> dict:
         if record.branch != branch:
             raise BridgeError("registered Task branch identity changed")
         status = lifecycle.state_status(lifecycle.state_path(target))
-        if status not in {"publication-ready", "draft-pr-created"}:
+        if status not in {"blocked", "publication-ready", "draft-pr-created"}:
             raise BridgeError(
-                "publication recovery requires publication-ready or "
+                "publication recovery requires blocked, publication-ready, or "
                 f"draft-pr-created; found {status}"
             )
         repository = agent_core.canonical_repository(target)
@@ -613,6 +624,7 @@ def _publication_snapshot(modules: dict, target: Path, task: str) -> dict:
     verification = _state_bytes(target, "verification.json", contract_module)
     contract = _state_bytes(target, "contract.json", contract_module)
     state = _state_bytes(target, "task.md", contract_module)
+    issue = _optional_state_bytes(target, "issue.json", contract_module)
     try:
         modules["publication_metadata"].verification_evidence(target, task, head)
         modules["publication_metadata"].completed_reviews(target, task)
@@ -626,6 +638,7 @@ def _publication_snapshot(modules: dict, target: Path, task: str) -> dict:
         "work_units": work_units,
         "verification": verification,
         "contract": contract,
+        "issue": issue,
         "state": state,
         "status": status,
     }
@@ -633,8 +646,8 @@ def _publication_snapshot(modules: dict, target: Path, task: str) -> dict:
 
 def _assert_publication_postconditions(modules: dict, target: Path, task: str, before: dict) -> None:
     after = _publication_snapshot_for_post(modules, target, task)
-    for name in ("head", "branch", "repository", "work_units", "verification", "contract"):
-        if after[name] != before[name]:
+    for name in ("record", "head", "branch", "repository", "work_units", "verification", "contract", "issue"):
+        if after.get(name) != before.get(name):
             raise BridgeError(f"publication recovery changed immutable target evidence: {name}")
     if before["status"] == "publication-ready":
         expected_state = re.sub(
@@ -648,6 +661,18 @@ def _assert_publication_postconditions(modules: dict, target: Path, task: str, b
     elif before["status"] == "draft-pr-created":
         if after["state"] != before["state"]:
             raise BridgeError("publication recovery changed Task State from draft-pr-created")
+    elif before["status"] == "blocked":
+        expected_state = re.sub(
+            rb"(?m)^- Status: blocked$", b"- Status: publication-ready", before["state"], count=1
+        )
+        expected_state = re.sub(
+            rb"(?m)^- Status: publication-ready$",
+            b"- Status: draft-pr-created",
+            expected_state,
+            count=1,
+        )
+        if expected_state == before["state"] or after["state"] != expected_state:
+            raise BridgeError("publication recovery changed Task State beyond the guarded lifecycle transition")
     else:  # pragma: no cover - the initial snapshot rejects this state
         raise BridgeError(f"publication recovery started from an unsupported state: {before['status']}")
     if _target_git("diff", "--name-only", target=target) or _target_git(
@@ -687,12 +712,14 @@ def _publication_snapshot_for_post(modules: dict, target: Path, task: str) -> di
         raise BridgeError("target tracked worktree changed during publication recovery")
     contract_module = modules["task_contract"]
     return {
+        "record": record,
         "head": head,
         "branch": branch,
         "repository": repository,
         "work_units": _state_bytes(target, "work-units.json", contract_module),
         "verification": _state_bytes(target, "verification.json", contract_module),
         "contract": _state_bytes(target, "contract.json", contract_module),
+        "issue": _optional_state_bytes(target, "issue.json", contract_module),
         "state": _state_bytes(target, "task.md", contract_module),
         "status": status,
     }
@@ -700,6 +727,7 @@ def _publication_snapshot_for_post(modules: dict, target: Path, task: str) -> di
 
 def _publication_recover(modules: dict, target: Path, task: str) -> dict:
     before = _publication_snapshot(modules, target, task)
+    lifecycle = modules["task_lifecycle"]
     agent_core = modules["agent_core"]
     publication = modules["publication_metadata"]
 
@@ -708,9 +736,40 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
             not isinstance(existing, dict)
             or not isinstance(existing.get("number"), int)
             or isinstance(existing.get("number"), bool)
+            or existing.get("number") < 1
         ):
             raise BridgeError("existing Draft PR has an invalid or ambiguous number")
         return existing["number"]
+
+    def validate_blocked_pr(existing: object, expected_base: str) -> int:
+        number = existing_pr_number(existing)
+        if (
+            existing.get("state") != "OPEN"
+            or existing.get("isDraft") is not True
+            or existing.get("isCrossRepository") is not False
+            or existing.get("headRefName") != before["branch"]
+            or existing.get("baseRefName") != expected_base
+            or existing.get("headRefOid") != before["head"]
+        ):
+            raise BridgeError("blocked publication recovery requires the exact existing Draft PR")
+        return number
+
+    def prove_canonical_metadata() -> None:
+        base_match = re.search(
+            rb"(?m)^- Base revision: ([0-9a-fA-F]{40,64})$", before["state"]
+        )
+        if base_match is None:
+            raise BridgeError("Task State has no valid Base revision")
+        base = base_match.group(1).decode("ascii")
+        paths = _target_git(
+            "diff", "--name-only", f"{base}...{before['head']}", target=target
+        ).splitlines()
+        try:
+            publication.canonical_metadata(
+                target, task, head=before["head"], changed_paths=paths
+            )
+        except Exception as exc:
+            raise BridgeError(str(exc)) from exc
 
     def require_persisted_verification(root: Path, requested_task: str) -> None:
         if root.resolve() != target or requested_task != task:
@@ -730,6 +789,71 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
         agent_core.verify = require_persisted_verification
         with redirect_stdout(output):
             initial_pr_number = None
+            blocked_base = None
+            authority_before = before
+            if before["status"] == "blocked":
+                initial_pr = agent_core.pr_for_branch(
+                    target, before["branch"], before["repository"]
+                )
+                if initial_pr is None:
+                    raise BridgeError(
+                        "blocked publication recovery requires the existing Draft PR"
+                    )
+                blocked_base = agent_core.default_branch(target)
+                initial_pr_number = validate_blocked_pr(initial_pr, blocked_base)
+                prove_canonical_metadata()
+                immediately_before = _publication_snapshot(modules, target, task)
+                for name in (
+                    "record", "head", "branch", "repository", "work_units", "verification",
+                    "contract", "issue", "state", "status",
+                ):
+                    if immediately_before[name] != before[name]:
+                        raise BridgeError(
+                            f"publication authority changed before blocked recovery: {name}"
+                        )
+                confirmed = agent_core.pr_for_branch(
+                    target, before["branch"], before["repository"]
+                )
+                if agent_core.default_branch(target) != blocked_base:
+                    raise BridgeError("default branch changed before blocked recovery")
+                if (
+                    confirmed is None
+                    or validate_blocked_pr(confirmed, blocked_base) != initial_pr_number
+                ):
+                    raise BridgeError("existing Draft PR identity changed before blocked recovery")
+                try:
+                    lifecycle.recover_blocked_publication_ready(
+                        before["record"],
+                        task,
+                        before["state"],
+                        {
+                            "work-units.json": before["work_units"],
+                            "verification.json": before["verification"],
+                            "contract.json": before["contract"],
+                            "issue.json": before["issue"],
+                        },
+                    )
+                except Exception as exc:
+                    raise BridgeError(str(exc)) from exc
+                authority_before = {
+                    **before,
+                    "state": re.sub(
+                        rb"(?m)^- Status: blocked$",
+                        b"- Status: publication-ready",
+                        before["state"],
+                        count=1,
+                    ),
+                    "status": "publication-ready",
+                }
+                recovered = _publication_snapshot(modules, target, task)
+                for name in (
+                    "record", "head", "branch", "repository", "work_units",
+                    "verification", "contract", "issue", "state", "status",
+                ):
+                    if recovered.get(name) != authority_before.get(name):
+                        raise BridgeError(
+                            f"blocked publication recovery changed unexpected authority: {name}"
+                        )
             if before["status"] == "draft-pr-created":
                 initial_pr = agent_core.pr_for_branch(
                     target, before["branch"], before["repository"]
@@ -741,17 +865,20 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
                 initial_pr_number = existing_pr_number(initial_pr)
             agent_core.pr_prepare(target, task)
             immediately_before = _publication_snapshot(modules, target, task)
-            for name in (
-                "head", "branch", "repository", "work_units", "verification",
+            names = [
+                "record", "head", "branch", "repository", "work_units", "verification",
                 "contract", "state", "status",
-            ):
-                if immediately_before[name] != before[name]:
+            ]
+            if "issue" in before:
+                names.append("issue")
+            for name in names:
+                if immediately_before.get(name) != authority_before.get(name):
                     raise BridgeError(f"publication authority changed before GitHub write: {name}")
             existing = agent_core.pr_for_branch(target, before["branch"], before["repository"])
             if existing is None:
-                if before["status"] != "publication-ready":
+                if before["status"] != "publication-ready" or initial_pr_number is not None:
                     raise BridgeError(
-                        "draft-pr-created recovery requires the existing Draft PR"
+                        f"{before['status']} recovery requires the existing Draft PR"
                     )
                 pr = agent_core.pr_create(target, task)
             else:
@@ -771,7 +898,12 @@ def _publication_recover(modules: dict, target: Path, task: str) -> dict:
     finally:
         agent_core.verify = original_verify
 
-    if not pr or not isinstance(pr.get("number"), int) or isinstance(pr.get("number"), bool):
+    if (
+        not pr
+        or not isinstance(pr.get("number"), int)
+        or isinstance(pr.get("number"), bool)
+        or pr.get("number") < 1
+    ):
         raise BridgeError("published Draft PR cannot be resolved exactly")
     live = agent_core.pr_for_branch(target, before["branch"], before["repository"])
     if not live or live.get("number") != pr["number"]:


### PR DESCRIPTION
## 概要

publication-only failure で `blocked` に残った Task を、source-side `publication-recover` から限定的に復旧できるようにします。

- `blocked` の場合は既存の exact same-repository OPEN Draft を必須化
- current HEAD に紐づく verification と effective review evidence を再検証
- repository / Task / worktree / branch / exact HEAD / base / base revision / original PR / Task State variants / immutable evidence digests に結び付く Git-private recovery receipt を durable に保存
- receipt を durable status CAS より先に作成し、`blocked` / `publication-ready` / `draft-pr-created` の全 retry で original Draft PR を強制
- original PR 不在または replacement PR の場合は `pr_create` や GitHub mutation を行わず fail closed
- final `draft-pr-created` postconditions と同一 canonical Draft の直前再検証後のみ receipt を消費
- pinned Task State directory と共有 lock 上で、evidence byte CAS を伴う専用 `blocked -> publication-ready` transition を実装
- canonical `pr_prepare` / number-bound `pr_edit` のみで同一 Draft を修復
- generic state transition、通常の receipt-free publication-ready path、canonical `pr_edit`、Agent Core VERSION 3 は変更しない

## 検証

- focused private-state / lifecycle / source recovery / Agent Core tests: 142 tests PASS
- full Python unittest suite: 626 tests PASS
- `git diff --check`: PASS
- `just template::check`: PASS
- `just template::distribution-verify`: PASS
- `nix flake check --no-update-lock-file`: PASS
- `nix flake check --all-systems --no-build --no-update-lock-file`: PASS
- `nix build .#checks.x86_64-linux.opencode-contract --no-link --no-update-lock-file`: PASS

## レビュー

- correctness reviewer: blocking/actionable findings なし
- security reviewer: findings なし

## Downstream preservation

実 AgentKnowledgeVault Task #13 / PR #29 は、実装・テスト・レビュー中に変更していません。テストは隔離された AKV #13/#29-shaped fixture のみを使用しています。

Closes #148